### PR TITLE
ci: add manual PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Publish to PyPI
+
+# Manual only — no push/tag/release triggers. A maintainer runs this from the
+# Actions tab and picks the target index. It can never fire on its own.
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Target index"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+
+      - name: Check metadata and show artifacts
+        run: |
+          python -m twine check dist/*
+          ls -1 dist/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Environment name == chosen target, so PyPI's trusted publisher and
+    # GitHub's required-reviewer / branch-policy gates both key off it.
+    environment: ${{ inputs.repository }}
+    permissions:
+      id-token: write   # OIDC token for Trusted Publishing — no stored secret
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        if: inputs.repository == 'testpypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true   # re-runs of an existing version are a no-op, not a failure
+
+      - name: Publish to PyPI
+        if: inputs.repository == 'pypi'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml`, a manual (`workflow_dispatch`-only) workflow that builds the `unirl` sdist + wheel and publishes to either TestPyPI or PyPI. It never triggers on push/tag/release — a maintainer runs it from the Actions tab and picks the target index. Uploads use PyPI Trusted Publishing (OIDC), so no API token is stored; the job's `environment` is set to the chosen index, so the trusted-publisher match and any required-reviewer / branch-policy gates attach per-destination. `skip-existing: true` makes re-running an already-published version a no-op instead of a failure.

This PR adds only the mechanism. Real uploads also need one-time external setup (registering a trusted publisher on (Test)PyPI and creating `pypi`/`testpypi` GitHub environments). Until that exists the build job passes and the publish step is inert. Nothing publishes on merge.

## Related Issue

N/A

## Test Plan

Built and validated the artifacts locally on Python 3.12 (matches the workflow runner):

- `uv build --python 3.12` → produced `unirl-0.1.0-py3-none-any.whl` and `unirl-0.1.0.tar.gz`.
- `twine check dist/*` → PASSED for both.
- Confirmed the wheel contains only `unirl/` + `dist-info` — no `DRPO/`, `FlowDPPO/`, `examples/`, `datasets/`, `assets/`, or `unirl-reward-service/`.

The publish step is not exercised here: it requires the Trusted Publisher / environment setup and is invoked manually after merge (TestPyPI first).

## Compatibility / Risk

N/A — additive CI only. The workflow has no automatic triggers and cannot run without a manual dispatch; merging it publishes nothing.

## Reviewer Notes

- AI-assisted (Claude). Duplicate-work check: no existing open PR or workflow on this repo covers PyPI publishing.
- Follow-up, not addressed here: the `sglang`/`vllm` optional extras won't resolve via `pip install unirl[...]` because their `+cuXXX` torch pins and custom indexes live in `[tool.uv]` config that isn't carried in published metadata. Base `pip install unirl` is unaffected.
- `setup.py` carries a stale duplicate `version`/deps; the build uses `pyproject.toml`, but it's a drift trap worth cleaning separately.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
