### PR TITLE
docs: point Flow-DPPO citation to arXiv and drop bundled PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## News 🚀
 
 - **[2026-05]** **DRPO** released — *"Rethinking the Divergence Regularization in LLM RL"* ([arXiv](https://arxiv.org/abs/2606.09821)).
-- **[2026-06]** **Flow-DPPO** released — *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* ([paper](FlowDPPO/HY_FlowDPPO.pdf)).
+- **[2026-06]** **Flow-DPPO** released — *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* ([arXiv](https://arxiv.org/abs/2606.11025)).
 
 ## About 💡
 
@@ -46,7 +46,7 @@ runtime loop, deployment modes, and module map.
 
 | Algorithm | Paper | Tutorial | Notes |
 |---|---|---|---|
-| **Flow-DPPO** | [*"Flow-DPPO: Divergence Proximal Policy Optimization for Flow Matching Models"*](FlowDPPO/HY_FlowDPPO.pdf) | [FlowDPPO/](FlowDPPO/) | Diffusion/flow RL with an exact divergence-based trust-region mask. |
+| **Flow-DPPO** | [*"Flow-DPPO: Divergence Proximal Policy Optimization for Flow Matching Models"*](https://arxiv.org/abs/2606.11025) | [FlowDPPO/](FlowDPPO/) | Diffusion/flow RL with an exact divergence-based trust-region mask. |
 | **DRPO** | [*"Rethinking the Divergence Regularization in LLM RL"*](https://arxiv.org/abs/2606.09821) | [DRPO/](DRPO/) | Token-level LLM RL with a smooth advantage-weighted quadratic regularizer. |
 
 UniRL also wires in standard reference algorithms — **(LLM's)GRPO**, **DiffusionNFT**,


### PR DESCRIPTION
## Summary

Follow-up to #18. That PR updated the Flow-DPPO BibTeX entry to cite
`arXiv:2606.11025`, but the README still linked to the in-repo
`FlowDPPO/HY_FlowDPPO.pdf` in two places: the **News** entry and the
**Team-Proposed Algorithms** table. This points both links at the arXiv
abstract (`https://arxiv.org/abs/2606.11025`) and removes the bundled ~6 MB
PDF so the repo no longer ships a stale binary artifact.

## Related Issue

N/A (follow-up to #18).

## Test Plan

Not run; reason: documentation-only change. Verified via `grep -rn HY_FlowDPPO`
that no references to the removed PDF remain in the tree.

## Compatibility / Risk

N/A — README links and removal of a binary artifact only; no code, config, or
API impact.

## Reviewer Notes

Checked open PRs for overlap before opening this — none touch the Flow-DPPO
links or the PDF. AI-assisted change; the full diff was reviewed by the
submitter.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
