### PR TITLE
perf(recipe): one-wave decode — concurrency 32 + cuda_graph_max_bs 32

### DIFF
--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -117,7 +117,7 @@ rollout:
     max_new_tokens: 8192
     temperature: 1.0
     top_p: 1.0
-    concurrency: 16
+    concurrency: 32
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
     samples_pre_expanded: true
@@ -135,7 +135,7 @@ rollout:
       skip_server_warmup: true
       attention_backend: triton
       disable_cuda_graph: false
-      cuda_graph_max_bs: 16
+      cuda_graph_max_bs: 32
       enable_lora: false
 
 reward:


### PR DESCRIPTION
Part of the verl performance-parity series tracked in #40.

## Summary
Each worker submits 32 requests but the engine concurrency semaphore (16) split them into two decode waves — paying the straggler tail twice — and CUDA graphs capped at bs16 left the second half of the batch off-graph. Raise both to 32 so the full per-engine batch decodes in one wave on graphs.

## Benchmark
Isolated ablation (16-GPU, matched window, `abl_v11c_conc16` vs `perfphase16_unirl`): **no measurable generate-phase difference at len ~1k** (48.9s vs 48.3s, within run noise) — the engine appears to pipeline the two waves well at short lengths. Keeping as draft: the knobs may matter in the heavy regime (graphs at bs32 during long decode), unverified.

## Test Plan
- ablation run `abl_v11c_conc16` vs `perfphase16_unirl` (wandb project unirl-grpo)
- memory headroom check: graphs at bs32 vs the weight-push peak