### PR TITLE
build: require diffusers>=0.37.0 for Qwen-Image RoPE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   # one engine extra below, which is what allows the per-engine CUDA stacks.
   "numpy>=1.24,<3",
   "ray[default]>=2.9,<2.55",  # 2.55 removed the ray.util.placement_group re-export of PlacementGroupSchedulingStrategy that unirl/distributed/utils.py imports
-  "diffusers>=0.30",
+  "diffusers>=0.37.0",  # Qwen-Image RoPE: <0.37 requires txt_seq_lens (max(None) crash); 0.37 derives text len from encoder_hidden_states_mask
   "hydra-core>=1.3",
   "omegaconf>=2.3",
   "transformers>=4.41",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 accelerate>=0.30
 aiohttp>=3.9
-diffusers>=0.30
+diffusers>=0.37.0
 easyocr>=1.7
 hydra-core>=1.3
 # Core dependency set aligned with:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "torch>=2.1",
         "ray[default]>=2.9,<3",
         "sglang[diffusion]==0.5.12.post1",
-        "diffusers>=0.30",
+        "diffusers>=0.37.0",
         "hydra-core>=1.3",
         "omegaconf>=2.3",
         "transformers>=4.41",


### PR DESCRIPTION
## Summary

  Raise the minimum `diffusers` version from `>=0.30` to `>=0.37.0` across
  `pyproject.toml`, `setup.py`, and `requirements.txt`.

  Qwen-Image's train-side `predict_noise`
  (`unirl/models/qwen_image/diffusion.py`) calls `QwenImageTransformer2DModel`
  without `txt_seq_lens`. On `diffusers <0.37`, `QwenEmbedRope.forward`
  computes `max_len = max(txt_seq_lens)`, so passing `txt_seq_lens=None`
  raises `TypeError: 'NoneType' object is not iterable` at the text-stream
  ("sequence") RoPE — the model crashes on the first transformer forward.
  `diffusers 0.37` reworked this: it derives the text sequence length from
  `encoder_hidden_states_mask` via `compute_text_seq_len_from_mask()` and
  passes `max_txt_seq_len=text_seq_len` to the RoPE module, so omitting
  `txt_seq_lens` is the supported path. The old `>=0.30` floor advertised
  support for versions on which Qwen-Image cannot run.

## Related Issue

  N/A

## Test Plan
- [x] Local repro on `diffusers==0.36.0` (CPU, tiny randomly-initialised
    `QwenImageTransformer2DModel`, no weights): calling `forward(...)` the
    way `predict_noise` does (no `txt_seq_lens`) raises
    `TypeError: 'NoneType' object is not iterable`; a direct
    `QwenEmbedRope.forward(video_fhw, None, cpu)` raises the same; control
    call with `txt_seq_lens=[8]` succeeds. Confirms the <0.37 crash.
- [x] Verified against an installed `diffusers==0.37.0` tree that
    `transformer_qwenimage.py` derives text length via
    `compute_text_seq_len_from_mask` and calls
    `self.pos_embed(img_shapes, max_txt_seq_len=text_seq_len, ...)` — the
    no-`txt_seq_lens` call path is correct on 0.37+.
  - Metadata-only change; not run: full training/rollout smoke test.

## Compatibility / Risk

  - Dependency floor change only; no code/API/checkpoint/data-format change.
  - The floor is repo-wide, so SD3 / Wan / Flux2 / HunyuanVideo also move to
    a minimum of `diffusers 0.37.0`. Reviewers who validated those models on
    `0.3x` should confirm they are fine on `>=0.37`.
  - PyPI's latest published `diffusers` is `0.36.0` (0.37+ exists as git
    tags / source installs), so a pure-PyPI `pip install` will now fail to
    resolve and must use a source/Git install. This matches how on-pod envs
    already install `diffusers`.
  - A `pip` floor does not constrain an already-installed editable
    `diffusers`; a runtime version assert in `QwenImageBundle.from_config`
    would additionally cover source installs (not included here).

## Reviewer Notes

  - Duplicate-work check: no other open PR touches the `diffusers` pin.

## Checklist

  - [x] I reviewed the changed code and removed unrelated/generated artifacts.
  - [x] I updated tests, docs, and configs where needed, or explained why not.