### PR TITLE
feat(trainer): add checkpoint save/load for diffusion, ar and unified trainers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,9 +49,11 @@ Pass cluster-local paths and W&B identity through env vars (`PRETRAINED_MODEL`,
 The mooncake-backed recipe (`*_tq_mooncake`) needs its metadata server up first —
 start it on the head node with `bash examples/mooncake_master.sh start` before launching.
 
-To save or resume checkpoints, append the `+save_interval` / `+save_dir` / `+load_dir`
-overrides (diffusion/ar/unified trainers; the hi3 meta-init recipe is not yet
-supported) — see [Checkpointing](../unirl/trainer/README.md#checkpointing).
+To save and resume checkpoints and export them to Hugging Face, append the
+`+save_interval` / `+save_dir` / `+load_dir` overrides (diffusion/ar/unified
+trainers; the hi3 meta-init recipe is not yet supported) — the full
+train → resume → export → upload lifecycle is in
+[Checkpointing](../unirl/trainer/README.md#checkpointing).
 
 ## Reading a recipe name
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,9 @@ Pass cluster-local paths and W&B identity through env vars (`PRETRAINED_MODEL`,
 The mooncake-backed recipe (`*_tq_mooncake`) needs its metadata server up first —
 start it on the head node with `bash examples/mooncake_master.sh start` before launching.
 
+To save or resume checkpoints, append the `+save_interval` / `+save_dir` / `+load_dir`
+overrides (diffusion/ar/unified trainers) — see [Checkpointing](../unirl/trainer/README.md#checkpointing).
+
 ## Reading a recipe name
 
 A recipe filename is a fixed-order, `_`-joined chain of segments. Every segment

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,8 @@ The mooncake-backed recipe (`*_tq_mooncake`) needs its metadata server up first 
 start it on the head node with `bash examples/mooncake_master.sh start` before launching.
 
 To save or resume checkpoints, append the `+save_interval` / `+save_dir` / `+load_dir`
-overrides (diffusion/ar/unified trainers) — see [Checkpointing](../unirl/trainer/README.md#checkpointing).
+overrides (diffusion/ar/unified trainers; the hi3 meta-init recipe is not yet
+supported) — see [Checkpointing](../unirl/trainer/README.md#checkpointing).
 
 ## Reading a recipe name
 

--- a/unirl/tools/__init__.py
+++ b/unirl/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Offline checkpoint tools: LoRA merge + Hugging Face export.
+
+File-to-file counterparts of the runtime LoRA merging in
+``unirl.utils.peft_merge`` (which engines and weight sync use on live
+modules). Entry point: ``python -m unirl.tools.export_hf``.
+"""

--- a/unirl/tools/export_hf.py
+++ b/unirl/tools/export_hf.py
@@ -7,7 +7,9 @@ trainable module's state dict with PEFT-injected names
 scheduler state. This script folds the LoRA delta into the base weights,
 restores the upstream parameter names, strict-loads them into the base model
 class, and writes a standard HF folder — ready for ``from_pretrained`` or
-``hf upload``.
+``hf upload``. Both checkpoint flavors work: ``save_mode=full`` merges
+self-contained, ``save_mode=adapter`` folds the LoRA keys onto the freshly
+loaded base weights.
 
 The fold mirrors :func:`unirl.utils.peft_merge.merged_state_dict` (fp32 merge,
 same key grammar) but runs offline on the checkpoint dict, so the LoRA scaling
@@ -17,13 +19,13 @@ from the weights).
 
 Examples:
     # SD3.5 LoRA run (alpha from the recipe), diffusers transformer subfolder
-    python -m unirl.utils.export_hf \\
+    python -m unirl.tools.export_hf \\
         --checkpoint /ckpts/sd3_trainside/checkpoint-500 \\
         --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \\
         --lora-alpha 64 --output /ckpts/sd3_trainside/hf-500
 
     # AR (transformers CausalLM)
-    python -m unirl.utils.export_hf \\
+    python -m unirl.tools.export_hf \\
         --checkpoint /ckpts/qwen3/checkpoint-300 --library transformers \\
         --base Qwen/Qwen3-4B-Base --lora-alpha 64 --output /ckpts/qwen3/hf-300
 
@@ -43,25 +45,37 @@ import torch
 DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
 
 
+def _require_alpha(alpha: Optional[float]) -> float:
+    if alpha is None:
+        raise SystemExit(
+            "checkpoint contains LoRA adapters — pass --lora-alpha (backend.lora_cfg.alpha in the training recipe)"
+        )
+    return float(alpha)
+
+
+def _fold(base: torch.Tensor, lora_a: torch.Tensor, lora_b: torch.Tensor, alpha: float) -> torch.Tensor:
+    # Merge in fp32: a bf16 base + bf16 delta rounds the update away.
+    scaling = alpha / lora_a.shape[0]
+    return (base.float() + (lora_b.float() @ lora_a.float()) * scaling).to(base.dtype)
+
+
 def merge_lora_state_dict(
     state_dict: Dict[str, torch.Tensor],
     *,
     adapter: str = "default",
     alpha: Optional[float] = None,
 ) -> Dict[str, torch.Tensor]:
-    """Fold ``adapter``'s LoRA delta into the base weights; restore upstream names.
+    """``save_mode=full`` checkpoint → HF-named dict with the LoRA delta folded in.
 
     No-op (copy) for checkpoints without LoRA keys (full-finetune recipes).
     Other adapters' keys (e.g. the NFT shadow ``old``) are dropped.
     """
     if not any(".lora_A." in k for k in state_dict):
         return dict(state_dict)
-    if alpha is None:
-        raise SystemExit(
-            "checkpoint contains LoRA adapters — pass --lora-alpha (backend.lora_cfg.alpha in the training recipe)"
-        )
+    alpha = _require_alpha(alpha)
 
     out: Dict[str, torch.Tensor] = {}
+    folded = 0
     for key, value in state_dict.items():
         if ".lora_A." in key or ".lora_B." in key:
             continue  # folded below, or a non-exported adapter
@@ -74,10 +88,40 @@ def merge_lora_state_dict(
             lora_a = state_dict.get(f"{stem}.lora_A.{adapter}.weight")
             lora_b = state_dict.get(f"{stem}.lora_B.{adapter}.weight")
             if lora_a is not None and lora_b is not None:
-                scaling = float(alpha) / lora_a.shape[0]
-                # Merge in fp32: a bf16 base + bf16 delta rounds the update away.
-                value = (value.float() + (lora_b.float() @ lora_a.float()) * scaling).to(value.dtype)
+                value = _fold(value, lora_a, lora_b, alpha)
+                folded += 1
         out[original] = value
+    if not folded:
+        raise SystemExit(f"no LoRA pairs for adapter {adapter!r} in the checkpoint (try --adapter)")
+    print(f"folded {folded} LoRA pairs into the checkpoint's base weights")
+    return out
+
+
+def fold_adapter_into_base(
+    base_state_dict: Dict[str, torch.Tensor],
+    adapter_state_dict: Dict[str, torch.Tensor],
+    *,
+    adapter: str = "default",
+    alpha: Optional[float] = None,
+) -> Dict[str, torch.Tensor]:
+    """``save_mode=adapter`` checkpoint + base-model state dict → merged HF dict."""
+    alpha = _require_alpha(alpha)
+    marker = f".lora_A.{adapter}.weight"
+    out = dict(base_state_dict)
+    folded = 0
+    for key, lora_a in adapter_state_dict.items():
+        if not key.endswith(marker):
+            continue
+        stem = key[: -len(marker)]
+        lora_b = adapter_state_dict.get(f"{stem}.lora_B.{adapter}.weight")
+        target = f"{stem}.weight"
+        if lora_b is None or target not in out:
+            raise SystemExit(f"adapter pair {stem!r} does not match the base model (missing lora_B or {target!r})")
+        out[target] = _fold(out[target], lora_a, lora_b, alpha)
+        folded += 1
+    if not folded:
+        raise SystemExit(f"no LoRA pairs for adapter {adapter!r} in the checkpoint (try --adapter)")
+    print(f"folded {folded} LoRA pairs onto the base model's weights")
     return out
 
 
@@ -100,8 +144,6 @@ def main() -> None:
     state_dict = checkpoint["policy_state_dict"]
     print(f"loaded {path}: {len(state_dict)} tensors, step={checkpoint.get('step')}")
 
-    merged = merge_lora_state_dict(state_dict, adapter=args.adapter, alpha=args.lora_alpha)
-
     dtype = DTYPES[args.dtype]
     from_pretrained_kwargs = {"torch_dtype": dtype}
     if args.subfolder:
@@ -114,6 +156,13 @@ def main() -> None:
         from transformers import AutoModelForCausalLM
 
         model = AutoModelForCausalLM.from_pretrained(args.base, **from_pretrained_kwargs)
+
+    if any(".base_layer." in k for k in state_dict):  # save_mode=full: self-contained
+        merged = merge_lora_state_dict(state_dict, adapter=args.adapter, alpha=args.lora_alpha)
+    elif any(".lora_A." in k for k in state_dict):  # save_mode=adapter: fold onto the base
+        merged = fold_adapter_into_base(model.state_dict(), state_dict, adapter=args.adapter, alpha=args.lora_alpha)
+    else:  # full finetune, no LoRA
+        merged = dict(state_dict)
 
     # strict: naming drift between checkpoint and base class is a hard error,
     # not a silently half-loaded export.

--- a/unirl/tools/export_hf.py
+++ b/unirl/tools/export_hf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Export a UniRL training checkpoint to a Hugging Face ``save_pretrained`` folder.
 
 ``checkpoint.pt`` (see ``FSDPBackend.save``) is a raw trainer pickle: the

--- a/unirl/tools/export_hf.py
+++ b/unirl/tools/export_hf.py
@@ -12,22 +12,22 @@ self-contained, ``save_mode=adapter`` folds the LoRA keys onto the freshly
 loaded base weights.
 
 The fold mirrors :func:`unirl.utils.peft_merge.merged_state_dict` (fp32 merge,
-same key grammar) but runs offline on the checkpoint dict, so the LoRA scaling
-cannot be read off a live ``peft_config`` — pass ``--lora-alpha`` from the
-recipe (``backend.lora_cfg.alpha``; scaling = alpha / rank, rank is inferred
-from the weights).
+same key grammar) but runs offline on the checkpoint dict. The LoRA scaling
+(alpha / rank) comes from the ``lora_config`` the checkpoint records;
+``--lora-alpha`` overrides it (and is the only path for checkpoints predating
+the record).
 
 Examples:
-    # SD3.5 LoRA run (alpha from the recipe), diffusers transformer subfolder
+    # SD3.5 LoRA run, diffusers transformer subfolder
     python -m unirl.tools.export_hf \\
         --checkpoint /ckpts/sd3_trainside/checkpoint-500 \\
         --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \\
-        --lora-alpha 64 --output /ckpts/sd3_trainside/hf-500
+        --output /ckpts/sd3_trainside/hf-500
 
     # AR (transformers CausalLM)
     python -m unirl.tools.export_hf \\
         --checkpoint /ckpts/qwen3/checkpoint-300 --library transformers \\
-        --base Qwen/Qwen3-4B-Base --lora-alpha 64 --output /ckpts/qwen3/hf-300
+        --base Qwen/Qwen3-4B-Base --output /ckpts/qwen3/hf-300
 
 Loading the SD3 result back into a pipeline:
     transformer = AutoModel.from_pretrained("/ckpts/sd3_trainside/hf-500", torch_dtype=torch.bfloat16)
@@ -48,7 +48,8 @@ DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
 def _require_alpha(alpha: Optional[float]) -> float:
     if alpha is None:
         raise SystemExit(
-            "checkpoint contains LoRA adapters — pass --lora-alpha (backend.lora_cfg.alpha in the training recipe)"
+            "checkpoint contains LoRA adapters but records no lora_config — "
+            "pass --lora-alpha (backend.lora_cfg.alpha in the training recipe)"
         )
     return float(alpha)
 
@@ -133,7 +134,12 @@ def main() -> None:
     parser.add_argument("--subfolder", default=None, help='base subfolder, e.g. "transformer" for diffusers pipelines')
     parser.add_argument("--library", choices=("diffusers", "transformers"), default="diffusers")
     parser.add_argument("--adapter", default="default", help='LoRA adapter to fold ("old" = the NFT EMA shadow)')
-    parser.add_argument("--lora-alpha", type=float, default=None, help="backend.lora_cfg.alpha from the recipe")
+    parser.add_argument(
+        "--lora-alpha",
+        type=float,
+        default=None,
+        help="override the lora alpha recorded in the checkpoint (required only for checkpoints without one)",
+    )
     parser.add_argument("--dtype", choices=tuple(DTYPES), default="bf16")
     args = parser.parse_args()
 
@@ -142,7 +148,9 @@ def main() -> None:
         path = os.path.join(path, "checkpoint.pt")
     checkpoint = torch.load(path, map_location="cpu", weights_only=True)
     state_dict = checkpoint["policy_state_dict"]
-    print(f"loaded {path}: {len(state_dict)} tensors, step={checkpoint.get('step')}")
+    recorded = checkpoint.get("lora_config") or {}
+    alpha = args.lora_alpha if args.lora_alpha is not None else recorded.get("alpha")
+    print(f"loaded {path}: {len(state_dict)} tensors, step={checkpoint.get('step')}, lora_alpha={alpha}")
 
     dtype = DTYPES[args.dtype]
     from_pretrained_kwargs = {"torch_dtype": dtype}
@@ -158,9 +166,9 @@ def main() -> None:
         model = AutoModelForCausalLM.from_pretrained(args.base, **from_pretrained_kwargs)
 
     if any(".base_layer." in k for k in state_dict):  # save_mode=full: self-contained
-        merged = merge_lora_state_dict(state_dict, adapter=args.adapter, alpha=args.lora_alpha)
+        merged = merge_lora_state_dict(state_dict, adapter=args.adapter, alpha=alpha)
     elif any(".lora_A." in k for k in state_dict):  # save_mode=adapter: fold onto the base
-        merged = fold_adapter_into_base(model.state_dict(), state_dict, adapter=args.adapter, alpha=args.lora_alpha)
+        merged = fold_adapter_into_base(model.state_dict(), state_dict, adapter=args.adapter, alpha=alpha)
     else:  # full finetune, no LoRA
         merged = dict(state_dict)
 

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -31,11 +31,14 @@ from unirl.train.configs import (
 from unirl.train.ema import EMA, make_decay_fn
 from unirl.train.factories import build_lr_scheduler, build_optimizer
 from unirl.train.fsdp_utils import (
+    _current_rank,
     clip_grad_norm,
     fsdp_offload,
     fsdp_onload,
+    gather_optimizer_state_dict,
     gather_state_dict,
     load_model_state_dict,
+    load_optimizer_state_dict,
     trainable_params,
 )
 from unirl.train.inject import (
@@ -283,31 +286,96 @@ class FSDPBackend(Remote):
     # ------------------------------------------------------------------
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
-    def save(self, path: str) -> None:
-        """Gather state on all ranks; write to ``path/checkpoint.pt`` on rank 0."""
+    def save(self, path: str, step: Optional[int] = None) -> None:
+        """Gather full state (collective on every rank); write ``path/checkpoint.pt`` on dist rank 0.
+
+        ``step`` is the trainer's rollout step — stored for checkpoint
+        inspection and future loop-resume logic.
+        """
+        self._reject_meta_params("save")
         state: Dict[str, object] = {
             "policy_state_dict": gather_state_dict(self.model),
-            "optimizer_state_dict": self.optimizer.state_dict(),
+            "optimizer_state_dict": gather_optimizer_state_dict(self.model, self.optimizer),
+            "optimizer_step_count": self._optimizer_step_count,
+            "step": step,
         }
         if self.scheduler is not None:
             state["scheduler_state_dict"] = self.scheduler.state_dict()
 
-        if self._rank != 0:
+        # The DCP gathers above populate dist rank 0 only — that rank writes.
+        # (NOT self._rank: that is a constructor kwarg, identical on every worker.)
+        if _current_rank() != 0:
             return
         os.makedirs(path, exist_ok=True)
         torch.save(state, os.path.join(path, "checkpoint.pt"))
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def load(self, path: str) -> None:
-        checkpoint_path = os.path.join(path, "checkpoint.pt")
-        if not os.path.exists(checkpoint_path):
-            raise FileNotFoundError(f"FSDPBackend.load: checkpoint not found: {checkpoint_path}")
-        checkpoint = torch.load(checkpoint_path, map_location=self._device)
+        """Restore the state written by :meth:`save`.
 
-        load_model_state_dict(self.model, checkpoint["policy_state_dict"])
-        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-        if self.scheduler is not None and "scheduler_state_dict" in checkpoint:
-            self.scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
+        Every rank participates (the DCP set is a collective): dist rank 0
+        reads the file, tensors broadcast from rank 0 and re-shard into each
+        rank's local model/optimizer state. The small header (scheduler state,
+        counters — or the error verdict) broadcasts first, so a bad checkpoint
+        raises on EVERY rank together instead of stranding the others in a
+        collective.
+        """
+        self._reject_meta_params("load")
+        checkpoint_path = os.path.join(path, "checkpoint.pt")
+        is_rank_zero = _current_rank() == 0
+
+        checkpoint: Dict[str, object] = {}
+        header: Optional[Dict[str, object]] = None
+        if is_rank_zero:
+            if not os.path.exists(checkpoint_path):
+                header = {"error": f"checkpoint not found: {checkpoint_path}"}
+            else:
+                checkpoint = torch.load(checkpoint_path, map_location="cpu")
+                missing = [k for k in ("policy_state_dict", "optimizer_state_dict") if k not in checkpoint]
+                if missing:
+                    header = {"error": f"malformed checkpoint {checkpoint_path}: missing {missing}"}
+                else:
+                    header = {
+                        "scheduler_state_dict": checkpoint.get("scheduler_state_dict"),
+                        "optimizer_step_count": checkpoint.get("optimizer_step_count"),
+                    }
+        header = self._broadcast_obj(header)
+        if header.get("error"):
+            raise RuntimeError(f"FSDPBackend.load: {header['error']}")
+
+        load_model_state_dict(self.model, checkpoint.get("policy_state_dict", {}))
+        load_optimizer_state_dict(self.model, self.optimizer, checkpoint.get("optimizer_state_dict", {}))
+        if self.scheduler is not None and header.get("scheduler_state_dict") is not None:
+            self.scheduler.load_state_dict(header["scheduler_state_dict"])
+        if header.get("optimizer_step_count") is not None:
+            self._optimizer_step_count = int(header["optimizer_step_count"])
+
+    def _reject_meta_params(self, op: str) -> None:
+        """Fail fast when the trainable module still has never-materialized params.
+
+        Meta-init bundles (hi3 80B) keep frozen aux (vae / vit) on meta; a
+        full-state-dict gather would die deep inside DCP ("Cannot copy out of
+        meta tensor"). Same verdict on every rank, so raising here is
+        collective-safe. Sharded DCP checkpointing is the planned path for
+        these bundles.
+        """
+        meta = [name for name, p in self.model.named_parameters() if p.is_meta]
+        if meta:
+            raise RuntimeError(
+                f"FSDPBackend.{op}: {len(meta)} params are on meta (e.g. {meta[:3]}); "
+                "full-state-dict checkpointing of meta-init bundles is not supported yet."
+            )
+
+    @staticmethod
+    def _broadcast_obj(obj):
+        """Broadcast a small picklable object from dist rank 0 (identity without dist)."""
+        import torch.distributed as dist
+
+        if not (dist.is_available() and dist.is_initialized()):
+            return obj
+        box = [obj]
+        dist.broadcast_object_list(box, src=0)
+        return box[0]
 
     # ------------------------------------------------------------------
     # Memory lifecycle

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -282,6 +282,7 @@ class FSDPBackend(Remote):
     # Checkpoint
     # ------------------------------------------------------------------
 
+    @distributed(dispatch_mode=Dispatch.BROADCAST)
     def save(self, path: str) -> None:
         """Gather state on all ranks; write to ``path/checkpoint.pt`` on rank 0."""
         state: Dict[str, object] = {
@@ -296,6 +297,7 @@ class FSDPBackend(Remote):
         os.makedirs(path, exist_ok=True)
         torch.save(state, os.path.join(path, "checkpoint.pt"))
 
+    @distributed(dispatch_mode=Dispatch.BROADCAST)
     def load(self, path: str) -> None:
         checkpoint_path = os.path.join(path, "checkpoint.pt")
         if not os.path.exists(checkpoint_path):

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -313,51 +313,31 @@ class FSDPBackend(Remote):
     def load(self, path: str) -> None:
         """Restore the state written by :meth:`save`.
 
-        Every rank participates (the DCP set is a collective): dist rank 0
-        reads the file, tensors broadcast from rank 0 and re-shard into each
-        rank's local model/optimizer state. The small header (scheduler state,
-        counters — or the error verdict) broadcasts first, so a bad checkpoint
-        raises on EVERY rank together instead of stranding the others in a
-        collective.
+        Every rank runs this (the DCP set is a collective): each reads the
+        checkpoint from the shared filesystem to CPU, then tensors broadcast
+        from dist rank 0 and re-shard into the local model/optimizer state.
+        Identical checks on the identical file mean a bad path raises on
+        every rank together.
         """
         self._reject_meta_params("load")
         checkpoint_path = os.path.join(path, "checkpoint.pt")
-        is_rank_zero = _current_rank() == 0
+        if not os.path.exists(checkpoint_path):
+            raise FileNotFoundError(f"FSDPBackend.load: checkpoint not found: {checkpoint_path}")
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
 
-        checkpoint: Dict[str, object] = {}
-        header: Optional[Dict[str, object]] = None
-        if is_rank_zero:
-            if not os.path.exists(checkpoint_path):
-                header = {"error": f"checkpoint not found: {checkpoint_path}"}
-            else:
-                checkpoint = torch.load(checkpoint_path, map_location="cpu")
-                missing = [k for k in ("policy_state_dict", "optimizer_state_dict") if k not in checkpoint]
-                if missing:
-                    header = {"error": f"malformed checkpoint {checkpoint_path}: missing {missing}"}
-                else:
-                    header = {
-                        "scheduler_state_dict": checkpoint.get("scheduler_state_dict"),
-                        "optimizer_step_count": checkpoint.get("optimizer_step_count"),
-                    }
-        header = self._broadcast_obj(header)
-        if header.get("error"):
-            raise RuntimeError(f"FSDPBackend.load: {header['error']}")
-
-        load_model_state_dict(self.model, checkpoint.get("policy_state_dict", {}))
-        load_optimizer_state_dict(self.model, self.optimizer, checkpoint.get("optimizer_state_dict", {}))
-        if self.scheduler is not None and header.get("scheduler_state_dict") is not None:
-            self.scheduler.load_state_dict(header["scheduler_state_dict"])
-        if header.get("optimizer_step_count") is not None:
-            self._optimizer_step_count = int(header["optimizer_step_count"])
+        load_model_state_dict(self.model, checkpoint["policy_state_dict"])
+        load_optimizer_state_dict(self.model, self.optimizer, checkpoint["optimizer_state_dict"])
+        if self.scheduler is not None and "scheduler_state_dict" in checkpoint:
+            self.scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
+        if checkpoint.get("optimizer_step_count") is not None:
+            self._optimizer_step_count = int(checkpoint["optimizer_step_count"])
 
     def _reject_meta_params(self, op: str) -> None:
-        """Fail fast when the trainable module still has never-materialized params.
+        """Fail fast on never-materialized params (meta-init bundles, e.g. hi3 80B).
 
-        Meta-init bundles (hi3 80B) keep frozen aux (vae / vit) on meta; a
-        full-state-dict gather would die deep inside DCP ("Cannot copy out of
-        meta tensor"). Same verdict on every rank, so raising here is
-        collective-safe. Sharded DCP checkpointing is the planned path for
-        these bundles.
+        Their frozen aux (vae / vit) stays on meta and a full-state-dict gather
+        would die deep inside DCP ("Cannot copy out of meta tensor"). Same
+        verdict on every rank, so raising here is collective-safe.
         """
         meta = [name for name, p in self.model.named_parameters() if p.is_meta]
         if meta:
@@ -365,17 +345,6 @@ class FSDPBackend(Remote):
                 f"FSDPBackend.{op}: {len(meta)} params are on meta (e.g. {meta[:3]}); "
                 "full-state-dict checkpointing of meta-init bundles is not supported yet."
             )
-
-    @staticmethod
-    def _broadcast_obj(obj):
-        """Broadcast a small picklable object from dist rank 0 (identity without dist)."""
-        import torch.distributed as dist
-
-        if not (dist.is_available() and dist.is_initialized()):
-            return obj
-        box = [obj]
-        dist.broadcast_object_list(box, src=0)
-        return box[0]
 
     # ------------------------------------------------------------------
     # Memory lifecycle

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -16,6 +16,7 @@ import os
 from typing import Dict, List, Optional, Tuple
 
 import torch
+import torch.distributed as dist
 from torch import nn
 
 from unirl.distributed.group.dispatch import Dispatch, distributed
@@ -286,18 +287,30 @@ class FSDPBackend(Remote):
     # ------------------------------------------------------------------
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
-    def save(self, path: str, step: Optional[int] = None) -> None:
-        """Gather full state (collective on every rank); write ``path/checkpoint.pt`` on dist rank 0.
+    def save(self, path: str, step: Optional[int] = None, mode: str = "full") -> None:
+        """Gather state (collective on every rank); write ``path/checkpoint.pt`` on dist rank 0.
 
-        ``step`` is the trainer's rollout step — stored for checkpoint
-        inspection and future loop-resume logic.
+        ``step`` is the trainer's rollout step — :meth:`load` returns it so
+        the loop resumes where it stopped. ``mode="adapter"`` keeps only the
+        LoRA keys in the model state (MBs instead of GBs; the frozen base
+        reloads from the pretrained snapshot on resume). The optimizer state
+        is identical under both modes — it only ever covers the trainable
+        (LoRA) params.
         """
+        if mode not in ("full", "adapter"):
+            raise ValueError(f"FSDPBackend.save: unknown mode {mode!r} (use 'full' or 'adapter')")
+        if mode == "adapter" and not any("lora_" in name for name, _ in self.model.named_parameters()):
+            raise RuntimeError("FSDPBackend.save: mode='adapter' but the model has no LoRA params")
         self._reject_meta_params("save")
+        policy_state = gather_state_dict(self.model)
+        if mode == "adapter":
+            policy_state = {k: v for k, v in policy_state.items() if "lora_A" in k or "lora_B" in k}
         state: Dict[str, object] = {
-            "policy_state_dict": gather_state_dict(self.model),
+            "policy_state_dict": policy_state,
             "optimizer_state_dict": gather_optimizer_state_dict(self.model, self.optimizer),
             "optimizer_step_count": self._optimizer_step_count,
             "step": step,
+            "save_mode": mode,
         }
         if self.scheduler is not None:
             state["scheduler_state_dict"] = self.scheduler.state_dict()
@@ -310,27 +323,42 @@ class FSDPBackend(Remote):
         torch.save(state, os.path.join(path, "checkpoint.pt"))
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
-    def load(self, path: str) -> None:
-        """Restore the state written by :meth:`save`.
+    def load(self, path: str) -> int:
+        """Restore the state written by :meth:`save`; return the saved rollout step (0 if absent).
 
         Every rank runs this (the DCP set is a collective): each reads the
-        checkpoint from the shared filesystem to CPU, then tensors broadcast
-        from dist rank 0 and re-shard into the local model/optimizer state.
-        Identical checks on the identical file mean a bad path raises on
-        every rank together.
+        checkpoint from shared storage to CPU, then tensors broadcast from
+        dist rank 0 and re-shard into the local model/optimizer state.
+        Adapter-mode checkpoints load non-strict — only the LoRA keys are
+        present; the frozen base keeps the weights the bundle loaded.
         """
         self._reject_meta_params("load")
         checkpoint_path = os.path.join(path, "checkpoint.pt")
-        if not os.path.exists(checkpoint_path):
-            raise FileNotFoundError(f"FSDPBackend.load: checkpoint not found: {checkpoint_path}")
+        # Agree on visibility BEFORE the collectives: on multi-node, a rank
+        # whose node does not mount the checkpoint path would raise alone and
+        # strand the others in the DCP broadcast until the NCCL timeout.
+        exists = os.path.exists(checkpoint_path)
+        if dist.is_available() and dist.is_initialized():
+            verdicts: List[Optional[bool]] = [None] * dist.get_world_size()
+            dist.all_gather_object(verdicts, exists)
+            missing_on = [rank for rank, ok in enumerate(verdicts) if not ok]
+        else:
+            missing_on = [] if exists else [0]
+        if missing_on:
+            raise FileNotFoundError(
+                f"FSDPBackend.load: checkpoint not visible on rank(s) {missing_on}: {checkpoint_path} "
+                "(save_dir/load_dir must live on storage mounted on every node)"
+            )
         checkpoint = torch.load(checkpoint_path, map_location="cpu")
 
-        load_model_state_dict(self.model, checkpoint["policy_state_dict"])
+        strict = checkpoint.get("save_mode", "full") == "full"
+        load_model_state_dict(self.model, checkpoint["policy_state_dict"], strict=strict)
         load_optimizer_state_dict(self.model, self.optimizer, checkpoint["optimizer_state_dict"])
         if self.scheduler is not None and "scheduler_state_dict" in checkpoint:
             self.scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
         if checkpoint.get("optimizer_step_count") is not None:
             self._optimizer_step_count = int(checkpoint["optimizer_step_count"])
+        return int(checkpoint.get("step") or 0)
 
     def _reject_meta_params(self, op: str) -> None:
         """Fail fast on never-materialized params (meta-init bundles, e.g. hi3 80B).

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -170,6 +170,18 @@ class FSDPBackend(Remote):
         self.model: nn.Module = model
         self._optimizer_step_count: int = 0
         self._eval_ema_active: bool = False
+        # Checkpointed for export tooling: the LoRA fold needs scaling =
+        # alpha / rank, and alpha is not derivable from the weights.
+        active_lora = lora_cfg or ema_lora_cfg
+        self._lora_meta: Optional[Dict[str, object]] = (
+            {
+                "rank": int(active_lora.rank),
+                "alpha": int(active_lora.alpha),
+                "target_modules": list(active_lora.target_modules),
+            }
+            if active_lora is not None
+            else None
+        )
         # No-sync gradient accumulation (see set_grad_sync). Only active under
         # ZeRO-2 (reshard_after_forward=False); a no-op under ZeRO-3, where the
         # per-micro reshard/re-gather interacts badly with deferred sync.
@@ -311,6 +323,7 @@ class FSDPBackend(Remote):
             "optimizer_step_count": self._optimizer_step_count,
             "step": step,
             "save_mode": mode,
+            "lora_config": self._lora_meta,
         }
         if self.scheduler is not None:
             state["scheduler_state_dict"] = self.scheduler.state_dict()

--- a/unirl/train/fsdp_utils.py
+++ b/unirl/train/fsdp_utils.py
@@ -27,14 +27,19 @@ def gather_state_dict(model: nn.Module) -> StateDict:
     return _to_cpu_state_dict(full)
 
 
-def load_model_state_dict(model: nn.Module, state_dict: StateDict) -> None:
-    """Load a full state dict, broadcasting from rank 0 across ranks."""
+def load_model_state_dict(model: nn.Module, state_dict: StateDict, *, strict: bool = True) -> None:
+    """Load a full state dict, broadcasting from rank 0 across ranks.
+
+    ``strict=False`` loads a partial dict (adapter-only checkpoints): keys
+    absent from ``state_dict`` keep the model's current weights.
+    """
     from torch.distributed.checkpoint.state_dict import set_model_state_dict
 
     options = _build_state_dict_options(
         full_state_dict=True,
         broadcast_from_rank0=True,
         cpu_offload=False,
+        strict=strict,
     )
     try:
         set_model_state_dict(model, state_dict, options=options)

--- a/unirl/train/fsdp_utils.py
+++ b/unirl/train/fsdp_utils.py
@@ -42,6 +42,47 @@ def load_model_state_dict(model: nn.Module, state_dict: StateDict) -> None:
         set_model_state_dict(model, state_dict)
 
 
+def gather_optimizer_state_dict(model: nn.Module, optimizer: torch.optim.Optimizer) -> StateDict:
+    """Rank-0 DCP gather of optimizer state.  Full state on rank 0, empty on others.
+
+    All ranks must call this (the gather is a collective).  Values are full
+    (unsharded) CPU tensors keyed by parameter FQN — symmetric with
+    :func:`gather_state_dict`.  ``optimizer.state_dict()`` is NOT a substitute:
+    under FSDP2 its values are this rank's local DTensor shards.
+    """
+    from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
+
+    options = _build_state_dict_options(full_state_dict=True, cpu_offload=True)
+    try:
+        full = dict(get_optimizer_state_dict(model, optimizer, options=options))
+    except TypeError:
+        full = dict(get_optimizer_state_dict(model, optimizer))
+
+    if _current_rank() != 0:
+        return {}
+    return full
+
+
+def load_optimizer_state_dict(model: nn.Module, optimizer: torch.optim.Optimizer, state_dict: StateDict) -> None:
+    """Load a full optimizer state dict, broadcasting from rank 0 across ranks.
+
+    Pass the rank-0 dict from :func:`gather_optimizer_state_dict`; other ranks
+    pass ``{}`` (their input is ignored — tensors broadcast from rank 0 and
+    re-shard into each rank's local state).
+    """
+    from torch.distributed.checkpoint.state_dict import set_optimizer_state_dict
+
+    options = _build_state_dict_options(
+        full_state_dict=True,
+        broadcast_from_rank0=True,
+        cpu_offload=False,
+    )
+    try:
+        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict, options=options)
+    except TypeError:
+        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict)
+
+
 def local_view(tensor: Tensor) -> Tensor:
     """DTensor -> local shard.  Identity for non-DTensors."""
     if hasattr(tensor, "_local_tensor"):
@@ -276,8 +317,10 @@ def _global_clip_for_sharded_grads(
 __all__ = [
     "StateDict",
     "clip_grad_norm",
+    "gather_optimizer_state_dict",
     "gather_state_dict",
     "load_model_state_dict",
+    "load_optimizer_state_dict",
     "local_view",
     "is_materialized",
     "trainable_params",

--- a/unirl/train_ar.py
+++ b/unirl/train_ar.py
@@ -51,6 +51,7 @@ def main(cfg: DictConfig) -> None:
         save_interval=int(cfg.get("save_interval", 0)),
         save_dir=cfg.get("save_dir"),
         load_dir=cfg.get("load_dir"),
+        save_mode=str(cfg.get("save_mode", "full")),
     )
 
 

--- a/unirl/train_ar.py
+++ b/unirl/train_ar.py
@@ -48,6 +48,9 @@ def main(cfg: DictConfig) -> None:
     trainer.train(
         num_rollouts=int(cfg.get("num_rollouts", 100)),
         weight_sync_interval=int(cfg.get("weight_sync_interval", 1)),
+        save_interval=int(cfg.get("save_interval", 0)),
+        save_dir=cfg.get("save_dir"),
+        load_dir=cfg.get("load_dir"),
     )
 
 

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -43,6 +43,9 @@ def main(cfg: DictConfig) -> None:
     trainer.train(
         num_rollouts=int(cfg.get("num_rollouts", 100)),
         weight_sync_interval=int(cfg.get("weight_sync_interval", 1)),
+        save_interval=int(cfg.get("save_interval", 0)),
+        save_dir=cfg.get("save_dir"),
+        load_dir=cfg.get("load_dir"),
     )
 
 

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -46,6 +46,7 @@ def main(cfg: DictConfig) -> None:
         save_interval=int(cfg.get("save_interval", 0)),
         save_dir=cfg.get("save_dir"),
         load_dir=cfg.get("load_dir"),
+        save_mode=str(cfg.get("save_mode", "full")),
     )
 
 

--- a/unirl/train_unified_model.py
+++ b/unirl/train_unified_model.py
@@ -43,6 +43,9 @@ def main(cfg: DictConfig) -> None:
     trainer.train(
         num_rollouts=int(cfg.get("num_rollouts", 100)),
         weight_sync_interval=int(cfg.get("weight_sync_interval", 1)),
+        save_interval=int(cfg.get("save_interval", 0)),
+        save_dir=cfg.get("save_dir"),
+        load_dir=cfg.get("load_dir"),
     )
 
 

--- a/unirl/train_unified_model.py
+++ b/unirl/train_unified_model.py
@@ -46,6 +46,7 @@ def main(cfg: DictConfig) -> None:
         save_interval=int(cfg.get("save_interval", 0)),
         save_dir=cfg.get("save_dir"),
         load_dir=cfg.get("load_dir"),
+        save_mode=str(cfg.get("save_mode", "full")),
     )
 
 

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -58,65 +58,83 @@ matching `../train_<domain>.py` entrypoint composes the recipe and calls it.
 ## Checkpointing
 
 Available for the single-backend trainers (`DiffusionTrainer`, `ARTrainer`,
-`UnifiedModelTrainer`); `PETrainer` is not wired. A checkpoint bundles the full
-model `state_dict` (frozen base + LoRA adapters), the optimizer state (gathered
-full via DCP — not per-rank shards), the scheduler state, and the step counters
-(`step`, `optimizer_step_count`) — enough to resume training. Each one is
-written to `<save_dir>/checkpoint-<step>/checkpoint.pt`. Save and load are
-collectives (every rank participates in the gather/broadcast); only dist rank 0
-writes the file, and on load every rank reads it from the shared filesystem.
+`UnifiedModelTrainer`); `PETrainer` is not wired. A checkpoint bundles the
+model state (`save_mode=full`: frozen base + LoRA adapters; `save_mode=adapter`:
+LoRA keys only — MBs instead of GBs), the optimizer state (gathered full via
+DCP — not per-rank shards; it only ever covers the trainable params, so it is
+adapter-sized either way), the scheduler state, and the step counters (`step`,
+`optimizer_step_count`) — enough to resume training. Each one is written to
+`<save_dir>/checkpoint-<step>/checkpoint.pt`. Save and load are collectives
+(every rank participates in the gather/broadcast); only dist rank 0 writes the
+file, and on load every rank reads it.
+
+**Multi-node**: `save_dir` / `load_dir` must live on storage mounted on every
+node — the same contract the recipes already place on `PRETRAINED_MODEL` and
+data paths. A rank that cannot see the checkpoint fails fast on every rank at
+load (instead of stranding the others in the broadcast until the NCCL timeout).
 
 **Meta-init caveat**: full-state-dict checkpointing rejects bundles with
 never-materialized params — the hi3 80B recipe keeps frozen vae/vit on meta, so
 `UnifiedModelTrainer` checkpointing currently works only for fully-materialized
 bundles. Sharded DCP checkpointing is the planned follow-up.
 
-Driven by three top-level config keys, read by the entrypoints and forwarded to
+Driven by top-level config keys, read by the entrypoints and forwarded to
 `train(...)`:
 
 | Key | Default | Meaning |
 | --- | --- | --- |
 | `save_interval` | `0` | Save every N rollouts (and on the last); `0` disables saving. |
 | `save_dir` | `./checkpoints` | Output folder for `checkpoint-<step>/`, resolved on the driver (with Hydra's legacy chdir the default lands in the run output dir). |
-| `load_dir` | unset | A checkpoint dir to restore from before training starts; unset trains fresh. |
+| `save_mode` | `full` | `full` = whole model state; `adapter` = LoRA keys only (the frozen base reloads from the pretrained snapshot on resume). |
+| `load_dir` | unset | A checkpoint dir to restore and resume from; unset trains fresh. |
 
 These keys are not in the recipe YAMLs, so append them with Hydra's `+` syntax:
 
 ```bash
-# Save every 200 rollouts
+# Save every 200 rollouts (LoRA-only checkpoints)
 bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
     +save_interval=200 \
-    +save_dir=/path/to/checkpoints/sd3_trainside
+    +save_dir=/path/to/checkpoints/sd3_trainside \
+    +save_mode=adapter
 
-# Resume from a saved step (point load_dir at the checkpoint-<step> dir).
-# Use a FRESH save_dir: the loop counts from 0 again on resume, so the same
-# save_dir would overwrite the first run's checkpoint-<N> dirs.
+# Resume from checkpoint-500. num_rollouts is the TOTAL budget (here: rollouts
+# 500..699); the same save_dir is fine — checkpoint numbering continues.
 bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
+    num_rollouts=700 \
     +load_dir=/path/to/checkpoints/sd3_trainside/checkpoint-500 \
     +save_interval=200 \
-    +save_dir=/path/to/checkpoints/sd3_trainside_resumed
+    +save_dir=/path/to/checkpoints/sd3_trainside \
+    +save_mode=adapter
 ```
 
 `load_dir` restores model/optimizer/scheduler (plus the optimizer-step counter,
-so EMA decay schedules continue) and forces a weight sync into the rollout
-engine on the first rollout — but the rollout loop itself still counts from 0:
-step numbering, `training_progress`, and the data/noise schedule restart.
+so EMA decay schedules continue) and resumes the loop from the saved step:
+`training_progress` and the driver-authored x_T noise schedule continue, the
+data stream fast-forwards to the resume point (exact when `run.seed` is set —
+the shuffle is generator-seeded), and the first rollout force-syncs the
+restored adapter into the rollout engine (which booted with fresh weights).
+RNG state is not yet checkpointed — sampling noise after resume differs from
+an uninterrupted run.
 
 ### Export to Hugging Face format
 
 `checkpoint.pt` is a raw training checkpoint (PEFT-injected names, optimizer
-state), not a release artifact. `unirl/utils/export_hf.py` folds the LoRA delta
-into the base weights and writes a standard `save_pretrained` folder you can
+state), not a release artifact. The offline checkpoint toolset lives in
+`unirl/tools/` (the runtime counterpart for engine weight sync is
+`unirl/utils/peft_merge.py`): `export_hf` folds the LoRA delta into the base
+weights and writes a standard `save_pretrained` folder you can
 `from_pretrained` or `hf upload`:
 
 ```bash
-python -m unirl.utils.export_hf \
+python -m unirl.tools.export_hf \
     --checkpoint /path/to/checkpoints/sd3_trainside/checkpoint-500 \
     --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \
     --lora-alpha 64 \
     --output /path/to/sd3-grpo-hf
 ```
 
+Works with both checkpoint flavors: `save_mode=full` merges self-contained;
+`save_mode=adapter` folds the LoRA keys onto the freshly loaded base weights.
 `--lora-alpha` is `backend.lora_cfg.alpha` from the recipe (the checkpoint
 stores weights only; scaling = alpha / rank, rank inferred from the weights).
 AR models: `--library transformers`, no `--subfolder`. NFT runs can export the

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -113,8 +113,9 @@ so EMA decay schedules continue) and resumes the loop from the saved step:
 data stream fast-forwards to the resume point (exact when `run.seed` is set —
 the shuffle is generator-seeded), and the first rollout force-syncs the
 restored adapter into the rollout engine (which booted with fresh weights).
-RNG state is not yet checkpointed — sampling noise after resume differs from
-an uninterrupted run.
+The wandb run also continues: `trainer_state.json` (driver-written, beside
+`checkpoint.pt`) carries the run id and the `train/` step axis, and
+`_init_wandb` reattaches to that run instead of starting a fresh one.
 
 ### Export to Hugging Face format
 

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -89,23 +89,35 @@ Driven by top-level config keys, read by the entrypoints and forwarded to
 | `save_mode` | `full` | `full` = whole model state; `adapter` = LoRA keys only (the frozen base reloads from the pretrained snapshot on resume). |
 | `load_dir` | unset | A checkpoint dir to restore and resume from; unset trains fresh. |
 
-These keys are not in the recipe YAMLs, so append them with Hydra's `+` syntax:
+These keys are not in the recipe YAMLs, so append them with Hydra's `+` syntax.
+The whole lifecycle — train with saves, resume, fold the LoRA into the base and
+export to Hugging Face, share:
 
 ```bash
-# Save every 200 rollouts (LoRA-only checkpoints)
+# 1. Train, saving LoRA-only checkpoints every 200 rollouts
 bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
-    +save_interval=200 \
-    +save_dir=/path/to/checkpoints/sd3_trainside \
-    +save_mode=adapter
+    num_rollouts=500 \
+    +save_interval=200 +save_dir=/ckpts/sd3_run +save_mode=adapter
 
-# Resume from checkpoint-500. num_rollouts is the TOTAL budget (here: rollouts
-# 500..699); the same save_dir is fine — checkpoint numbering continues.
+# 2. Resume (after a preemption, or to extend the budget). num_rollouts is the
+#    TOTAL budget (here: rollouts 400..999); the same save_dir is fine —
+#    checkpoint numbering continues, and the wandb run reattaches.
 bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
-    num_rollouts=700 \
-    +load_dir=/path/to/checkpoints/sd3_trainside/checkpoint-500 \
-    +save_interval=200 \
-    +save_dir=/path/to/checkpoints/sd3_trainside \
-    +save_mode=adapter
+    num_rollouts=1000 \
+    +load_dir=/ckpts/sd3_run/checkpoint-400 \
+    +save_interval=200 +save_dir=/ckpts/sd3_run +save_mode=adapter
+
+# 3. Export: fold the LoRA into the base weights (scaling from the checkpoint's
+#    recorded lora_config) and write a standard save_pretrained folder
+python -m unirl.tools.export_hf \
+    --checkpoint /ckpts/sd3_run/checkpoint-1000 \
+    --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \
+    --output /ckpts/sd3_run/hf-1000
+
+# 4. Share / use
+hf upload <user>/<repo> /ckpts/sd3_run/hf-1000
+#   transformer = AutoModel.from_pretrained("<user>/<repo>", torch_dtype=torch.bfloat16)
+#   pipe = StableDiffusion3Pipeline.from_pretrained(base, transformer=transformer)
 ```
 
 `load_dir` restores model/optimizer/scheduler (plus the optimizer-step counter,
@@ -124,24 +136,14 @@ The wandb run also continues: `trainer_state.json` (driver-written, beside
 state), not a release artifact. The offline checkpoint toolset lives in
 `unirl/tools/` (the runtime counterpart for engine weight sync is
 `unirl/utils/peft_merge.py`): `export_hf` folds the LoRA delta into the base
-weights and writes a standard `save_pretrained` folder you can
-`from_pretrained` or `hf upload`:
-
-```bash
-python -m unirl.tools.export_hf \
-    --checkpoint /path/to/checkpoints/sd3_trainside/checkpoint-500 \
-    --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \
-    --output /path/to/sd3-grpo-hf
-```
+weights and writes a standard `save_pretrained` folder — step 3 above.
 
 Works with both checkpoint flavors: `save_mode=full` merges self-contained;
 `save_mode=adapter` folds the LoRA keys onto the freshly loaded base weights.
 The LoRA scaling comes from the `lora_config` recorded in the checkpoint;
 `--lora-alpha` overrides it (needed only for checkpoints predating the record).
 AR models: `--library transformers`, no `--subfolder`. NFT runs can export the
-EMA shadow adapter with `--adapter old`. Load the SD3 result back with
-`AutoModel.from_pretrained(out_dir)` and plug it into the base pipeline via
-`StableDiffusion3Pipeline.from_pretrained(base, transformer=...)`.
+EMA shadow adapter with `--adapter old`.
 
 ## Gotchas
 

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -64,7 +64,7 @@ full via DCP — not per-rank shards), the scheduler state, and the step counter
 (`step`, `optimizer_step_count`) — enough to resume training. Each one is
 written to `<save_dir>/checkpoint-<step>/checkpoint.pt`. Save and load are
 collectives (every rank participates in the gather/broadcast); only dist rank 0
-reads or writes the file.
+writes the file, and on load every rank reads it from the shared filesystem.
 
 **Meta-init caveat**: full-state-dict checkpointing rejects bundles with
 never-materialized params — the hi3 80B recipe keeps frozen vae/vit on meta, so
@@ -101,6 +101,28 @@ bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
 so EMA decay schedules continue) and forces a weight sync into the rollout
 engine on the first rollout — but the rollout loop itself still counts from 0:
 step numbering, `training_progress`, and the data/noise schedule restart.
+
+### Export to Hugging Face format
+
+`checkpoint.pt` is a raw training checkpoint (PEFT-injected names, optimizer
+state), not a release artifact. `unirl/utils/export_hf.py` folds the LoRA delta
+into the base weights and writes a standard `save_pretrained` folder you can
+`from_pretrained` or `hf upload`:
+
+```bash
+python -m unirl.utils.export_hf \
+    --checkpoint /path/to/checkpoints/sd3_trainside/checkpoint-500 \
+    --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \
+    --lora-alpha 64 \
+    --output /path/to/sd3-grpo-hf
+```
+
+`--lora-alpha` is `backend.lora_cfg.alpha` from the recipe (the checkpoint
+stores weights only; scaling = alpha / rank, rank inferred from the weights).
+AR models: `--library transformers`, no `--subfolder`. NFT runs can export the
+EMA shadow adapter with `--adapter old`. Load the SD3 result back with
+`AutoModel.from_pretrained(out_dir)` and plug it into the base pipeline via
+`StableDiffusion3Pipeline.from_pretrained(base, transformer=...)`.
 
 ## Gotchas
 

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -55,11 +55,47 @@ The four trainers are three shapes:
 remotes inside a `placement(...)` scope and implements `train_step` + `train`; the
 matching `../train_<domain>.py` entrypoint composes the recipe and calls it.
 
+## Checkpointing
+
+Available for the single-backend trainers (`DiffusionTrainer`, `ARTrainer`,
+`UnifiedModelTrainer`); `PETrainer` is not wired. A checkpoint bundles the full
+model `state_dict` (frozen base + LoRA adapters), the optimizer state, and the
+scheduler state — enough to resume training. Each one is written to
+`<save_dir>/checkpoint-<step>/checkpoint.pt`.
+
+Driven by three top-level config keys, read by the entrypoints and forwarded to
+`train(...)`:
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `save_interval` | `0` | Save every N rollouts (and on the last); `0` disables saving. |
+| `save_dir` | `./checkpoints` | Output folder for `checkpoint-<step>/`. |
+| `load_dir` | unset | A checkpoint dir to restore from before training starts; unset trains fresh. |
+
+These keys are not in the recipe YAMLs, so append them with Hydra's `+` syntax:
+
+```bash
+# Save every 200 rollouts
+bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
+    +save_interval=200 \
+    +save_dir=/path/to/checkpoints/sd3_trainside
+
+# Resume from a saved step (point load_dir at the checkpoint-<step> dir)
+bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
+    +load_dir=/path/to/checkpoints/sd3_trainside/checkpoint-500 \
+    +save_interval=200 \
+    +save_dir=/path/to/checkpoints/sd3_trainside
+```
+
+`load_dir` only restores model/optimizer/scheduler — the rollout loop still
+counts from 0, so step numbering and saved filenames restart.
+
 ## Gotchas
 
 - **The reference loop is intentionally minimal** — `num_updates_per_batch` multi-epoch
-  replay, **checkpoint cadence, and eval cadence are deferred**. `FSDPBackend.save()/load()`
-  exist as primitives, but the loop never schedules them; there is no resume entrypoint yet.
+  replay and **eval cadence are deferred**. Checkpointing is wired (see
+  [Checkpointing](#checkpointing)) for the single-backend trainers; `PETrainer` (two
+  backends) is not covered.
 - **`layout` only branches on `"separate"`** (`"colocate"` == `"colocated"`). The
   trainside direct-sampling engine cannot live on a `separate` slab — `_build_rollout`
   raises (it needs the pipeline as a local sibling).

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -62,8 +62,9 @@ Available for the single-backend trainers (`DiffusionTrainer`, `ARTrainer`,
 model state (`save_mode=full`: frozen base + LoRA adapters; `save_mode=adapter`:
 LoRA keys only — MBs instead of GBs), the optimizer state (gathered full via
 DCP — not per-rank shards; it only ever covers the trainable params, so it is
-adapter-sized either way), the scheduler state, and the step counters (`step`,
-`optimizer_step_count`) — enough to resume training. Each one is written to
+adapter-sized either way), the scheduler state, the step counters (`step`,
+`optimizer_step_count`), and the LoRA config (rank / alpha / target_modules —
+export tooling reads its scaling from it) — enough to resume training. Each one is written to
 `<save_dir>/checkpoint-<step>/checkpoint.pt`. Save and load are collectives
 (every rank participates in the gather/broadcast); only dist rank 0 writes the
 file, and on load every rank reads it.
@@ -130,14 +131,13 @@ weights and writes a standard `save_pretrained` folder you can
 python -m unirl.tools.export_hf \
     --checkpoint /path/to/checkpoints/sd3_trainside/checkpoint-500 \
     --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \
-    --lora-alpha 64 \
     --output /path/to/sd3-grpo-hf
 ```
 
 Works with both checkpoint flavors: `save_mode=full` merges self-contained;
 `save_mode=adapter` folds the LoRA keys onto the freshly loaded base weights.
-`--lora-alpha` is `backend.lora_cfg.alpha` from the recipe (the checkpoint
-stores weights only; scaling = alpha / rank, rank inferred from the weights).
+The LoRA scaling comes from the `lora_config` recorded in the checkpoint;
+`--lora-alpha` overrides it (needed only for checkpoints predating the record).
 AR models: `--library transformers`, no `--subfolder`. NFT runs can export the
 EMA shadow adapter with `--adapter old`. Load the SD3 result back with
 `AutoModel.from_pretrained(out_dir)` and plug it into the base pipeline via

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -59,9 +59,17 @@ matching `../train_<domain>.py` entrypoint composes the recipe and calls it.
 
 Available for the single-backend trainers (`DiffusionTrainer`, `ARTrainer`,
 `UnifiedModelTrainer`); `PETrainer` is not wired. A checkpoint bundles the full
-model `state_dict` (frozen base + LoRA adapters), the optimizer state, and the
-scheduler state — enough to resume training. Each one is written to
-`<save_dir>/checkpoint-<step>/checkpoint.pt`.
+model `state_dict` (frozen base + LoRA adapters), the optimizer state (gathered
+full via DCP — not per-rank shards), the scheduler state, and the step counters
+(`step`, `optimizer_step_count`) — enough to resume training. Each one is
+written to `<save_dir>/checkpoint-<step>/checkpoint.pt`. Save and load are
+collectives (every rank participates in the gather/broadcast); only dist rank 0
+reads or writes the file.
+
+**Meta-init caveat**: full-state-dict checkpointing rejects bundles with
+never-materialized params — the hi3 80B recipe keeps frozen vae/vit on meta, so
+`UnifiedModelTrainer` checkpointing currently works only for fully-materialized
+bundles. Sharded DCP checkpointing is the planned follow-up.
 
 Driven by three top-level config keys, read by the entrypoints and forwarded to
 `train(...)`:
@@ -69,7 +77,7 @@ Driven by three top-level config keys, read by the entrypoints and forwarded to
 | Key | Default | Meaning |
 | --- | --- | --- |
 | `save_interval` | `0` | Save every N rollouts (and on the last); `0` disables saving. |
-| `save_dir` | `./checkpoints` | Output folder for `checkpoint-<step>/`. |
+| `save_dir` | `./checkpoints` | Output folder for `checkpoint-<step>/`, resolved on the driver (with Hydra's legacy chdir the default lands in the run output dir). |
 | `load_dir` | unset | A checkpoint dir to restore from before training starts; unset trains fresh. |
 
 These keys are not in the recipe YAMLs, so append them with Hydra's `+` syntax:
@@ -80,15 +88,19 @@ bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
     +save_interval=200 \
     +save_dir=/path/to/checkpoints/sd3_trainside
 
-# Resume from a saved step (point load_dir at the checkpoint-<step> dir)
+# Resume from a saved step (point load_dir at the checkpoint-<step> dir).
+# Use a FRESH save_dir: the loop counts from 0 again on resume, so the same
+# save_dir would overwrite the first run's checkpoint-<N> dirs.
 bash examples/run_experiment_single_node.sh diffusion/sd3_trainside \
     +load_dir=/path/to/checkpoints/sd3_trainside/checkpoint-500 \
     +save_interval=200 \
-    +save_dir=/path/to/checkpoints/sd3_trainside
+    +save_dir=/path/to/checkpoints/sd3_trainside_resumed
 ```
 
-`load_dir` only restores model/optimizer/scheduler — the rollout loop still
-counts from 0, so step numbering and saved filenames restart.
+`load_dir` restores model/optimizer/scheduler (plus the optimizer-step counter,
+so EMA decay schedules continue) and forces a weight sync into the rollout
+engine on the first rollout — but the rollout loop itself still counts from 0:
+step numbering, `training_progress`, and the data/noise schedule restart.
 
 ## Gotchas
 

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -265,8 +265,6 @@ class ARTrainer(BaseTrainer):
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, result, mean_reward, logger=logger)
                 if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
                     self.evaluate(rollout_id=rollout_id)
-                self.maybe_save_checkpoint(
-                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir
-                )
+                self.maybe_save_checkpoint(rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir)
         finally:
             self._finish_wandb()

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -215,16 +215,29 @@ class ARTrainer(BaseTrainer):
             self.wandb_logger.log_eval(rollout_id + 1, {"acc": acc})
         return acc
 
-    def train(self, *, num_rollouts: int, weight_sync_interval: int = 1) -> None:
+    def train(
+        self,
+        *,
+        num_rollouts: int,
+        weight_sync_interval: int = 1,
+        save_interval: int = 0,
+        save_dir: Optional[str] = None,
+        load_dir: Optional[str] = None,
+    ) -> None:
         """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
 
         ``weight_sync_interval``: sync the adapter into the engine every N
         rollouts (fused into ``train_step``'s generate; no-op trainside).
 
-        Deferred: ``num_updates_per_batch`` multi-epoch replay, checkpoint /
-        eval cadence.
+        ``save_interval``: write a checkpoint every N rollouts (and on the last
+        one); ``0`` disables it. ``save_dir`` is the output folder (defaults to
+        ``./checkpoints``). ``load_dir``: restore from a checkpoint directory
+        before training (``None`` starts fresh).
+
+        Deferred: ``num_updates_per_batch`` multi-epoch replay, eval cadence.
         """
         interval = max(1, weight_sync_interval)
+        self.maybe_load_checkpoint(load_dir)
         self._init_wandb(
             num_rollouts=num_rollouts,
             extra={"adv_normalization_scope": self.adv_normalization_scope},
@@ -255,5 +268,8 @@ class ARTrainer(BaseTrainer):
                 )
                 if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
                     self.evaluate(rollout_id=rollout_id)
+                self.maybe_save_checkpoint(
+                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir
+                )
         finally:
             self._finish_wandb()

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -228,6 +228,7 @@ class ARTrainer(BaseTrainer):
         save_interval: int = 0,
         save_dir: Optional[str] = None,
         load_dir: Optional[str] = None,
+        save_mode: str = "full",
     ) -> None:
         """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
 
@@ -236,13 +237,20 @@ class ARTrainer(BaseTrainer):
 
         ``save_interval``: write a checkpoint every N rollouts (and on the last
         one); ``0`` disables it. ``save_dir`` is the output folder (defaults to
-        ``./checkpoints``). ``load_dir``: restore from a checkpoint directory
-        before training (``None`` starts fresh).
+        ``./checkpoints``); ``save_mode="adapter"`` keeps only the LoRA keys.
+        ``load_dir``: restore from a checkpoint directory and RESUME from its
+        saved step — ``num_rollouts`` is the TOTAL budget.
 
         Deferred: ``num_updates_per_batch`` multi-epoch replay, eval cadence.
         """
         interval = max(1, weight_sync_interval)
-        resumed = self.maybe_load_checkpoint(load_dir)
+        start_rollout = self.maybe_load_checkpoint(load_dir, num_rollouts=num_rollouts)
+        resumed = bool(load_dir)
+        # Fast-forward the data stream to the resume point — exact when
+        # run.seed is set (deterministic shuffle); with seed=null the stream
+        # is non-reproducible anyway.
+        for _ in range(start_rollout):
+            self.data_source.get_samples(self.batch_size)
         self._init_wandb(
             num_rollouts=num_rollouts,
             extra={"adv_normalization_scope": self.adv_normalization_scope},
@@ -250,14 +258,16 @@ class ARTrainer(BaseTrainer):
         try:
             if self.eval_interval > 0:
                 self.evaluate(rollout_id=-1)  # baseline AIME accuracy, logged at eval step 0
-            for rollout_id in range(num_rollouts):
+            for rollout_id in range(start_rollout, num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet) —
-                # unless resuming: the engine booted with fresh weights and
-                # needs the restored adapter before its first generate.
-                sync_weights = (rollout_id > 0 or resumed) and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet). On
+                # resume, force the first sync — the engine booted with fresh
+                # weights and needs the restored adapter before generate.
+                sync_weights = (rollout_id > 0 and rollout_id % interval == 0) or (
+                    resumed and rollout_id == start_rollout
+                )
                 result, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,
@@ -267,6 +277,8 @@ class ARTrainer(BaseTrainer):
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, result, mean_reward, logger=logger)
                 if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
                     self.evaluate(rollout_id=rollout_id)
-                self.maybe_save_checkpoint(rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir)
+                self.maybe_save_checkpoint(
+                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir, save_mode=save_mode
+                )
         finally:
             self._finish_wandb()

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -242,7 +242,7 @@ class ARTrainer(BaseTrainer):
         Deferred: ``num_updates_per_batch`` multi-epoch replay, eval cadence.
         """
         interval = max(1, weight_sync_interval)
-        self.maybe_load_checkpoint(load_dir)
+        resumed = self.maybe_load_checkpoint(load_dir)
         self._init_wandb(
             num_rollouts=num_rollouts,
             extra={"adv_normalization_scope": self.adv_normalization_scope},
@@ -254,8 +254,10 @@ class ARTrainer(BaseTrainer):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet).
-                sync_weights = rollout_id > 0 and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet) —
+                # unless resuming: the engine booted with fresh weights and
+                # needs the restored adapter before its first generate.
+                sync_weights = (rollout_id > 0 or resumed) and rollout_id % interval == 0
                 result, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -265,7 +265,8 @@ class BaseTrainer:
 
         ``save_interval <= 0`` disables saving. Writes the backend state to
         ``<save_dir>/checkpoint-<step>/checkpoint.pt`` (``save_dir`` defaults
-        to ``./checkpoints``).
+        to ``./checkpoints``). Paths resolve to absolute here, on the driver —
+        the backend runs in Ray workers whose CWD differs from the driver's.
         """
         if save_interval <= 0:
             return
@@ -273,14 +274,23 @@ class BaseTrainer:
         # Save on the interval, and always on the final rollout.
         if step % save_interval != 0 and step < num_rollouts:
             return
-        base_dir = save_dir or os.path.join(os.getcwd(), "checkpoints")
+        base_dir = os.path.abspath(save_dir) if save_dir else os.path.join(os.getcwd(), "checkpoints")
         path = os.path.join(base_dir, f"checkpoint-{step}")
         logger.info("Saving checkpoint at rollout %d/%d -> %s", step, num_rollouts, path)
-        self.backend.save(path)
+        self.backend.save(path, step=step)
 
-    def maybe_load_checkpoint(self, load_dir: Optional[str]) -> None:
-        """Restore model/optimizer/scheduler from ``load_dir`` before training (skip if empty)."""
+    def maybe_load_checkpoint(self, load_dir: Optional[str]) -> bool:
+        """Restore model/optimizer/scheduler from ``load_dir`` before training.
+
+        Returns True when a checkpoint was restored — callers use it to force a
+        weight sync into the rollout engine on the first rollout (the restored
+        adapter is no longer ~0, so the engine's fresh-load weights are stale).
+        No-op returning False when ``load_dir`` is empty. Resolved to an
+        absolute path on the driver (worker CWDs differ).
+        """
         if not load_dir:
-            return
+            return False
+        load_dir = os.path.abspath(load_dir)
         logger.info("Loading checkpoint from %s", load_dir)
         self.backend.load(load_dir)
+        return True

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import logging
 import os
 from typing import Any, Dict, List, Optional
@@ -89,6 +90,10 @@ class BaseTrainer:
 
         self.logging_cfg = logging_cfg
         self.wandb_logger = UniRLWandBLogger(enabled=False)
+        # Driver-side state from a resumed checkpoint's trainer_state.json
+        # (wandb run id / step axis); populated by maybe_load_checkpoint,
+        # consumed by _init_wandb. Empty for fresh runs.
+        self._resume_state: Dict[str, Any] = {}
 
         # Reclaim per-rollout transport buffers after every train_step, centrally,
         # so each subclass train loop doesn't have to remember to.
@@ -187,6 +192,8 @@ class BaseTrainer:
             media_max_items=int(cfg.get("media_max_items", 8)),
             media_log_interval=int(cfg.get("media_log_interval", 1)),
             enabled=report,
+            run_id=self._resume_state.get("wandb_run_id"),
+            optimizer_step=int(self._resume_state.get("optimizer_step") or 0),
         )
         if self.wandb_logger.initialized:
             logger.info("WandB initialized: project=%s run=%s", project, cfg.get("run_name"))
@@ -288,6 +295,11 @@ class BaseTrainer:
         path = os.path.join(base_dir, f"checkpoint-{step}")
         logger.info("Saving checkpoint at rollout %d/%d -> %s", step, num_rollouts, path)
         self.backend.save(path, step=step, mode=save_mode)
+        # Driver-owned state rides beside the worker-written checkpoint.pt:
+        # the wandb run id + train/ step axis let a resume append to the SAME
+        # wandb run instead of starting a fresh, misaligned one.
+        with open(os.path.join(path, "trainer_state.json"), "w") as f:
+            json.dump({"wandb_run_id": self.wandb_logger.run_id, "optimizer_step": self.wandb_logger.optimizer_step}, f)
 
     def maybe_load_checkpoint(self, load_dir: Optional[str], *, num_rollouts: Optional[int] = None) -> int:
         """Restore training state from ``load_dir``; return the rollout step to resume from.
@@ -305,6 +317,10 @@ class BaseTrainer:
         if isinstance(result, list):  # BROADCAST dispatch collects one result per worker
             result = result[0]
         start = int(result or 0)
+        state_path = os.path.join(load_dir, "trainer_state.json")
+        if os.path.exists(state_path):
+            with open(state_path) as f:
+                self._resume_state = json.load(f)
         logger.info("Checkpoint restored; resuming at rollout %d", start)
         if num_rollouts is not None and start >= num_rollouts:
             logger.warning(

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -268,13 +268,15 @@ class BaseTrainer:
         *,
         save_interval: int,
         save_dir: Optional[str],
+        save_mode: str = "full",
     ) -> None:
         """Save every ``save_interval`` rollouts (and on the last one).
 
         ``save_interval <= 0`` disables saving. Writes the backend state to
         ``<save_dir>/checkpoint-<step>/checkpoint.pt`` (``save_dir`` defaults
-        to ``./checkpoints``). Paths resolve to absolute here, on the driver —
-        the backend runs in Ray workers whose CWD differs from the driver's.
+        to ``./checkpoints``; ``save_mode="adapter"`` keeps only the LoRA keys).
+        Paths resolve to absolute here, on the driver — the backend runs in
+        Ray workers whose CWD differs from the driver's.
         """
         if save_interval <= 0:
             return
@@ -285,20 +287,29 @@ class BaseTrainer:
         base_dir = os.path.abspath(save_dir) if save_dir else os.path.join(os.getcwd(), "checkpoints")
         path = os.path.join(base_dir, f"checkpoint-{step}")
         logger.info("Saving checkpoint at rollout %d/%d -> %s", step, num_rollouts, path)
-        self.backend.save(path, step=step)
+        self.backend.save(path, step=step, mode=save_mode)
 
-    def maybe_load_checkpoint(self, load_dir: Optional[str]) -> bool:
-        """Restore model/optimizer/scheduler from ``load_dir`` before training.
+    def maybe_load_checkpoint(self, load_dir: Optional[str], *, num_rollouts: Optional[int] = None) -> int:
+        """Restore training state from ``load_dir``; return the rollout step to resume from.
 
-        Returns True when a checkpoint was restored — callers use it to force a
-        weight sync into the rollout engine on the first rollout (the restored
-        adapter is no longer ~0, so the engine's fresh-load weights are stale).
-        No-op returning False when ``load_dir`` is empty. Resolved to an
-        absolute path on the driver (worker CWDs differ).
+        Returns 0 for a fresh run (``load_dir`` empty) or a checkpoint that
+        predates step recording. Restores model/optimizer/scheduler plus the
+        optimizer-step counter; the trainer loop continues from the returned
+        step. Resolved to an absolute path on the driver (worker CWDs differ).
         """
         if not load_dir:
-            return False
+            return 0
         load_dir = os.path.abspath(load_dir)
         logger.info("Loading checkpoint from %s", load_dir)
-        self.backend.load(load_dir)
-        return True
+        result = self.backend.load(load_dir)
+        if isinstance(result, list):  # BROADCAST dispatch collects one result per worker
+            result = result[0]
+        start = int(result or 0)
+        logger.info("Checkpoint restored; resuming at rollout %d", start)
+        if num_rollouts is not None and start >= num_rollouts:
+            logger.warning(
+                "Checkpoint step %d >= num_rollouts %d — nothing left to train (num_rollouts is the TOTAL budget).",
+                start,
+                num_rollouts,
+            )
+        return start

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from omegaconf import DictConfig
@@ -257,3 +258,37 @@ class BaseTrainer:
         """Close the wandb run if one is open."""
         if self.wandb_logger is not None:
             self.wandb_logger.finish()
+
+    # ---- checkpointing (shared by single-backend trainers) -----------------
+
+    def maybe_save_checkpoint(
+        self,
+        rollout_id: int,
+        num_rollouts: int,
+        *,
+        save_interval: int,
+        save_dir: Optional[str],
+    ) -> None:
+        """Save every ``save_interval`` rollouts (and on the last one).
+
+        ``save_interval <= 0`` disables saving. Writes the backend state to
+        ``<save_dir>/checkpoint-<step>/checkpoint.pt`` (``save_dir`` defaults
+        to ``./checkpoints``).
+        """
+        if save_interval <= 0:
+            return
+        step = rollout_id + 1
+        # Save on the interval, and always on the final rollout.
+        if step % save_interval != 0 and step < num_rollouts:
+            return
+        base_dir = save_dir or os.path.join(os.getcwd(), "checkpoints")
+        path = os.path.join(base_dir, f"checkpoint-{step}")
+        logger.info("Saving checkpoint at rollout %d/%d -> %s", step, num_rollouts, path)
+        self.backend.save(path)
+
+    def maybe_load_checkpoint(self, load_dir: Optional[str]) -> None:
+        """Restore model/optimizer/scheduler from ``load_dir`` before training (skip if empty)."""
+        if not load_dir:
+            return
+        logger.info("Loading checkpoint from %s", load_dir)
+        self.backend.load(load_dir)

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -404,8 +404,6 @@ class DiffusionTrainer(BaseTrainer):
                     rollout_id=rollout_id,
                 )
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, result, mean_reward, logger=logger)
-                self.maybe_save_checkpoint(
-                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir
-                )
+                self.maybe_save_checkpoint(rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir)
         finally:
             self._finish_wandb()

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -457,17 +457,27 @@ class DiffusionTrainer(BaseTrainer):
         self._log_rollout(rollout_id, result, resp, step_time_s=time.perf_counter() - t0)
         return result, mean_reward
 
-    def train(self, *, num_rollouts: int, weight_sync_interval: int = 1) -> None:
+    def train(
+        self,
+        *,
+        num_rollouts: int,
+        weight_sync_interval: int = 1,
+        save_interval: int = 0,
+        save_dir: Optional[str] = None,
+        load_dir: Optional[str] = None,
+    ) -> None:
         """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
 
         ``weight_sync_interval``: sync the adapter into the engine every N
         rollouts (fused into ``train_step``'s generate; no-op trainside).
 
-        Deferred (out of scope for the first runnable trainer):
-        ``num_updates_per_batch`` multi-epoch replay, checkpoint cadence,
-        evaluation cadence.
+        ``save_interval``: write a checkpoint every N rollouts (and on the last
+        one); ``0`` disables it. ``save_dir`` is the output folder (defaults to
+        ``./checkpoints``). ``load_dir``: restore from a checkpoint directory
+        before training (``None`` starts fresh).
         """
         interval = max(1, weight_sync_interval)
+        self.maybe_load_checkpoint(load_dir)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
             for rollout_id in range(num_rollouts):
@@ -490,6 +500,9 @@ class DiffusionTrainer(BaseTrainer):
                     result.loss,
                     result.grad_norm,
                     result.lr,
+                )
+                self.maybe_save_checkpoint(
+                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir
                 )
         finally:
             self._finish_wandb()

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -388,15 +388,17 @@ class DiffusionTrainer(BaseTrainer):
         before training (``None`` starts fresh).
         """
         interval = max(1, weight_sync_interval)
-        self.maybe_load_checkpoint(load_dir)
+        resumed = self.maybe_load_checkpoint(load_dir)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
             for rollout_id in range(num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet).
-                sync_weights = rollout_id > 0 and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet) —
+                # unless resuming: the engine booted with fresh weights and
+                # needs the restored adapter before its first generate.
+                sync_weights = (rollout_id > 0 or resumed) and rollout_id % interval == 0
                 result, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -376,6 +376,7 @@ class DiffusionTrainer(BaseTrainer):
         save_interval: int = 0,
         save_dir: Optional[str] = None,
         load_dir: Optional[str] = None,
+        save_mode: str = "full",
     ) -> None:
         """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
 
@@ -384,21 +385,31 @@ class DiffusionTrainer(BaseTrainer):
 
         ``save_interval``: write a checkpoint every N rollouts (and on the last
         one); ``0`` disables it. ``save_dir`` is the output folder (defaults to
-        ``./checkpoints``). ``load_dir``: restore from a checkpoint directory
-        before training (``None`` starts fresh).
+        ``./checkpoints``); ``save_mode="adapter"`` keeps only the LoRA keys.
+        ``load_dir``: restore from a checkpoint directory and RESUME from its
+        saved step — ``num_rollouts`` is the TOTAL budget, so resuming
+        checkpoint-500 with ``num_rollouts=600`` runs rollouts 500..599.
         """
         interval = max(1, weight_sync_interval)
-        resumed = self.maybe_load_checkpoint(load_dir)
+        start_rollout = self.maybe_load_checkpoint(load_dir, num_rollouts=num_rollouts)
+        resumed = bool(load_dir)
+        # Fast-forward the data stream to the resume point — exact when
+        # run.seed is set (deterministic shuffle); with seed=null the stream
+        # is non-reproducible anyway.
+        for _ in range(start_rollout):
+            self.data_source.get_samples(self.batch_size)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
-            for rollout_id in range(num_rollouts):
+            for rollout_id in range(start_rollout, num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet) —
-                # unless resuming: the engine booted with fresh weights and
-                # needs the restored adapter before its first generate.
-                sync_weights = (rollout_id > 0 or resumed) and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet). On
+                # resume, force the first sync — the engine booted with fresh
+                # weights and needs the restored adapter before generate.
+                sync_weights = (rollout_id > 0 and rollout_id % interval == 0) or (
+                    resumed and rollout_id == start_rollout
+                )
                 result, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,
@@ -406,6 +417,8 @@ class DiffusionTrainer(BaseTrainer):
                     rollout_id=rollout_id,
                 )
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, result, mean_reward, logger=logger)
-                self.maybe_save_checkpoint(rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir)
+                self.maybe_save_checkpoint(
+                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir, save_mode=save_mode
+                )
         finally:
             self._finish_wandb()

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -695,32 +695,42 @@ class UnifiedModelTrainer(BaseTrainer):
         save_interval: int = 0,
         save_dir: Optional[str] = None,
         load_dir: Optional[str] = None,
+        save_mode: str = "full",
     ) -> None:
         """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
 
         ``save_interval``: write a checkpoint every N rollouts (and on the last
-        one); ``0`` disables it. ``save_dir`` defaults to ``./checkpoints``.
-        ``load_dir``: restore from a checkpoint directory before training.
+        one); ``0`` disables it. ``save_dir`` defaults to ``./checkpoints``;
+        ``save_mode="adapter"`` keeps only the LoRA keys. ``load_dir``: restore
+        from a checkpoint directory and RESUME from its saved step —
+        ``num_rollouts`` is the TOTAL budget.
         """
         interval = max(1, weight_sync_interval)
-        resumed = self.maybe_load_checkpoint(load_dir)
+        start_rollout = self.maybe_load_checkpoint(load_dir, num_rollouts=num_rollouts)
+        resumed = bool(load_dir)
+        # Fast-forward the data stream to the resume point — exact when
+        # run.seed is set (deterministic shuffle); with seed=null the stream
+        # is non-reproducible anyway.
+        for _ in range(start_rollout):
+            self.data_source.get_samples(self.batch_size)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
-            for rollout_id in range(num_rollouts):
+            for rollout_id in range(start_rollout, num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 self._dump_rollout_id = rollout_id  # picked up by train_step's dump
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet) — unless
-                # resuming (the engine booted with fresh weights and needs the
-                # restored adapter before its first generate). The HI3_SYNC_FIRST
-                # env forces a sync on rollout 0 too — a debug knob to exercise the
-                # LoRA-sync path early (cheaply) without a full extra rollout; the
-                # rollout-0 adapter is ~0 but that's fine for testing the
-                # register→activate mechanism.
-                sync_weights = (
-                    rollout_id > 0 or resumed or bool(os.environ.get("HI3_SYNC_FIRST"))
-                ) and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet). On
+                # resume, force the first sync — the engine booted with fresh
+                # weights and needs the restored adapter before generate. The
+                # HI3_SYNC_FIRST env forces a sync on rollout 0 too — a debug knob
+                # to exercise the LoRA-sync path early (cheaply) without a full
+                # extra rollout; the rollout-0 adapter is ~0 but that's fine for
+                # testing the register→activate mechanism.
+                force_sync = (resumed and rollout_id == start_rollout) or (
+                    rollout_id == 0 and bool(os.environ.get("HI3_SYNC_FIRST"))
+                )
+                sync_weights = force_sync or (rollout_id > 0 and rollout_id % interval == 0)
                 results, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,
@@ -733,7 +743,9 @@ class UnifiedModelTrainer(BaseTrainer):
                 # logp convention (temperature / top-k-p filtering / full-vs-renorm
                 # softmax) doesn't match vLLM's sampler.
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, results, mean_reward, logger=logger)
-                self.maybe_save_checkpoint(rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir)
+                self.maybe_save_checkpoint(
+                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir, save_mode=save_mode
+                )
         finally:
             self._finish_wandb()
 

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -703,7 +703,7 @@ class UnifiedModelTrainer(BaseTrainer):
         ``load_dir``: restore from a checkpoint directory before training.
         """
         interval = max(1, weight_sync_interval)
-        self.maybe_load_checkpoint(load_dir)
+        resumed = self.maybe_load_checkpoint(load_dir)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
             for rollout_id in range(num_rollouts):
@@ -711,12 +711,16 @@ class UnifiedModelTrainer(BaseTrainer):
                 self._dump_rollout_id = rollout_id  # picked up by train_step's dump
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet). The
-                # HI3_SYNC_FIRST env forces a sync on rollout 0 too — a debug knob to
-                # exercise the LoRA-sync path early (cheaply) without a full extra
-                # rollout; the rollout-0 adapter is ~0 but that's fine for testing
-                # the register→activate mechanism.
-                sync_weights = (rollout_id > 0 or os.environ.get("HI3_SYNC_FIRST")) and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet) — unless
+                # resuming (the engine booted with fresh weights and needs the
+                # restored adapter before its first generate). The HI3_SYNC_FIRST
+                # env forces a sync on rollout 0 too — a debug knob to exercise the
+                # LoRA-sync path early (cheaply) without a full extra rollout; the
+                # rollout-0 adapter is ~0 but that's fine for testing the
+                # register→activate mechanism.
+                sync_weights = (
+                    rollout_id > 0 or resumed or bool(os.environ.get("HI3_SYNC_FIRST"))
+                ) and rollout_id % interval == 0
                 results, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -729,9 +729,7 @@ class UnifiedModelTrainer(BaseTrainer):
                 # logp convention (temperature / top-k-p filtering / full-vs-renorm
                 # softmax) doesn't match vLLM's sampler.
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, results, mean_reward, logger=logger)
-                self.maybe_save_checkpoint(
-                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir
-                )
+                self.maybe_save_checkpoint(rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir)
         finally:
             self._finish_wandb()
 

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -675,9 +675,23 @@ class UnifiedModelTrainer(BaseTrainer):
         except Exception as exc:  # noqa: BLE001 — dump must never break training
             logger.warning("[HI3-DUMP] rollout %d dump failed (non-fatal): %s", rollout_id, exc)
 
-    def train(self, *, num_rollouts: int, weight_sync_interval: int = 1) -> None:
-        """Minimal training loop: ``num_rollouts`` iterations of ``train_step``."""
+    def train(
+        self,
+        *,
+        num_rollouts: int,
+        weight_sync_interval: int = 1,
+        save_interval: int = 0,
+        save_dir: Optional[str] = None,
+        load_dir: Optional[str] = None,
+    ) -> None:
+        """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
+
+        ``save_interval``: write a checkpoint every N rollouts (and on the last
+        one); ``0`` disables it. ``save_dir`` defaults to ``./checkpoints``.
+        ``load_dir``: restore from a checkpoint directory before training.
+        """
         interval = max(1, weight_sync_interval)
+        self.maybe_load_checkpoint(load_dir)
         self._init_wandb()
         for rollout_id in range(num_rollouts):
             training_progress = rollout_id / max(1, num_rollouts - 1)
@@ -759,6 +773,10 @@ class UnifiedModelTrainer(BaseTrainer):
                 )
                 self._global_optimizer_step += 1
                 self.wandb_logger.log_step(self._global_optimizer_step, training_metrics)
+
+            self.maybe_save_checkpoint(
+                rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir
+            )
 
         if self.wandb_logger is not None:
             self.wandb_logger.finish()

--- a/unirl/utils/export_hf.py
+++ b/unirl/utils/export_hf.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""Export a UniRL training checkpoint to a Hugging Face ``save_pretrained`` folder.
+
+``checkpoint.pt`` (see ``FSDPBackend.save``) is a raw trainer pickle: the
+trainable module's state dict with PEFT-injected names
+(``*.base_layer.weight`` / ``*.lora_A.<adapter>.weight``) plus optimizer and
+scheduler state. This script folds the LoRA delta into the base weights,
+restores the upstream parameter names, strict-loads them into the base model
+class, and writes a standard HF folder — ready for ``from_pretrained`` or
+``hf upload``.
+
+The fold mirrors :func:`unirl.utils.peft_merge.merged_state_dict` (fp32 merge,
+same key grammar) but runs offline on the checkpoint dict, so the LoRA scaling
+cannot be read off a live ``peft_config`` — pass ``--lora-alpha`` from the
+recipe (``backend.lora_cfg.alpha``; scaling = alpha / rank, rank is inferred
+from the weights).
+
+Examples:
+    # SD3.5 LoRA run (alpha from the recipe), diffusers transformer subfolder
+    python -m unirl.utils.export_hf \\
+        --checkpoint /ckpts/sd3_trainside/checkpoint-500 \\
+        --base stabilityai/stable-diffusion-3.5-medium --subfolder transformer \\
+        --lora-alpha 64 --output /ckpts/sd3_trainside/hf-500
+
+    # AR (transformers CausalLM)
+    python -m unirl.utils.export_hf \\
+        --checkpoint /ckpts/qwen3/checkpoint-300 --library transformers \\
+        --base Qwen/Qwen3-4B-Base --lora-alpha 64 --output /ckpts/qwen3/hf-300
+
+Loading the SD3 result back into a pipeline:
+    transformer = AutoModel.from_pretrained("/ckpts/sd3_trainside/hf-500", torch_dtype=torch.bfloat16)
+    pipe = StableDiffusion3Pipeline.from_pretrained(base, transformer=transformer)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Dict, Optional
+
+import torch
+
+DTYPES = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}
+
+
+def merge_lora_state_dict(
+    state_dict: Dict[str, torch.Tensor],
+    *,
+    adapter: str = "default",
+    alpha: Optional[float] = None,
+) -> Dict[str, torch.Tensor]:
+    """Fold ``adapter``'s LoRA delta into the base weights; restore upstream names.
+
+    No-op (copy) for checkpoints without LoRA keys (full-finetune recipes).
+    Other adapters' keys (e.g. the NFT shadow ``old``) are dropped.
+    """
+    if not any(".lora_A." in k for k in state_dict):
+        return dict(state_dict)
+    if alpha is None:
+        raise SystemExit(
+            "checkpoint contains LoRA adapters — pass --lora-alpha (backend.lora_cfg.alpha in the training recipe)"
+        )
+
+    out: Dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        if ".lora_A." in key or ".lora_B." in key:
+            continue  # folded below, or a non-exported adapter
+        if ".base_layer." not in key:
+            out[key] = value
+            continue
+        original = key.replace(".base_layer.", ".")
+        if key.endswith(".base_layer.weight"):
+            stem = key[: -len(".base_layer.weight")]
+            lora_a = state_dict.get(f"{stem}.lora_A.{adapter}.weight")
+            lora_b = state_dict.get(f"{stem}.lora_B.{adapter}.weight")
+            if lora_a is not None and lora_b is not None:
+                scaling = float(alpha) / lora_a.shape[0]
+                # Merge in fp32: a bf16 base + bf16 delta rounds the update away.
+                value = (value.float() + (lora_b.float() @ lora_a.float()) * scaling).to(value.dtype)
+        out[original] = value
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--checkpoint", required=True, help="checkpoint-<step> dir, or the checkpoint.pt itself")
+    parser.add_argument("--base", required=True, help="HF repo id / local snapshot of the BASE model")
+    parser.add_argument("--output", required=True, help="output folder for save_pretrained")
+    parser.add_argument("--subfolder", default=None, help='base subfolder, e.g. "transformer" for diffusers pipelines')
+    parser.add_argument("--library", choices=("diffusers", "transformers"), default="diffusers")
+    parser.add_argument("--adapter", default="default", help='LoRA adapter to fold ("old" = the NFT EMA shadow)')
+    parser.add_argument("--lora-alpha", type=float, default=None, help="backend.lora_cfg.alpha from the recipe")
+    parser.add_argument("--dtype", choices=tuple(DTYPES), default="bf16")
+    args = parser.parse_args()
+
+    path = args.checkpoint
+    if os.path.isdir(path):
+        path = os.path.join(path, "checkpoint.pt")
+    checkpoint = torch.load(path, map_location="cpu", weights_only=True)
+    state_dict = checkpoint["policy_state_dict"]
+    print(f"loaded {path}: {len(state_dict)} tensors, step={checkpoint.get('step')}")
+
+    merged = merge_lora_state_dict(state_dict, adapter=args.adapter, alpha=args.lora_alpha)
+
+    dtype = DTYPES[args.dtype]
+    from_pretrained_kwargs = {"torch_dtype": dtype}
+    if args.subfolder:
+        from_pretrained_kwargs["subfolder"] = args.subfolder
+    if args.library == "diffusers":
+        from diffusers import AutoModel
+
+        model = AutoModel.from_pretrained(args.base, **from_pretrained_kwargs)
+    else:
+        from transformers import AutoModelForCausalLM
+
+        model = AutoModelForCausalLM.from_pretrained(args.base, **from_pretrained_kwargs)
+
+    # strict: naming drift between checkpoint and base class is a hard error,
+    # not a silently half-loaded export.
+    model.load_state_dict({k: v.to(dtype) if v.is_floating_point() else v for k, v in merged.items()}, strict=True)
+    model.save_pretrained(args.output)
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -202,6 +202,8 @@ class UniRLWandBLogger:
         enabled: bool = True,
         tags: Optional[List[str]] = None,
         entity: Optional[str] = None,
+        run_id: Optional[str] = None,
+        optimizer_step: int = 0,
     ):
         """Initialize WandB logger.
 
@@ -222,6 +224,9 @@ class UniRLWandBLogger:
             enabled: Whether to enable logging (disabled => no-op null-object)
             tags: List of tags for the WandB run. Defaults to ['unirl'] if not provided.
             entity: WandB entity (team or username). If None, uses the default entity.
+            run_id: Resume this wandb run id (from a checkpoint's
+                trainer_state.json) instead of starting a fresh run.
+            optimizer_step: Seed for the ``train/`` step axis on resume.
         """
         self.project = project
         self.run_name = run_name
@@ -232,10 +237,11 @@ class UniRLWandBLogger:
         self.log_media = bool(log_media)
         self.rank = rank
         self.tags = tags if tags is not None else ["unirl"]
+        self.run_id = run_id
         self._initialized = False
         # Optimizer-step counter for the ``train/`` panel (moved here from
         # BaseTrainer so all step-axis bookkeeping lives in the logger).
-        self._optimizer_step = 0
+        self._optimizer_step = int(optimizer_step)
 
         # Only enable on rank 0
         self.enabled = enabled and rank == 0
@@ -250,6 +256,11 @@ class UniRLWandBLogger:
     def initialized(self) -> bool:
         """Whether wandb.init completed successfully."""
         return bool(self._initialized)
+
+    @property
+    def optimizer_step(self) -> int:
+        """Current ``train/`` step-axis value — checkpointed for resume."""
+        return self._optimizer_step
 
     def _handle_init_failure(
         self,
@@ -292,7 +303,13 @@ class UniRLWandBLogger:
             )
             if self.entity:
                 init_kwargs["entity"] = self.entity
+            if self.run_id:
+                # Resume the checkpoint's run ("allow": append if the id
+                # exists, else create it) so curves continue in one run.
+                init_kwargs["id"] = self.run_id
+                init_kwargs["resume"] = "allow"
             wandb.init(**init_kwargs)
+            self.run_id = wandb.run.id
             self._init_metric_axes()
             self._initialized = True
         except Exception as e:


### PR DESCRIPTION

## Summary
Adds checkpoint save and resume to the single-backend trainers — `DiffusionTrainer`, `ARTrainer`, and `UnifiedModelTrainer`. Previously the training loop had no way to persist or restore state, so a run could not survive interruption or be continued.The loop is now driven by three top-level config keys, read by each entrypoint and
  forwarded into `train(...)`:

  - `save_interval` — save a checkpoint every N rollouts (and on the last one); `0`(the default) disables saving, so existing runs are unaffected.
  - `save_dir` — output folder; defaults to `./checkpoints`. Each checkpoint lands in`<save_dir>/checkpoint-<step>/checkpoint.pt`.
  - `load_dir` — a checkpoint directory to restore from before training starts; unset means train fresh.

  A checkpoint bundles the full model `state_dict` (frozen base + LoRA adapters), the optimizer state, and the scheduler state — enough to resume training. The shared`maybe_save_checkpoint` / `maybe_load_checkpoint` helpers live on `BaseTrainer`, and `FSDPBackend.save`/`load` are marked `@distributed(BROADCAST)` so the gather (save)
  and broadcast (load) collectives fire on every rank while only rank 0 touches disk.
`PETrainer` (two backends) is intentionally out of scope; docs in`unirl/trainer/README.md` and `examples/README.md` are updated with usage.
## Related Issue

 "N/A" 
## Test Plan

- Verified checkpoint save and resume on diffusion/sd3_trainside (8×GPU):
    saved at the configured interval and resumed from a `checkpoint-<step>` dir,
    both worked as expected.
## Compatibility / Risk

Opt-in only — `save_interval` defaults to `0`, so existing runs are unaffected.

## Reviewer Notes
N/A"

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.