### PR TITLE
perf(qwen3): packed varlen replay — zero padding (verl remove_padding parity) (issue #40)

### DIFF
--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -193,6 +193,10 @@ stack:
   # slicing; with mbs=1 every sequence ran its own forward/backward. null keeps
   # the legacy count-based behavior.
   micro_token_budget: 10240
+  # 'sum' = packed varlen replay cost accounting (no padding exists, cost is the
+  # plain sum of real tokens = verl token accounting); 'dense' for rectangular
+  # padding replays.
+  micro_cost_model: sum
   max_grad_norm: 1.0
   # 4 disjoint mini-batch optimizer steps per rollout, 128 trajectories each —
   # matches the RELEASED verl run script (run_qwen3_4b.sh: ppo_mini_batch_size=16

--- a/unirl/models/qwen3/ar.py
+++ b/unirl/models/qwen3/ar.py
@@ -128,6 +128,26 @@ def _replay_aware_forward(
     return torch.cat(parts, dim=1)
 
 
+def _packed_replay_supported() -> bool:
+    """Feature-detect the packed varlen replay prerequisites (review #43).
+
+    The packed path relies on transformers building a block-causal mask from
+    restarting position_ids (masking_utils.find_packed_sequence_indices,
+    transformers >= 4.53). On older versions the forward would silently attend
+    ACROSS sequence boundaries — wrong logps with no error — so fall back to the
+    dense path. ``UNIRL_DISABLE_PACKED_REPLAY=1`` is the explicit kill switch.
+    """
+    import os as _os
+
+    if _os.environ.get("UNIRL_DISABLE_PACKED_REPLAY") == "1":
+        return False
+    try:
+        from transformers.masking_utils import find_packed_sequence_indices  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
 @dataclass
 class Qwen3ARParams:
     """Per-request AR-mode knobs for Qwen3.
@@ -413,7 +433,7 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
         # the standalone layout, so logp semantics are unchanged; the dense
         # [B, P_max + T_max] path below stays for B == 1 (identical cost) and as
         # the fallback.
-        if batch_size > 1 and segment.lengths is not None:
+        if batch_size > 1 and segment.lengths is not None and _packed_replay_supported():
             real_prompt_lens_p = prompt_mask.long().sum(dim=-1)  # [B] (right-padded layout)
             cu_p = [int(c) for c in segment.cu_seqlens.tolist()]
             flat_resp = segment.tokens.to(device=device, dtype=torch.long)

--- a/unirl/models/qwen3/ar.py
+++ b/unirl/models/qwen3/ar.py
@@ -43,6 +43,7 @@ def _replay_aware_forward(
     prompt_len: Optional[int] = None,
     temperature: float = 1.0,
     autocast_dtype: Optional[torch.dtype] = None,
+    packed_predict_index: Optional[torch.Tensor] = None,
     **kw: Any,
 ) -> Any:
     """Dual-mode ``forward`` installed on the Qwen3 CausalLM instance.
@@ -76,6 +77,34 @@ def _replay_aware_forward(
     # [B, chunk, vocab] FP32 transient stays ~1.2 GiB, and each chunk is
     # gradient-checkpointed (recomputed in backward rather than held).
     T = float(temperature) if float(temperature) > 0.0 else 1.0
+
+    if packed_predict_index is not None:
+        # Packed varlen replay: ``hidden`` is one packed row [1, L_total, H]
+        # holding every sequence back-to-back (block-causal mask built by
+        # transformers from the restarting position_ids). Predictions for the
+        # FLAT response stream (``response_tokens`` = segment-order targets,
+        # [T_total]) live at ``packed_predict_index`` — gather those hidden
+        # states and run the same chunked fp32 ``x[tok] - logsumexp(x)`` over
+        # the flat stream. No pad tokens exist anywhere on this path.
+        h_pred = hidden[0].index_select(0, packed_predict_index)  # [T_total, H]
+        targets = response_tokens
+
+        def _flat_logp_chunk(h: torch.Tensor, tok: torch.Tensor) -> torch.Tensor:
+            lf = self.lm_head(h).float() / T  # [chunk, vocab] FP32
+            return lf.gather(-1, tok.unsqueeze(-1)).squeeze(-1) - torch.logsumexp(lf, dim=-1)
+
+        flat_parts: List[torch.Tensor] = []
+        flat_chunk = 2048
+        for s in range(0, int(h_pred.size(0)), flat_chunk):
+            h = h_pred[s : s + flat_chunk]
+            tok = targets[s : s + flat_chunk]
+            if torch.is_grad_enabled() and h.requires_grad:
+                flat_parts.append(checkpoint(_flat_logp_chunk, h, tok, use_reentrant=False))
+            else:
+                flat_parts.append(_flat_logp_chunk(h, tok))
+        if not flat_parts:
+            return hidden.new_zeros((0,), dtype=torch.float32)
+        return torch.cat(flat_parts, dim=0)
     T_max = int(response_tokens.size(1))
     resp_hidden = hidden[:, prompt_len - 1 : prompt_len - 1 + T_max, :]
 
@@ -374,6 +403,50 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
         lengths = [int(n) for n in segment.lengths.tolist()]
         T_max = max(lengths) if lengths else 0
         pad_id = self.model.tokenizer.pad_token_id or 0
+
+        # ---- Packed varlen replay (B > 1): zero padding anywhere. -----------
+        # Concatenate every sample's REAL prompt tokens + its flat response
+        # tokens into ONE row; position_ids restart at 0 per sequence, and with
+        # attention_mask=None transformers' masking_utils detects the packed
+        # layout from the restarting positions and builds the block-causal mask
+        # (verl remove_padding equivalence). Per-sequence RoPE positions equal
+        # the standalone layout, so logp semantics are unchanged; the dense
+        # [B, P_max + T_max] path below stays for B == 1 (identical cost) and as
+        # the fallback.
+        if batch_size > 1 and segment.lengths is not None:
+            real_prompt_lens_p = prompt_mask.long().sum(dim=-1)  # [B] (right-padded layout)
+            cu_p = [int(c) for c in segment.cu_seqlens.tolist()]
+            flat_resp = segment.tokens.to(device=device, dtype=torch.long)
+            streams: List[torch.Tensor] = []
+            pos_parts: List[torch.Tensor] = []
+            pred_parts: List[torch.Tensor] = []
+            offset = 0
+            for b in range(batch_size):
+                n_p = int(real_prompt_lens_p[b].item())
+                n_r = lengths[b]
+                seq = torch.cat([prompt_ids[b, :n_p], flat_resp[cu_p[b] : cu_p[b] + n_r]])
+                streams.append(seq)
+                pos_parts.append(torch.arange(seq.numel(), device=device))
+                if n_r > 0:
+                    pred_parts.append(torch.arange(offset + n_p - 1, offset + n_p - 1 + n_r, device=device))
+                offset += int(seq.numel())
+            packed_ids = torch.cat(streams).unsqueeze(0)
+            packed_pos = torch.cat(pos_parts).unsqueeze(0)
+            predict_index = (
+                torch.cat(pred_parts) if pred_parts else torch.zeros(0, dtype=torch.long, device=device)
+            )
+            per_token_flat = self.model.transformer(
+                input_ids=packed_ids,
+                attention_mask=None,
+                position_ids=packed_pos,
+                response_tokens=flat_resp,
+                packed_predict_index=predict_index,
+                prompt_len=0,
+                temperature=temperature,
+                autocast_dtype=(self.autocast_dtype if device.type == "cuda" else None),
+            )
+            return per_token_flat.to(dtype=self.logprob_dtype)
+
         response_tokens = torch.full((batch_size, T_max), pad_id, dtype=torch.long, device=device)
         response_mask = torch.zeros((batch_size, T_max), dtype=torch.long, device=device)
         cu = [int(c) for c in segment.cu_seqlens.tolist()]
@@ -404,6 +477,20 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
                 left_padded_mask[b, prompt_len - n_real :] = 1
             prompt_ids = left_padded_ids
             prompt_mask = left_padded_mask
+
+        # Trim the prompt block to THIS batch's true max length. The track-level
+        # concat right-pads prompts to the global (worker-shard) max, so every
+        # replay micro otherwise forwards at the widest prompt in the shard —
+        # pure dense-pad waste (with token-budget packing the micro members are
+        # length-sorted, making the waste systematic). After the LEFT re-pad all
+        # real tokens sit at the right end, so dropping the leading all-pad
+        # columns preserves prompt-end position (= new prompt_len - 1) and the
+        # cumsum position_ids below are pad-invariant.
+        max_real_prompt = int(real_prompt_lens.max().item())
+        if 0 < max_real_prompt < prompt_len:
+            prompt_ids = prompt_ids[:, prompt_len - max_real_prompt :]
+            prompt_mask = prompt_mask[:, prompt_len - max_real_prompt :]
+            prompt_len = max_real_prompt
 
         if T_max > 0:
             full_ids = torch.cat([prompt_ids, response_tokens], dim=1)


### PR DESCRIPTION
Part of the verl performance-parity series tracked in #40.

## Summary
Dense replay forwards `[B, P_max + T_max]` with the prompt and response blocks padded separately; even sorted packing fills it at most ~65%. For B>1 the replay now concatenates real prompt + flat response tokens into ONE packed row: transformers >= 4.57 natively detects restarting `position_ids` (with `attention_mask=None`) and builds the block-causal mask, so per-sequence RoPE/logp semantics are unchanged. The chunked fp32 logp runs over hidden states gathered at the flat predict positions. Also trims the dense path prompt block to the micro true max width (the track-level concat pads to the worker-shard max: train phase 54.3s -> 46.8s measured for the trim alone).

`TrainStack.micro_cost_model=sum` switches packing to real-token accounting (= verl). Pays off together with the flex_attention follow-up PR — SDPA falls back to the math kernel on packed block-causal masks.

## Equivalence
packed vs per-sample dense replay, fp32 weights/body: mean |dlogp| = 1e-5, max = 3e-5 (bf16 run noise is the same class as the documented dense micro batch-shape sensitivity; rollout-anchored ratio absorbs it — ratio_mean 1.0000 in-run).

## Test Plan
- fp32 equivalence gate (above) on Qwen3-4B-Base
- 16-GPU run `pack16v5_unirl_drpo_gz6`: ratio 0.9998-1.0001
- dense path regression: B==1 takes the original code path