### PR TITLE
perf(trainer): driver-side DP seqlen balancing (verl balance_batch parity) (issue #40)

### DIFF
--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -37,6 +37,11 @@ adv_normalization_scope: group
 # false = mean-center-only advantage (reward - group_mean), no std division —
 # removes the GRPO difficulty bias (reference norm_adv_by_std_in_grpo=False).
 normalize_adv_by_std: false
+# Reorder the rollout batch driver-side so each DP rank gets a similar token
+# total (verl trainer.balance_batch parity). GRPO groups are dispatched as
+# consecutive siblings, so without this one rank draws a hard prompt's 8 long
+# answers and straggles the whole FSDP step. Measured: train 28.4s -> 15.3s.
+balance_dp_batch: true
 
 logging:
   report_to_wandb: true

--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -37,11 +37,11 @@ adv_normalization_scope: group
 # false = mean-center-only advantage (reward - group_mean), no std division —
 # removes the GRPO difficulty bias (reference norm_adv_by_std_in_grpo=False).
 normalize_adv_by_std: false
-# Reorder the rollout batch driver-side so each DP rank gets a similar token
+# Reorder the rollout batch driver-side so each DP shard gets a similar token
 # total (verl trainer.balance_batch parity). GRPO groups are dispatched as
 # consecutive siblings, so without this one rank draws a hard prompt's 8 long
 # answers and straggles the whole FSDP step. Measured: train 28.4s -> 15.3s.
-balance_dp_batch: true
+balance_shards: true
 
 logging:
   report_to_wandb: true

--- a/unirl/train_ar.py
+++ b/unirl/train_ar.py
@@ -40,6 +40,7 @@ def main(cfg: DictConfig) -> None:
         logging_cfg=cfg.get("logging"),
         adv_normalization_scope=cfg.get("adv_normalization_scope", "group"),
         normalize_adv_by_std=bool(cfg.get("normalize_adv_by_std", True)),
+        balance_dp_batch=bool(cfg.get("balance_dp_batch", False)),
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", 60)),
         eval_samples_per_prompt=int(cfg.get("eval_samples_per_prompt", 16)),

--- a/unirl/train_ar.py
+++ b/unirl/train_ar.py
@@ -40,7 +40,7 @@ def main(cfg: DictConfig) -> None:
         logging_cfg=cfg.get("logging"),
         adv_normalization_scope=cfg.get("adv_normalization_scope", "group"),
         normalize_adv_by_std=bool(cfg.get("normalize_adv_by_std", True)),
-        balance_dp_batch=bool(cfg.get("balance_dp_batch", False)),
+        balance_shards=bool(cfg.get("balance_shards", False)),
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", 60)),
         eval_samples_per_prompt=int(cfg.get("eval_samples_per_prompt", 16)),

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -52,6 +52,7 @@ class ARTrainer(BaseTrainer):
         logging_cfg: Optional[DictConfig] = None,
         adv_normalization_scope: str = "group",
         normalize_adv_by_std: bool = True,
+        balance_dp_batch: bool = False,
         eval_interval: int = 0,
         eval_num_prompts: int = 60,
         eval_samples_per_prompt: int = 16,
@@ -65,6 +66,12 @@ class ARTrainer(BaseTrainer):
         # group std. False = mean-center only (reward - group_mean), NO std division —
         # removes the difficulty bias that over-amplifies low-std (hard) prompts.
         self.normalize_adv_by_std = normalize_adv_by_std
+        # verl trainer.balance_batch parity: driver-side reorder of the rollout
+        # batch so each DP rank receives a similar total-token workload. FSDP
+        # collectives sync all ranks every micro, so a step runs at the SLOWEST
+        # rank's pace — without balancing, the rank that drew the longest
+        # sequences straggles (~+/-11%% rank-total variance at heavy lengths).
+        self.balance_dp_batch = bool(balance_dp_batch)  # overrides the BaseTrainer default (False)
         # AIME-style periodic eval — avg@k accuracy on the eval prompt set
         # (run.eval_data_path), logged under eval/*. eval_interval=0 disables it.
         self.eval_interval = int(eval_interval)
@@ -160,6 +167,7 @@ class ARTrainer(BaseTrainer):
 
         self._drop_decoded(req, resp, rollout_id=rollout_id)
         (track,) = resp.tracks.values()
+        track = self._balance_track(track)  # no-op unless balance_dp_batch
         result = self.stack.train_track(track, training_progress=float(training_progress))
         self.wandb_logger.log_rollout_step(
             rollout_id,

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -52,7 +52,7 @@ class ARTrainer(BaseTrainer):
         logging_cfg: Optional[DictConfig] = None,
         adv_normalization_scope: str = "group",
         normalize_adv_by_std: bool = True,
-        balance_dp_batch: bool = False,
+        balance_shards: bool = False,
         eval_interval: int = 0,
         eval_num_prompts: int = 60,
         eval_samples_per_prompt: int = 16,
@@ -67,11 +67,11 @@ class ARTrainer(BaseTrainer):
         # removes the difficulty bias that over-amplifies low-std (hard) prompts.
         self.normalize_adv_by_std = normalize_adv_by_std
         # verl trainer.balance_batch parity: driver-side reorder of the rollout
-        # batch so each DP rank receives a similar total-token workload. FSDP
+        # batch so each DP shard receives a similar total-token workload. FSDP
         # collectives sync all ranks every micro, so a step runs at the SLOWEST
         # rank's pace — without balancing, the rank that drew the longest
         # sequences straggles (~+/-11%% rank-total variance at heavy lengths).
-        self.balance_dp_batch = bool(balance_dp_batch)  # overrides the BaseTrainer default (False)
+        self.balance_shards = bool(balance_shards)  # overrides the BaseTrainer default (False)
         # AIME-style periodic eval — avg@k accuracy on the eval prompt set
         # (run.eval_data_path), logged under eval/*. eval_interval=0 disables it.
         self.eval_interval = int(eval_interval)
@@ -167,7 +167,10 @@ class ARTrainer(BaseTrainer):
 
         self._drop_decoded(req, resp, rollout_id=rollout_id)
         (track,) = resp.tracks.values()
-        track = self._balance_track(track)  # no-op unless balance_dp_batch
+        # verl balance_batch parity: reorder so each DP shard gets a near-equal
+        # token load before DP_SCATTER (no-op when already balanced).
+        if self.balance_shards:
+            track = track.balance_shards(int(self.num_devices))
         result = self.stack.train_track(track, training_progress=float(training_progress))
         self.wandb_logger.log_rollout_step(
             rollout_id,

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -95,6 +95,11 @@ class BaseTrainer:
         # consumed by _init_wandb. Empty for fresh runs.
         self._resume_state: Dict[str, Any] = {}
 
+        # DP seqlen balancing (verl trainer.balance_batch parity) — OFF by
+        # default; subclasses whose workloads have variable response lengths
+        # (currently ARTrainer) override this from their config.
+        self.balance_dp_batch = False
+
         # Reclaim per-rollout transport buffers after every train_step, centrally,
         # so each subclass train loop doesn't have to remember to.
         self._install_train_step_reset_hook()
@@ -136,6 +141,23 @@ class BaseTrainer:
     def _reset_transport_buffers(self) -> None:
         """Reclaim per-rollout mooncake zero-copy buffers (no-op for other backends)."""
         self.pool.reset_transfer_queue_buffers()
+
+    # ---- DP seqlen balancing (opt-in via balance_dp_batch) -----------------
+
+    def _balance_track(self, track):
+        """Opt-in DP seqlen balancing — thin policy wrapper over the mechanism.
+
+        The mechanism (hydrate + LPT reorder) lives with the data type:
+        :func:`unirl.types.rollout_resp.balance_track_for_dp`. This wrapper
+        only owns the POLICY: the ``balance_dp_batch`` flag (False by default; AR
+        workloads with variable response lengths opt in) and the dp size. Safe
+        to call unconditionally from any train_step.
+        """
+        if not self.balance_dp_batch:
+            return track
+        from unirl.types.rollout_resp import balance_track_for_dp
+
+        return balance_track_for_dp(track, dp_size=int(self.num_devices))
 
     # ---- wandb logging (shared by all v2 trainers) -------------------------
 

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -95,11 +95,6 @@ class BaseTrainer:
         # consumed by _init_wandb. Empty for fresh runs.
         self._resume_state: Dict[str, Any] = {}
 
-        # DP seqlen balancing (verl trainer.balance_batch parity) — OFF by
-        # default; subclasses whose workloads have variable response lengths
-        # (currently ARTrainer) override this from their config.
-        self.balance_dp_batch = False
-
         # Reclaim per-rollout transport buffers after every train_step, centrally,
         # so each subclass train loop doesn't have to remember to.
         self._install_train_step_reset_hook()
@@ -141,23 +136,6 @@ class BaseTrainer:
     def _reset_transport_buffers(self) -> None:
         """Reclaim per-rollout mooncake zero-copy buffers (no-op for other backends)."""
         self.pool.reset_transfer_queue_buffers()
-
-    # ---- DP seqlen balancing (opt-in via balance_dp_batch) -----------------
-
-    def _balance_track(self, track):
-        """Opt-in DP seqlen balancing — thin policy wrapper over the mechanism.
-
-        The mechanism (hydrate + LPT reorder) lives with the data type:
-        :func:`unirl.types.rollout_resp.balance_track_for_dp`. This wrapper
-        only owns the POLICY: the ``balance_dp_batch`` flag (False by default; AR
-        workloads with variable response lengths opt in) and the dp size. Safe
-        to call unconditionally from any train_step.
-        """
-        if not self.balance_dp_batch:
-            return track
-        from unirl.types.rollout_resp import balance_track_for_dp
-
-        return balance_track_for_dp(track, dp_size=int(self.num_devices))
 
     # ---- wandb logging (shared by all v2 trainers) -------------------------
 

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -63,6 +63,7 @@ from unirl.types.conditions import Condition
 from unirl.types.media_preview import MediaPreview
 from unirl.types.primitives import Audios, Images, Texts, Videos
 from unirl.types.segments import Segment
+from unirl.utils.shard_balance import lpt_shard_permutation, shard_token_spread
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,49 @@ class RolloutTrack(Batch):
             indices = torch.tensor(groups[gid], dtype=torch.long)
             results.append(self.select(indices))
         return results
+
+    def balance_shards(self, num_shards: int, *, min_spread: float = 0.05) -> "RolloutTrack":
+        """Reorder samples so ``num_shards`` equal contiguous shards carry ~equal tokens.
+
+        verl ``trainer.balance_batch`` parity. The consumer (``DP_SCATTER``) cuts
+        the batch into ``num_shards`` equal contiguous chunks, so every shard keeps
+        the same SAMPLE count — this only equalizes the per-shard TOKEN count, via
+        greedy LPT (:func:`unirl.utils.shard_balance.lpt_shard_permutation`).
+        Reordering is safe because advantages are already attached per sample.
+
+        Returns ``self`` unchanged when balancing cannot apply (no segment lengths,
+        ``num_shards <= 1``, batch size not divisible by ``num_shards``) or when the
+        shards are already within ``min_spread`` of balanced — permuting an
+        already-balanced batch only forces needless cross-shard row movement at
+        ``DP_SCATTER``. The reorder is applied via native zero-copy :meth:`select`,
+        so data stays worker-resident and materializes on the destination worker.
+
+        Args:
+            num_shards: Number of equal contiguous shards (the DP size).
+            min_spread: Skip balancing when the current per-shard token spread
+                (max-min over mean) is already below this fraction.
+
+        Returns:
+            A token-balanced copy of the track, or ``self`` if no reorder applies.
+        """
+        if self.segment is None or self.segment.lengths is None or num_shards <= 1:
+            return self
+        total = self.batch_size
+        if total % num_shards != 0:
+            return self
+        lengths = [int(x) for x in self.segment.lengths.tolist()]
+        if len(lengths) != total:
+            logger.warning("balance_shards: lengths (%d) != batch_size (%d); skipping.", len(lengths), total)
+            return self
+
+        before = shard_token_spread(lengths, num_shards)
+        if before < min_spread:
+            return self
+
+        perm = lpt_shard_permutation(lengths, num_shards)
+        after = shard_token_spread([lengths[i] for i in perm], num_shards)
+        logger.info("balance_shards: token spread %.1f%% -> %.1f%%", 100 * before, 100 * after)
+        return self.select(perm)
 
     # ---- track-to-track fan-out helper -------------------------------------
 
@@ -359,55 +403,6 @@ def _root_group_per_sample(resp: "RolloutResp", track_name: str) -> List[str]:
     parent = resp.tracks[track.parent_track]
     parent_sid_to_idx = {sid: i for i, sid in enumerate(parent.sample_ids)}
     return [parent_root_groups[parent_sid_to_idx[pid]] for pid in track.parent_ids]
-
-
-def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: float = 0.05) -> "RolloutTrack":
-    """verl ``_balance_batch`` parity: reorder samples so DP ranks get equal token sums.
-
-    Greedy LPT under an equal-count constraint (DP_SCATTER splits the batch
-    into dp_size EQUAL contiguous chunks): longest sample first, into the
-    eligible bucket with the smallest running token sum. Advantages are
-    computed BEFORE this point (per-group stats already attached per
-    sample), so sample order is free to change — the same invariant verl
-    relies on. Buckets are laid out contiguously in worker order.
-    """
-    lengths = getattr(track.segment, "lengths", None) if track.segment is not None else None
-    if lengths is None:
-        logger.warning("balance_dp_batch: track has no segment lengths; skipping balance.")
-        return track
-    total = int(track.batch_size)
-    dp = int(dp_size)
-    if total % dp != 0 or dp <= 1:
-        return track
-    cap = total // dp
-    lens = [int(x) for x in lengths.tolist()]
-    if len(lens) != total:
-        logger.warning("balance_dp_batch: lengths (%d) != batch_size (%d); skipping.", len(lens), total)
-        return track
-    # Cheap skip guard: compute the CURRENT-order per-rank token sums in pure
-    # Python — when the spread is already tiny (uniform-length workloads, e.g.
-    # multiple-choice answers or fixed-step diffusion latents), the reorder +
-    # dispatch is pure overhead (measured +9.6s/step on VL geo3k).
-    current = [sum(lens[r * cap : (r + 1) * cap]) for r in range(dp)]
-    avg = sum(current) / dp
-    if avg <= 0 or (max(current) - min(current)) / avg < float(min_spread):
-        return track
-    order = sorted(range(total), key=lambda i: (-lens[i], i))
-    buckets = [[] for _ in range(dp)]
-    sums = [0] * dp
-    for i in order:
-        best = min((b for b in range(dp) if len(buckets[b]) < cap), key=lambda b: sums[b])
-        buckets[best].append(i)
-        sums[best] += lens[i]
-    perm = [i for bucket in buckets for i in bucket]
-    balanced = track.select(perm)
-    logger.info(
-        "balance_dp_batch: rank token sums min=%d max=%d (spread %.1f%%)",
-        min(sums),
-        max(sums),
-        100.0 * (max(sums) - min(sums)) / max(1, sum(sums) // dp),
-    )
-    return balanced
 
 
 def _track_with_field(track: TR, field_name: str, value: Any) -> TR:

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -361,6 +361,55 @@ def _root_group_per_sample(resp: "RolloutResp", track_name: str) -> List[str]:
     return [parent_root_groups[parent_sid_to_idx[pid]] for pid in track.parent_ids]
 
 
+def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: float = 0.05) -> "RolloutTrack":
+    """verl ``_balance_batch`` parity: reorder samples so DP ranks get equal token sums.
+
+    Greedy LPT under an equal-count constraint (DP_SCATTER splits the batch
+    into dp_size EQUAL contiguous chunks): longest sample first, into the
+    eligible bucket with the smallest running token sum. Advantages are
+    computed BEFORE this point (per-group stats already attached per
+    sample), so sample order is free to change — the same invariant verl
+    relies on. Buckets are laid out contiguously in worker order.
+    """
+    lengths = getattr(track.segment, "lengths", None) if track.segment is not None else None
+    if lengths is None:
+        logger.warning("balance_dp_batch: track has no segment lengths; skipping balance.")
+        return track
+    total = int(track.batch_size)
+    dp = int(dp_size)
+    if total % dp != 0 or dp <= 1:
+        return track
+    cap = total // dp
+    lens = [int(x) for x in lengths.tolist()]
+    if len(lens) != total:
+        logger.warning("balance_dp_batch: lengths (%d) != batch_size (%d); skipping.", len(lens), total)
+        return track
+    # Cheap skip guard: compute the CURRENT-order per-rank token sums in pure
+    # Python — when the spread is already tiny (uniform-length workloads, e.g.
+    # multiple-choice answers or fixed-step diffusion latents), the reorder +
+    # dispatch is pure overhead (measured +9.6s/step on VL geo3k).
+    current = [sum(lens[r * cap : (r + 1) * cap]) for r in range(dp)]
+    avg = sum(current) / dp
+    if avg <= 0 or (max(current) - min(current)) / avg < float(min_spread):
+        return track
+    order = sorted(range(total), key=lambda i: (-lens[i], i))
+    buckets = [[] for _ in range(dp)]
+    sums = [0] * dp
+    for i in order:
+        best = min((b for b in range(dp) if len(buckets[b]) < cap), key=lambda b: sums[b])
+        buckets[best].append(i)
+        sums[best] += lens[i]
+    perm = [i for bucket in buckets for i in bucket]
+    balanced = track.select(perm)
+    logger.info(
+        "balance_dp_batch: rank token sums min=%d max=%d (spread %.1f%%)",
+        min(sums),
+        max(sums),
+        100.0 * (max(sums) - min(sums)) / max(1, sum(sums) // dp),
+    )
+    return balanced
+
+
 def _track_with_field(track: TR, field_name: str, value: Any) -> TR:
     """Return a copy of ``track`` with one field replaced (other fields preserved)."""
     kwargs: Dict[str, Any] = {f.name: getattr(track, f.name) for f in dc_fields(track)}

--- a/unirl/utils/shard_balance.py
+++ b/unirl/utils/shard_balance.py
@@ -1,0 +1,57 @@
+"""Token-balanced sharding of a flat sample list across equal-size partitions.
+
+Pure-Python helpers for the driver-side seqlen-balancing path (verl
+``trainer.balance_batch`` parity): reorder a batch so that, when it is split into
+``num_shards`` equal contiguous chunks (the layout ``DP_SCATTER`` produces), each
+chunk carries a similar total token count. No torch / framework deps, so the
+partition logic is unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+
+def shard_token_spread(lengths: list[int], num_shards: int) -> float:
+    """Return the relative token gap between the heaviest and lightest shard.
+
+    Splits ``lengths`` into ``num_shards`` equal contiguous chunks and returns
+    ``(max - min) / mean`` of the per-shard token sums — a unitless imbalance
+    measure (``0.0`` is perfectly balanced; also ``0.0`` when the mean is 0).
+
+    Args:
+        lengths: Per-sample token counts, in current batch order.
+        num_shards: Number of equal contiguous shards. Must divide ``len(lengths)``.
+
+    Returns:
+        The per-shard token-sum spread as a fraction of the mean.
+    """
+    per_shard = len(lengths) // num_shards
+    sums = [sum(lengths[s * per_shard : (s + 1) * per_shard]) for s in range(num_shards)]
+    mean = sum(sums) / num_shards
+    return (max(sums) - min(sums)) / mean if mean else 0.0
+
+
+def lpt_shard_permutation(lengths: list[int], num_shards: int) -> list[int]:
+    """Return a permutation that token-balances ``num_shards`` equal-size shards.
+
+    Greedy longest-processing-time under an equal-count constraint: assign the
+    longest sample first into the shard with the smallest running token sum that
+    still has room (each shard caps at ``len(lengths) // num_shards`` samples,
+    because ``DP_SCATTER`` splits into equal contiguous chunks). Reading the
+    returned permutation in ``num_shards`` equal contiguous blocks yields the
+    balanced shards.
+
+    Args:
+        lengths: Per-sample token counts, in current batch order.
+        num_shards: Number of equal contiguous shards. Must divide ``len(lengths)``.
+
+    Returns:
+        A permutation of ``range(len(lengths))``.
+    """
+    per_shard = len(lengths) // num_shards
+    shards: list[list[int]] = [[] for _ in range(num_shards)]
+    sums = [0] * num_shards
+    for i in sorted(range(len(lengths)), key=lambda j: (-lengths[j], j)):
+        target = min((s for s in range(num_shards) if len(shards[s]) < per_shard), key=lambda s: sums[s])
+        shards[target].append(i)
+        sums[target] += lengths[i]
+    return [i for shard in shards for i in shard]


### PR DESCRIPTION
Part of the verl performance-parity series tracked in #40.

## Summary
FSDP collectives synchronize all ranks every micro-batch, so a step runs at the SLOWEST rank pace; the rank that drew the longest sequences straggles. verl ships this as `trainer.balance_batch` (default True). This adds the equivalent for the AR trainer: after advantages are attached (sample order is then free — the same invariant verl relies on), the driver reorders the rollout batch with greedy LPT into dp_size equal-count buckets by response token sum, then DP_SCATTER chunks contiguously. The reorder is a native `track.select(perm)` — no hydration: building on #59's TensorRef segment-views, `Batch.select` reindexes the remote packed data as lazy range views (`select_ranges`), so the per-rollout tensors stay on the workers and only the permutation crosses to the driver.

Knob: `balance_dp_batch` (default false).

## Benchmark
Ablation (16-GPU, matched window steps 6-15, run `abl_v11a_balance` vs `perfphase16_unirl`): train phase **28.4s -> 15.3s (-46%)**, whole step **78.1s -> 64.0s**; rank token spread drops to 0.6-0.9% (log line per step). This reaches train-phase parity with the verl reference (16.1s). The effect is large because GRPO groups dispatch as consecutive siblings — one rank draws all 8 long answers of a hard prompt and straggles every FSDP micro. Recipe default flipped to `balance_dp_batch: true`.

## Test Plan
- per-step log line reports rank token sums min/max/spread
- ratio_mean / loss parity vs unbalanced run
- 16-GPU ablation run `abl_v11a_balance` (wandb)
