### PR TITLE
fix(deps): pin tokenizers>=0.22,<0.23 to block the broken 0.23 line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,17 @@ index-strategy = "unsafe-best-match"
 # integration unpinned; kernels >=0.15 changed LayerRepository's signature and
 # breaks transformers 5.6.0 at import time. Hold it to transformers' own
 # declared bound.
+#
+# transformers 5.6.0 accepts tokenizers<=0.23.0, but tokenizers 0.23.0(rc)
+# dropped the `cls` kwarg from RobertaProcessing.__new__, so deserializing a
+# saved CLIP tokenizer.json raises TypeError at rollout init (the SD3 text
+# encoders, e2e-confirmed on H20). The sglang install's --prerelease=allow flag
+# (see INSTALL.md) otherwise selects 0.23.0rc*; this override outranks it AND
+# guards against 0.23.0 shipping stable. tokenizers 0.22.2 verified on both
+# engine venvs.
 override-dependencies = [
   "kernels>=0.12,<0.13",
+  "tokenizers>=0.22,<0.23",
 ]
 environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",


### PR DESCRIPTION
## Summary

Sync only PR haonan3/UniRL#310 into this repo: pin `tokenizers>=0.22,<0.23` in `pyproject.toml` `override-dependencies`.

`tokenizers` 0.23.0(rc) dropped the `cls` kwarg from `RobertaProcessing.__new__`, so deserializing a saved CLIP `tokenizer.json` raises `TypeError` at rollout init (the SD3 text encoders, e2e-confirmed on H20). The sglang install's `--prerelease=allow` otherwise selects 0.23.0rc*; this override outranks it and guards against 0.23.0 shipping stable. `tokenizers` 0.22.2 verified on both engine venvs.

Scope: `pyproject.toml` only — 1 file, +9 lines. Matches haonan3/UniRL `main` for this file exactly.

## Test Plan

Not run locally; dependency-pin change only. Validated upstream in haonan3/UniRL#310 (TypeError reproduced and fixed; tokenizers 0.22.2 confirmed on both engine venvs, e2e on H20). Gated by the `lint` CI check on this PR.
