### PR TITLE
Add Flow-DPPO SD3.5 checkpoint link

### DIFF
--- a/FlowDPPO/README.md
+++ b/FlowDPPO/README.md
@@ -9,6 +9,7 @@ pushes too aggressively in the reward-improving direction.
 - **Loss:** [`unirl/algorithms/flowdppo.py`](../unirl/algorithms/flowdppo.py) (`_gaussian_kl_div`, `_flowdppo_kl_adv_loss`, `FlowDPPO`)
 - **SDE / replay path:** [`unirl/models/sd3/diffusion.py`](../unirl/models/sd3/diffusion.py), [`unirl/sde/kernels.py`](../unirl/sde/kernels.py)
 - **Recipe:** [`examples/diffusion/sd3_flowdppo.yaml`](../examples/diffusion/sd3_flowdppo.yaml) · **Config extract:** [`config.yaml`](config.yaml)
+- **Checkpoints:** [🤗 FlowDPPO](https://huggingface.co/Eculid/sd3.5-flowdppo)
 - **Paper:** *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models."*
 
 FlowDPPO builds on the same GRPO-style SDE rollout, trained-step gating, and


### PR DESCRIPTION
## Summary

This PR adds a community-contributed Flow-DPPO checkpoint link to the README.

The checkpoint was trained with the Flow-DPPO recipe on Stable Diffusion 3.5.

Related to #31 .

## Training curves

| `rollout/reward_mean`               | `train/ratio_mean`                  |
| ----------------------------------- | ----------------------------------- |
| <img width="1930" height="1009" alt="Weixin Image_20260611165650_770_36" src="https://github.com/user-attachments/assets/2c2fbd9e-1b0f-426b-bf68-aad207e6ed74" /> | <img width="1929" height="1003" alt="Weixin Image_20260611165654_771_36" src="https://github.com/user-attachments/assets/7920f69f-809d-4de2-a4f3-4fc10baaaa7d" /> |

## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan

<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [ ] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
