### PR TITLE
chore: drop tqdm progress bar from PickScore reward

### DIFF
--- a/unirl/reward/local/pickscore.py
+++ b/unirl/reward/local/pickscore.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import List
 
 import torch
-from tqdm import tqdm
 
 from unirl.reward.base import BaseRewardComponentSpec
 from unirl.reward.local.device import resolve_device
@@ -58,12 +56,7 @@ class PickScoreRewardScorer(LocalRewardBackend):
                 return output[0]
             raise TypeError(f"Unexpected output format: {type(output)}")
 
-        rank = int(os.environ.get("RANK", 0))
-        for i in tqdm(
-            range(0, len(images), self.batch_size),
-            desc="Computing PickScore rewards",
-            disable=(rank != 0),
-        ):
+        for i in range(0, len(images), self.batch_size):
             batch_images = images[i : i + self.batch_size]
             batch_prompts = prompts[i : i + self.batch_size]
 


### PR DESCRIPTION
## Summary

Removes the per-batch `tqdm` progress bar in `PickScoreRewardScorer._compute_model_rewards` (`unirl/reward/local/pickscore.py`). The bar only added log noise during reward scoring. Also drops the now-unused `tqdm` and `os` imports and the `RANK` lookup that existed solely to gate the bar; the loop is now a plain `range(...)`.

## Related Issue

N/A

## Test Plan

- `python -m py_compile unirl/reward/local/pickscore.py` (passes)
- Static check: no remaining references to `tqdm` / `os` / `rank` in the file.
- Not run: full reward scoring on GPU (no behavior change beyond removing the progress bar).

## Compatibility / Risk

N/A — no functional change to reward values; only the progress bar and unused imports are removed.

## Reviewer Notes

AI-assisted change; checked upstream open PRs for overlap (none). The sibling `unirl-reward-service/reward_service/scorers/pickscore.py` has no `tqdm` and is untouched.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.

Made with [Cursor](https://cursor.com)