### PR TITLE
docs: link DRPO arXiv paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## News 🚀
 
-- **[2026-05]** **DRPO** released — *"Rethinking the Divergence Regularization in LLM Reinforcement Learning"* ([arXiv]()).
+- **[2026-05]** **DRPO** released — *"Rethinking the Divergence Regularization in LLM RL"* ([arXiv](https://arxiv.org/abs/2606.09821)).
 - **[2026-05]** **FlowDPPO** released — *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* ([arXiv]()).
 
 ## About 💡
@@ -47,7 +47,7 @@ runtime loop, deployment modes, and module map.
 | Algorithm | Paper | Tutorial | Notes |
 |---|---|---|---|
 | **FlowDPPO** | *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* | [FlowDPPO/](FlowDPPO/) | Diffusion/flow RL with an exact divergence-based trust-region mask. |
-| **DRPO** | *"Rethinking the Divergence Regularization in LLM RL"* | [DRPO/](DRPO/) | Token-level LLM RL with a smooth advantage-weighted quadratic regularizer. |
+| **DRPO** | [*"Rethinking the Divergence Regularization in LLM RL"*](https://arxiv.org/abs/2606.09821) | [DRPO/](DRPO/) | Token-level LLM RL with a smooth advantage-weighted quadratic regularizer. |
 
 UniRL also wires in standard reference algorithms — **(LLM's)GRPO**, **DiffusionNFT**,
 **DanceGRPO**, and **MixGRPO** — in [`unirl/algorithms/`](unirl/algorithms/README.md).


### PR DESCRIPTION
## Summary

The DRPO news entry and the Team-Proposed Algorithms table referenced the paper *"Rethinking the Divergence Regularization in LLM RL"* but left the arXiv link empty (`[arXiv]()`). This fills in the link to the published paper (https://arxiv.org/abs/2606.09821) and corrects the news-entry title to match the published title (previously "…in LLM Reinforcement Learning", now "…in LLM RL", consistent with the algorithms table).

## Related Issue

N/A

## Test Plan

Not run; reason: documentation-only change (README link/title fix). Verified that https://arxiv.org/abs/2606.09821 resolves to the DRPO paper "Rethinking the Divergence Regularization in LLM RL".

## Compatibility / Risk

N/A — no code, config, or interface changes.

## Reviewer Notes

The FlowDPPO arXiv link is intentionally left untouched (no public arXiv ID available yet).

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
