### PR TITLE
docs: add DRPO citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ If you find UniRL helpful, please cite:
 }
 ```
 
+If you use DRPO, please also cite:
+
+```bibtex
+@misc{yao2026drpo,
+  title         = {{Rethinking the Divergence Regularization in LLM RL}},
+  author        = {Jiarui Yao and Xiangxin Zhou and Penghui Qi and Wee Sun Lee and Liefeng Bo and Tianyu Pang},
+  year          = {2026},
+  eprint        = {2606.09821},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG},
+  url           = {https://arxiv.org/abs/2606.09821}
+}
+```
+
 If you use Flow-DPPO, please also cite:
 
 ```bibtex


### PR DESCRIPTION
## Summary

Adds a BibTeX citation for **DRPO** (*"Rethinking the Divergence Regularization in LLM RL"*, arXiv:2606.09821) to the Citation section. Previously only UniRL and Flow-DPPO had citation entries, even though DRPO is a team-proposed algorithm with a public arXiv paper. The DRPO block is placed before Flow-DPPO to match the release order in the News section.

## Related Issue

N/A

## Test Plan

Not run; reason: documentation-only change (adds a BibTeX block to the README). Verified the arXiv id 2606.09821 (cs.LG) resolves to the DRPO paper and that author list/title match the published version.

## Compatibility / Risk

N/A — no code, config, or interface changes.

## Reviewer Notes

DRPO uses the standard arXiv `eprint`/`archivePrefix` BibTeX format since it has a public arXiv id, whereas the existing UniRL/Flow-DPPO entries use `howpublished`. Happy to switch to `howpublished` for visual consistency if the team prefers.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
