### PR TITLE
docs: add DGX Spark aarch64 bring-up path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,29 @@
 # Installation
 
 UniRL ships two mutually exclusive inference engines (`vllm` and `sglang`) — install each in its own virtual environment.
+DGX Spark / GB10 / linux-aarch64 users should start with the `spark` smoke-test
+extra before attempting engine extras; see [DGX Spark bring-up](docs/dgx-spark-aarch64.md).
 
-| Engine | CUDA | glibc |
-|---|---|---|
-| **vllm-omni** | 12.9 | ≥ 2.28 |
-| **sglang** | 13.0 | ≥ 2.34 |
+| Engine / stack | CUDA | glibc | Arch |
+|---|---|---|---|
+| **spark smoke test** | 13.0 | ≥ 2.39 | linux/aarch64 |
+| **vllm-omni** | 12.9 | ≥ 2.28 | linux/x86_64 verified |
+| **sglang** | 13.0 | ≥ 2.34 | linux/x86_64 verified |
+
+## DGX Spark / GB10 / linux-aarch64
+
+```bash
+python3 -m venv .venv-spark && source .venv-spark/bin/activate
+python -m pip install -U pip uv
+uv pip install -e ".[spark,train,infer,dev]"
+python scripts/dgx_spark_probe.py
+```
+
+The probe validates the layer order that usually finds the first Arm/CUDA break:
+PyTorch CUDA → Diffusers/Transformers/PEFT/Ray → UniRL core → optional rollout
+engines. Optional failures for `sglang`, `vllm`, `flash_attn`, and
+`sglang_kernel` are expected until their linux-aarch64 CUDA 13 wheels or local
+source-build recipes are confirmed.
 
 ## vllm-omni
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ schema, and how to add a recipe.
 
 ## Getting Started ⚡
 
-Install dependencies first — see [INSTALL.md](INSTALL.md).
+Install dependencies first — see [INSTALL.md](INSTALL.md). DGX Spark / GB10
+linux-aarch64 users should begin with the `spark` smoke-test path in
+[`docs/dgx-spark-aarch64.md`](docs/dgx-spark-aarch64.md) before attempting
+`sglang` or `vllm` engine extras.
 
 ```bash
 # compose-check, then launch a single-node example

--- a/docs/dgx-spark-aarch64.md
+++ b/docs/dgx-spark-aarch64.md
@@ -1,0 +1,96 @@
+# DGX Spark / GB10 / linux-aarch64 bring-up
+
+This page tracks the supported path for running UniRL on DGX Spark-class hosts:
+
+- CPU/OS architecture: `aarch64`
+- GPU: NVIDIA GB10
+- CUDA user stack: 13.x
+- glibc: 2.39+
+- Python: 3.12 aarch64
+
+The CUDA driver/runtime can be present while Python packages and native CUDA
+extensions are still the blocker. Treat the stack as layers and validate them in
+order.
+
+## Current support boundary
+
+The `spark` extra is the DGX Spark smoke-test stack. It deliberately does not
+install rollout engines (`sglang`, `vllm`, `vllm-omni`, `flash-attn`,
+`sglang-kernel`) because those packages frequently lag linux-aarch64/GB10/CUDA 13
+wheel availability.
+
+Expected first milestone:
+
+1. PyTorch CUDA imports and sees GB10.
+2. Diffusers/Transformers/PEFT/Ray import.
+3. UniRL core imports.
+4. Hydra configs compose.
+
+Only after that should we try the engine extras.
+
+## Install
+
+Use a fresh virtual environment. `uv` is preferred because this project declares
+the CUDA torch indexes in `pyproject.toml`.
+
+```bash
+python3 -m venv .venv-spark
+source .venv-spark/bin/activate
+python -m pip install -U pip uv
+uv pip install -e ".[spark,train,infer,dev]"
+```
+
+If using `pip` directly, pass the CUDA 13 PyTorch index explicitly:
+
+```bash
+python3 -m venv .venv-spark
+source .venv-spark/bin/activate
+python -m pip install -U pip
+python -m pip install -e ".[spark,train,infer,dev]" \
+  --extra-index-url https://download.pytorch.org/whl/cu130
+```
+
+## Validate layers
+
+```bash
+source .venv-spark/bin/activate
+python scripts/dgx_spark_probe.py
+python -m unirl.train_diffusion --config-name=diffusion/sd3_trainside --cfg job --resolve
+```
+
+The probe exits non-zero if the required DGX Spark smoke-test layer fails. It also
+prints optional failures for `sglang`, `vllm`, `flash_attn`, and
+`sglang_kernel`; those are expected until their linux-aarch64 CUDA 13 wheels (or a
+working local source-build recipe) are available.
+
+## Engine triage order
+
+After the smoke-test stack passes, test native engines one at a time in separate
+venvs:
+
+1. `sglang-kernel`
+2. `flash-attn` / `flash-attn-4`
+3. `sglang[diffusion]`
+4. `vllm`
+5. `vllm-omni`
+
+Do not mix `sglang` and `vllm` in the same environment; their CUDA/PyTorch pins
+are intentionally conflicting.
+
+For every native-extension failure, record:
+
+- package and version
+- whether a linux-aarch64 wheel exists
+- Python tag (`cp312` here)
+- CUDA version encoded by the wheel or build
+- PyTorch version and CUDA ABI
+- compiler and CUDA header versions if building from source
+- GB10 compute capability reported by `scripts/dgx_spark_probe.py`
+
+## Known risks
+
+- x86_64 wheels are not usable on DGX Spark.
+- Docker images for research ML projects often publish only `linux/amd64`.
+- CUDA 13 support does not imply GB10/Blackwell tuning support.
+- Source builds can fail independently on Python 3.12, PyTorch ABI, CUDA headers,
+  compute capability flags, or Arm-specific compiler issues.

--- a/docs/dgx-spark-aarch64.md
+++ b/docs/dgx-spark-aarch64.md
@@ -26,7 +26,9 @@ Expected first milestone:
 3. UniRL core imports.
 4. Hydra configs compose.
 
-Only after that should we try the engine extras.
+This milestone has been verified on DGX Spark with Python 3.12.3,
+glibc 2.39, CUDA 13.0 user wheels, `torch==2.12.0+cu130`, and GB10 reporting
+`sm_121`. Only after this layer passes should we try the engine extras.
 
 ## Install
 
@@ -58,7 +60,9 @@ python scripts/dgx_spark_probe.py
 python -m unirl.train_diffusion --config-name=diffusion/sd3_trainside --cfg job --resolve
 ```
 
-The probe exits non-zero if the required DGX Spark smoke-test layer fails. It also
+A passing DGX Spark smoke test should report `torch.cuda.is_available=true`,
+`torch.version.cuda=13.0`, `torch.cuda.device=NVIDIA GB10`, and a successful CUDA
+tensor smoke test. The probe exits non-zero if the required layer fails. It also
 prints optional failures for `sglang`, `vllm`, `flash_attn`, and
 `sglang_kernel`; those are expected until their linux-aarch64 CUDA 13 wheels (or a
 working local source-build recipe) are available.

--- a/docs/dgx-spark-aarch64.md
+++ b/docs/dgx-spark-aarch64.md
@@ -67,6 +67,32 @@ prints optional failures for `sglang`, `vllm`, `flash_attn`, and
 `sglang_kernel`; those are expected until their linux-aarch64 CUDA 13 wheels (or a
 working local source-build recipe) are available.
 
+## Run one tiny end-to-end diffusion rollout
+
+The default SD3.5 checkpoint is gated on Hugging Face. For an ungated functional
+smoke run, override it with a tiny random SD3 repo and shrink the batch/step
+counts:
+
+```bash
+source .venv-spark/bin/activate
+export PRETRAINED_MODEL=optimum-internal-testing/tiny-random-stable-diffusion-3
+export REPORT_TO_WANDB=false
+python -m unirl.train_diffusion --config-name=diffusion/sd3_trainside \
+  num_devices=1 +devices_per_node=1 batch_size=1 \
+  data_source.args.algorithm.prompts_per_rollout=1 \
+  sampling.samples_per_prompt=1 sampling.num_inference_steps=1 \
+  sampling.scheduler.num_timesteps=1 sampling.scheduler.num_sde_steps=0 \
+  rollout.forward_batch_size=1 reward.backend.config.batch_size=1 \
+  stack.num_updates_per_batch=1 +num_rollouts=1
+```
+
+This exercises Ray worker setup, dataset loading, model component loading,
+trainside rollout, reward attachment, and the train loop without requiring a gated
+or large production checkpoint. On DGX Spark this completed one rollout with
+`unirl_tiny_sd3_status=0`; with a single sample it may log a PyTorch warning about
+reward standard deviation degrees of freedom and skip an optimizer step when no
+micro-batch reports backward.
+
 ## Engine triage order
 
 After the smoke-test stack passes, test native engines one at a time in separate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,20 @@ train = [
   # MathVerifyRewardScorer (unirl/reward/local/mathverify.py) — the paper's grader.
   "math-verify>=0.6",
 ]
+# DGX Spark / GB10 smoke-test stack.  This intentionally keeps rollout engines
+# out: sglang/vllm/flash-attn remain the volatile native-extension boundary on
+# linux/aarch64, while this extra pins the first layer we can validate locally
+# (PyTorch CUDA + UniRL core/config/training imports).
+#
+# Install with uv so the torch-cu130 index below participates in resolution:
+#   uv pip install -e ".[spark,train,infer,dev]"
+# If using pip directly, add:
+#   --extra-index-url https://download.pytorch.org/whl/cu130
+spark = [
+  "torch>=2.11,<2.13 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
+  "torchvision>=0.26,<0.28 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
+  "torchaudio>=2.11,<2.13 ; sys_platform == 'linux' and platform_machine == 'aarch64'",
+]
 infer = [
   "accelerate>=0.30",
 ]
@@ -110,6 +124,7 @@ override-dependencies = [
 ]
 environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 
 # vllm's PyPI wheel is manylinux_2_35 and its GitHub +cu129 wheel manylinux_2_31;

--- a/scripts/dgx_spark_probe.py
+++ b/scripts/dgx_spark_probe.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Probe UniRL compatibility layers on DGX Spark / linux-aarch64.
+
+The probe is intentionally read-only: it imports installed packages, reports CUDA
+visibility, and identifies the first missing layer in the aarch64 stack.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata as md
+import json
+import platform
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass
+class Check:
+    name: str
+    ok: bool
+    detail: str
+
+
+def version_of(dist: str) -> str | None:
+    try:
+        return md.version(dist)
+    except md.PackageNotFoundError:
+        return None
+
+
+def import_check(module: str, dist: str | None = None) -> Check:
+    dist = dist or module.split(".", 1)[0].replace("_", "-")
+    try:
+        imported = importlib.import_module(module)
+    except Exception as exc:  # noqa: BLE001 - diagnostic tool
+        return Check(module, False, f"{type(exc).__name__}: {exc}")
+    version = version_of(dist) or getattr(imported, "__version__", "unknown")
+    return Check(module, True, f"version={version}")
+
+
+def torch_check() -> list[Check]:
+    checks: list[Check] = [import_check("torch")]
+    if not checks[-1].ok:
+        return checks
+
+    import torch
+
+    checks.append(Check("torch.cuda.is_available", bool(torch.cuda.is_available()), str(torch.cuda.is_available())))
+    checks.append(Check("torch.version.cuda", bool(torch.version.cuda), str(torch.version.cuda)))
+    if torch.cuda.is_available():
+        try:
+            checks.append(Check("torch.cuda.device", True, torch.cuda.get_device_name(0)))
+            major, minor = torch.cuda.get_device_capability(0)
+            checks.append(Check("torch.cuda.capability", True, f"sm_{major}{minor}"))
+            x = torch.ones((2, 2), device="cuda")
+            checks.append(Check("torch.cuda.tensor_smoke", bool((x + x).sum().item() == 8.0), "2x2 tensor add"))
+        except Exception as exc:  # noqa: BLE001 - diagnostic tool
+            checks.append(Check("torch.cuda.tensor_smoke", False, f"{type(exc).__name__}: {exc}"))
+    return checks
+
+
+def main() -> int:
+    report: dict[str, Any] = {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "glibc": platform.libc_ver(),
+        "checks": [],
+    }
+
+    checks: list[Check] = []
+    checks.append(Check("linux-aarch64", sys.platform == "linux" and platform.machine() == "aarch64", f"{sys.platform}/{platform.machine()}"))
+
+    # Layer 1: package metadata and UniRL import surface.
+    checks.extend(
+        [
+            import_check("unirl"),
+            import_check("hydra", "hydra-core"),
+            import_check("omegaconf"),
+            import_check("ray"),
+            import_check("diffusers"),
+            import_check("transformers"),
+            import_check("peft"),
+        ]
+    )
+
+    # Layer 2: CUDA-bearing torch stack.
+    checks.extend(torch_check())
+
+    # Layer 3: risky rollout/native-extension boundary. These may legitimately
+    # be missing on DGX Spark until upstream publishes aarch64 wheels.
+    checks.extend(
+        [
+            import_check("sglang"),
+            import_check("vllm"),
+            import_check("flash_attn", "flash-attn"),
+            import_check("sglang_kernel", "sglang-kernel"),
+        ]
+    )
+
+    report["checks"] = [asdict(check) for check in checks]
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    required = ["linux-aarch64", "unirl", "hydra", "omegaconf", "ray", "diffusers", "transformers", "peft", "torch", "torch.cuda.is_available"]
+    by_name = {check.name: check for check in checks}
+    failed_required = [name for name in required if not by_name.get(name, Check(name, False, "missing")).ok]
+    if failed_required:
+        print("\nFAILED_REQUIRED=" + ",".join(failed_required), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a `spark` optional dependency set for DGX Spark / GB10 linux-aarch64 smoke testing.
- Allows uv resolution on linux/aarch64 while keeping existing x86_64 environment support.
- Adds `scripts/dgx_spark_probe.py` to report the first failing layer across UniRL core, PyTorch CUDA, and optional native rollout engines.
- Documents the DGX Spark bring-up order and current support boundary before trying sglang/vLLM/flash-attn.

## Test Plan
- `python3 - <<'PY' ... tomllib.load(open('pyproject.toml','rb')) ... PY`
- `python3 -m py_compile scripts/dgx_spark_probe.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY' ... import unirl ... PY`
- `uv pip compile pyproject.toml --extra spark --extra train --extra infer --extra dev -q -o /tmp/unirl-spark-requirements.txt`
- `uv pip install -e ".[spark,train,infer,dev]"`
- `python scripts/dgx_spark_probe.py`
- `python -m unirl.train_diffusion --config-name=diffusion/sd3_trainside --cfg job --resolve`

Observed on DGX Spark:
- Python 3.12.3 aarch64
- glibc 2.39
- NVIDIA GB10
- `torch==2.12.0+cu130`
- `torch.version.cuda == 13.0`
- `torch.cuda.is_available() == True`
- device capability reported as `sm_121`

Expected current boundary:
- `sglang`, `vllm`, `flash_attn`, and `sglang_kernel` are intentionally not installed by the `spark` smoke-test extra and are reported as optional missing packages by the probe.

## Contribution notes
- Checked for overlapping open PRs with `gh pr list --repo Tencent-Hunyuan/UniRL --search 'DGX Spark aarch64 OR aarch64 GB10 OR linux-aarch64' --state open --limit 20`; none were returned.
- This PR was prepared with AI assistance; the diff is limited to the DGX Spark/aarch64 bring-up path and validation docs/scripts.
