### PR TITLE
fix(sde,flowdppo): derive KL sigma_t from each SDE strategy (flow/dance/cps)

### DIFF
--- a/unirl/algorithms/flowdppo.py
+++ b/unirl/algorithms/flowdppo.py
@@ -363,7 +363,10 @@ class FlowDPPO(StageAlgorithm):
         s = sigmas[idx]
         s_next = sigmas[idx + 1]
         dt = s_next - s  # negative for denoising
-        std_dev_t = torch.sqrt(s / (1.0 - torch.clamp(s, max=0.99))) * eta
+        # Match FlowSDEStrategy.step at sigma==1: denominator uses sigma_max=sigmas[1],
+        # not a 0.99 clamp, so sigma_t equals the transition's std_var.
+        sigma_max = sigmas[1] if int(sigmas.shape[0]) > 1 else torch.tensor(0.99, device=device, dtype=sigmas.dtype)
+        std_dev_t = torch.sqrt(s / (1.0 - torch.where(s == 1.0, sigma_max, s))) * eta
         sigma_t = std_dev_t * torch.sqrt(-dt)
         return sigma_t.reshape(1, -1, 1, 1, 1)
 

--- a/unirl/algorithms/flowdppo.py
+++ b/unirl/algorithms/flowdppo.py
@@ -345,10 +345,13 @@ class FlowDPPO(StageAlgorithm):
         target_steps: List[int],
         device: torch.device,
     ) -> torch.Tensor:
-        """Compute sigma_t = std_dev_t * sqrt(-dt) for KL normalization.
+        """Per-step KL-normalization sigma_t, delegated to the SDE strategy.
 
-        When ``add_kl_coefficient=False``, returns ones (unnormalized MSE).
-        Returns shape ``[1, S', 1, 1, 1]`` for broadcasting with means tensors.
+        Returns ``stage.strategy.transition_std(...)`` so the KL uses each
+        strategy's own transition std (Flow/Dance: ``std_dev_t * sqrt(-dt)``;
+        CPS: ``std_dev_t``, no ``sqrt(-dt)``). When ``add_kl_coefficient=False``,
+        returns ones (unnormalized MSE). Shape ``[1, S', 1, 1, 1]`` for
+        broadcasting with the means tensors.
         """
         if not self.add_kl_coefficient:
             return torch.ones(1, len(target_steps), 1, 1, 1, device=device)
@@ -362,12 +365,11 @@ class FlowDPPO(StageAlgorithm):
         idx = torch.tensor(target_steps, dtype=torch.long, device=device)
         s = sigmas[idx]
         s_next = sigmas[idx + 1]
-        dt = s_next - s  # negative for denoising
-        # Match FlowSDEStrategy.step at sigma==1: denominator uses sigma_max=sigmas[1],
-        # not a 0.99 clamp, so sigma_t equals the transition's std_var.
+        # Delegate to the SDE strategy so the KL normalizer matches each strategy's
+        # transition std (Flow/Dance: std_dev_t*sqrt(-dt); CPS: std_dev_t, no sqrt(-dt)).
+        # sigma_max=sigmas[1] mirrors the stage's sigma==1 handling (used by Flow only).
         sigma_max = sigmas[1] if int(sigmas.shape[0]) > 1 else torch.tensor(0.99, device=device, dtype=sigmas.dtype)
-        std_dev_t = torch.sqrt(s / (1.0 - torch.where(s == 1.0, sigma_max, s))) * eta
-        sigma_t = std_dev_t * torch.sqrt(-dt)
+        sigma_t = self.stage.strategy.transition_std(sigma=s, sigma_next=s_next, eta=eta, sigma_max=sigma_max)
         return sigma_t.reshape(1, -1, 1, 1, 1)
 
 

--- a/unirl/sde/kernels.py
+++ b/unirl/sde/kernels.py
@@ -151,6 +151,42 @@ class SDEStrategy(StepStrategy, ABC):
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Implement StepStrategy.step by delegating to step_with_log_prob or Euler ODE."""
 
+    @abstractmethod
+    def _std_dev_t(
+        self,
+        *,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        eta: float,
+        sigma_max: float = 0.99,
+    ) -> torch.Tensor:
+        """Per-step diffusion coefficient ``std_dev_t`` for this SDE.
+
+        Pure function of the schedule + ``eta`` (independent of the model
+        output), so it is the single source shared by :meth:`step` (drift /
+        noise scaling) and :meth:`transition_std` (KL / log-prob std).
+        """
+
+    def transition_std(
+        self,
+        *,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        eta: float,
+        sigma_max: float = 0.99,
+    ) -> torch.Tensor:
+        """Std of the per-step transition Gaussian ``N(mean, std**2)``.
+
+        Equals the ``std_var`` returned by :meth:`step` and used in
+        :meth:`compute_log_prob`, and is the correct normalizer for the FlowDPPO
+        KL ``(delta_mean)**2 / (2 * std**2)``. Default (Flow / Dance):
+        ``std_dev_t * sqrt(-dt)``. CPS overrides it (its noise carries no
+        ``sqrt(-dt)`` factor).
+        """
+        dt = sigma_next - sigma
+        std_dev_t = self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
+        return std_dev_t * torch.sqrt(-dt)
+
     def _finalize_logp(
         self,
         *,
@@ -204,6 +240,16 @@ class FlowSDEStrategy(SDEStrategy):
         )
         return log_prob
 
+    def _std_dev_t(
+        self,
+        *,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        eta: float,
+        sigma_max: float = 0.99,
+    ) -> torch.Tensor:
+        return torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma))) * eta
+
     def step(
         self,
         noise_pred: torch.Tensor,
@@ -220,7 +266,7 @@ class FlowSDEStrategy(SDEStrategy):
 
         device = noise_pred.device
         dt = sigma_next - sigma
-        std_dev_t = torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma))) * eta
+        std_dev_t = self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
 
         prev_sample_mean = (
             sample * (1 + std_dev_t**2 / (2 * sigma) * dt)
@@ -252,6 +298,28 @@ class CPSSDEStrategy(SDEStrategy):
     ) -> torch.Tensor:
         return -((prev_sample.detach() - prev_sample_mean) ** 2)
 
+    def _std_dev_t(
+        self,
+        *,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        eta: float,
+        sigma_max: float = 0.99,
+    ) -> torch.Tensor:
+        return sigma_next * math.sin(eta * math.pi / 2)
+
+    def transition_std(
+        self,
+        *,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        eta: float,
+        sigma_max: float = 0.99,
+    ) -> torch.Tensor:
+        # CPS adds noise as std_dev_t * noise (no sqrt(-dt)), so the transition
+        # Gaussian std IS std_dev_t -- the KL must not multiply by sqrt(-dt).
+        return self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
+
     def step(
         self,
         noise_pred: torch.Tensor,
@@ -267,7 +335,7 @@ class CPSSDEStrategy(SDEStrategy):
         from diffusers.utils.torch_utils import randn_tensor
 
         device = noise_pred.device
-        std_dev_t = sigma_next * math.sin(eta * math.pi / 2)
+        std_dev_t = self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
         pred_original = sample - sigma * noise_pred
         noise_estimate = sample + noise_pred * (1 - sigma)
         prev_sample_mean = pred_original * (1 - sigma_next) + noise_estimate * torch.sqrt(sigma_next**2 - std_dev_t**2)
@@ -301,6 +369,16 @@ class DanceSDEStrategy(SDEStrategy):
         )
         return log_prob
 
+    def _std_dev_t(
+        self,
+        *,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        eta: float,
+        sigma_max: float = 0.99,
+    ) -> torch.Tensor:
+        return torch.full_like(sigma, float(eta))
+
     def step(
         self,
         noise_pred: torch.Tensor,
@@ -317,7 +395,7 @@ class DanceSDEStrategy(SDEStrategy):
 
         device = noise_pred.device
         dt = sigma_next - sigma
-        std_dev_t = eta
+        std_dev_t = self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
 
         prev_sample_mean = (
             sample * (1 + std_dev_t**2 / (2 * sigma) * dt)


### PR DESCRIPTION
## Summary

`FlowDPPO._compute_sigma_t` hardcoded the Flow-SDE std, so the KL normalizer was wrong for Dance and CPS (and, at the first `sigma == 1` step, for Flow too). This adds a single source of truth on the SDE strategies -- `_std_dev_t` + `transition_std` -- and routes each strategy's `step()` through them (numerically identical). `FlowDPPO._compute_sigma_t` now delegates to `strategy.transition_std`, so the KL `(d_mean)^2 / (2 * std^2)` uses each strategy's actual transition std: Flow/Dance use `std_dev_t * sqrt(-dt)`, CPS uses `std_dev_t` (no `sqrt(-dt)`). This also folds in the earlier fix to Flow's `sigma == 1` denominator (`sigma_max = sigmas[1]` instead of a `0.99` clamp).

## Related Issue

N/A

## Test Plan

- Pure-Python numeric check (no local torch env): the new `transition_std` equals each strategy's original `step()` std at representative sigmas including `sigma == 1` for Flow; CPS omits `sqrt(-dt)` (e.g. 0.859 vs 0.162 at step 0); `sigma < 1` Flow/Dance steps are unchanged.
- Not run; reason: no local Python/torch environment (`pre-commit`, `pytest`, Hydra config validation, and training/rollout smoke tests were not run). The `step()` refactor is numerically identical (same formula relocated into `_std_dev_t`); a rollout smoke on GPU is recommended.

## Compatibility / Risk

Low-to-moderate. Sampling/log_prob math is unchanged (each `step()`'s `std_dev_t` is the same formula moved into `_std_dev_t`). The behavior change is limited to the FlowDPPO KL normalizer, which is now correct per strategy (previously only Flow was handled, and Flow was wrong at `sigma == 1`). No config, checkpoint, data-format, or API changes. The new abstract `SDEStrategy._std_dev_t` is implemented by all SDE strategies (Flow/Dance/CPS); ODE/DPM2 is not an `SDEStrategy` and is unaffected.

## Reviewer Notes

AI-assisted. Single-source-of-truth refactor so `step()` and the KL share one std definition. Scope is limited to sigma_t consistency; other FlowDPPO gaps (reference-KL, advantage clipping, EMA) remain out of scope. Supersedes the earlier `sigma == 1`-only commit on this branch (now folded in).

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not (no test infra exists for this path; verified numerically).