### PR TITLE
feat: log generated rollout media to wandb in DiffusionTrainer

### DIFF
--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import os
 import time
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import torch
 from hydra.utils import get_class, instantiate
@@ -64,6 +64,15 @@ class DiffusionTrainer(BaseTrainer):
         # ``use_global_std=True`` scale) instead of each prompt's own std. Off by
         # default → unchanged per-group GRPO normalization for every other recipe.
         self._adv_use_global_std = bool(adv_use_global_std)
+        # WandB rollout media (generated images/videos): read from the optional
+        # ``logging`` block. ``log_media`` gates it; ``media_log_interval`` throttles
+        # it (every N rollouts); ``media_max_items`` caps samples per panel. Logged
+        # from the rollout's ``decoded`` payload before it is dropped (see train_step).
+        self._log_media = bool(logging_cfg.get("log_media", False)) if logging_cfg is not None else False
+        self._media_max_items = int(logging_cfg.get("media_max_items", 8)) if logging_cfg is not None else 8
+        self._media_log_interval = (
+            max(1, int(logging_cfg.get("media_log_interval", 1))) if logging_cfg is not None else 1
+        )
         # Set in _build_rollout: True when the rollout is the trainside
         # direct-sampling engine (it reuses the train model → must NOT offload).
         self._rollout_is_trainside = False
@@ -291,6 +300,39 @@ class DiffusionTrainer(BaseTrainer):
             init_noise_latent_shape=init_noise_latent_shape,
         )
 
+    def _maybe_log_media(self, rollout_id: int, req: RolloutReq, resp: Any) -> None:
+        """Log generated rollout media (images/videos) to wandb.
+
+        No-op unless ``logging.log_media`` is set and this rollout falls on the
+        ``media_log_interval`` cadence. Must be called AFTER scoring (rewards
+        drive the captions) and BEFORE :meth:`_drop_decoded` nulls the generated
+        payload.
+
+        ``track.decoded`` arrives at the driver with its tensor leaves dehydrated
+        to ``TensorMeta`` proxies (``Worker.call`` packs every returned tensor),
+        so we hydrate them back to real ``Images`` / ``Videos`` before building
+        the preview. ``build_media_preview_for_track`` returns ``None`` for a
+        track without materialized media, so this stays safe across topologies.
+        Hydration pulls the full decoded batch to the driver, so keep
+        ``media_log_interval`` modest (not every rollout) on large batches."""
+        if not self._log_media or (rollout_id % self._media_log_interval != 0):
+            return
+        wb = self.wandb_logger
+        if wb is None or not wb.initialized:
+            return
+        from unirl.distributed.tensor.transport import map_tree
+        from unirl.types.media_preview import build_media_preview_for_track
+        from unirl.types.rollout_resp import _hydrate_tensor_meta
+
+        for track in resp.tracks.values():
+            if track.decoded is None:
+                continue
+            track.decoded = map_tree(track.decoded, _hydrate_tensor_meta)
+            media = build_media_preview_for_track(req=req, track=track, max_items=self._media_max_items)
+            if media is not None:
+                wb.log_generated_media(rollout_id, media)
+                break  # single-track for now; revisit if multi-track lands
+
     def train_step(
         self,
         req: RolloutReq,
@@ -362,6 +404,8 @@ class DiffusionTrainer(BaseTrainer):
             if track.rewards is not None:
                 resp.tracks[name] = track.compute_advantages(normalize=True, use_global_std=self._adv_use_global_std)
 
+        # Log generated media (images/videos) to wandb BEFORE decoded is dropped.
+        self._maybe_log_media(rollout_id, req, resp)
         self._drop_decoded(resp)
         (track,) = resp.tracks.values()
         result = self.stack.train_track(track, training_progress=float(training_progress))

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -10,8 +10,11 @@ from hydra.utils import get_class, instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
+from unirl.distributed.tensor.transport import TensorMeta, map_tree
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer
+from unirl.types.media_preview import build_media_preview_for_track
+from unirl.types.primitives import Images, Videos
 from unirl.types.prompts import RolloutInputs
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.rollout_resp import _hydrate_tensor_meta
@@ -19,6 +22,47 @@ from unirl.types.sampling import BaseSamplingParams
 from unirl.utils.hydra import parse_hydra_cfg, remote_hydra
 
 logger = logging.getLogger(__name__)
+
+
+def _ref_aligned_prefix_len(decoded: Any, min_items: int) -> int:
+    """Smallest sample count >= ``min_items`` landing on a TensorMeta ref boundary.
+
+    ``decoded`` reaches the driver dehydrated: its tensor leaf (``Images.pixels``
+    / ``Videos.frames``) is a ``TensorMeta`` whose refs partition the batch by DP
+    shard, and ``TensorMeta`` only supports ref-boundary slicing. The cheapest
+    preview prefix is therefore the first shard boundary covering ``min_items``
+    samples — slicing there lets media logging hydrate one shard instead of the
+    full decoded batch. ``Videos`` ref sizes count frames (PACKED), so shard
+    frame boundaries are mapped back to sample indices via the driver-side
+    ``cu_seqlens``. Returns the full batch size when the leaf is already a real
+    tensor (nothing to save) or a boundary cannot be mapped.
+    """
+    total = len(decoded)
+    want = max(1, min(int(min_items), total))
+    if isinstance(decoded, Images):
+        meta = decoded.pixels
+        if not isinstance(meta, TensorMeta):
+            return total
+        rows = 0
+        for size in meta.sizes:
+            rows += int(size)
+            if rows >= want:
+                return rows
+        return total
+    meta = decoded.frames
+    cu = decoded.cu_seqlens
+    if not isinstance(meta, TensorMeta) or cu is None:
+        return total
+    sample_at_frame = {int(v): i for i, v in enumerate(cu.tolist())}
+    frames = 0
+    for size in meta.sizes:
+        frames += int(size)
+        sample_idx = sample_at_frame.get(frames)
+        if sample_idx is None:
+            return total
+        if sample_idx >= want:
+            return sample_idx
+    return total
 
 
 class DiffusionTrainer(BaseTrainer):
@@ -311,22 +355,23 @@ class DiffusionTrainer(BaseTrainer):
         ``track.decoded`` arrives at the driver with its tensor leaves dehydrated
         to ``TensorMeta`` proxies (``Worker.call`` packs every returned tensor),
         so we hydrate them back to real ``Images`` / ``Videos`` before building
-        the preview. ``build_media_preview_for_track`` returns ``None`` for a
-        track without materialized media, so this stays safe across topologies.
-        Hydration pulls the full decoded batch to the driver, so keep
-        ``media_log_interval`` modest (not every rollout) on large batches."""
+        the preview. Only ``media_max_items`` samples end up in the preview, so
+        the dehydrated batch is first sliced to the smallest DP-shard
+        (ref-boundary) prefix covering them — the driver pulls one shard instead
+        of the full decoded batch (see :func:`_ref_aligned_prefix_len`).
+        Non-media tracks (``Texts``, ``Audios``, …) are skipped without any
+        fetch."""
         if not self._log_media or (rollout_id % self._media_log_interval != 0):
             return
         wb = self.wandb_logger
         if wb is None or not wb.initialized:
             return
-        from unirl.distributed.tensor.transport import map_tree
-        from unirl.types.media_preview import build_media_preview_for_track
-        from unirl.types.rollout_resp import _hydrate_tensor_meta
-
         for track in resp.tracks.values():
-            if track.decoded is None:
+            if not isinstance(track.decoded, (Images, Videos)):
                 continue
+            prefix = _ref_aligned_prefix_len(track.decoded, self._media_max_items)
+            if 0 < prefix < len(track.decoded):
+                track.decoded = track.decoded.slice(0, prefix)
             track.decoded = map_tree(track.decoded, _hydrate_tensor_meta)
             media = build_media_preview_for_track(req=req, track=track, max_items=self._media_max_items)
             if media is not None:


### PR DESCRIPTION
## Summary

Wires up wandb logging of generated rollout media (images/videos) in `DiffusionTrainer`. The `logging.log_media` / `media_max_items` / `media_log_interval` recipe keys were previously inert — nothing read them, and `build_media_preview_for_track` / `log_generated_media` were never called, so no media reached wandb.

New `_maybe_log_media` builds a `MediaPreview` from each track's `decoded` images/videos and logs it right before `_drop_decoded`. Because `Worker.call` packs every returned tensor into a `TensorMeta` proxy, `track.decoded` is hydrated via `map_tree` + `_hydrate_tensor_meta` before building the preview. Gated by `log_media` and throttled by `media_log_interval` (hydration pulls the full decoded batch to the driver).

## Related Issue

N/A

## Test Plan

- `python -m py_compile unirl/trainer/diffusion.py` (passes).
- Static checks: `Images`/`Videos` are `Batch` subclasses, so `map_tree` recurses and hydrates `.pixels`; `_hydrate_tensor_meta` is the same driver-side path already used for `track.rewards`.
- Not run: end-to-end GPU run. Recommended: `examples/diffusion/sd3_nft.yaml` (trainside) with `REPORT_TO_WANDB=true` and a modest `media_log_interval`, then confirm panels under `rollout/generated_media`.

## Compatibility / Risk

- No-op unless `logging.log_media` is set; off by default, so existing runs are unchanged.
- Covers the trainside/colocate path; separate-engine recipes (sglang/vllm) return decoded differently and may need follow-up.
- Hydration is per-logged-rollout and pulls the full decoded batch — keep `media_log_interval` above 1 on large batches.

## Reviewer Notes

AI-assisted; checked upstream open PRs for overlap (none). Builds on existing helpers (`build_media_preview_for_track`, `UniRLWandBLogger.log_generated_media`) that were unused before this change.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.

Made with [Cursor](https://cursor.com)