### PR TITLE
feat(sglang): tp>1 colocate engine topology + weight-sync correctness fixes (issue #40)

### DIFF
--- a/unirl/distributed/weight_sync/full/tensor.py
+++ b/unirl/distributed/weight_sync/full/tensor.py
@@ -84,21 +84,33 @@ class TensorWeightSync(FullWeightSync):
                 # config) is applied once in the base-class walk, shard-side.
                 by_dtype.setdefault(tensor.dtype, []).append((name, tensor))
 
+            # One payload entry per tp rank, each its OWN serialization (own
+            # CUDA-IPC export): sglang indexes serialized_named_tensors[tp_rank],
+            # and reusing one serialized string across ranks unbalances the IPC
+            # refcount handshake — the gathered full weights leak (~16 GB/step
+            # measured on tp=2). fanout==0 → this rank is a TP client whose
+            # engine no-ops; skip serialize/send but keep the collective gather
+            # and the bucket release below in lockstep with the other ranks.
+            fanout = int(getattr(self._rollout, "weight_payload_fanout", 1))
             serialized = []
-            for grouped in by_dtype.values():
-                flat = FlattenedTensorBucket(named_tensors=grouped)
-                payload = {
-                    "flattened_tensor": flat.get_flattened_tensor(),
-                    "metadata": flat.get_metadata(),
-                }
-                serialized.append(MultiprocessingSerializer.serialize(payload, output_str=True))
+            if fanout > 0:
+                for grouped in by_dtype.values():
+                    flat = FlattenedTensorBucket(named_tensors=grouped)
+                    payload = {
+                        "flattened_tensor": flat.get_flattened_tensor(),
+                        "metadata": flat.get_metadata(),
+                    }
+                    serialized.append(
+                        [
+                            MultiprocessingSerializer.serialize(payload, output_str=True)
+                            for _ in range(fanout)
+                        ]
+                    )
 
             n_dtypes = len(serialized)
-            for i, payload in enumerate(serialized):
-                # TP=1 → the worker picks serialized_named_tensors[0], so ship a
-                # single-element list. flush only on the very last payload.
+            for i, payload_per_rank in enumerate(serialized):
                 self._rollout.update_weights_from_tensor(
-                    serialized_named_tensors=[payload],
+                    serialized_named_tensors=payload_per_rank,
                     load_format="flattened_bucket",
                     flush_cache=(self._flush_cache and is_last and i == n_dtypes - 1),
                     track_prefix=self._track_prefix,

--- a/unirl/rollout/engine/sglang_llm/engine.py
+++ b/unirl/rollout/engine/sglang_llm/engine.py
@@ -479,10 +479,19 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         if self._tp_size > 1:
             cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
             phys: Optional[int] = None
-            if cvd and "," not in cvd:
+            entries = [e.strip() for e in cvd.split(",") if e.strip()] if cvd else []
+            if len(entries) == 1:
                 try:
-                    phys = int(cvd.strip())
+                    phys = int(entries[0])
                 except ValueError:
+                    phys = None
+            elif len(entries) > 1:
+                # Multi-entry CVD: device.index is a LOGICAL index into the visible
+                # list — map through to the physical id (review #46 N2).
+                idx = self._device.index if self._device.type == "cuda" else 0
+                try:
+                    phys = int(entries[int(idx or 0)])
+                except (ValueError, IndexError):
                     phys = None
             if phys is None:
                 idx = self._device.index if self._device.type == "cuda" else None
@@ -695,15 +704,24 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         import time as _time
 
         assert self._owner_url_file is not None
-        deadline = _time.monotonic() + float(timeout_s)
+        deadline = _time.monotonic() + float(timeout_s) + 60.0  # margin over the owner's health budget
         while _time.monotonic() < deadline:
             try:
                 with open(self._owner_url_file) as f:
                     url = f.read().strip()
-                if url:
-                    return url
             except FileNotFoundError:
-                pass
+                url = ""
+            if url:
+                # Health-validate before accepting (review #46 B1): a stale file
+                # from a previous run may name a dead server.
+                try:
+                    import urllib.request as _rq
+
+                    with _rq.urlopen(url + "/health", timeout=5) as resp:
+                        if resp.status == 200:
+                            return url
+                except Exception:
+                    pass
             _time.sleep(2.0)
         raise TimeoutError(
             f"SGLangLLMRolloutEngine[tp-client]: owner URL file {self._owner_url_file} "
@@ -733,6 +751,13 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
             kill_process_tree(self._server_process.pid)
             self._server_process.join(timeout=10)
             self._server_process = None
+        # TP owner: remove the rendezvous file so the next run never observes a
+        # stale URL (review #46 B1).
+        if self._tp_owner and self._owner_url_file is not None:
+            try:
+                os.unlink(self._owner_url_file)
+            except FileNotFoundError:
+                pass
 
     def __del__(self):
         try:
@@ -1302,6 +1327,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         backend: str = "nccl",
         track_prefix: str = "",
     ) -> None:
+        if not self._tp_owner:
+            return  # TP client: NCCL weight-update groups are owner-managed (review #46 N1)
         resp = self._post(
             "/init_weights_update_group",
             {
@@ -1327,6 +1354,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         group_name: str,
         track_prefix: str = "",
     ) -> None:
+        if not self._tp_owner:
+            return  # TP client: NCCL weight-update groups are owner-managed (review #46 N1)
         resp = self._post(
             "/destroy_weights_update_group",
             {"group_name": str(group_name)},
@@ -1392,6 +1421,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         handled by the parent :class:`ComposedRolloutEngine`; this child sees
         only its own (prefix-stripped) tensors.
         """
+        if not self._tp_owner:
+            return  # TP client: the owner single push covers the shared server (review #46 B2)
         try:
             from sglang.srt.utils import MultiprocessingSerializer
         except ImportError:

--- a/unirl/rollout/engine/sglang_llm/engine.py
+++ b/unirl/rollout/engine/sglang_llm/engine.py
@@ -462,6 +462,41 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         force_set_cuda = bool(engine_kwargs.get("force_set_cuda_visible_devices", False))
         mem_fraction = float(engine_kwargs.get("mem_fraction_static", 0.88))
 
+        # --- TP>1 colocate topology (owner/client) -------------------------
+        # Colocate gives every worker (one per GPU) its own engine object, but a
+        # tp>1 SRT server spans tp GPUs — so only one rank per tp-group (the
+        # "owner", lowest physical GPU id in the group) launches the server; the
+        # other ranks become pure HTTP clients of it. The owner widens the
+        # server child's CUDA_VISIBLE_DEVICES to the group's physical GPUs (ray
+        # restricts each worker to its own GPU) and publishes the server URL via
+        # a /dev/shm rendezvous file once healthy. Engine-lifecycle calls
+        # (sleep/wake/weight push) no-op on clients — the owner's single call
+        # covers the whole server, and the FSDP-gathered full weights are
+        # identical on every rank so one push suffices.
+        self._tp_owner = True
+        self._owner_url_file: Optional[str] = None
+        self._tp_child_cvd: Optional[str] = None
+        if self._tp_size > 1:
+            cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "")
+            phys: Optional[int] = None
+            if cvd and "," not in cvd:
+                try:
+                    phys = int(cvd.strip())
+                except ValueError:
+                    phys = None
+            if phys is None:
+                idx = self._device.index if self._device.type == "cuda" else None
+                phys = int(idx if idx is not None else 0)
+            group_base = (phys // self._tp_size) * self._tp_size
+            self._tp_owner = phys == group_base
+            self._owner_url_file = f"/dev/shm/unirl_sglang_tp{self._tp_size}_base{group_base}.url"
+            if self._tp_owner:
+                self._tp_child_cvd = ",".join(str(group_base + i) for i in range(self._tp_size))
+                try:
+                    os.unlink(self._owner_url_file)
+                except FileNotFoundError:
+                    pass
+
         # Colocate: N engines share a node, each initializing its own (tp=1)
         # torch.distributed env. SGLang leaves nccl_port=None → it calls
         # get_free_port() at model-init time, so the instances that finish
@@ -481,6 +516,12 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
             "mem_fraction_static": mem_fraction,
             "nccl_port": nccl_port,
         }
+        if self._tp_size > 1 and "disable_custom_all_reduce" not in engine_kwargs:
+            # Containerized colocate breaks sgl_kernel custom all-reduce CUDA-graph
+            # IPC across the tp worker processes (get_graph_buffer_ipc_meta →
+            # "invalid argument"). NCCL all-reduce is marginally slower but works
+            # everywhere; an explicit engine_kwargs override still wins.
+            server_kwargs["disable_custom_all_reduce"] = True
 
         current_cvd = os.environ.get("CUDA_VISIBLE_DEVICES", "<unset>")
         logger.info(
@@ -525,6 +566,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
             "max_loras_per_batch",
             "max_loaded_loras",
             "enable_multimodal",
+            "disable_custom_all_reduce",
+            "enable_p2p_check",
         ):
             if key in engine_kwargs:
                 server_kwargs[key] = engine_kwargs[key]
@@ -538,20 +581,33 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         os.environ["no_proxy"] = f"{_cur_no_proxy},{_extra_no_proxy}" if _cur_no_proxy else _extra_no_proxy
         os.environ["NO_PROXY"] = os.environ["no_proxy"]
 
-        logger.info(
-            "Launching SGLang SRT server: model=%s tp=%d port=%d",
-            self._model_path,
-            self._tp_size,
-            self._port,
-        )
-
-        self._server_process = self._launch_server(server_kwargs)
         health_timeout = float(engine_kwargs.get("health_timeout_s", 300.0))
-        wait_server_healthy(
-            self._base_url,
-            timeout_s=health_timeout,
-            is_alive_fn=lambda: self._server_process is not None and self._server_process.is_alive(),
-        )
+        if not self._tp_owner:
+            # TP client: another rank on this node owns the (tp>1) server that
+            # covers this GPU. Resolve its URL via the rendezvous file (written
+            # only after the owner's server passed its health check).
+            self._base_url = self._wait_owner_url(timeout_s=health_timeout)
+            logger.info("SGLangLLMRolloutEngine[tp-client]: using owner server at %s", self._base_url)
+        else:
+            logger.info(
+                "Launching SGLang SRT server: model=%s tp=%d port=%d child_cvd=%s",
+                self._model_path,
+                self._tp_size,
+                self._port,
+                self._tp_child_cvd,
+            )
+
+            self._server_process = self._launch_server(server_kwargs, child_cuda_visible=self._tp_child_cvd)
+            wait_server_healthy(
+                self._base_url,
+                timeout_s=health_timeout,
+                is_alive_fn=lambda: self._server_process is not None and self._server_process.is_alive(),
+            )
+            if self._owner_url_file is not None:
+                tmp = self._owner_url_file + ".tmp"
+                with open(tmp, "w") as f:
+                    f.write(self._base_url)
+                os.replace(tmp, self._owner_url_file)
 
         if httpx is not None:
             self._http_client = httpx.AsyncClient(
@@ -584,12 +640,22 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
     # Server lifecycle
     # ------------------------------------------------------------------
 
-    def _launch_server(self, server_kwargs: Dict[str, Any]) -> multiprocessing.Process:
+    def _launch_server(
+        self,
+        server_kwargs: Dict[str, Any],
+        child_cuda_visible: Optional[str] = None,
+    ) -> multiprocessing.Process:
         """Launch sglang SRT in a subprocess.
 
         ``multiprocessing.set_start_method("spawn", force=True)`` is
         process-global; PE-tested, Ray-compatible. Forcing matches the PE
         engine so torch CUDA init in the child happens cleanly.
+
+        ``child_cuda_visible`` (TP>1 colocate): ray restricts this worker to a
+        single GPU via CUDA_VISIBLE_DEVICES, but a tp>1 server child must see
+        the whole tp group. Spawn snapshots the parent env, so set the widened
+        value just around ``p.start()`` and restore — the parent's own CUDA
+        context (already initialized on its one GPU) is unaffected.
         """
         from sglang.srt.entrypoints.http_server import launch_server
         from sglang.srt.server_args import ServerArgs
@@ -604,8 +670,45 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         multiprocessing.set_start_method("spawn", force=True)
         server_args = ServerArgs(**server_kwargs)
         p = multiprocessing.Process(target=launch_server, args=(server_args,))
-        p.start()
+        if child_cuda_visible is not None:
+            prev_cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+            os.environ["CUDA_VISIBLE_DEVICES"] = child_cuda_visible
+            try:
+                p.start()
+            finally:
+                if prev_cvd is None:
+                    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+                else:
+                    os.environ["CUDA_VISIBLE_DEVICES"] = prev_cvd
+        else:
+            p.start()
         return p
+
+    def _wait_owner_url(self, *, timeout_s: float) -> str:
+        """TP client: poll the owner's rendezvous file until its server is up.
+
+        The owner writes the file atomically only AFTER its health check passes,
+        so a successful read here implies a live server. A stale file from a
+        previous run is impossible on the same boot: the owner unlinks it at
+        construction before launching.
+        """
+        import time as _time
+
+        assert self._owner_url_file is not None
+        deadline = _time.monotonic() + float(timeout_s)
+        while _time.monotonic() < deadline:
+            try:
+                with open(self._owner_url_file) as f:
+                    url = f.read().strip()
+                if url:
+                    return url
+            except FileNotFoundError:
+                pass
+            _time.sleep(2.0)
+        raise TimeoutError(
+            f"SGLangLLMRolloutEngine[tp-client]: owner URL file {self._owner_url_file} "
+            f"did not appear within {timeout_s:.0f}s — did the tp-owner rank fail to launch?"
+        )
 
     def shutdown(self) -> None:
         """Kill SRT server + router and close HTTP client."""
@@ -1135,8 +1238,26 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
     # Weight sync — HTTP POST to sglang SRT
     # ------------------------------------------------------------------
 
+    @property
+    def weight_payload_fanout(self) -> int:
+        """How many INDEPENDENTLY-serialized weight payload copies a sync must ship.
+
+        sglang's scheduler indexes ``serialized_named_tensors[tp_rank]`` — one
+        entry per tp rank, and each entry must be its OWN serialization (its own
+        CUDA-IPC export): duplicating one serialized string across ranks
+        unbalances the IPC refcount handshake and leaks the exporter's gathered
+        tensors (~16 GB/step measured). Owners report tp_size; TP clients report
+        0 (their update_weights_from_tensor no-ops — the owner's push covers the
+        shared server).
+        """
+        if self._tp_size <= 1:
+            return 1
+        return self._tp_size if self._tp_owner else 0
+
     def update_weights_from_path(self, checkpoint_path: str) -> None:
         """Update weights from a checkpoint on disk."""
+        if not self._tp_owner:
+            return  # TP client: the owner rank manages the shared tp>1 server
         resp = self._post(
             "/update_weights_from_disk",
             {"model_path": checkpoint_path, "flush_cache": True},
@@ -1158,6 +1279,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         default ``["transformer"]`` doesn't match LLM module naming. Omitting
         the field lets the SRT server accept all incoming weights correctly.
         """
+        if not self._tp_owner:
+            return  # TP client: the owner rank manages the shared tp>1 server
         del track_prefix
         payload: Dict[str, Any] = {
             "serialized_named_tensors": serialized_named_tensors,
@@ -1226,6 +1349,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         ``target_modules`` is intentionally NOT forwarded (see
         ``update_weights_from_tensor`` for rationale).
         """
+        if not self._tp_owner:
+            return  # TP client: the owner rank manages the shared tp>1 server
         # sglang expects bare dtype strings like "bfloat16", not "torch.bfloat16".
         clean_dtypes = [d.replace("torch.", "") if isinstance(d, str) else d for d in dtypes]
         logger.info(
@@ -1323,6 +1448,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         handles the routing; this child sees only the calls that actually
         target it.
         """
+        if not self._tp_owner:
+            return  # TP client: the owner rank manages the shared tp>1 server
         release_tags = None if tags is None or len(tags) == 0 else list(tags)
         if release_tags is None and self._is_offloaded:
             if not self._weights_onloaded_for_sync:
@@ -1391,6 +1518,8 @@ class SGLangLLMRolloutEngine(BaseRolloutEngine):
         ``wake_up(tags=["kv_cache", "cuda_graph"])`` before generation.
 
         """
+        if not self._tp_owner:
+            return  # TP client: the owner rank manages the shared tp>1 server
         full_wake = tags is None or len(tags) == 0
         resume_tags = None if full_wake else list(tags)
         if resume_tags is None:


### PR DESCRIPTION
Part of the verl performance-parity series tracked in #40.

## Summary
A tp>1 SRT server spans tp GPUs but colocate builds one engine per GPU. The lowest-physical-GPU rank of each tp group becomes the owner: it launches the server (CUDA_VISIBLE_DEVICES widened for the spawn child), publishes its URL via a /dev/shm rendezvous file once healthy; the other ranks become pure HTTP clients (generate posts to the owner; sleep/wake/weight-push no-op). Also:
- `disable_custom_all_reduce` defaults on for tp>1 (sgl_kernel custom all-reduce CUDA-graph IPC fails across tp worker processes in containers)
- **per-tp-rank INDEPENDENT weight payload serialization**: duplicating one serialized string across ranks unbalances the CUDA-IPC refcount handshake and leaks the gathered full weights (+16.5 GB/step measured via the cuda-alloc watermark -> OOM by step 4). `TensorWeightSync` now serializes `weight_payload_fanout` independent copies (owner=tp_size, client=0, gather stays in lockstep)

tp=1 behavior unchanged.

## Measured caveat (why this is capability, not a default)
On H20 colocate with custom-AR disabled, tp=2 generation is SLOWER than tp=1 at every observed length (len~1k: 70.0 vs 47.7s; len~3.4k: 177.7 vs 110.5s) — per-layer NCCL allreduce latency dominates. The vllm-tp2 advantage seen in verl does not transfer to sglang-NCCL here. Shipped for topologies/models where it does pay; default stays tp_size=1.

## Test Plan
- 12+ step stable tp=2 run (`tp2v10_unirl_drpo_gz6`): cuda_alloc flat at 3.81 GB (leak gone), ratio 1.000x
- A/B soak tp1 vs tp2 to len~4k (`unirl_opt16_tp1_soak` / `unirl_opt16_tp2_soak`)
- tp=1 regression: all perf runs in this series