### PR TITLE
feat: sync latest from haonan3/UniRL (incl. #310)

### DIFF
--- a/DRPO/README.md
+++ b/DRPO/README.md
@@ -136,7 +136,7 @@ The practical consequence:
    expands advantages to tokens, calls `_ar_drpo_loss`, applies `segment.loss_mask`,
    reduces, and `backward()`s.
 
-Unlike diffusion GRPO/FlowDPPO, `ARDRPO` does **not** freeze a train-side `old_logp` in
+Unlike diffusion GRPO/DPPO, `ARDRPO` does **not** freeze a train-side `old_logp` in
 `prepare_segment` — it reuses the rollout log-prob, so the recipe must keep
 `stack.num_updates_per_batch: 1` (`TrainStack` raises otherwise:
 `supports_multi_update = False`).
@@ -183,7 +183,7 @@ modality-agnostic and shares the AR trainer.)
 ## Related tutorial
 
 - **[FlowDPPO](../FlowDPPO/)** is the closest conceptual sibling: both replace ratio
-  clipping with divergence-aware control. FlowDPPO has *exact* Gaussian KL over latent
+  clipping with divergence-aware control. flowDPPO has *exact* Gaussian KL over latent
   transitions; `ARDRPO` approximates token-distribution shift from chosen-token log-probs.
 
 ## References

--- a/FlowBP/README.md
+++ b/FlowBP/README.md
@@ -1,0 +1,126 @@
+# FlowBP - Reward Backpropagation for Flow Matching
+
+`FlowBP` is the reward-gradient alignment framework from the paper
+*"Exploring the Design Space of Reward Backpropagation for Flow Matching."*
+It keeps the sampling rollout under `no_grad`, caches the trajectory, and then
+builds a lightweight surrogate backward graph from cached and selectively
+re-forwarded velocities.
+
+The paper names are used throughout this document.
+
+- **Implementation:** TODO
+- **Paper:** *"Exploring the Design Space of Reward Backpropagation for Flow Matching."*
+
+## What problem it solves
+
+Direct reward backpropagation is sample-efficient: instead of estimating a
+policy-gradient objective, it differentiates a scalar reward through the
+flow-matching sampler. The naive version is not practical at modern scale:
+
+- storing activations for every sampling step is too expensive;
+- chained Jacobian products over many Euler steps can inflate gradients;
+- connector methods such as LeapAlign avoid full backpropagation, but long
+  single-velocity jumps can create large connector residuals, so the reward
+  gradient is routed through an inaccurate surrogate endpoint.
+
+FlowBP treats the backward trajectory itself as the design object. The forward
+sample is produced by the normal rollout and cached. The reward still sees the
+sampled endpoint `x_0`, but the gradient flows only through a sparse surrogate
+graph whose active velocity calls are chosen by the method.
+
+## The FlowBP design axes
+
+The paper separates reward backpropagation into four choices:
+
+| Axis | Meaning in FlowBP |
+|---|---|
+| Reward-model input | Whether the reward sees the actual rollout image `x_0` or a posterior-mean estimate |
+| Active set | Which cached steps are re-forwarded with gradients |
+| Integration weights | Euler weights `h_i` or Lagrange quadrature weights `w_i^L` |
+| Bridge coupling | Whether a split latent `x_j` lets post-segment gradients affect pre-segment active calls |
+
+This recovers prior methods as settings of the same framework: ReFL,
+DRaFT-LV, and DRTune use detached short/sparse posterior-mean reward targets;
+LeapAlign uses two connector-pinned single-velocity hops; FlowBP explores
+endpoint-faithful sparse reconstruction, controlled bridge coupling, and
+higher-order leap quadrature.
+
+## Core surrogate
+
+The cached rollout follows the flow Euler update:
+
+$$
+x_{i+1} = x_i + (\sigma_{i+1} - \sigma_i) v_\theta(x_i, \sigma_i, c).
+$$
+
+FlowBP caches this rollout without storing the full backward graph. The
+surrogate then replaces only selected velocities with gradient-bearing
+evaluations while treating the rest of the cached trajectory as fixed. This
+keeps the forward sample tied to the actual rollout and bounds memory by the
+active set size rather than by the full sampling length.
+
+## FlowBP-Sparse
+
+`FlowBP-Sparse` reconstructs the full endpoint with Euler composition while
+only exposing `K` selected velocities to autograd.
+
+Mathematically, it uses no bridge (`j = 0`) and Euler weights:
+
+$$
+x_0 = x_N - \sum_{i=1}^{N} h_i \tilde v_i,
+\qquad
+\frac{\partial x_0}{\partial \theta}
+= -\sum_{i \in A} h_i
+\frac{\partial v_\theta(x_i, \sigma_i, c)}{\partial \theta}.
+$$
+
+## FlowBP-Bridge
+
+`FlowBP-Bridge` keeps the Euler endpoint reconstruction of `FlowBP-Sparse`,
+but splits the trajectory at `j` and lets the post-segment anchor consume an
+`alpha`-mixed `x_j`.
+
+The gradient has the sparse direct terms plus one controlled nested term:
+
+$$
+\frac{\partial x_0}{\partial \theta}
+= -\sum_{i \in A} h_i
+\frac{\partial v_\theta(x_i, \sigma_i, c)}{\partial \theta}
++ \alpha h_j
+\frac{\partial v_\theta(x_j, \sigma_j, c)}{\partial x_j}
+\sum_{i \in A_\text{pre}} h_i
+\frac{\partial v_\theta(x_i, \sigma_i, c)}{\partial \theta}.
+$$
+
+## FlowBP-Lagrange
+
+`FlowBP-Lagrange` stays closest to LeapAlign's two connector topology, but
+replaces each single-velocity leap with integrated Lagrange quadrature over a
+small support set.
+
+For a segment from `s` to `t`, it selects support velocities `S` and computes
+integral weights:
+
+$$
+w_i^L = \int_{\sigma_s}^{\sigma_t}
+\prod_{q \in S, q \ne i}
+\frac{\sigma - \sigma_q}{\sigma_i - \sigma_q}\,d\sigma.
+$$
+
+The connector prediction is:
+
+$$
+\hat x_t = x_s + \sum_{i \in S} w_i^L \tilde v_i,
+\qquad
+x_t = \hat x_t + \mathrm{sg}(x_t - \hat x_t).
+$$
+
+Compared with LeapAlign, this reduces connector residuals `d_j` and `d_0`
+over long intervals.
+
+## References
+
+- FlowBP: *"Exploring the Design Space of Reward Backpropagation for Flow Matching."*
+- LeapAlign: connector-based two-step reward backpropagation for flow matching.
+- ReFL, DRaFT-LV, and DRTune: prior direct reward-gradient baselines recovered
+  as settings of the FlowBP surrogate design space.

--- a/FlowDPPO/README.md
+++ b/FlowDPPO/README.md
@@ -1,26 +1,26 @@
 # FlowDPPO — KL-masked diffusion policy optimization
 
-`FlowDPPO` keeps GRPO's setup — the same SDE rollout, the same group-relative
+`DiffusionDPPO` keeps GRPO's setup — the same SDE rollout, the same group-relative
 advantage, the same per-step ratio — but **replaces PPO's uniform clipping with a
 KL-ADV mask**. It computes the exact Gaussian KL between the old and new SDE transition
 policies and zeroes an update only when it *both* diverges far from the old policy *and*
 pushes too aggressively in the reward-improving direction.
 
-- **Loss:** [`unirl/algorithms/flowdppo.py`](../unirl/algorithms/flowdppo.py) (`_gaussian_kl_div`, `_flowdppo_kl_adv_loss`, `FlowDPPO`)
+- **Loss:** [`unirl/algorithms/dppo.py`](../unirl/algorithms/dppo.py) (`_gaussian_kl_div`, `_dppo_kl_adv_loss`, `DiffusionDPPO`)
 - **SDE / replay path:** [`unirl/models/sd3/diffusion.py`](../unirl/models/sd3/diffusion.py), [`unirl/sde/kernels.py`](../unirl/sde/kernels.py)
 - **Recipe:** [`examples/diffusion/sd3_flowdppo.yaml`](../examples/diffusion/sd3_flowdppo.yaml) · **Config extract:** [`config.yaml`](config.yaml)
-- **Paper:** *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models."*
+- **Paper:** *"Flow-DPPO: Divergence Proximal Policy Optimization for Flow Matching Models."*
 
-FlowDPPO builds on the same GRPO-style SDE rollout, trained-step gating, and
+flowDPPO builds on the same GRPO-style SDE rollout, trained-step gating, and
 group-relative advantage, then additionally records the per-step Gaussian means.
 
-> Do not confuse this with the robotics algorithm also abbreviated DPPO. Here, FlowDPPO
+> Do not confuse this with the robotics algorithm also abbreviated DPPO. Here, flowDPPO
 > is the flow-matching image/video trust-region method in
-> [`flowdppo.py`](../unirl/algorithms/flowdppo.py): GRPO replay plus a KL-ADV mask.
+> [`dppo.py`](../unirl/algorithms/dppo.py): GRPO replay plus a KL-ADV mask.
 
 ## What problem it solves
 
-GRPO-style diffusion RL clips the sampled ratio `ρ`. The FlowDPPO paper argues
+GRPO-style diffusion RL clips the sampled ratio `ρ`. The Flow-DPPO paper argues
 that for continuous latent Gaussian policies this ratio is a *noisy single-sample*
 proxy for the true policy divergence, so a fixed ratio window over-constrains some
 steps and under-constrains others. Flow models offer something better: each SDE step
@@ -28,7 +28,7 @@ is an **equal-covariance Gaussian** transition, so the old/new KL is a cheap clo
 form — the squared difference of two velocity-network forward passes, no Binary/Top-k
 surrogate (the LLM-DPPO needs one; flow models do not).
 
-![FlowDPPO overview: the same GRPO-style SDE rollout — denoise a prompt to an image, score it, and form a group-relative advantage A — then replay each SDE step for the new log-prob and the new Gaussian transition means. The trust region is a two-stage KL-ADV mask: if the per-step KL on the mean shift is small the update always passes (the safe regime runs at full speed); only if the KL is large AND the move is aggressive in the reward direction ((ratio>1 and A>0) or (ratio<1 and A<0)) is the update masked to 0. The loss is mean(-A*ratio*keep_mask), the policy anchor (old log-prob and old means) is frozen across the mini-batches, and the brake is applied only to the large, over-aggressive steps rather than uniformly clipping every step like GRPO.](../assets/flowdppo_overview.png)
+![flowDPPO overview: the same GRPO-style SDE rollout — denoise a prompt to an image, score it, and form a group-relative advantage A — then replay each SDE step for the new log-prob and the new Gaussian transition means. The trust region is a two-stage KL-ADV mask: if the per-step KL on the mean shift is small the update always passes (the safe regime runs at full speed); only if the KL is large AND the move is aggressive in the reward direction ((ratio>1 and A>0) or (ratio<1 and A<0)) is the update masked to 0. The loss is mean(-A*ratio*keep_mask), the policy anchor (old log-prob and old means) is frozen across the mini-batches, and the brake is applied only to the large, over-aggressive steps rather than uniformly clipping every step like GRPO.](../assets/flowdppo_overview.png)
 
 ## The math
 
@@ -54,7 +54,7 @@ $$ \text{drop} = (\mathrm{kl\_score} \ge \tau)\ \wedge\ \big[(\rho>1 \wedge A>0)
 
 $$ \mathcal{L} = \mathbb{E}_{i,k}\big[\, \ell_{i,k}\cdot\mathbb{1}[\neg\,\text{drop}]\,\big] $$
 
-The code in `_flowdppo_kl_adv_loss` follows this directly:
+The code in `_dppo_kl_adv_loss` follows this directly:
 
 ```python
 ratio = torch.exp(new_logp - old_logp)
@@ -80,10 +80,10 @@ policy. Like the GRPO-style diffusion recipes, the recipe sets
 | New transition log-prob | `stage.replay(...).log_probs` → `new_logp` |
 | Old Gaussian mean `µ_old` | `segment.sde_means`, populated by `prepare_segment` |
 | New Gaussian mean `µ_θ` | `stage.replay(...).prev_sample_means` → `new_means` |
-| Gaussian scale `σ_t` | `FlowDPPO._compute_sigma_t` (from `segment.sigmas`, `dt`, `params.eta`) |
+| Gaussian scale `σ_t` | `DiffusionDPPO._compute_sigma_t` (from `segment.sigmas`, `dt`, `params.eta`) |
 | KL threshold `τ` (paper `δ`) | `algorithm.kl_mask_threshold` |
 | Advantage `A_i` | `track.advantages`, broadcast to `[B, S]` |
-| Masked objective | `_flowdppo_kl_adv_loss` |
+| Masked objective | `_dppo_kl_adv_loss` |
 
 ## From rollout to update
 
@@ -94,7 +94,7 @@ The rollout follows the same GRPO-style SDE path, plus the per-step Gaussian mea
 2. `RewardService` scores the decoded images, then
    `RolloutTrack.compute_advantages(normalize=True, use_global_std=True)` writes
    prompt-centered, batch-std advantages.
-3. `TrainStack.train_track` calls `FlowDPPO.prepare_segment` once: a `no_grad`
+3. `TrainStack.train_track` calls `DiffusionDPPO.prepare_segment` once: a `no_grad`
    replay at pre-update weights that keeps `sde_logp` if present, fills it if missing,
    and **always** writes `segment.sde_means`.
 4. Each micro-batch calls `compute_loss_and_backward`: replay at current weights for
@@ -142,7 +142,7 @@ mean-difference / 2. The canonical recipe keeps it `true`.
 | No trained steps | `segment.sde_indices`, `num_sde_steps`, `sampling.eta` |
 
 Metric source: `masked_fraction`, `kl_mask_fraction`, `kl_new_old_mean/max`, and the
-`ratio_*` values are all emitted by `_flowdppo_kl_adv_loss`.
+`ratio_*` values are all emitted by `_dppo_kl_adv_loss`.
 
 ## Run it
 
@@ -151,7 +151,7 @@ PRETRAINED_MODEL=stabilityai/stable-diffusion-3.5-medium \
 python -m unirl.train_diffusion --config-name=diffusion/sd3_flowdppo num_devices=8
 ```
 
-![FlowDPPO training curve: rollout/reward_mean for SD3.5-medium rises from ~0.75 to ~0.89 over ~270 rollout steps.](../assets/flowdppo_wandb.png)
+![flowDPPO training curve: rollout/reward_mean for SD3.5-medium rises from ~0.75 to ~0.89 over ~270 rollout steps.](../assets/flowdppo_wandb.png)
 
 A healthy run climbs `rollout/reward_mean` quickly and then keeps inching up — here
 SD3.5-medium goes from ~0.75 to ~0.89 over ~270 steps.
@@ -164,8 +164,8 @@ SD3.5-medium goes from ~0.75 to ~0.89 over ~270 steps.
 
 ## References
 
-- FlowDPPO — the exact equal-covariance Gaussian KL is its Eq. 14, the asymmetric
+- Flow-DPPO — the exact equal-covariance Gaussian KL is its Eq. 14, the asymmetric
   mask its Eq. 18.
 - DPPO (the LLM ancestor of the divergence mask): Qi et al., *"Rethinking the Trust
   Region in LLM Reinforcement Learning"* — [arXiv:2602.04879](https://arxiv.org/abs/2602.04879).
-- Flow-GRPO (the SDE rollout FlowDPPO reuses): [arXiv:2505.05470](https://arxiv.org/abs/2505.05470).
+- Flow-GRPO (the SDE rollout flowDPPO reuses): [arXiv:2505.05470](https://arxiv.org/abs/2505.05470).

--- a/FlowDPPO/config.yaml
+++ b/FlowDPPO/config.yaml
@@ -1,21 +1,21 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# FlowDPPO — annotated config EXTRACT (for reading, not launching).
+# flowDPPO — annotated config EXTRACT (for reading, not launching).
 #
 # Lifted from the full runnable recipe:
 #     examples/diffusion/sd3_flowdppo.yaml
-# Launch that recipe to actually train (see this folder's README.md). FlowDPPO
+# Launch that recipe to actually train (see this folder's README.md). flowDPPO
 # uses the SAME GRPO-style SDE rollout; it only swaps the loss (KL-mask instead of
 # ratio-clip) and so additionally records the per-step Gaussian means.
 # ─────────────────────────────────────────────────────────────────────────────
 
 algorithm:
-  _target_: unirl.algorithms.flowdppo.FlowDPPO
+  _target_: unirl.algorithms.dppo.DiffusionDPPO
   stage_attr: diffusion
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.sd3.conditions.SD3Conditions
   params: ${sampling}
-  # ── FlowDPPO loss hyperparameters ──
+  # ── Flow-DPPO loss hyperparameters ──
   kl_mask_threshold: 1.0e-5     # per-sample KL-style score below this ⇒ update
                                  # passes freely (no clipping). Above it, the
                                  # advantage-aware mask may zero the update
@@ -25,7 +25,7 @@ algorithm:
                                  # step noise scale. false ⇒ raw squared mean
                                  # shift / 2 (still mean-reduced).
 
-# Same GRPO-style SDE rollout (eta>0, SDE steps recorded). FlowDPPO additionally needs
+# Same GRPO-style SDE rollout (eta>0, SDE steps recorded). DPPO additionally needs
 # the per-step Gaussian transition means (prev_sample_means) — replay() emits them.
 sampling:
   _target_: unirl.types.sampling.DiffusionSamplingParams

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,4 @@
-Tencent is pleased to support the open source community by making UniRL available.
-
-Copyright (C) 2026 Tencent.  All rights reserved.
-
-UniRL is licensed under the Apache-2.0.
-
-
-Terms of the Apache-2.0:
---------------------------------------------------------------------
-Apache License
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -195,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Tencent
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@
 
 ## News 🚀
 
+- **[2026-06]** **FlowBP** released — *"Exploring the Design Space of Reward Backpropagation for Flow Matching"* ([arXiv]()).
 - **[2026-05]** **DRPO** released — *"Rethinking the Divergence Regularization in LLM Reinforcement Learning"* ([arXiv]()).
-- **[2026-05]** **FlowDPPO** released — *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* ([arXiv]()).
+- **[2026-05]** **FlowDPPO** released — *"Flow-DPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* ([arXiv]()).
 
 ## About 💡
 
@@ -46,8 +47,9 @@ runtime loop, deployment modes, and module map.
 
 | Algorithm | Paper | Tutorial | Notes |
 |---|---|---|---|
-| **FlowDPPO** | *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* | [FlowDPPO/](FlowDPPO/) | Diffusion/flow RL with an exact divergence-based trust-region mask. |
+| **FlowDPPO** | *"Flow-DPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* | [FlowDPPO/](FlowDPPO/) | Diffusion/flow RL with an exact divergence-based trust-region mask. |
 | **DRPO** | *"Rethinking the Divergence Regularization in LLM RL"* | [DRPO/](DRPO/) | Token-level LLM RL with a smooth advantage-weighted quadratic regularizer. |
+| **FlowBP** | *"Exploring the Design Space of Reward Backpropagation for Flow Matching"* | [FlowBP/](FlowBP/) | Reward-gradient alignment framework. |
 
 UniRL also wires in standard reference algorithms — **(LLM's)GRPO**, **DiffusionNFT**,
 **DanceGRPO**, and **MixGRPO** — in [`unirl/algorithms/`](unirl/algorithms/README.md).

--- a/examples/diffusion/sd3_flowdppo.yaml
+++ b/examples/diffusion/sd3_flowdppo.yaml
@@ -1,11 +1,11 @@
 # @package _global_
-# FlowDPPO SD3.5 trainside (FSDP) colocate, v2 trainer, 1x8.
+# Flow-DPPO SD3.5 trainside (FSDP) colocate, v2 trainer, 1x8.
 #
-# FlowDPPO replaces PPO ratio clipping with KL-divergence-based masking:
-#   - algorithm._target_ = FlowDPPO (vs DiffusionGRPO).
+# Flow-DPPO replaces PPO ratio clipping with KL-divergence-based masking:
+#   - algorithm._target_ = DiffusionDPPO (vs DiffusionGRPO).
 #   - kl_mask_threshold: KL threshold below which updates pass unmasked.
 #   - add_kl_coefficient: normalize KL by sigma_t (flow-matching noise scale).
-#   - No clip_range (replaced by KL masking). FlowDPPO's prepare_segment replays at
+#   - No clip_range (replaced by KL masking). DPPO's prepare_segment replays at
 #     pre-update weights to capture old means (the KL reference).
 # SDE indices: sparse over the first half (timestep_fraction [0.0, 0.5], 3 steps).
 #
@@ -14,7 +14,7 @@
 # Not carried over: v1 training.ema (full-model decay-0.99 mirror) — it was an
 #   eval/export EMA; the minimal v2 trainer does no eval-EMA swap, so a mirror
 #   would only double model memory unused. v1 num_updates_per_batch=2 IS restored
-#   (v2 TrainStack multi-update; FlowDPPO freezes its KL anchor in prepare_segment).
+#   (v2 TrainStack multi-update; DPPO freezes its KL anchor in prepare_segment).
 
 num_devices: 8                # 1 node x 8 GPUs (v1 actor_count 8)
 batch_size: 48                # prompts_per_rollout
@@ -106,13 +106,13 @@ reward:
       model_id: yuvalkirstain/PickScore_v1
 
 algorithm:
-  _target_: unirl.algorithms.flowdppo.FlowDPPO
+  _target_: unirl.algorithms.dppo.DiffusionDPPO
   stage_attr: diffusion
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.sd3.conditions.SD3Conditions
   params: ${sampling}
-  # FlowDPPO hyperparameters (v1 algorithm.algorithms.diffusion block).
+  # Flow-DPPO hyperparameters (v1 algorithm.algorithms.diffusion block).
   kl_mask_threshold: 1.0e-5
   add_kl_coefficient: true
 
@@ -153,10 +153,10 @@ sampling:
 
 logging:
   report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
-  project_name: ${oc.env:WANDB_PROJECT,unirl-flowdppo}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-flow-dppo}
   run_name: ${oc.env:WANDB_RUN_NAME,sd3_flowdppo}
   entity: ${oc.env:WANDB_ENTITY,null}
-  tags: ["sd3.5", "dppo", "flowdppo", "kl-adv", "trainside", "v2"]
+  tags: ["sd3.5", "dppo", "flow-dppo", "kl-adv", "trainside", "v2"]
   log_media: false
   media_max_items: 8
   media_log_interval: 1

--- a/examples/diffusion/sd3_flowdppo_vllmomni.yaml
+++ b/examples/diffusion/sd3_flowdppo_vllmomni.yaml
@@ -1,7 +1,7 @@
 # @package _global_
-# FlowDPPO SD3.5 — vLLM-Omni colocate variant, v2 trainer, 1x8.
+# Flow-DPPO SD3.5 — vLLM-Omni colocate variant, v2 trainer, 1x8.
 #
-# Same FlowDPPO algorithm as sd3_flowdppo.yaml (KL-divergence masking), but the
+# Same Flow-DPPO algorithm as sd3_flowdppo.yaml (KL-divergence masking), but the
 # rollout runs on a vLLM-Omni engine (separate sampler, LoRA weight-synced into
 # the engine each rollout) instead of the in-process trainside engine.
 #
@@ -110,7 +110,7 @@ reward:
       model_id: yuvalkirstain/PickScore_v1
 
 algorithm:
-  _target_: unirl.algorithms.flowdppo.FlowDPPO
+  _target_: unirl.algorithms.dppo.DiffusionDPPO
   stage_attr: diffusion
   conditions_cls:
     _target_: hydra.utils.get_class
@@ -163,10 +163,10 @@ sync:
 
 logging:
   report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
-  project_name: ${oc.env:WANDB_PROJECT,unirl-flowdppo}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-flow-dppo}
   run_name: ${oc.env:WANDB_RUN_NAME,sd3_flowdppo_vllmomni}
   entity: ${oc.env:WANDB_ENTITY,null}
-  tags: ["sd3.5", "dppo", "flowdppo", "kl-adv", "vllm-omni", "v2"]
+  tags: ["sd3.5", "dppo", "flow-dppo", "kl-adv", "vllm-omni", "v2"]
   log_media: false
   media_max_items: 8
   media_log_interval: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,17 @@ index-strategy = "unsafe-best-match"
 # integration unpinned; kernels >=0.15 changed LayerRepository's signature and
 # breaks transformers 5.6.0 at import time. Hold it to transformers' own
 # declared bound.
+#
+# transformers 5.6.0 accepts tokenizers<=0.23.0, but tokenizers 0.23.0(rc)
+# dropped the `cls` kwarg from RobertaProcessing.__new__, so deserializing a
+# saved CLIP tokenizer.json raises TypeError at rollout init (the SD3 text
+# encoders, e2e-confirmed on H20). The sglang install's --prerelease=allow flag
+# (see INSTALL.md) otherwise selects 0.23.0rc*; this override outranks it AND
+# guards against 0.23.0 shipping stable. tokenizers 0.22.2 verified on both
+# engine venvs.
 override-dependencies = [
   "kernels>=0.12,<0.13",
+  "tokenizers>=0.22,<0.23",
 ]
 environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",

--- a/unirl/README.md
+++ b/unirl/README.md
@@ -39,7 +39,7 @@ which places a Worker pool and wires each stage as a `Remote` from the recipe's
 | `distributed/` | Ray worker base (`Remote`) + placement/dispatch (`group/`), tensor transport (`tensor/`), and weight sync (`weight_sync/`) |
 | `rollout/` | Rollout engine contracts and implementations (`engine/`: trainside, sglang, sglang_llm, vllm_omni, composed) |
 | `train/` | Train stack: `TrainStack`, FSDP backend, LoRA/NFT/mirror injection, EMA shadow, optimizer/lr |
-| `algorithms/` | Per-track loss algorithms (GRPO, NFT, FlowDPPO, DRPO) |
+| `algorithms/` | Per-track loss algorithms (GRPO, NFT, DPPO, DRPO) |
 | `models/` | Per-model bundles, pipelines, stages, conditions; text/vision/vae helpers |
 | `reward/` | `RewardService` holding one backend — local scorers or the remote HTTP client |
 | `sde/` | SDE step kernels, σ schedule/shift, initial-noise generation (the `NoiseRecipe` contract lives in `types/`) |

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -6,7 +6,7 @@
 > Full map: [`../README.md`](../README.md).
 
 <div align="center">
-  <img src="../../assets/algorithm-contract-new.png" alt="UniRL algorithm contract: a StageAlgorithm combines new_logp from replay, the frozen pi_old anchor, and advantages into a loss (four interchangeable families: GRPO, FlowDPPO, DRPO, and NFT as the ratio-free exception), and declares knobs — requires_ema_rollout, supports_multi_update, anchor_fields/recomputes_anchor — that reconfigure the sampler and train stack around it" width="100%">
+  <img src="../../assets/algorithm-contract-new.png" alt="UniRL algorithm contract: a StageAlgorithm combines new_logp from replay, the frozen pi_old anchor, and advantages into a loss (four interchangeable families: GRPO, Flow-DPPO, DRPO, and NFT as the ratio-free exception), and declares knobs — requires_ema_rollout, supports_multi_update, anchor_fields/recomputes_anchor — that reconfigure the sampler and train stack around it" width="100%">
 </div>
 
 *A `StageAlgorithm` is two things: a **loss combine** (`stage.replay → new_logp`, mixed with the frozen **π_old** anchor and advantages — four interchangeable families) and a few **declared knobs** (`requires_ema_rollout`, `supports_multi_update`, `anchor_fields`/`recomputes_anchor()`) that reconfigure the sampler and the train loop around it.*
@@ -43,12 +43,12 @@ not just three-tensor arithmetic.
   whole forward — CFG batching, noise prediction, SDE stepping — to
   `stage.replay(...)` and gets back `new_logp` (NFT is the exception: it runs its own
   dual-adapter loop via `predict_noise_at_step`). The families: GRPO is a
-  PPO-clipped ratio (`diffusion_grpo.py` / `ar_grpo.py`); FlowDPPO masks `-A·r` by a
-  Gaussian-KL-vs-advantage criterion (`flowdppo.py`); NFT is a dual-adapter
+  PPO-clipped ratio (`diffusion_grpo.py` / `ar_grpo.py`); Flow-DPPO masks `-A·r` by a
+  Gaussian-KL-vs-advantage criterion (`dppo.py`); NFT is a dual-adapter
   reconstruction MSE (`nft.py`); DRPO is a token-adaptive SPO quadratic (`drpo.py`).
 - **The anchor contract — the subtle part.** bf16 forwards are batch-shape
   sensitive, so a π_old anchor computed at a different geometry than `new_logp`
-  drifts the on-policy ratio off 1 (and FlowDPPO's KL off 0). Algorithms just declare
+  drifts the on-policy ratio off 1 (and DPPO's KL off 0). Algorithms just declare
   `anchor_fields` (which segment fields to freeze) and `recomputes_anchor()`
   (whether `prepare_segment` replays); `TrainStack` then recomputes the anchor over
   the *exact same* mini/micro slices it will train on. No hardcoded field names.
@@ -69,11 +69,11 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   `prepare_segment`. Use `replay` (the cost is one extra `torch.no_grad` replay).
 - **`num_updates_per_batch > 1` on NFT** raises in `TrainStack.__init__` — NFT keeps
   the default `supports_multi_update = False`. The four that allow it all freeze a
-  stable anchor: `DiffusionGRPO`/`FlowDPPO` freeze `sde_logp` once in
+  stable anchor: `DiffusionGRPO`/`DiffusionDPPO` freeze `sde_logp` once in
   `prepare_segment`, while `ARGRPO`/`ARDRPO` reuse the rollout log-prob as the anchor
   for all N steps (verl `bypass_mode` parity — so the AR ratio also carries the
   rollout-vs-train engine gap, by design).
-- **FlowDPPO isn't fully on-policy under `rollout`** — it always replays `sde_means`
+- **DPPO isn't fully on-policy under `rollout`** — it always replays `sde_means`
   (KL = 0) but keeps the engine's `sde_logp`, so its ratio isn't pinned to 1. Use
   `replay` to also pin the ratio.
 - **`params` must reuse the rollout `guidance_scale`/`eta`/`shift`** — single-track

--- a/unirl/algorithms/__init__.py
+++ b/unirl/algorithms/__init__.py
@@ -8,18 +8,17 @@ from __future__ import annotations
 from .ar_grpo import ARGRPO
 from .base import AlgorithmStepResult, StageAlgorithm
 from .diffusion_grpo import DiffusionGRPO
+from .dppo import DiffusionDPPO
 from .drpo import ARDRPO
-from .flowdppo import FlowDPPO, FlowDPPOConfig
 from .nft import DiffusionNFT, DiffusionNFTConfig
 
 __all__ = [
     "ARGRPO",
     "ARDRPO",
     "AlgorithmStepResult",
+    "DiffusionDPPO",
     "DiffusionGRPO",
     "DiffusionNFT",
     "DiffusionNFTConfig",
-    "FlowDPPO",
-    "FlowDPPOConfig",
     "StageAlgorithm",
 ]

--- a/unirl/algorithms/base.py
+++ b/unirl/algorithms/base.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Shared helpers used by DiffusionGRPO, FlowDPPO, DiffusionNFT
+# Shared helpers used by DiffusionGRPO, DiffusionDPPO, DiffusionNFT
 # ---------------------------------------------------------------------------
 
 
@@ -56,7 +56,7 @@ def gather_sde_field(
     ``torch.searchsorted`` (O(S' log S)) and returns
     ``tensor[:, positions, ...]``.
 
-    Used by GRPO (for ``sde_logp``) and FlowDPPO (for ``sde_logp`` + ``sde_means``).
+    Used by GRPO (for ``sde_logp``) and DPPO (for ``sde_logp`` + ``sde_means``).
     """
     if tensor is None or sde_indices is None:
         raise ValueError(
@@ -201,7 +201,7 @@ class StageAlgorithm(Remote, ABC):
             ``num_updates_per_batch > 1`` (the train stack splitting one
             rollout into N optimizer steps over disjoint mini-batches).
             True only when the PPO ``old_logp`` anchor stays frozen across all
-            N steps: ``DiffusionGRPO`` / ``FlowDPPO`` capture
+            N steps: ``DiffusionGRPO`` / ``DiffusionDPPO`` capture
             ``segment.sde_logp`` once in :meth:`prepare_segment`; ``ARGRPO`` /
             ``ARDRPO`` keep the rollout log-prob as the anchor for all N steps
             (verl ``bypass_mode`` parity — the ratio then also carries the
@@ -216,7 +216,7 @@ class StageAlgorithm(Remote, ABC):
     requires_ema_rollout: bool = False
     supports_multi_update: bool = False
     # Segment fields this algorithm freezes as the π_old anchor in
-    # :meth:`prepare_segment` (GRPO: ``("sde_logp",)``; FlowDPPO:
+    # :meth:`prepare_segment` (GRPO: ``("sde_logp",)``; DPPO:
     # ``("sde_logp", "sde_means")``). When the anchor is recomputed
     # (:meth:`recomputes_anchor`), the train stack re-slices and reassembles
     # exactly these fields at train-time geometry — it never hardcodes them.
@@ -229,7 +229,7 @@ class StageAlgorithm(Remote, ABC):
         True ⇒ :meth:`prepare_segment` replays the anchor AND bf16 batch-shape
         sensitivity matters, so the train stack drives it per micro-slice over
         those exact slices; the old/new forwards then match bit-for-bit
-        (on-policy ratio = 1; FlowDPPO on-policy KL = 0). FlowDPPO is always True
+        (on-policy ratio = 1; DPPO on-policy KL = 0). DPPO is always True
         (``sde_means`` exist only via replay); ``DiffusionGRPO`` is True only
         under ``old_logp_source='replay'``. False (default) ⇒ one full-segment
         call suffices: the anchor is either the engine's own emission (no
@@ -251,7 +251,7 @@ class StageAlgorithm(Remote, ABC):
         can ignore the hook entirely.
 
         Algorithms that establish a frozen anchor override this. The canonical
-        use case is :class:`DiffusionGRPO` / :class:`FlowDPPO`, which here
+        use case is :class:`DiffusionGRPO` / :class:`DiffusionDPPO`, which here
         set ``segment.sde_logp`` according to ``old_logp_source``: ``"rollout"``
         keeps the rollout engine's best-effort emission (raising if it emitted
         nothing); ``"replay"`` recomputes via a ``torch.no_grad``

--- a/unirl/algorithms/dppo.py
+++ b/unirl/algorithms/dppo.py
@@ -1,12 +1,12 @@
-"""FlowDPPO: KL-divergence-based masking for diffusion RL.
+"""Flow-DPPO: KL-divergence-based masking for diffusion RL.
 
-Implements :class:`FlowDPPO` — a :class:`StageAlgorithm` that replaces
+Implements :class:`DiffusionDPPO` — a :class:`StageAlgorithm` that replaces
 PPO-style ratio clipping with a KL-ADV masking criterion. Uses
 ``prev_sample_means`` from replay to compute Gaussian KL between old and
 new policy, then masks updates where KL is high AND the ratio direction is
 aligned with advantage (i.e. overly aggressive policy updates).
 
-Module-level helpers ``_gaussian_kl_div`` and ``_flowdppo_kl_adv_loss`` contain
+Module-level helpers ``_gaussian_kl_div`` and ``_dppo_kl_adv_loss`` contain
 the core math; the class wires them into the stage-driven training contract.
 """
 
@@ -26,7 +26,7 @@ from .base import AlgorithmStepResult, BaseAlgorithmConfig, StageAlgorithm, gath
 
 
 @dataclass
-class FlowDPPOConfig(BaseAlgorithmConfig):
+class DiffusionDPPOConfig(BaseAlgorithmConfig):
     stage_attr: str = "diffusion"
     conditions_cls: str = ""
     kl_mask_threshold: float = 1e-5
@@ -51,7 +51,7 @@ def _gaussian_kl_div(p: torch.Tensor, q: torch.Tensor, sigma: torch.Tensor) -> t
     return (p - q) ** 2 / (2 * sigma**2)
 
 
-def _flowdppo_kl_adv_loss(
+def _dppo_kl_adv_loss(
     *,
     new_logp: torch.Tensor,
     old_logp: torch.Tensor,
@@ -61,7 +61,7 @@ def _flowdppo_kl_adv_loss(
     sigma_t: torch.Tensor,
     kl_mask_threshold: float,
 ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
-    """FlowDPPO KL-ADV masking loss.
+    """Flow-DPPO KL-ADV masking loss.
 
     Instead of PPO's ratio clipping, this function:
     1. Computes per-sample KL between new and old policy means
@@ -143,8 +143,8 @@ def _flowdppo_kl_adv_loss(
 # ---------------------------------------------------------------------------
 
 
-class FlowDPPO(StageAlgorithm):
-    """FlowDPPO: KL-divergence-based masking for diffusion RL.
+class DiffusionDPPO(StageAlgorithm):
+    """Flow-DPPO: KL-divergence-based masking for diffusion RL.
 
     Replaces PPO's ratio clipping (``DiffusionGRPO``) with a KL-ADV masking
     criterion:
@@ -183,7 +183,7 @@ class FlowDPPO(StageAlgorithm):
     anchor_fields = ("sde_logp", "sde_means")
 
     def recomputes_anchor(self) -> bool:
-        # FlowDPPO always replays sde_means for the KL term (regardless of
+        # DPPO always replays sde_means for the KL term (regardless of
         # old_logp_source), so the anchor always needs train-time geometry.
         return True
 
@@ -204,7 +204,7 @@ class FlowDPPO(StageAlgorithm):
         if stage is None and pipeline is not None:
             stage = getattr(pipeline, stage_attr)
         if stage is None:
-            raise ValueError("FlowDPPO: either `stage` or `pipeline` must be provided")
+            raise ValueError("DiffusionDPPO: either `stage` or `pipeline` must be provided")
         self.stage = stage
         self.params = params
         self.kl_mask_threshold = float(kl_mask_threshold)
@@ -212,7 +212,7 @@ class FlowDPPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         require(
             self.old_logp_source in ("rollout", "replay"),
-            f"FlowDPPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}",
+            f"DiffusionDPPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}",
         )
         self.conditions_cls = conditions_cls
 
@@ -226,7 +226,7 @@ class FlowDPPO(StageAlgorithm):
         (``segment.sde_means``) at pre-update weights, before the
         ``num_updates_per_batch`` loop.
 
-        ``stage.replay`` always runs under ``torch.no_grad`` — FlowDPPO needs the
+        ``stage.replay`` always runs under ``torch.no_grad`` — DPPO needs the
         old policy's ``prev_sample_means`` for the KL term — so ``sde_means``
         is always written from this pre-update replay. The log-prob anchor is
         chosen by ``old_logp_source``:
@@ -245,7 +245,7 @@ class FlowDPPO(StageAlgorithm):
             return
         if self.old_logp_source == "rollout" and segment.sde_logp is None:
             raise RuntimeError(
-                "FlowDPPO.prepare_segment: old_logp_source='rollout' but the "
+                "DiffusionDPPO.prepare_segment: old_logp_source='rollout' but the "
                 "rollout engine emitted no per-step log-probs (segment.sde_logp is "
                 "None). Pin a rollout build that emits trajectory log-probs, or set "
                 "old_logp_source='replay'."
@@ -256,10 +256,10 @@ class FlowDPPO(StageAlgorithm):
         # Log-prob anchor: replay overwrites; rollout keeps the engine's emission.
         if self.old_logp_source == "replay":
             segment.sde_logp = result.log_probs.detach().cpu()
-        # Always populate old means (core of FlowDPPO)
+        # Always populate old means (core of DPPO)
         if result.prev_sample_means is None:
             raise RuntimeError(
-                "FlowDPPO.prepare_segment: stage.replay() returned "
+                "DiffusionDPPO.prepare_segment: stage.replay() returned "
                 "prev_sample_means=None. Ensure the stage's replay method "
                 "produces means (required for KL-ADV masking)."
             )
@@ -290,7 +290,7 @@ class FlowDPPO(StageAlgorithm):
 
         if new_means is None:
             raise RuntimeError(
-                "FlowDPPO requires stage.replay() to return prev_sample_means, "
+                "DiffusionDPPO requires stage.replay() to return prev_sample_means, "
                 "but got None. Ensure the stage's replay method produces means."
             )
 
@@ -306,7 +306,7 @@ class FlowDPPO(StageAlgorithm):
 
         adv_b = advantages.detach().to(dtype=new_logp.dtype, device=new_logp.device).reshape(-1, 1).expand_as(new_logp)
 
-        loss_per_elem, ratio_metrics = _flowdppo_kl_adv_loss(
+        loss_per_elem, ratio_metrics = _dppo_kl_adv_loss(
             new_logp=new_logp,
             old_logp=old_logp,
             new_means=new_means,
@@ -354,7 +354,7 @@ class FlowDPPO(StageAlgorithm):
             return torch.ones(1, len(target_steps), 1, 1, 1, device=device)
 
         if segment.sigmas is None:
-            raise ValueError("FlowDPPO with add_kl_coefficient=True requires segment.sigmas.")
+            raise ValueError("DiffusionDPPO with add_kl_coefficient=True requires segment.sigmas.")
         sigmas = segment.sigmas.to(device=device, dtype=torch.float32)
         eta = float(self.params.eta)
 
@@ -368,4 +368,4 @@ class FlowDPPO(StageAlgorithm):
         return sigma_t.reshape(1, -1, 1, 1, 1)
 
 
-__all__ = ["FlowDPPO", "FlowDPPOConfig"]
+__all__ = ["DiffusionDPPO"]

--- a/unirl/models/sd3/diffusion.py
+++ b/unirl/models/sd3/diffusion.py
@@ -80,7 +80,7 @@ class SD3DiffusionStep(DiffusionStep[SD3Bundle, SD3Conditions]):
 
         # Cast latent/embeds to the transformer's param dtype before the bf16
         # pos_embed conv — autocast doesn't reliably catch the first conv input
-        # under FSDP2 wrap (the NFT forward-process path hits this; GRPO/FlowDPPO
+        # under FSDP2 wrap (the NFT forward-process path hits this; GRPO/DPPO
         # replay feeds already-bf16 latents). Idempotent when dtype matches.
         try:
             model_dtype = next(model.transformer.parameters()).dtype

--- a/unirl/sde/README.md
+++ b/unirl/sde/README.md
@@ -5,7 +5,7 @@
 > Full map: [`../README.md`](../README.md).
 
 <div align="center">
-  <img src="../../assets/sde-kernel-modes-new.png" alt="UniRL SDE: one multi-step denoise loop (x_T to x_0) walked twice — rollout (diffuse) walks all T steps, drawing fresh noise and keeping a Gaussian log-prob on the eta>0 SDE steps while the rest stay deterministic, and stores the trajectory; train (replay) re-walks only those SDE steps, feeding the stored transitions back through the same kernel to get new log-probs for the GRPO/FlowDPPO ratio" width="100%">
+  <img src="../../assets/sde-kernel-modes-new.png" alt="UniRL SDE: one multi-step denoise loop (x_T to x_0) walked twice — rollout (diffuse) walks all T steps, drawing fresh noise and keeping a Gaussian log-prob on the eta>0 SDE steps while the rest stay deterministic, and stores the trajectory; train (replay) re-walks only those SDE steps, feeding the stored transitions back through the same kernel to get new log-probs for the GRPO/DPPO ratio" width="100%">
 </div>
 
 *One `strategy.denoise()` per step, under two **orthogonal** switches: **sampling** vs **replay** is the `prev_sample` argument; **stochastic** vs **deterministic** is the per-index `eta` (a step degenerates to deterministic at `eta=0` — there is no separate Euler solver).*
@@ -24,7 +24,7 @@ the *same* trajectory. That requires three things to be bit-identical across ver
 different engines (trainside, SGLang, vLLM-Omni): the σ schedule, the start noise
 `x_T`, and the per-step transition math. Centralizing all three here — instead of
 letting each engine compute its own — is what keeps the ratio honest. Get any of
-them wrong and GRPO/FlowDPPO optimize noise.
+them wrong and GRPO/DPPO optimize noise.
 
 ## How it works
 
@@ -64,7 +64,7 @@ MixGRPO keeps `FlowSDEStrategy` and adds a `WindowScheduler` under
 ## Gotchas
 
 - **`DPM2Strategy` can't train** — it returns `log_prob=None` everywhere, so
-  GRPO/FlowDPPO have no ratio. Eval-only, and stateful (needs `init_schedule`/`reset`).
+  GRPO/DPPO have no ratio. Eval-only, and stateful (needs `init_schedule`/`reset`).
 - **σ silently arrives as float64** — `torch.linspace` (the static-σ branch) defaults
   to float64, so without `denoise`'s `.float()` cast the transition computes in float64
   while SGLang uses float32; the `1/(2σ²)` term amplifies the gap into the replayed

--- a/unirl/train/stack.py
+++ b/unirl/train/stack.py
@@ -183,7 +183,7 @@ class TrainStack(Remote):
             raise ValueError(
                 f"num_updates_per_batch={self.num_updates_per_batch} requires an algorithm whose "
                 f"old_logp anchor stays frozen across the N optimizer steps "
-                f"(DiffusionGRPO / FlowDPPO / ARGRPO / ARDRPO). "
+                f"(DiffusionGRPO / DiffusionDPPO / ARGRPO / ARDRPO). "
                 f"{type(algorithm).__name__} sets supports_multi_update=False, so >1 optimizer "
                 f"step would train against a moving anchor. Set num_updates_per_batch=1."
             )
@@ -201,7 +201,7 @@ class TrainStack(Remote):
         :meth:`prepare_segment` consume this, so the π_old anchor is frozen at
         exactly the ``(mini, micro)`` geometry ``new_logp`` is later computed at —
         the only way bf16 batch-shape sensitivity cancels and the on-policy ratio
-        is exactly 1 (FlowDPPO on-policy KL exactly 0).
+        is exactly 1 (DPPO on-policy KL exactly 0).
 
         Invariant: any *cross-sample* statistic (e.g. advantage mean/std) must be
         computed on the full shard BEFORE this slicing — the trainer does so in
@@ -226,13 +226,13 @@ class TrainStack(Remote):
         No-op if ``segment`` is None. If the algorithm does NOT replay the anchor
         (``recomputes_anchor() == False`` — e.g. rollout GRPO), the anchor is the
         rollout engine's own emission, so one full-segment call suffices. If it DOES
-        replay (replay GRPO; FlowDPPO always, for ``sde_means``), the recomputed
+        replay (replay GRPO; DPPO always, for ``sde_means``), the recomputed
         ``anchor_fields`` are computed at the SAME mini/micro geometry training will
         use — driven by the shared :meth:`_optimizer_step_slices` — so the old/new
         forwards match bf16-element-for-element on those fields. Concretely, the
         on-policy PPO ratio is exactly 1 only where ``sde_logp`` is replayed (replay
-        GRPO, or FlowDPPO under ``old_logp_source='replay'``), and the on-policy KL is
-        exactly 0 wherever ``sde_means`` is replayed (FlowDPPO always). FlowDPPO-rollout keeps
+        GRPO, or DPPO under ``old_logp_source='replay'``), and the on-policy KL is
+        exactly 0 wherever ``sde_means`` is replayed (DPPO always). DPPO-rollout keeps
         the engine's ``sde_logp``, so its KL is 0 on-policy but its ratio is not
         pinned to 1. A single slice degenerates to one full-segment call; only the
         algorithm's declared ``anchor_fields`` are re-sliced and reassembled (no

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -59,7 +59,7 @@ class DiffusionTrainer(BaseTrainer):
         # default; only safe (and only set true) for layout=="colocate" with a
         # SEPARATE engine rollout under GRPO — gated again in train_step.
         self._enable_fsdp_offload = bool(enable_fsdp_offload)
-        # FlowDPPO advantage parity: when True, RolloutTrack.compute_advantages
+        # Flow-DPPO advantage parity: when True, RolloutTrack.compute_advantages
         # keeps the per-group mean but divides by ONE batch-wide std (the v1
         # ``use_global_std=True`` scale) instead of each prompt's own std. Off by
         # default → unchanged per-group GRPO normalization for every other recipe.

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -253,7 +253,7 @@ class RolloutTrack(Batch):
             prompts); the v2 single-controller reduces over all groups at once.
             The two share an expectation (both estimate the population reward std),
             but the full-batch scope is intentional — topology-independent and
-            lower-variance. Used by the FlowDPPO recipe; left ``False`` elsewhere.
+            lower-variance. Used by the Flow-DPPO recipe; left ``False`` elsewhere.
         :return: A new :class:`RolloutTrack` with ``advantages`` set.
 
         Population std (``unbiased=False``) is used so the math degenerates


### PR DESCRIPTION
## Summary

Sync Tencent-Hunyuan/UniRL `main` up to haonan3/UniRL `main` (includes PR #310 and changes accumulated since the initial release snapshot).

This branch's tree is set to exactly match haonan3/UniRL `main` — 19 files changed (+223/-96):
- FlowBP `README.md` added; FlowDPPO docs/config updates
- `unirl/algorithms/flowdppo.py` → `dppo.py` rename plus related wiring (`algorithms/__init__.py`, `base.py`, `train/stack.py`, `trainer/diffusion.py`)
- LICENSE and top-level `README.md` touch-ups; `pyproject.toml`, `sde/README.md`, `types/rollout_resp.py`, `models/sd3/diffusion.py` tweaks

## Test Plan

Not run locally; this is a content sync, not a code change. The branch tree is byte-identical to haonan3/UniRL `main` (verified: `git diff origin/main` on the sync branch is empty). Correctness is gated by the `lint` CI check on this PR.
