### PR TITLE
feat(z-image): add Z-Image base model integration and trainside recipe

### DIFF
--- a/examples/diffusion/z_image_trainside.yaml
+++ b/examples/diffusion/z_image_trainside.yaml
@@ -1,0 +1,171 @@
+# @package _global_
+# Z-Image (base) + trainside (FSDP) colocate, v2 trainer, FlowGRPO.
+#
+# Trainside = rollout runs in-process on the FSDP-wrapped training pipeline
+# (no separate rollout actor, no weight sync). Strongest colocate form.
+#
+# This recipe targets the BASE checkpoint Tongyi-MAI/Z-Image (not the distilled
+# Turbo): multi-step sampling WITH classifier-free guidance (guidance_scale>0,
+# empty-string negatives auto-added by the pipeline) and static shift=6.0. The
+# S3-DiT single-stream transformer + Qwen3 text encoder are loaded by the
+# bundle; the VAE is the flux-style 16-channel AutoencoderKL. (To run Turbo
+# instead: set Z_IMAGE_PATH=.../Z-Image-Turbo and override shift=3.0,
+# sampling.guidance_scale=0.0, sampling.num_inference_steps=8.)
+#
+# Scale is set by the launcher (num_devices = cluster GPU count); this same
+# recipe runs on 2 (H20 smoke), 8 (1-node) and 32 (4x8) GPUs. batch_size=64
+# divides 2/8/32 evenly. For a quick smoke, shrink via CLI overrides, e.g.:
+#   batch_size=2 sampling.samples_per_prompt=4 num_rollouts=2
+
+num_devices: 8
+batch_size: 64                # prompts_per_rollout (divisible by 8 and 32)
+adv_use_global_std: true     # advantage: divide by ONE batch-wide std (v1 parity), not per-group
+num_rollouts: 10000
+
+logging:
+  # Env-driven so multi-node runs enable W&B with REPORT_TO_WANDB=true (the
+  # launcher exports it). rank-0/driver only; no-op when false.
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,false}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-zimage}
+  run_name: ${oc.env:WANDB_RUN_NAME,z_image_base_trainside}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: null
+
+bundle:
+  _target_: unirl.models.z_image.bundle.ZImageBundle.from_config
+  config:
+    _target_: unirl.models.z_image.config.ZImagePipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:Z_IMAGE_PATH,Tongyi-MAI/Z-Image}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: bf16
+    logprob_precision: fp32
+    max_sequence_length: 512
+    # Static FlowMatch shift; base Z-Image's scheduler_config.json declares
+    # use_dynamic_shifting=false + shift=6.0 (read by build_schedule_policy).
+    shift: 6.0
+
+# Pipeline relies on the optional-stages constructor (mirrors SD3/Qwen-Image):
+# the trainer auto-injects `bundle=self.bundle`; text_embed/diffusion/vae_decode
+# are built from the bundle here using the precision policy below.
+pipeline:
+  _target_: unirl.models.z_image.pipeline.ZImagePipeline
+  shift: 6.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["ZImageTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    # 6B S3-DiT + Qwen3 text encoder under full-graph replay: keep AC on.
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    # Z-Image single-stream attention (diffusers Attention inside
+    # ZImageTransformerBlock): query/key/value projections + output proj.
+    # Matches every block (main layers + noise/context refiners).
+    target_modules:
+      - to_k
+      - to_out.0
+      - to_q
+      - to_v
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  # 6B DiT + Qwen3 encoder are heavy; chunk the generate() forward so the
+  # rollout/decode peak stays bounded on an H20.
+  forward_batch_size: 8
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.pickscore.PickScoreRewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.pickscore.PickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  # forward_batch_size (8) != micro_batch_size (1); recompute pi_old at the
+  # train micro-geometry so the on-policy ratio is exactly 1 (see SD3 recipe).
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.z_image.conditions.ZImageConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2      # PPO mini-batches per rollout (π_old frozen once); v1 parity
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 16       # base Z-Image: multi-step (RL-reduced from ~30-50)
+  guidance_scale: 4.0           # base needs CFG; empty-string negatives auto-added.
+                                # diffusers default is 5.0 — lower => more in-group
+                                # diversity for GRPO. Set 0.0 only for Turbo.
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 3
+    # SDE-step window: confine SDE noise to the early high-σ steps.
+    timestep_fraction: [0, 0.5]

--- a/unirl/models/z_image/__init__.py
+++ b/unirl/models/z_image/__init__.py
@@ -1,0 +1,27 @@
+"""Z-Image pipeline on the typed four-tier architecture.
+
+Implements the typed ``Bundle`` / ``Pipeline`` / ``EmbedStage`` /
+``DiffusionStage`` / ``DecodeStage`` protocols. Sibling of
+:mod:`unirl.models.sd3` and :mod:`unirl.models.qwen_image`.
+
+Z-Image (Tongyi-MAI) is a 6B Scalable Single-Stream DiT (S3-DiT) image
+diffusion model: text tokens, (optional) visual semantic tokens, and image
+VAE tokens are concatenated into one unified sequence. This package wires
+the text-to-image path (``Z-Image`` / ``Z-Image-Turbo``); Z-Image-Turbo is
+the RL-friendly distilled checkpoint (few-step, no CFG).
+
+Importing this package re-exports its bundle / pipeline / config classes;
+recipes wire them by ``_target_`` dotpath.
+"""
+
+from unirl.models.z_image.bundle import ZImageBundle
+from unirl.models.z_image.conditions import ZImageConditions
+from unirl.models.z_image.config import ZImagePipelineConfig
+from unirl.models.z_image.pipeline import ZImagePipeline
+
+__all__ = [
+    "ZImageBundle",
+    "ZImageConditions",
+    "ZImagePipeline",
+    "ZImagePipelineConfig",
+]

--- a/unirl/models/z_image/bundle.py
+++ b/unirl/models/z_image/bundle.py
@@ -91,9 +91,9 @@ class ZImageBundle(Bundle):
         te_raw = config.text_encoder_dtype if config.text_encoder_dtype is not None else config.model_precision
         te_dtype = parse_torch_dtype(te_raw, field_name="text_encoder_dtype")
 
-        transformer = ZImageTransformer2DModel.from_pretrained(
-            path, subfolder="transformer", torch_dtype=dtype
-        ).to(device)
+        transformer = ZImageTransformer2DModel.from_pretrained(path, subfolder="transformer", torch_dtype=dtype).to(
+            device
+        )
 
         vae = AutoencoderKL.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(device).eval()
         vae.requires_grad_(False)

--- a/unirl/models/z_image/bundle.py
+++ b/unirl/models/z_image/bundle.py
@@ -1,0 +1,127 @@
+"""ZImageBundle — concrete weights+params holder for Z-Image.
+
+Loads either variant (architecture-identical): the base
+``Tongyi-MAI/Z-Image`` (CFG, ``shift: 6.0``) or the distilled
+``Z-Image-Turbo`` (no CFG, ``shift: 3.0``). Implements the empty
+:class:`Bundle` Protocol. Pure container of the modules Z-Image ships with:
+1× ``ZImageTransformer2DModel`` (the S3-DiT single-stream backbone), 1×
+``AutoencoderKL`` (the 16-channel flux-style 2D VAE), 1× Qwen3 text encoder
+(loaded via ``AutoModel``) + matching tokenizer, 1×
+``FlowMatchEulerDiscreteScheduler``.
+
+Diverges from :class:`unirl.models.qwen_image.QwenImageBundle` in two ways:
+
+- **Standard 2D VAE** (``AutoencoderKL``, 4D latents ``[B, C, H, W]``)
+  rather than Qwen-Image's video VAE — so the decode stage is the plain
+  SD3-style ``scaling_factor`` / ``shift_factor`` round trip, no temporal
+  squeeze/expand.
+- **Qwen3 text encoder** (a pure causal LM, ``Qwen3Model``) consumed via a
+  chat template, taking ``hidden_states[-2]`` (the second-to-last layer);
+  no fixed-prefix strip and no pooled vector.
+
+No LoRA injection, FSDP wrap, adapter switching, autocast helpers, or
+weight-sync logic — those are lifecycle concerns owned outside the bundle
+(``cfg.training.policies``).
+
+Use :meth:`ZImageBundle.from_config` to load a checkpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from unirl.models.types.bundle import Bundle
+from unirl.utils.dtypes import parse_torch_dtype
+
+from .config import ZImagePipelineConfig
+
+
+class ZImageBundle(Bundle):
+    """Z-Image bundle: S3-DiT transformer + AutoencoderKL + Qwen3 text encoder + scheduler."""
+
+    def __init__(
+        self,
+        *,
+        transformer: nn.Module,
+        vae: nn.Module,
+        text_encoder: nn.Module,
+        tokenizer: Any,
+        scheduler: Any,
+        dtype: torch.dtype,
+        device: torch.device,
+        pretrained_path: str,
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.vae = vae
+        self.text_encoder = text_encoder
+        self.tokenizer = tokenizer
+        self.scheduler = scheduler
+        self.dtype = dtype
+        self.device = device
+        self.pretrained_path = pretrained_path
+
+    @classmethod
+    def from_config(cls, config: ZImagePipelineConfig) -> "ZImageBundle":
+        """Load all Z-Image components from a HuggingFace-layout checkpoint.
+
+        Honors per-component path overrides (``vae_ckpt_path`` /
+        ``text_encoder_ckpt_path``) so fine-tuning recipes can swap in
+        alternate VAE / text-encoder checkpoints without re-downloading
+        the transformer. Both default to ``pretrained_model_ckpt_path``.
+        """
+        from diffusers import AutoencoderKL, ZImageTransformer2DModel
+        from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+        from transformers import AutoModel, AutoTokenizer
+
+        path = config.pretrained_model_ckpt_path
+        vae_path = config.vae_ckpt_path or path
+        text_encoder_path = config.text_encoder_ckpt_path or path
+
+        device = config.device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if isinstance(device, str):
+            device = torch.device(device)
+
+        dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
+        vae_raw = config.vae_dtype if config.vae_dtype is not None else config.model_precision
+        vae_dtype = parse_torch_dtype(vae_raw, field_name="vae_dtype")
+        te_raw = config.text_encoder_dtype if config.text_encoder_dtype is not None else config.model_precision
+        te_dtype = parse_torch_dtype(te_raw, field_name="text_encoder_dtype")
+
+        transformer = ZImageTransformer2DModel.from_pretrained(
+            path, subfolder="transformer", torch_dtype=dtype
+        ).to(device)
+
+        vae = AutoencoderKL.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(device).eval()
+        vae.requires_grad_(False)
+
+        # AutoModel (not a hardcoded Qwen3Model) mirrors the official Z-Image
+        # loader: it instantiates the base encoder named in the checkpoint's
+        # text_encoder/config.json, so a future text-encoder swap just works.
+        text_encoder = (
+            AutoModel.from_pretrained(text_encoder_path, subfolder="text_encoder", torch_dtype=te_dtype)
+            .to(device)
+            .eval()
+        )
+        text_encoder.requires_grad_(False)
+
+        tokenizer = AutoTokenizer.from_pretrained(text_encoder_path, subfolder="tokenizer")
+
+        scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(path, subfolder="scheduler")
+
+        return cls(
+            transformer=transformer,
+            vae=vae,
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            scheduler=scheduler,
+            dtype=dtype,
+            device=device,
+            pretrained_path=path,
+        )
+
+
+__all__ = ["ZImageBundle"]

--- a/unirl/models/z_image/conditions.py
+++ b/unirl/models/z_image/conditions.py
@@ -1,0 +1,73 @@
+"""ZImageConditions — typed conditions container for Z-Image diffusion.
+
+Concrete instantiation of the ``DiffusionStage[C]`` type parameter.
+Mirrors :class:`unirl.models.sd3.SD3Conditions` /
+:class:`unirl.models.qwen_image.QwenImageConditions`: text + optional
+negative_text, both as :class:`TextEmbedCondition` instances. Z-Image
+does not emit a ``pooled`` text vector, so ``TextEmbedCondition.pooled``
+is always ``None``; the ``attn_mask`` field carries the per-prompt valid
+token mask used to rebuild the variable-length caption list the
+single-stream transformer consumes.
+
+The CFG negative branch is split into a sibling ``negative_text`` field
+(rather than nested under ``text.negative``) so the schema is honest
+about which slots travel on the wire — a reader of
+``RolloutResp.tracks["image"].conditions`` sees ``"text"`` and
+``"negative_text"`` as two equal-status entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from unirl.distributed.tensor.batch import Batch, FieldKind, field
+from unirl.types.conditions import Condition, TextEmbedCondition
+
+
+@dataclass
+class ZImageConditions(Batch):
+    """Typed conditions container for Z-Image diffusion."""
+
+    text: Optional[TextEmbedCondition] = field(kind=FieldKind.CONCAT, default=None)
+    negative_text: Optional[TextEmbedCondition] = field(kind=FieldKind.CONCAT, default=None)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Condition]) -> "ZImageConditions":
+        """Build from the generic ``Conditions`` dict shape.
+
+        Validates that the ``"text"`` slot is present and is a
+        ``TextEmbedCondition``. The ``"negative_text"`` slot is optional;
+        when absent the result has ``negative_text=None`` (CFG-off).
+        """
+        text = d.get("text")
+        if not isinstance(text, TextEmbedCondition):
+            raise TypeError(
+                f"ZImageConditions.from_dict: expected d['text'] to be a "
+                f"TextEmbedCondition, got "
+                f"{type(text).__name__ if text is not None else 'None'}"
+            )
+        negative_text = d.get("negative_text")
+        if negative_text is not None and not isinstance(negative_text, TextEmbedCondition):
+            raise TypeError(
+                f"ZImageConditions.from_dict: expected d['negative_text'] to be a "
+                f"TextEmbedCondition or absent, got {type(negative_text).__name__}"
+            )
+        return cls(text=text, negative_text=negative_text)
+
+    def to_dict(self) -> Dict[str, Condition]:
+        """Convert back to the generic ``Conditions`` dict shape for
+        packing into ``RolloutResp.tracks["image"].conditions``.
+
+        Emits ``"negative_text"`` only when ``negative_text is not None``
+        so the dict shape stays minimal for CFG-off rollouts.
+        """
+        if self.text is None:
+            raise ValueError("ZImageConditions.to_dict: text field is None")
+        out: Dict[str, Condition] = {"text": self.text}
+        if self.negative_text is not None:
+            out["negative_text"] = self.negative_text
+        return out
+
+
+__all__ = ["ZImageConditions"]

--- a/unirl/models/z_image/config.py
+++ b/unirl/models/z_image/config.py
@@ -1,0 +1,76 @@
+"""Construction config for the typed Z-Image pipeline.
+
+Sibling of :class:`unirl.models.sd3.SD3PipelineConfig` and
+:class:`unirl.models.qwen_image.QwenImagePipelineConfig`. Carries
+weights+precision knobs only; LoRA injection, FSDP wrapping, gradient
+checkpointing, and offload control all live in ``cfg.training.policies``
+(``LoRAPolicy`` / ``FSDPPolicy``) — the bundle is weights+params only.
+
+``shift`` lives here so the hosting engine can build the
+:class:`FlowMatchSchedulePolicy` at startup. Both Z-Image variants ship a
+``scheduler/scheduler_config.json`` with ``use_dynamic_shifting: false``
+(plain static FlowMatch shift), but the shift value differs:
+**base ``Tongyi-MAI/Z-Image`` uses ``shift: 6.0``**, while the distilled
+``Z-Image-Turbo`` uses ``shift: 3.0``. The default below targets the base
+model. :meth:`ZImagePipeline.build_schedule_policy` pins the static posture
+from this value (unlike Qwen-Image / Flux.2, which are dynamic-shift).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from unirl.config.validation import validate_precision_type
+
+
+@dataclass
+class ZImagePipelineConfig:
+    """Construction args for ``ZImagePipeline.from_config``.
+
+    ``device`` may be runtime-injected by the actor after compose; the
+    other fields are set at compose time and read once during pipeline
+    construction.
+    """
+
+    pretrained_model_ckpt_path: str
+    vae_ckpt_path: Optional[str] = None
+    text_encoder_ckpt_path: Optional[str] = None
+    vae_dtype: Any = None
+    text_encoder_dtype: Any = None
+    model_precision: Any = "bf16"
+    device: Any = None
+
+    # Stage-level precision / numerical policy. Lives here (not on
+    # DiffusionSamplingParams) because these are operator/runtime knobs,
+    # not per-request shape.
+    autocast_precision: str = "bf16"
+    trajectory_precision: str = "fp16"
+    logprob_precision: str = "fp32"
+
+    # Static FlowMatch shift. Both Z-Image variants set
+    # ``use_dynamic_shifting: false``; the value differs — base Z-Image uses
+    # ``shift: 6.0`` (the default here), Z-Image-Turbo uses ``shift: 3.0``.
+    # The hosting engine reads this to build the σ schedule.
+    shift: float = 6.0
+
+    # Trainer-side policy wraps the bare DiT, while engines load it under
+    # the pipeline's ``transformer.*`` namespace.
+    weight_sync_param_name_prefix: str = "transformer."
+
+    # Z-Image text token budget for the Qwen3 encoder. The diffusers
+    # reference pads/truncates to this length before encoding; see
+    # ``ZImageTextEmbedStage`` for the slicing contract.
+    max_sequence_length: int = 512
+
+    # LoRA hints for rollout-side engines. Mirrors SD3PipelineConfig; the
+    # trainer-side LoRA injection lives in ``cfg.training.policies`` via
+    # LoRAPolicy.
+    use_lora: bool = False
+    lora_target_modules: Optional[List[str]] = None
+
+    def __post_init__(self) -> None:
+        validate_precision_type(self.model_precision, field="ZImagePipelineConfig.model_precision")
+
+
+__all__ = ["ZImagePipelineConfig"]

--- a/unirl/models/z_image/diffusion.py
+++ b/unirl/models/z_image/diffusion.py
@@ -1,0 +1,512 @@
+"""Z-Image diffusion: per-step kernel + rollout-level stage.
+
+Two classes mirror :mod:`unirl.models.sd3.diffusion`:
+
+- :class:`ZImageDiffusionStep` — stateless per-step kernel. Wraps
+  :meth:`predict_noise` (which adapts the single-stream
+  ``ZImageTransformer2DModel``'s list-based forward to the framework's
+  batched ``[B, C, H, W]`` SDE math) around ``StepStrategy.denoise``. The
+  protocol-matching ``forward`` / ``step`` / ``step_with_logp`` ride on
+  top.
+- :class:`ZImageDiffusionStage` — implements
+  ``DiffusionStage[ZImageConditions]``. Owns the SDE strategy and loop
+  bookkeeping; segment latents stay in spatial ``[B, C, H, W]`` shape so
+  :class:`ZImageVAEDecodeStage` can read them directly.
+
+Transformer adapter
+-------------------
+Z-Image's S3-DiT consumes **lists**: a list of per-sample latents
+``[C, F=1, H, W]`` and a list of per-sample caption embeddings
+``[t_i, D]`` (variable length). It returns a list of per-sample velocity
+predictions ``[C, F=1, H, W]``. :meth:`predict_noise`:
+
+1. lifts the batched latent ``[B, C, H, W]`` → list of ``[C, 1, H, W]``;
+2. rebuilds the per-prompt caption list from the padded
+   ``conditions.text.embeds`` + ``attn_mask``;
+3. passes ``t = 1 - sigma`` as the timestep (the diffusers reference
+   feeds ``(1000 - sigma*1000)/1000``);
+4. **negates** the model output (the reference does ``noise_pred =
+   -model_out`` before the scheduler step) so the result is the
+   FlowMatch velocity ``FlowSDEStrategy`` expects;
+5. stacks the list back to ``[B, C, H, W]``.
+
+CFG math
+--------
+Z-Image's CFG is ``pred = pos + scale * (pos - neg)`` (gated on
+``guidance_scale > 0``), batched as a single ``[pos; neg]`` forward.
+Z-Image-Turbo is distilled to run **without** CFG (``guidance_scale = 0``),
+which is the RL-friendly setting; the CFG branch supports the undistilled
+base model.
+
+Math mirrors diffusers ``ZImagePipeline.__call__`` denoising loop.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import ClassVar, List, Optional, Set, Tuple
+
+import torch
+
+from unirl.models.types.diffusion import DiffusionStage, DiffusionStep
+from unirl.models.types.replay_result import ReplayResult
+from unirl.sde.kernels import StepStrategy
+from unirl.types.sampling import DiffusionSamplingParams
+from unirl.types.segments.latent import LatentSegment
+from unirl.types.trajectory_store import compute_trajectory_positions
+from unirl.utils.dtypes import parse_torch_dtype
+
+from .bundle import ZImageBundle
+from .conditions import ZImageConditions
+
+
+def _caption_list(text, dtype: torch.dtype, device: torch.device) -> List[torch.Tensor]:
+    """Rebuild the per-prompt variable-length caption list from a padded
+    ``TextEmbedCondition`` (``embeds [B, T, D]`` + ``attn_mask [B, T]``).
+
+    Dedicated-engine replay can hand conditions back on CPU; pin both the
+    embeds and mask to the transformer's device before splitting.
+    """
+    if text is None or text.embeds is None:
+        raise ValueError("ZImage predict_noise: conditions text/embeds is None")
+    embeds = text.embeds.to(device=device, dtype=dtype)
+    mask = text.attn_mask
+    bsz = int(embeds.shape[0])
+    if mask is None:
+        return [embeds[i] for i in range(bsz)]
+    bool_mask = mask.to(device).bool()
+    return [embeds[i][bool_mask[i]] for i in range(bsz)]
+
+
+class ZImageDiffusionStep(DiffusionStep[ZImageBundle, ZImageConditions]):
+    """Per-step Z-Image denoising kernel — stateless."""
+
+    def predict_noise(
+        self,
+        model: ZImageBundle,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        conditions: ZImageConditions,
+        *,
+        guidance_scale: float,
+    ) -> torch.Tensor:
+        """Run the single-stream Z-Image transformer and return the
+        FlowMatch velocity ``[B, C, H, W]`` (negated model output, with CFG
+        applied when ``guidance_scale > 0`` and a negative is present)."""
+        if conditions.text is None:
+            raise ValueError("ZImageDiffusionStep.predict_noise: conditions.text is None")
+
+        dev = model.device
+        sample = sample.to(dev)
+        sigma = sigma.to(dev)
+        try:
+            model_dtype = next(model.transformer.parameters()).dtype
+        except StopIteration:
+            model_dtype = sample.dtype
+        sample = sample.to(dtype=model_dtype)
+
+        batch_size = int(sample.shape[0])
+        # Z-Image timestep input: (1000 - sigma*1000)/1000 == 1 - sigma.
+        if sigma.dim() == 0:
+            timestep = (1.0 - sigma).expand(batch_size)
+        elif sigma.shape[0] != batch_size:
+            timestep = (1.0 - sigma).expand(batch_size)
+        else:
+            timestep = 1.0 - sigma
+        timestep = timestep.to(device=dev, dtype=torch.float32)
+
+        cap_list = _caption_list(conditions.text, model_dtype, dev)
+
+        # Lift batched latent [B, C, H, W] -> list of [C, 1, H, W].
+        x_5d = sample.unsqueeze(2)  # [B, C, 1, H, W]
+
+        use_cfg = guidance_scale > 0.0 and conditions.negative_text is not None
+        if use_cfg:
+            neg_list = _caption_list(conditions.negative_text, model_dtype, dev)
+            x_list = list(torch.cat([x_5d, x_5d], dim=0).unbind(dim=0))
+            cap_all = cap_list + neg_list
+            timestep_all = timestep.repeat(2)
+            out_list = model.transformer(x_list, timestep_all, cap_all, return_dict=False)[0]
+            pos = torch.stack(out_list[:batch_size], dim=0)
+            neg = torch.stack(out_list[batch_size:], dim=0)
+            combined = pos + guidance_scale * (pos - neg)
+            noise_pred = -combined
+        else:
+            x_list = list(x_5d.unbind(dim=0))
+            out_list = model.transformer(x_list, timestep, cap_list, return_dict=False)[0]
+            noise_pred = -torch.stack(out_list, dim=0)
+
+        # Drop the temporal dim (Z-Image t2i uses F=1).
+        return noise_pred.squeeze(2)
+
+    # ---- Protocol surface ---------------------------------------------------
+
+    def forward(
+        self,
+        *,
+        strategy: StepStrategy,
+        noise_pred: torch.Tensor,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        prev_sample: Optional[torch.Tensor] = None,
+        sigma_max: float = 0.99,
+        eta: float = 1.0,
+        step_index: int = 0,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Run one SDE transition given a precomputed ``noise_pred``."""
+        return strategy.denoise(
+            noise_pred=noise_pred,
+            sample=sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            eta=eta,
+            prev_sample=prev_sample,
+            sigma_max=sigma_max,
+            step_index=step_index,
+        )
+
+    def step(
+        self,
+        model: ZImageBundle,
+        conditions: ZImageConditions,
+        *,
+        strategy: StepStrategy,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        guidance_scale: float,
+        prev_sample: Optional[torch.Tensor] = None,
+        sigma_max: float = 0.99,
+        eta: float = 1.0,
+        step_index: int = 0,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Run model forward + SDE transition. End-to-end one diffusion step."""
+        noise_pred = self.predict_noise(model, sample, sigma, conditions, guidance_scale=guidance_scale)
+        return self.forward(
+            strategy=strategy,
+            noise_pred=noise_pred,
+            sample=sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            prev_sample=prev_sample,
+            sigma_max=sigma_max,
+            eta=eta,
+            step_index=step_index,
+        )
+
+    def step_with_logp(
+        self,
+        model: ZImageBundle,
+        conditions: ZImageConditions,
+        *,
+        strategy: StepStrategy,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        guidance_scale: float,
+        prev_sample: Optional[torch.Tensor] = None,
+        sigma_max: float = 0.99,
+        eta: float = 1.0,
+        step_index: int = 0,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Run model forward + SDE transition.
+
+        Returns ``(prev_sample, log_prob, prev_sample_mean)``. ``log_prob``
+        and ``prev_sample_mean`` are ``None`` for deterministic strategies.
+        """
+        return self.step(
+            model,
+            conditions,
+            strategy=strategy,
+            sample=sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            guidance_scale=guidance_scale,
+            prev_sample=prev_sample,
+            sigma_max=sigma_max,
+            eta=eta,
+            step_index=step_index,
+        )
+
+
+class ZImageDiffusionStage(DiffusionStage[ZImageConditions]):
+    """Z-Image rollout-level diffusion stage.
+
+    Owns the SDE ``strategy`` (stateful strategies like ``DPM2Strategy``
+    require a stable instance across the loop), the bundle, the kernel, and
+    the precision policy. The kernel is stateless and invoked per-step.
+
+    Segment latents stay in spatial ``[B, C, H, W]`` shape (Z-Image's VAE
+    is the standard 2D ``AutoencoderKL``), so :class:`ZImageVAEDecodeStage`
+    reads ``segment.latents[:, -1]`` without per-shape handling.
+
+    ``_no_split_modules`` is the model-side fallback used by FSDPPolicy when
+    HF auto-discovery yields nothing — diffusers'
+    ``ZImageTransformer2DModel`` block class is ``ZImageTransformerBlock``.
+    """
+
+    _no_split_modules: ClassVar[Tuple[str, ...]] = ("ZImageTransformerBlock",)
+
+    def __init__(
+        self,
+        *,
+        model: ZImageBundle,
+        step: ZImageDiffusionStep,
+        strategy: StepStrategy,
+        autocast_precision: str = "bf16",
+        trajectory_precision: str = "fp16",
+        logprob_precision: str = "fp32",
+        vae_scale_factor: int = 8,
+        latent_channels: Optional[int] = None,
+    ) -> None:
+        self.model = model
+        self.step = step
+        self.strategy = strategy
+        self.autocast_dtype = parse_torch_dtype(autocast_precision, field_name="autocast_precision")
+        self.trajectory_dtype = parse_torch_dtype(trajectory_precision, field_name="trajectory_precision")
+        self.logprob_dtype = parse_torch_dtype(logprob_precision, field_name="logprob_precision")
+        self.vae_scale_factor = vae_scale_factor
+        if latent_channels is None:
+            tx_cfg = getattr(model.transformer, "config", None)
+            in_channels = getattr(tx_cfg, "in_channels", 16) if tx_cfg is not None else 16
+            latent_channels = int(in_channels)
+        self.latent_channels = int(latent_channels)
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+
+    def diffuse(
+        self,
+        conditions: ZImageConditions,
+        *,
+        schedule: torch.Tensor,
+        params: DiffusionSamplingParams,
+        initial_latents: Optional[torch.Tensor] = None,
+    ) -> LatentSegment:
+        """Run full Z-Image sampling. Returns a ``LatentSegment``.
+
+        ``initial_latents`` (optional) — driver-shipped x_T per
+        ``req.request_conditions['initial_latents']``; see
+        :class:`SD3DiffusionStage.diffuse` for the contract.
+        """
+        from unirl.sde.noise import generate_latents
+
+        if conditions.text is None or conditions.text.embeds is None:
+            raise ValueError("ZImageDiffusionStage.diffuse: conditions.text.embeds is None")
+        prompt_embeds = conditions.text.embeds
+        device = prompt_embeds.device
+        batch_size = int(prompt_embeds.shape[0])
+        T = int(params.num_inference_steps)
+        if int(schedule.shape[0]) != T + 1:
+            raise ValueError(f"ZImageDiffusionStage.diffuse: schedule length {schedule.shape[0]} != T+1={T + 1}")
+        schedule = schedule.to(device)
+        self.strategy.init_schedule(schedule)
+
+        # Latent grid follows the diffusers ZImagePipeline convention:
+        # latent_h = 2 * (H // (vae_scale_factor * 2)). Equals H // vae_scale_factor
+        # when H is a multiple of vae_scale_factor*2 (the pipeline enforces this).
+        vsf = int(self.vae_scale_factor)
+        latent_h = 2 * (int(params.height) // (vsf * 2))
+        latent_w = 2 * (int(params.width) // (vsf * 2))
+        expected_latent_shape = (int(self.latent_channels), latent_h, latent_w)
+        if initial_latents is not None:
+            if int(initial_latents.shape[0]) != batch_size:
+                raise ValueError(
+                    f"ZImageDiffusionStage.diffuse: initial_latents.shape[0]="
+                    f"{int(initial_latents.shape[0])} != batch_size={batch_size}."
+                )
+            if tuple(initial_latents.shape[1:]) != expected_latent_shape:
+                raise ValueError(
+                    f"ZImageDiffusionStage.diffuse: initial_latents.shape[1:]="
+                    f"{tuple(initial_latents.shape[1:])} != expected {expected_latent_shape} "
+                    f"for height={int(params.height)}, width={int(params.width)}."
+                )
+            latents = initial_latents.to(device=device, dtype=self.trajectory_dtype)
+        else:
+            latents = generate_latents(
+                batch_size=batch_size,
+                latent_shape=expected_latent_shape,
+                device=device,
+                dtype=self.trajectory_dtype,
+                init_same_noise=bool(params.init_same_noise),
+                samples_per_prompt=int(params.samples_per_prompt),
+                noise_group_ids=params.noise_group_ids,
+                base_seed=int(params.seed),
+            )
+
+        sde_set: Set[int] = set(int(i) for i in (params.sde_indices or []))
+        sde_sorted: List[int] = sorted(sde_set)
+
+        needed: Set[int] = set(compute_trajectory_positions(sde_set, T))
+        needed.add(T)
+
+        stored_pairs: List[Tuple[int, torch.Tensor]] = []
+        if 0 in needed:
+            stored_pairs.append((0, latents.detach().clone()))
+        sde_logp_list: List[torch.Tensor] = []
+
+        autocast_ctx = (
+            torch.autocast("cuda", self.autocast_dtype)
+            if device.type == "cuda" and self.autocast_dtype in (torch.float16, torch.bfloat16)
+            else nullcontext()
+        )
+        sigma_max = schedule[1].float() if int(schedule.shape[0]) > 1 else torch.tensor(0.99)
+
+        for i in range(T):
+            sigma = schedule[i].to(device)
+            sigma_next = schedule[i + 1].to(device)
+            step_eta = float(params.eta) if i in sde_set else 0.0
+
+            with torch.no_grad(), autocast_ctx:
+                new_latents, log_prob, _ = self.step.step_with_logp(
+                    self.model,
+                    conditions,
+                    strategy=self.strategy,
+                    sample=latents,
+                    sigma=sigma,
+                    sigma_next=sigma_next,
+                    guidance_scale=float(params.guidance_scale),
+                    eta=step_eta,
+                    sigma_max=sigma_max,
+                    step_index=i,
+                )
+            latents = new_latents.to(dtype=self.trajectory_dtype)
+
+            if (i + 1) in needed:
+                stored_pairs.append((i + 1, latents.detach().clone()))
+
+            if log_prob is not None:
+                sde_logp_list.append(log_prob.to(dtype=self.logprob_dtype))
+
+        positions_collected = [p for p, _ in stored_pairs]
+        latents_stacked = torch.stack([t for _, t in stored_pairs], dim=1)  # [B, K, C, H, W]
+
+        sde_logp = torch.stack(sde_logp_list, dim=1) if sde_logp_list else None
+        sde_indices_tensor = torch.tensor(sde_sorted, dtype=torch.long, device=device) if sde_sorted else None
+
+        indices_tensor = torch.tensor(positions_collected, dtype=torch.long, device=device)
+
+        return LatentSegment(
+            latents=latents_stacked,
+            sigmas=schedule,
+            indices=indices_tensor,
+            sde_logp=sde_logp,
+            sde_indices=sde_indices_tensor,
+        )
+
+    # ------------------------------------------------------------------
+    # Replay
+    # ------------------------------------------------------------------
+
+    def replay(
+        self,
+        conditions: ZImageConditions,
+        *,
+        segment: LatentSegment,
+        params: DiffusionSamplingParams,
+        step_indices: Optional[List[int]] = None,
+    ) -> ReplayResult:
+        """Segment-based log-prob replay over the rollout's SDE transitions.
+
+        Caller is responsible for ``.train()`` mode + grad scope; this method
+        only manages the autocast scope.
+        """
+        if segment.sde_indices is None or segment.latents is None:
+            raise ValueError("ZImageDiffusionStage.replay: segment.sde_indices / latents missing")
+        if segment.sigmas is None:
+            raise ValueError("ZImageDiffusionStage.replay: segment.sigmas missing")
+
+        sde_set = set(int(i) for i in segment.sde_indices.tolist())
+        target = (
+            [int(i) for i in step_indices]
+            if step_indices is not None
+            else [int(i) for i in segment.sde_indices.tolist()]
+        )
+        bad = [i for i in target if i not in sde_set]
+        if bad:
+            raise ValueError(
+                f"ZImageDiffusionStage.replay: step_indices {bad} not in segment.sde_indices={sorted(sde_set)}"
+            )
+
+        device = torch.device(self.model.device)
+        sigmas = segment.sigmas.to(device)
+        sigma_max = sigmas[1].float() if int(sigmas.shape[0]) > 1 else torch.tensor(0.99)
+
+        autocast_ctx = (
+            torch.autocast("cuda", self.autocast_dtype)
+            if device.type == "cuda" and self.autocast_dtype in (torch.float16, torch.bfloat16)
+            else nullcontext()
+        )
+        log_probs: List[torch.Tensor] = []
+        prev_sample_means: List[torch.Tensor] = []
+        with autocast_ctx:
+            for step_idx in target:
+                sigma = sigmas[step_idx].to(dtype=torch.float32)
+                sigma_next = sigmas[step_idx + 1].to(dtype=torch.float32)
+                sample = segment.latents_at(step_idx).to(device)
+                prev_sample = segment.latents_at(step_idx + 1).to(device)
+                _, log_prob, prev_mean = self.step.step_with_logp(
+                    self.model,
+                    conditions,
+                    strategy=self.strategy,
+                    sample=sample,
+                    prev_sample=prev_sample,
+                    sigma=sigma,
+                    sigma_next=sigma_next,
+                    guidance_scale=float(params.guidance_scale),
+                    eta=float(params.eta),
+                    sigma_max=sigma_max,
+                    step_index=step_idx,
+                )
+                if log_prob is None:
+                    raise RuntimeError(
+                        f"ZImageDiffusionStage.replay: strategy returned None log-prob "
+                        f"at step_index={step_idx} (deterministic mode); replay "
+                        f"requires a stochastic SDE strategy."
+                    )
+                log_probs.append(log_prob)
+                if prev_mean is not None:
+                    prev_sample_means.append(prev_mean)
+
+        log_probs_t = torch.stack(log_probs, dim=1).to(dtype=self.logprob_dtype)
+        means_t = torch.stack(prev_sample_means, dim=1).to(dtype=self.trajectory_dtype) if prev_sample_means else None
+        return ReplayResult(log_probs=log_probs_t, prev_sample_means=means_t)
+
+    # ------------------------------------------------------------------
+    # Single-step noise prediction (forward-process algorithms: DiffusionNFT et al.)
+    # ------------------------------------------------------------------
+
+    def predict_noise_at_step(
+        self,
+        conditions: ZImageConditions,
+        *,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        params: DiffusionSamplingParams,
+    ) -> torch.Tensor:
+        """Single ``(xt, sigma)`` model forward — no scheduler iteration.
+
+        Delegates to ``ZImageDiffusionStep.predict_noise`` so CFG batching
+        and guidance handling stay identical to the sampling path.
+        """
+        return self.step.predict_noise(
+            self.model,
+            sample,
+            sigma,
+            conditions,
+            guidance_scale=float(params.guidance_scale),
+        )
+
+    # ------------------------------------------------------------------
+    # Trainable surface for FSDPPolicy
+    # ------------------------------------------------------------------
+
+    def trainable_module(self) -> "torch.nn.Module":
+        """Return the module the diffusion forward operates on — the
+        bundle's ``ZImageTransformer2DModel`` (the FSDP wrap target)."""
+        return self.model.transformer
+
+
+__all__ = ["ZImageDiffusionStage", "ZImageDiffusionStep"]

--- a/unirl/models/z_image/pipeline.py
+++ b/unirl/models/z_image/pipeline.py
@@ -1,0 +1,239 @@
+"""ZImagePipeline — RolloutReq → RolloutResp end-to-end for Z-Image.
+
+Implements the four-tier flow::
+
+    Texts ──text_embed──▶ ZImageConditions ──diffuse──▶ LatentSegment
+                                                            │
+                                                            ▼
+                                                        vae_decode
+                                                            │
+                                                            ▼
+                                                          Images
+
+Hydra constructs a pipeline via
+``ZImagePipeline.from_config(ZImagePipelineConfig)`` (see ``config.py``);
+``from_config`` loads the :class:`ZImageBundle` then constructs the four
+stages with the precision policy from the config.
+
+σ schedule contract
+-------------------
+The hosting engine (``TrainsideRolloutEngine``) pins ``req.sigmas`` via
+:func:`unirl.sde.runtime.ensure_req_sigmas` BEFORE calling
+``generate(req)``; this pipeline reads ``req.sigmas`` and uses it
+verbatim. Both Z-Image variants' ``scheduler/scheduler_config.json`` declare
+``use_dynamic_shifting: false`` (the diffusers ``ZImagePipeline`` computes a
+Flux-style ``mu`` but ``FlowMatchEulerDiscreteScheduler`` discards it on the
+static branch), so this pipeline is **static-shift** (unlike Qwen-Image /
+Flux.2-Klein, which are dynamic-shift). The shift value differs by variant —
+base ``Z-Image`` uses ``6.0``, ``Z-Image-Turbo`` uses ``3.0``;
+:meth:`build_schedule_policy` pins that posture via
+``FlowMatchSchedulePolicy.static_only(self.shift)``.
+
+Base vs Turbo is purely a config difference (same architecture): base runs
+with CFG (``guidance_scale > 0`` + a negative prompt), Turbo runs CFG-free
+(``guidance_scale = 0``). The recipe sets the variant-specific values.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Optional
+
+from unirl.models.types.pipeline import Pipeline
+from unirl.sde.kernels import FlowSDEStrategy, StepStrategy
+from unirl.types.noise_recipe import NoiseRecipe
+from unirl.types.primitives import Texts
+from unirl.types.rollout_req import RolloutReq
+from unirl.types.rollout_resp import RolloutResp, RolloutTrack
+from unirl.types.sampling import DiffusionSamplingParams, get_diffusion_params
+
+from .bundle import ZImageBundle
+from .conditions import ZImageConditions
+from .config import ZImagePipelineConfig
+from .diffusion import ZImageDiffusionStage, ZImageDiffusionStep
+from .text_embed import ZImageTextEmbedStage
+from .vae import ZImageVAEDecodeStage
+
+
+class ZImagePipeline(Pipeline):
+    """Z-Image generate pipeline.
+
+    Reads from ``RolloutReq``:
+
+    - ``primitives["text"]: Texts`` — required prompts.
+    - ``primitives["negative_text"]: Texts`` — optional CFG negatives.
+    - ``stage_params["diffusion"]: dict`` — diffusion sampling kwargs.
+    - ``sigmas: Tensor[T+1]`` — pinned by the engine adapter (required).
+
+    Writes to ``RolloutResp`` (single ``"image"`` track):
+
+    - ``conditions["text"]: TextEmbedCondition``; plus
+      ``conditions["negative_text"]`` when negatives were supplied.
+    - ``segment: LatentSegment``.
+    - ``decoded: Images``.
+    """
+
+    def __init__(
+        self,
+        *,
+        bundle: ZImageBundle,
+        text_embed: Optional[ZImageTextEmbedStage] = None,
+        diffusion: Optional[ZImageDiffusionStage] = None,
+        vae_decode: Optional[ZImageVAEDecodeStage] = None,
+        strategy: Optional[StepStrategy] = None,
+        shift: float = 6.0,
+        autocast_precision: str = "bf16",
+        trajectory_precision: str = "fp16",
+        logprob_precision: str = "fp32",
+        max_sequence_length: int = 512,
+    ) -> None:
+        super().__init__()
+        self.bundle = bundle
+        self.text_embed = (
+            text_embed
+            if text_embed is not None
+            else ZImageTextEmbedStage(bundle, max_sequence_length=max_sequence_length)
+        )
+        if diffusion is None:
+            diffusion = ZImageDiffusionStage(
+                model=bundle,
+                step=ZImageDiffusionStep(),
+                strategy=strategy if strategy is not None else FlowSDEStrategy(),
+                autocast_precision=autocast_precision,
+                trajectory_precision=trajectory_precision,
+                logprob_precision=logprob_precision,
+            )
+        self.diffusion = diffusion
+        self.vae_decode = vae_decode if vae_decode is not None else ZImageVAEDecodeStage(bundle)
+        # ``shift`` is retained so the hosting engine can read it when
+        # constructing the FlowMatchSchedulePolicy at startup. Z-Image is
+        # static-shift, so this value (3.0) is the schedule shift.
+        self.shift = shift
+
+    @classmethod
+    def latent_shape(cls, *, model_config: Any, sampling_spec: Any) -> tuple:
+        """Per-sample latent shape ``(C, H_lat, W_lat)`` for driver-side
+        noise pre-computation. Z-Image: 16-channel ``AutoencoderKL``, 8×
+        spatial downsample with the patchify-2×2 rounding
+        (``latent_h = 2 * (H // 16)``)."""
+        height = int(sampling_spec.height)
+        width = int(sampling_spec.width)
+        vae_scale_factor = 8  # AutoencoderKL with 4 block_out_channels
+        latent_h = 2 * (height // (vae_scale_factor * 2))
+        latent_w = 2 * (width // (vae_scale_factor * 2))
+        return (16, latent_h, latent_w)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: ZImagePipelineConfig,
+        *,
+        strategy: Optional[StepStrategy] = None,
+    ) -> "ZImagePipeline":
+        """Build the full pipeline from a config.
+
+        ``strategy`` is the SDE step strategy. Defaults to
+        :class:`FlowSDEStrategy`; callers running GRPO with a different SDE
+        family (Dance / CPS / DPM2) pass an explicit strategy.
+        """
+        bundle = ZImageBundle.from_config(config)
+        text_embed = ZImageTextEmbedStage(bundle, max_sequence_length=config.max_sequence_length)
+        step = ZImageDiffusionStep()
+        diffusion = ZImageDiffusionStage(
+            model=bundle,
+            step=step,
+            strategy=strategy if strategy is not None else FlowSDEStrategy(),
+            autocast_precision=config.autocast_precision,
+            trajectory_precision=config.trajectory_precision,
+            logprob_precision=config.logprob_precision,
+        )
+        vae_decode = ZImageVAEDecodeStage(bundle)
+        return cls(
+            bundle=bundle,
+            text_embed=text_embed,
+            diffusion=diffusion,
+            vae_decode=vae_decode,
+            shift=float(config.shift),
+        )
+
+    def build_schedule_policy(self):
+        """Static-shift FlowMatch σ policy (Z-Image uses no dynamic shift).
+
+        Both Z-Image variants' ``scheduler/scheduler_config.json`` declare
+        ``use_dynamic_shifting: false`` (base ``shift: 6.0``, Turbo
+        ``shift: 3.0``): the upstream diffusers ``ZImagePipeline`` still
+        computes a Flux-style ``mu``, but ``FlowMatchEulerDiscreteScheduler``
+        ignores it on the static branch and applies
+        ``shift·t / (1 + (shift-1)·t)``. Returning an explicit ``static_only``
+        policy built from ``self.shift`` pins that posture regardless of whether
+        ``pretrained_path`` is an HF repo id or a local mount (so a checkpoint
+        shipping a stray dynamic ``scheduler_config.json`` can't silently flip
+        σ and drift the GRPO ratio). Mirrors ``BagelPipeline.build_schedule_policy``.
+        """
+        from unirl.sde.runtime import FlowMatchSchedulePolicy
+
+        return FlowMatchSchedulePolicy.static_only(float(self.shift))
+
+    def generate(self, req: RolloutReq) -> RolloutResp:
+        """Run Z-Image t2i end-to-end. Requires ``req.sigmas`` to be pinned
+        by the hosting engine adapter."""
+        if req.sigmas is None:
+            raise ValueError(
+                "ZImagePipeline.generate: req.sigmas is None. The hosting "
+                "engine must call unirl.sde.runtime.ensure_req_sigmas(req, "
+                "policy) before invoking pipeline.generate; see the σ "
+                "ownership note in unirl.models.types.pipeline."
+            )
+        texts = req.primitives.get("text")
+        if not isinstance(texts, Texts):
+            raise TypeError(
+                f"ZImagePipeline.generate: req.primitives['text'] must be Texts, "
+                f"got {type(texts).__name__ if texts is not None else 'None'}"
+            )
+        negatives_raw = req.primitives.get("negative_text")
+        negatives = negatives_raw if isinstance(negatives_raw, Texts) else None
+        if negatives is not None and len(negatives.texts) != len(texts.texts):
+            raise ValueError(
+                f"ZImagePipeline.generate: negative_text length "
+                f"{len(negatives.texts)} != text length {len(texts.texts)}"
+            )
+
+        params: DiffusionSamplingParams = get_diffusion_params(req.sampling_params)
+        if bool(params.init_same_noise) and not params.noise_group_ids:
+            params = dataclasses.replace(params, noise_group_ids=list(req.group_ids))
+
+        text_cond = self.text_embed.embed(texts)
+        # CFG empty negative: Z-Image upstream (diffusers ``ZImagePipeline``
+        # ``encode_prompt``) defaults to ``""`` (empty string) when CFG is
+        # enabled and no negative is passed. Z-Image gates CFG on
+        # ``guidance_scale > 0`` (Turbo runs with 0 → CFG off). The Qwen3
+        # chat template tokenizes ``""`` cleanly, so no ``" "`` workaround is
+        # needed (unlike Qwen-Image).
+        if negatives is None and float(params.guidance_scale) > 0.0:
+            negatives = Texts(texts=[""] * len(texts.texts))
+        negative_text_cond = self.text_embed.embed(negatives) if negatives is not None else None
+        z_conds = ZImageConditions(text=text_cond, negative_text=negative_text_cond)
+
+        schedule = req.sigmas.to(self.bundle.device)
+
+        # Driver-authoritative x_T via the model-aware recipe (NoiseRecipe); a
+        # pre-shipped initial_latents tensor still wins.
+        initial_latents = NoiseRecipe.from_rollout_req(req).resolve()
+
+        latent_seg = self.diffusion.diffuse(z_conds, schedule=schedule, params=params, initial_latents=initial_latents)
+        images = self.vae_decode.decode(latent_seg)
+
+        return RolloutResp(
+            tracks={
+                "image": RolloutTrack(
+                    sample_ids=list(req.sample_ids),
+                    parent_ids=list(req.group_ids),
+                    conditions=z_conds.to_dict(),
+                    segment=latent_seg,
+                    decoded=images,
+                ),
+            }
+        )
+
+
+__all__ = ["ZImagePipeline"]

--- a/unirl/models/z_image/text_embed.py
+++ b/unirl/models/z_image/text_embed.py
@@ -1,0 +1,119 @@
+"""ZImageTextEmbedStage — Qwen3 chat-template text → TextEmbedCondition.
+
+Implements ``EmbedStage[Texts, TextEmbedCondition]``. Mirrors the
+diffusers ``ZImagePipeline._encode_prompt`` byte-for-byte at the spec
+level:
+
+- **Single causal-LM encoder** (``Qwen3Model``). Each prompt is wrapped in
+  a chat template (``add_generation_prompt=True``, ``enable_thinking=True``)
+  before tokenizing.
+- **Second-to-last hidden layer**. Z-Image conditions on
+  ``encoder_out.hidden_states[-2]`` (not the final layer), per the
+  reference pipeline.
+- **No fixed-prefix strip** (unlike Qwen-Image). Every non-pad token of
+  the chat-templated prompt participates in conditioning.
+- **Variable-length token output**. After dropping pad positions each
+  prompt has a different residual length; the stage pads to the batch-max
+  with zero embeddings and emits a parallel ``attn_mask`` so the single-
+  stream transformer can rebuild the per-prompt caption list (the
+  transformer itself runs variable-length attention over the list).
+
+No ``pooled`` vector is produced — Z-Image's transformer accepts
+token-level hidden states only. ``TextEmbedCondition.pooled`` is left as
+``None``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+
+from unirl.models.types.embedding import EmbedStage
+from unirl.types.conditions import TextEmbedCondition
+from unirl.types.primitives import Texts
+
+from .bundle import ZImageBundle
+
+
+class ZImageTextEmbedStage(EmbedStage[Texts, TextEmbedCondition]):
+    """Qwen3 chat-template text → ``TextEmbedCondition`` stage."""
+
+    def __init__(
+        self,
+        bundle: ZImageBundle,
+        *,
+        max_sequence_length: int = 512,
+    ) -> None:
+        self.bundle = bundle
+        self.max_sequence_length = int(max_sequence_length)
+
+    def embed(self, p: Texts) -> TextEmbedCondition:
+        """Encode prompts into a ``TextEmbedCondition``."""
+        prompt_embeds, prompt_embeds_mask = self._encode(list(p.texts))
+        return TextEmbedCondition(
+            embeds=prompt_embeds,
+            attn_mask=prompt_embeds_mask,
+            pooled=None,
+        )
+
+    # ---- helpers -----------------------------------------------------------
+
+    def _encode(self, prompts: List[str]) -> Tuple[torch.Tensor, torch.Tensor]:
+        bundle = self.bundle
+        device = bundle.device
+        dtype = next(bundle.text_encoder.parameters()).dtype
+        tokenizer = bundle.tokenizer
+
+        templated = []
+        for prompt_item in prompts:
+            messages = [{"role": "user", "content": prompt_item}]
+            templated.append(
+                tokenizer.apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                    enable_thinking=True,
+                )
+            )
+
+        text_inputs = tokenizer(
+            templated,
+            padding="max_length",
+            max_length=self.max_sequence_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        input_ids = text_inputs.input_ids.to(device)
+        prompt_masks = text_inputs.attention_mask.to(device).bool()
+
+        with torch.no_grad():
+            encoder_out = bundle.text_encoder(
+                input_ids=input_ids,
+                attention_mask=prompt_masks,
+                output_hidden_states=True,
+            )
+        # Z-Image conditions on the second-to-last hidden layer.
+        hidden_states = encoder_out.hidden_states[-2]
+
+        # Split into per-prompt variable-length slices (drop pad positions).
+        split_hidden_states = [hidden_states[i][prompt_masks[i]] for i in range(len(prompts))]
+        attn_mask_list = [
+            torch.ones(item.size(0), dtype=torch.long, device=item.device) for item in split_hidden_states
+        ]
+        max_seq_len = max(item.size(0) for item in split_hidden_states)
+
+        prompt_embeds = torch.stack(
+            [
+                torch.cat([item, item.new_zeros(max_seq_len - item.size(0), item.size(1))])
+                for item in split_hidden_states
+            ]
+        )
+        prompt_embeds_mask = torch.stack(
+            [torch.cat([item, item.new_zeros(max_seq_len - item.size(0))]) for item in attn_mask_list]
+        )
+
+        return prompt_embeds.to(device=device, dtype=dtype), prompt_embeds_mask
+
+
+__all__ = ["ZImageTextEmbedStage"]

--- a/unirl/models/z_image/vae.py
+++ b/unirl/models/z_image/vae.py
@@ -1,0 +1,63 @@
+"""ZImageVAEDecodeStage — LatentSegment → Images via VAE decode.
+
+Implements ``DecodeStage[LatentSegment, Images]``. Reads the final stored
+position from ``LatentSegment.latents[:, -1]`` (``ZImageDiffusionStage``
+always stores position ``T``, the clean latent), runs the
+``AutoencoderKL`` decode in fp32, and normalizes the output from
+``[-1, 1]`` to ``[0, 1]`` before wrapping in ``Images``.
+
+Z-Image uses the flux-style 16-channel ``AutoencoderKL`` with both
+``scaling_factor`` and ``shift_factor`` — identical to SD3. The latent
+un-normalization mirrors the diffusers ``ZImagePipeline`` decode path:
+``x = latent / scaling_factor + shift_factor``.
+
+No ``ZImageVAEEncodeStage`` here — the reference pipeline supports only
+text-to-image; the encoder is unused. Add when img2img / SDEdit /
+ControlNet lands.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from unirl.models.types.codec import DecodeStage
+from unirl.types.primitives import Images
+from unirl.types.segments import LatentSegment
+
+from .bundle import ZImageBundle
+
+
+class ZImageVAEDecodeStage(DecodeStage[LatentSegment, Images]):
+    """Z-Image VAE decode stage."""
+
+    def __init__(self, bundle: ZImageBundle) -> None:
+        self.bundle = bundle
+
+    def decode(self, s: LatentSegment) -> Images:
+        """Decode the final-step latents in *s* into pixel images.
+
+        Reads ``s.latents[:, -1]`` (the final stored position, which is
+        ``T`` — the clean latent ``x_0`` in spatial shape
+        ``[B, C, H, W]``). VAE forward runs in fp32; output is clamped to
+        ``[0, 1]`` before being wrapped in ``Images``.
+        """
+        if s.latents is None:
+            raise ValueError("ZImageVAEDecodeStage.decode: segment.latents is None")
+        if s.latents.ndim < 5:
+            raise ValueError(
+                f"ZImageVAEDecodeStage.decode: expected latents shape [N, K, C, H, W], got {tuple(s.latents.shape)}"
+            )
+        clean = s.latents[:, -1]  # [B, C, H, W]
+
+        scaling_factor = self.bundle.vae.config.scaling_factor
+        shift_factor = getattr(self.bundle.vae.config, "shift_factor", None)
+        with torch.no_grad():
+            latents_f32 = clean.to(dtype=torch.float32) / scaling_factor
+            if shift_factor is not None:
+                latents_f32 = latents_f32 + float(shift_factor)
+            decoded = self.bundle.vae.to(torch.float32).decode(latents_f32).sample
+        pixels = ((decoded + 1.0) / 2.0).clamp(0.0, 1.0)
+        return Images(pixels=pixels)
+
+
+__all__ = ["ZImageVAEDecodeStage"]


### PR DESCRIPTION
## Summary

Add Z-Image text-to-image model support to UniRL, following the existing
qwen_image / sd3 model-bundle conventions. This introduces a new
`unirl/models/z_image` bundle (config, bundle loader, conditions, text
embedding, VAE decode, diffusion stage, pipeline) and a FlowGRPO trainside
recipe. Defaults target the **base** Z-Image model
(`Tongyi-MAI/Z-Image`): static `shift=6.0`, `num_inference_steps=16`,
`guidance_scale=4.0` (CFG enabled). The text encoder uses the Qwen3 chat
template and the second-to-last hidden state; the FlowMatch schedule uses a
static shift to match the model's `scheduler_config.json`
(`use_dynamic_shifting=false`).

## Related Issue

N/A

## Test Plan

- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=diffusion/z_image_trainside --cfg job --resolve`
- 2-GPU H20 trainside smoke run (overrides: `+devices_per_node=2`) — completed
  successfully, rollout + optimizer step run end to end.
- 4-node / 32-GPU full training run with wandb — pending (not yet run).

## Compatibility / Risk

New, self-contained model bundle and recipe; no changes to existing models or
shared code paths. Requires downloading the `Tongyi-MAI/Z-Image` checkpoint.
To run the Turbo variant instead, override
`pretrained_model_ckpt_path=Tongyi-MAI/Z-Image-Turbo`, `shift=3.0`,
`num_inference_steps=8`, `guidance_scale=0.0`.

## Reviewer Notes

Opened as a draft for early feedback while the full 4x8 multinode run is in
progress. AI assistance was used to scaffold the bundle from the qwen_image /
sd3 references. Please sanity-check the timestep convention (`1 - sigma`),
velocity negation, and CFG formula in `diffusion.py` first.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.