### PR TITLE
feat(transport): TensorMeta ref views (HandleView) — selection without hydration (issue #40)

### DIFF
--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -37,6 +37,11 @@ adv_normalization_scope: group
 # false = mean-center-only advantage (reward - group_mean), no std division —
 # removes the GRPO difficulty bias (reference norm_adv_by_std_in_grpo=False).
 normalize_adv_by_std: false
+# Reorder the rollout batch driver-side so each DP rank gets a similar token
+# total (verl trainer.balance_batch parity). GRPO groups are dispatched as
+# consecutive siblings, so without this one rank draws a hard prompt's 8 long
+# answers and straggles the whole FSDP step. Measured: train 28.4s -> 15.3s.
+balance_dp_batch: true
 
 logging:
   report_to_wandb: true

--- a/tests/test_tensormeta_views.py
+++ b/tests/test_tensormeta_views.py
@@ -1,13 +1,14 @@
-"""Unit tests for TensorMeta segment views (select/slice without hydration).
+"""Unit tests for TensorMeta ref views (select/slice without hydration).
 
-Pure-CPU: refs are faked with a minimal handle protocol (.local/.shape/.dtype/
-.device), no transport backend required (materialize falls back to per-handle
-fetch when backend is None).
+Selection emits :class:`HandleView` refs — unit-range views of the parent
+refs — instead of moving data. Pure-CPU: parent refs are faked with a minimal
+handle protocol (.local/.shape/.dtype/.device), no transport backend required
+(materialize falls back to per-ref fetch when backend is None).
 """
 
 import torch
 
-from unirl.distributed.tensor.transport import TensorMeta
+from unirl.distributed.tensor.transport import HandleView, TensorMeta, cat_rows
 
 
 class _FakeHandle:
@@ -38,7 +39,8 @@ def test_select_permutation_with_ragged_pad():
     tm = _meta(t0, t1, t2)
     perm = [5, 0, 3, 6, 2, 1, 4]
     v = tm.select(perm)
-    assert v.view_plan is not None and v.batch_size == 7
+    assert v.batch_size == 7
+    assert any(isinstance(r, HandleView) for r in v.refs)
     out = v.materialize(backend=None)
     assert out.shape == (7, 6)  # ragged refs right-padded to the max width
     assert torch.equal(out[0, :5], t2[0])
@@ -55,12 +57,23 @@ def test_view_slice_matches_materialized_rows():
     assert torch.equal(half.materialize(backend=None), full[1:3])
 
 
-def test_misaligned_slice_degrades_to_view():
+def test_aligned_slice_passes_refs_through():
+    # A ref-boundary-aligned slice is the structural inverse of concat:
+    # the original ref objects come back untouched (no HandleView wrapping).
+    t0 = torch.arange(12).reshape(3, 4).float()
+    t1 = torch.arange(100, 108).reshape(2, 4).float()
+    tm = _meta(t0, t1)
+    head = tm.slice(0, 3)
+    assert head.refs == [tm.refs[0]] and head.sizes == [3]
+
+
+def test_misaligned_slice_wraps_boundary_refs():
     t0 = torch.arange(12).reshape(3, 4).float()
     t1 = torch.arange(100, 108).reshape(2, 4).float()
     tm = _meta(t0, t1)
     mid = tm.slice(1, 4)  # crosses the ref boundary off-alignment
-    assert mid.view_plan is not None and mid.batch_size == 3
+    assert mid.batch_size == 3
+    assert isinstance(mid.refs[0], HandleView) and isinstance(mid.refs[1], HandleView)
     assert torch.equal(mid.materialize(backend=None), torch.cat([t0[1:], t1[:1]]))
 
 
@@ -73,11 +86,21 @@ def test_packed_segment_view():
     assert torch.equal(pv.materialize(backend=None), torch.cat([p1[2:6], p0[0:3]]))
 
 
-def test_with_refs_preserves_plan():
+def test_nested_views_flatten():
+    # A view of a view flattens to a single HandleView over the parent ref —
+    # repeated selection never builds an indirection chain.
+    t0 = torch.arange(40).reshape(8, 5).float()
+    v1 = _meta(t0).select([3, 4, 5, 6])  # rows 3..6 (one coalesced view)
+    v2 = v1.select([1, 2])  # rows 4..5 of the original
+    assert all(isinstance(r, HandleView) and isinstance(r.base, _FakeHandle) for r in v2.refs)
+    assert torch.equal(v2.materialize(backend=None), t0[4:6])
+
+
+def test_with_refs_preserves_sizes():
     t0 = torch.arange(8).reshape(2, 4).float()
     v = _meta(t0).select([1, 0])
     v2 = v.with_refs(list(v.refs))
-    assert v2.view_plan == v.view_plan
+    assert v2.sizes == v.sizes and v2.batch_size == v.batch_size
 
 
 def test_empty_selection():
@@ -87,8 +110,17 @@ def test_empty_selection():
     assert e.materialize(backend=None).numel() == 0
 
 
-def test_assemble_from_prefetched_parts():
+def test_view_shape_and_local():
     t0 = torch.arange(12).reshape(3, 4).float()
-    t1 = torch.arange(100, 112).reshape(2, 6).float()
-    v = _meta(t0, t1).select([4, 0, 2])
-    assert torch.equal(v.materialize(backend=None), v.assemble({0: t0, 1: t1}))
+    h = _FakeHandle(t0)
+    v = HandleView(h, 1, 3)
+    assert v.shape == (2, 4) and v.dtype == t0.dtype
+    assert torch.equal(v.local(), t0[1:3])
+
+
+def test_cat_rows_ragged_pad_contract():
+    a = torch.ones(2, 3)
+    b = torch.full((1, 5), 2.0)
+    out = cat_rows([a, b])
+    assert out.shape == (3, 5)
+    assert torch.all(out[:2, 3:] == 0)  # right-pad with zeros

--- a/tests/test_tensormeta_views.py
+++ b/tests/test_tensormeta_views.py
@@ -1,0 +1,94 @@
+"""Unit tests for TensorMeta segment views (select/slice without hydration).
+
+Pure-CPU: refs are faked with a minimal handle protocol (.local/.shape/.dtype/
+.device), no transport backend required (materialize falls back to per-handle
+fetch when backend is None).
+"""
+
+import torch
+
+from unirl.distributed.tensor.transport import TensorMeta
+
+
+class _FakeHandle:
+    def __init__(self, t: torch.Tensor):
+        self.t = t
+        self.shape = t.shape
+        self.dtype = t.dtype
+        self.device = t.device
+
+    def local(self) -> torch.Tensor:
+        return self.t
+
+
+def _meta(*tensors: torch.Tensor) -> TensorMeta:
+    return TensorMeta(
+        refs=[_FakeHandle(t) for t in tensors],
+        sizes=[int(t.shape[0]) for t in tensors],
+        shape=(sum(int(t.shape[0]) for t in tensors), *tensors[0].shape[1:]),
+        dtype=tensors[0].dtype,
+        device="cpu",
+    )
+
+
+def test_select_permutation_with_ragged_pad():
+    t0 = torch.arange(12).reshape(3, 4).float()
+    t1 = torch.arange(100, 112).reshape(2, 6).float()
+    t2 = torch.arange(200, 210).reshape(2, 5).float()
+    tm = _meta(t0, t1, t2)
+    perm = [5, 0, 3, 6, 2, 1, 4]
+    v = tm.select(perm)
+    assert v.view_plan is not None and v.batch_size == 7
+    out = v.materialize(backend=None)
+    assert out.shape == (7, 6)  # ragged refs right-padded to the max width
+    assert torch.equal(out[0, :5], t2[0])
+    assert torch.equal(out[1, :4], t0[0])
+    assert torch.all(out[1, 4:] == 0)
+
+
+def test_view_slice_matches_materialized_rows():
+    t0 = torch.arange(12).reshape(3, 4).float()
+    t1 = torch.arange(100, 108).reshape(2, 4).float()
+    v = _meta(t0, t1).select([4, 0, 2, 1])
+    full = v.materialize(backend=None)
+    half = v.slice(1, 3)
+    assert torch.equal(half.materialize(backend=None), full[1:3])
+
+
+def test_misaligned_slice_degrades_to_view():
+    t0 = torch.arange(12).reshape(3, 4).float()
+    t1 = torch.arange(100, 108).reshape(2, 4).float()
+    tm = _meta(t0, t1)
+    mid = tm.slice(1, 4)  # crosses the ref boundary off-alignment
+    assert mid.view_plan is not None and mid.batch_size == 3
+    assert torch.equal(mid.materialize(backend=None), torch.cat([t0[1:], t1[:1]]))
+
+
+def test_packed_segment_view():
+    p0 = torch.arange(10).float()
+    p1 = torch.arange(100, 106).float()
+    pm = _meta(p0, p1)
+    pv = pm.select_segments([(12, 16), (0, 3)])  # out-of-order token ranges
+    assert pv.batch_size == 7
+    assert torch.equal(pv.materialize(backend=None), torch.cat([p1[2:6], p0[0:3]]))
+
+
+def test_with_refs_preserves_plan():
+    t0 = torch.arange(8).reshape(2, 4).float()
+    v = _meta(t0).select([1, 0])
+    v2 = v.with_refs(list(v.refs))
+    assert v2.view_plan == v.view_plan
+
+
+def test_empty_selection():
+    p0 = torch.arange(10).float()
+    e = _meta(p0).select_segments([])
+    assert e.batch_size == 0
+    assert e.materialize(backend=None).numel() == 0
+
+
+def test_assemble_from_prefetched_parts():
+    t0 = torch.arange(12).reshape(3, 4).float()
+    t1 = torch.arange(100, 112).reshape(2, 6).float()
+    v = _meta(t0, t1).select([4, 0, 2])
+    assert torch.equal(v.materialize(backend=None), v.assemble({0: t0, 1: t1}))

--- a/tests/test_tensorref_spans.py
+++ b/tests/test_tensorref_spans.py
@@ -1,6 +1,6 @@
-"""Unit tests for TensorMeta ref views (select/slice without hydration).
+"""Unit tests for TensorRef ref views (select/slice without hydration).
 
-Selection emits :class:`HandleView` refs — unit-range views of the parent
+Selection emits :class:`TensorSpan` refs — unit-range views of the parent
 refs — instead of moving data. Pure-CPU: parent refs are faked with a minimal
 handle protocol (.local/.shape/.dtype/.device), no transport backend required
 (materialize falls back to per-ref fetch when backend is None).
@@ -8,7 +8,7 @@ handle protocol (.local/.shape/.dtype/.device), no transport backend required
 
 import torch
 
-from unirl.distributed.tensor.transport import HandleView, TensorMeta, cat_rows
+from unirl.distributed.tensor.transport import TensorSpan, TensorRef, cat_rows
 
 
 class _FakeHandle:
@@ -22,8 +22,8 @@ class _FakeHandle:
         return self.t
 
 
-def _meta(*tensors: torch.Tensor) -> TensorMeta:
-    return TensorMeta(
+def _meta(*tensors: torch.Tensor) -> TensorRef:
+    return TensorRef(
         refs=[_FakeHandle(t) for t in tensors],
         sizes=[int(t.shape[0]) for t in tensors],
         shape=(sum(int(t.shape[0]) for t in tensors), *tensors[0].shape[1:]),
@@ -40,7 +40,7 @@ def test_select_permutation_with_ragged_pad():
     perm = [5, 0, 3, 6, 2, 1, 4]
     v = tm.select(perm)
     assert v.batch_size == 7
-    assert any(isinstance(r, HandleView) for r in v.refs)
+    assert any(isinstance(r, TensorSpan) for r in v.refs)
     out = v.materialize(backend=None)
     assert out.shape == (7, 6)  # ragged refs right-padded to the max width
     assert torch.equal(out[0, :5], t2[0])
@@ -59,7 +59,7 @@ def test_view_slice_matches_materialized_rows():
 
 def test_aligned_slice_passes_refs_through():
     # A ref-boundary-aligned slice is the structural inverse of concat:
-    # the original ref objects come back untouched (no HandleView wrapping).
+    # the original ref objects come back untouched (no TensorSpan wrapping).
     t0 = torch.arange(12).reshape(3, 4).float()
     t1 = torch.arange(100, 108).reshape(2, 4).float()
     tm = _meta(t0, t1)
@@ -73,7 +73,7 @@ def test_misaligned_slice_wraps_boundary_refs():
     tm = _meta(t0, t1)
     mid = tm.slice(1, 4)  # crosses the ref boundary off-alignment
     assert mid.batch_size == 3
-    assert isinstance(mid.refs[0], HandleView) and isinstance(mid.refs[1], HandleView)
+    assert isinstance(mid.refs[0], TensorSpan) and isinstance(mid.refs[1], TensorSpan)
     assert torch.equal(mid.materialize(backend=None), torch.cat([t0[1:], t1[:1]]))
 
 
@@ -87,12 +87,12 @@ def test_packed_segment_view():
 
 
 def test_nested_views_flatten():
-    # A view of a view flattens to a single HandleView over the parent ref —
+    # A view of a view flattens to a single TensorSpan over the parent ref —
     # repeated selection never builds an indirection chain.
     t0 = torch.arange(40).reshape(8, 5).float()
     v1 = _meta(t0).select([3, 4, 5, 6])  # rows 3..6 (one coalesced view)
     v2 = v1.select([1, 2])  # rows 4..5 of the original
-    assert all(isinstance(r, HandleView) and isinstance(r.base, _FakeHandle) for r in v2.refs)
+    assert all(isinstance(r, TensorSpan) and isinstance(r.base, _FakeHandle) for r in v2.refs)
     assert torch.equal(v2.materialize(backend=None), t0[4:6])
 
 
@@ -113,7 +113,7 @@ def test_empty_selection():
 def test_view_shape_and_local():
     t0 = torch.arange(12).reshape(3, 4).float()
     h = _FakeHandle(t0)
-    v = HandleView(h, 1, 3)
+    v = TensorSpan(h, 1, 3)
     assert v.shape == (2, 4) and v.dtype == t0.dtype
     assert torch.equal(v.local(), t0[1:3])
 

--- a/tests/test_tensorref_spans.py
+++ b/tests/test_tensorref_spans.py
@@ -1,14 +1,14 @@
-"""Unit tests for TensorRef ref views (select/slice without hydration).
+"""Unit tests for TensorRef span views (select/slice without hydration).
 
-Selection emits :class:`TensorSpan` refs — unit-range views of the parent
-refs — instead of moving data. Pure-CPU: parent refs are faked with a minimal
-handle protocol (.local/.shape/.dtype/.device), no transport backend required
-(materialize falls back to per-ref fetch when backend is None).
+Selection emits :class:`TensorSpan` spans — contiguous row-windows over the
+parent handles — instead of moving data. Pure-CPU: handles are faked with a
+minimal protocol (.local/.shape/.dtype/.device), no transport backend required
+(materialize falls back to per-span fetch when backend is None).
 """
 
 import torch
 
-from unirl.distributed.tensor.transport import TensorSpan, TensorRef, cat_rows
+from unirl.distributed.tensor.transport import TensorRef, TensorSpan, cat_rows
 
 
 class _FakeHandle:
@@ -24,8 +24,7 @@ class _FakeHandle:
 
 def _meta(*tensors: torch.Tensor) -> TensorRef:
     return TensorRef(
-        refs=[_FakeHandle(t) for t in tensors],
-        sizes=[int(t.shape[0]) for t in tensors],
+        spans=[TensorSpan(_FakeHandle(t), 0, int(t.shape[0])) for t in tensors],
         shape=(sum(int(t.shape[0]) for t in tensors), *tensors[0].shape[1:]),
         dtype=tensors[0].dtype,
         device="cpu",
@@ -40,9 +39,9 @@ def test_select_permutation_with_ragged_pad():
     perm = [5, 0, 3, 6, 2, 1, 4]
     v = tm.select(perm)
     assert v.batch_size == 7
-    assert any(isinstance(r, TensorSpan) for r in v.refs)
+    assert any(isinstance(r, TensorSpan) for r in v.spans)
     out = v.materialize(backend=None)
-    assert out.shape == (7, 6)  # ragged refs right-padded to the max width
+    assert out.shape == (7, 6)  # ragged spans right-padded to the max width
     assert torch.equal(out[0, :5], t2[0])
     assert torch.equal(out[1, :4], t0[0])
     assert torch.all(out[1, 4:] == 0)
@@ -57,23 +56,25 @@ def test_view_slice_matches_materialized_rows():
     assert torch.equal(half.materialize(backend=None), full[1:3])
 
 
-def test_aligned_slice_passes_refs_through():
-    # A ref-boundary-aligned slice is the structural inverse of concat:
-    # the original ref objects come back untouched (no TensorSpan wrapping).
+def test_aligned_slice_passes_spans_through():
+    # A span-boundary-aligned slice is the structural inverse of concat:
+    # the original span object (and its handle) comes back untouched.
     t0 = torch.arange(12).reshape(3, 4).float()
     t1 = torch.arange(100, 108).reshape(2, 4).float()
     tm = _meta(t0, t1)
     head = tm.slice(0, 3)
-    assert head.refs == [tm.refs[0]] and head.sizes == [3]
+    assert head.spans == [tm.spans[0]] and head.sizes == [3]
+    assert head.spans[0] is tm.spans[0]
+    assert head.spans[0].handle is tm.spans[0].handle
 
 
-def test_misaligned_slice_wraps_boundary_refs():
+def test_misaligned_slice_wraps_boundary_spans():
     t0 = torch.arange(12).reshape(3, 4).float()
     t1 = torch.arange(100, 108).reshape(2, 4).float()
     tm = _meta(t0, t1)
-    mid = tm.slice(1, 4)  # crosses the ref boundary off-alignment
+    mid = tm.slice(1, 4)  # crosses the span boundary off-alignment
     assert mid.batch_size == 3
-    assert isinstance(mid.refs[0], TensorSpan) and isinstance(mid.refs[1], TensorSpan)
+    assert isinstance(mid.spans[0], TensorSpan) and isinstance(mid.spans[1], TensorSpan)
     assert torch.equal(mid.materialize(backend=None), torch.cat([t0[1:], t1[:1]]))
 
 
@@ -87,19 +88,19 @@ def test_packed_segment_view():
 
 
 def test_nested_views_flatten():
-    # A view of a view flattens to a single TensorSpan over the parent ref —
+    # A span of a span flattens to a single TensorSpan over the handle —
     # repeated selection never builds an indirection chain.
     t0 = torch.arange(40).reshape(8, 5).float()
-    v1 = _meta(t0).select([3, 4, 5, 6])  # rows 3..6 (one coalesced view)
+    v1 = _meta(t0).select([3, 4, 5, 6])  # rows 3..6 (one coalesced span)
     v2 = v1.select([1, 2])  # rows 4..5 of the original
-    assert all(isinstance(r, TensorSpan) and isinstance(r.base, _FakeHandle) for r in v2.refs)
+    assert all(isinstance(r, TensorSpan) and isinstance(r.handle, _FakeHandle) for r in v2.spans)
     assert torch.equal(v2.materialize(backend=None), t0[4:6])
 
 
-def test_with_refs_preserves_sizes():
+def test_with_spans_preserves_sizes():
     t0 = torch.arange(8).reshape(2, 4).float()
     v = _meta(t0).select([1, 0])
-    v2 = v.with_refs(list(v.refs))
+    v2 = v.with_spans(list(v.spans))
     assert v2.sizes == v.sizes and v2.batch_size == v.batch_size
 
 
@@ -110,7 +111,7 @@ def test_empty_selection():
     assert e.materialize(backend=None).numel() == 0
 
 
-def test_view_shape_and_local():
+def test_span_shape_and_local():
     t0 = torch.arange(12).reshape(3, 4).float()
     h = _FakeHandle(t0)
     v = TensorSpan(h, 1, 3)

--- a/unirl/distributed/group/handle.py
+++ b/unirl/distributed/group/handle.py
@@ -351,8 +351,8 @@ class Handle:
                     o.rebind(worker_handle)
                 return TensorRef.from_handles([o])
             if isinstance(o, TensorRef) and worker_local:
-                for h in o.refs:
-                    h.rebind(worker_handle)
+                for s in o.spans:
+                    s.handle.rebind(worker_handle)
             return o
 
         return map_tree(obj, rebind_leaf)

--- a/unirl/distributed/group/handle.py
+++ b/unirl/distributed/group/handle.py
@@ -41,13 +41,13 @@ from unirl.distributed.group.dispatch import (
     resolve_backward_dispatch_mode,
 )
 from unirl.distributed.group.remote import RankInfo, Remote
-from unirl.distributed.tensor.backend.colocate_store.handle import TensorHandle
+from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
 from unirl.distributed.tensor.grad_context import (
     RPCBackwardNode,
     current_grad_context,
 )
 from unirl.distributed.tensor.pytree import infer_batch_size
-from unirl.distributed.tensor.transport import TensorMeta, WorkerLocalTransport, map_tree
+from unirl.distributed.tensor.transport import TensorRef, WorkerLocalTransport, map_tree
 from unirl.distributed.utils import collect_leaves
 
 if TYPE_CHECKING:
@@ -266,7 +266,7 @@ class Handle:
             if ctx is not None:
                 bwd_dispatch_mode = resolve_backward_dispatch_mode(method_name, dispatch_mode, self.rank_infos)
                 call_id = f"{method_name}_{next(self._grad_call_counter)}"
-                input_metas = collect_leaves(args, TensorMeta) + collect_leaves(tuple(kwargs.values()), TensorMeta)
+                input_metas = collect_leaves(args, TensorRef) + collect_leaves(tuple(kwargs.values()), TensorRef)
 
             batch_size = infer_batch_size(args, kwargs)
             # Only DP_SCATTER/DP_SCATTER_HEAD split the per-sample batch by dp_size, so only
@@ -300,7 +300,7 @@ class Handle:
             collected = collect_fn(self, results)
 
             if ctx is not None:
-                output_metas = collect_leaves(collected, TensorMeta)
+                output_metas = collect_leaves(collected, TensorRef)
                 ctx.nodes.append(
                     RPCBackwardNode(
                         role_proxy=self,
@@ -335,7 +335,7 @@ class Handle:
     # ── TensorHandle rebinding ──
 
     def _rebind_tree(self, obj, worker_handle, *, worker_local: bool = True):
-        """Rebind every ref leaf onto ``worker_handle`` and wrap bare handles in TensorMeta.
+        """Rebind every ref leaf onto ``worker_handle`` and wrap bare handles in TensorRef.
 
         For worker-local backends, ``rebind`` attaches the worker actor handle and
         registers the decref GC finalizer. For GLOBAL backends the refs resolve
@@ -346,11 +346,11 @@ class Handle:
         """
 
         def rebind_leaf(o):
-            if isinstance(o, TensorHandle):
+            if isinstance(o, GPUTensorHandle):
                 if worker_local:
                     o.rebind(worker_handle)
-                return TensorMeta.from_handles([o])
-            if isinstance(o, TensorMeta) and worker_local:
+                return TensorRef.from_handles([o])
+            if isinstance(o, TensorRef) and worker_local:
                 for h in o.refs:
                     h.rebind(worker_handle)
             return o

--- a/unirl/distributed/group/worker.py
+++ b/unirl/distributed/group/worker.py
@@ -23,7 +23,7 @@ from torch import Tensor
 
 from unirl.distributed.group.remote import RankInfo, Remote
 from unirl.distributed.tensor.factory import build_transport
-from unirl.distributed.tensor.transport import TensorMeta, TensorTransport, TensorTransportRuntime, map_tree
+from unirl.distributed.tensor.transport import TensorRef, TensorTransport, TensorTransportRuntime, map_tree
 from unirl.distributed.utils import collect_leaves
 
 
@@ -275,8 +275,8 @@ class Worker:
     def call(self, role_name: str, method_name: str, args: tuple, kwargs: dict, grad_mode: bool = False, call_id=None):
         """Generic RPC entry point.
 
-        Resolves inputs (TensorMeta → Tensor via transport.get_batch) and packs
-        outputs (Tensor → TensorMeta via transport.put_batch). Non-tensor
+        Resolves inputs (TensorRef → Tensor via transport.get_batch) and packs
+        outputs (Tensor → TensorRef via transport.put_batch). Non-tensor
         args/kwargs/results pass through unchanged.
 
         grad_mode and call_id are dedicated parameters (not via kwargs) so
@@ -287,14 +287,14 @@ class Worker:
         """
         role = self._roles[role_name]
 
-        # Resolve: collect TensorMeta leaves (tree order), batch-fetch, substitute.
+        # Resolve: collect TensorRef leaves (tree order), batch-fetch, substitute.
         # Keys are positional indices so get_batch results align with the walk.
-        in_metas = self._collect(args, TensorMeta) + self._collect(kwargs, TensorMeta)
+        in_metas = self._collect(args, TensorRef) + self._collect(kwargs, TensorRef)
         fetched = self.transport.get_batch({str(i): m for i, m in enumerate(in_metas)})
         in_iter = iter(fetched[str(i)] for i in range(len(in_metas)))
 
         def resolve(o):
-            return next(in_iter) if isinstance(o, TensorMeta) else o
+            return next(in_iter) if isinstance(o, TensorRef) else o
 
         resolved_args = map_tree(args, resolve)
         resolved_kwargs = map_tree(kwargs, resolve)

--- a/unirl/distributed/tensor/__init__.py
+++ b/unirl/distributed/tensor/__init__.py
@@ -13,7 +13,7 @@ from unirl.distributed.tensor.batch import (
     sum_field,
 )
 from unirl.distributed.tensor.transport import (
-    TensorMeta,
+    TensorRef,
     TensorTransport,
     TensorTransportRuntime,
     TransportSession,
@@ -22,7 +22,7 @@ from unirl.distributed.tensor.transport import (
 __all__ = [
     "Batch",
     "FieldKind",
-    "TensorMeta",
+    "TensorRef",
     "TensorTransport",
     "TensorTransportRuntime",
     "TransportSession",

--- a/unirl/distributed/tensor/backend/colocate_store/handle.py
+++ b/unirl/distributed/tensor/backend/colocate_store/handle.py
@@ -1,9 +1,15 @@
-"""TensorHandle for the colocate_store backend.
+"""ColocateTensorHandle for the colocate_store backend.
 
-Re-exports the canonical TensorHandle from the gpu_store backend so both
-backends share a single handle type. See gpu_store/handle.py.
+A thin subclass of the canonical :class:`GPUTensorHandle` (gpu_store) — identical
+lifecycle and store-key semantics, but a distinct type so colocate refs are
+``TensorSpan[ColocateTensorHandle]``. See gpu_store/handle.py.
 """
 
-from unirl.distributed.tensor.backend.gpu_store.handle import TensorHandle
+from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
 
-__all__ = ["TensorHandle"]
+
+class ColocateTensorHandle(GPUTensorHandle):
+    pass
+
+
+__all__ = ["ColocateTensorHandle"]

--- a/unirl/distributed/tensor/backend/colocate_store/store.py
+++ b/unirl/distributed/tensor/backend/colocate_store/store.py
@@ -1,7 +1,7 @@
 """TensorStore — worker-local tensor registry with ref-counting.
 
 Each worker holds one TensorStore instance. Tensors stay on the worker's
-device; only lightweight TensorHandle refs cross the Ray RPC boundary.
+device; only lightweight ColocateTensorHandle refs cross the Ray RPC boundary.
 
 Single-slot per device (DevicePool enforces ``workers_per_device == 1`` for the
 colocate backend), so the store never shares tensors across processes — no CUDA-IPC,
@@ -9,9 +9,9 @@ no IPC reclaim. Cross-device moves go through NCCL. Colocated multi-slot is gpu_
 job.
 
 Lifecycle:
-  put(tensor) → TensorHandle (ref_count=1)
-  incref(key) → ref_count += 1  (called by TensorHandle.__copy__ on controller)
-  decref(key) → ref_count -= 1  (called by TensorHandle._release on controller GC)
+  put(tensor) → ColocateTensorHandle (ref_count=1)
+  incref(key) → ref_count += 1  (called by ColocateTensorHandle.__copy__ on controller)
+  decref(key) → ref_count -= 1  (called by ColocateTensorHandle._release on controller GC)
                 if ref_count == 0 → storage freed
 """
 
@@ -27,7 +27,7 @@ import torch
 import torch.distributed as dist
 from torch import Tensor
 
-from unirl.distributed.tensor.backend.colocate_store.handle import TensorHandle
+from unirl.distributed.tensor.backend.colocate_store.handle import ColocateTensorHandle
 
 
 class TensorStore:
@@ -59,15 +59,15 @@ class TensorStore:
         # Global ProcessGroup for cross-worker NCCL (initialized lazily)
         self._global_pg = None
 
-    def put(self, tensor: Tensor) -> TensorHandle:
-        """Store a tensor and return a lightweight TensorHandle.
+    def put(self, tensor: Tensor) -> ColocateTensorHandle:
+        """Store a tensor and return a lightweight ColocateTensorHandle.
 
         CUDA tensors: a contiguous copy is stored under a fresh key.
         CPU tensors: stored in Ray plasma store via ray.put(); not tracked here.
           Lifecycle managed by ObjectRef Python refcount (no decref RPC needed).
         """
         if not tensor.is_cuda:
-            return TensorHandle(
+            return ColocateTensorHandle(
                 store_key=None,
                 source_id=self.worker_id,
                 shape=tuple(tensor.shape),
@@ -83,7 +83,7 @@ class TensorStore:
             self._store[key] = t
             self._ref_counts[key] = 1
 
-        return TensorHandle(
+        return ColocateTensorHandle(
             store_key=key,
             source_id=self.worker_id,
             shape=tuple(t.shape),
@@ -91,7 +91,7 @@ class TensorStore:
             device=str(t.device),
         )
 
-    def get(self, handle: TensorHandle) -> Tensor:
+    def get(self, handle: ColocateTensorHandle) -> Tensor:
         """Return the stored tensor for this handle.
 
         This is the only safe public API for retrieving a stored tensor.
@@ -110,7 +110,7 @@ class TensorStore:
             return self._ref_counts[key]
 
     def incref(self, key: str) -> None:
-        """Increment reference count. Called by TensorHandle copy on controller."""
+        """Increment reference count. Called by ColocateTensorHandle copy on controller."""
         with self._lock:
             if key not in self._ref_counts:
                 raise KeyError(f"TensorStore: cannot incref unknown key '{key}'")
@@ -119,7 +119,7 @@ class TensorStore:
     def decref(self, key: str) -> None:
         """Decrement reference count. If zero, release the storage.
 
-        Called by TensorHandle._release (GC finalizer on controller side).
+        Called by ColocateTensorHandle._release (GC finalizer on controller side).
         """
         with self._lock:
             if key not in self._ref_counts:
@@ -154,7 +154,7 @@ class TensorStore:
         )
         self._global_pg = dist.ProcessGroupNCCL(store, global_rank, global_world_size)
 
-    def _nccl_send(self, dst_rank: int, handles: List[TensorHandle]) -> None:
+    def _nccl_send(self, dst_rank: int, handles: List[ColocateTensorHandle]) -> None:
         """Send tensors to dst_rank via NCCL.
 
         Uses ProcessGroupNCCL.send() natively so that privately-created PG
@@ -164,12 +164,12 @@ class TensorStore:
         """
         assert self._global_pg is not None, "Global PG not initialized. Call setup_global_pg first."
 
-        from unirl.distributed.tensor.transport import HandleView
+        from unirl.distributed.tensor.transport import TensorSpan
 
         for h in handles:
             assert h.object_ref is None, "CPU tensor (object_ref set) must not go through NCCL. Check localize routing."
-            tensor = self.get(h.base if isinstance(h, HandleView) else h)
-            if isinstance(h, HandleView):
+            tensor = self.get(h.base if isinstance(h, TensorSpan) else h)
+            if isinstance(h, TensorSpan):
                 tensor = tensor[h.start : h.end]  # exact-row routing: ship only the view's rows
             self._global_pg.send([tensor.contiguous()], dst_rank, 0).wait()
 
@@ -178,7 +178,7 @@ class TensorStore:
         src_global_rank: int,
         shapes: List[Tuple[int, ...]],
         dtypes: List[torch.dtype],
-    ) -> List[TensorHandle]:
+    ) -> List[ColocateTensorHandle]:
         """Receive tensors from another worker via NCCL p2p."""
         assert self._global_pg is not None, "Global PG not initialized. Call setup_global_pg first."
 

--- a/unirl/distributed/tensor/backend/colocate_store/store.py
+++ b/unirl/distributed/tensor/backend/colocate_store/store.py
@@ -164,10 +164,14 @@ class TensorStore:
         """
         assert self._global_pg is not None, "Global PG not initialized. Call setup_global_pg first."
 
+        from unirl.distributed.tensor.transport import HandleView
+
         for h in handles:
             assert h.object_ref is None, "CPU tensor (object_ref set) must not go through NCCL. Check localize routing."
-            tensor = self.get(h).contiguous()
-            self._global_pg.send([tensor], dst_rank, 0).wait()
+            tensor = self.get(h.base if isinstance(h, HandleView) else h)
+            if isinstance(h, HandleView):
+                tensor = tensor[h.start : h.end]  # exact-row routing: ship only the view's rows
+            self._global_pg.send([tensor.contiguous()], dst_rank, 0).wait()
 
     def _nccl_recv(
         self,

--- a/unirl/distributed/tensor/backend/colocate_store/store.py
+++ b/unirl/distributed/tensor/backend/colocate_store/store.py
@@ -154,23 +154,22 @@ class TensorStore:
         )
         self._global_pg = dist.ProcessGroupNCCL(store, global_rank, global_world_size)
 
-    def _nccl_send(self, dst_rank: int, handles: List[ColocateTensorHandle]) -> None:
-        """Send tensors to dst_rank via NCCL.
+    def _nccl_send(self, dst_rank: int, items: List) -> None:
+        """Send stored tensors (or row ranges of them) to dst_rank via NCCL.
 
-        Uses ProcessGroupNCCL.send() natively so that privately-created PG
-        (not registered in the global dist world) works correctly.
-        Each tensor is sent separately so send and recv always stay in sync.
-        Single-slot per device, so every handle reads from this worker's own store.
+        Each item is ``(store_key, start, stop)`` — a span ships only its
+        ``[start:stop)`` rows (exact-row routing); ``(key, None, None)`` sends the
+        whole block. Uses ProcessGroupNCCL.send() natively so a privately-created
+        PG (not registered in the global dist world) works; each tensor is sent
+        separately so send/recv stay in sync. Single-slot per device, so every
+        key is in this worker's own store.
         """
         assert self._global_pg is not None, "Global PG not initialized. Call setup_global_pg first."
-
-        from unirl.distributed.tensor.transport import TensorSpan
-
-        for h in handles:
-            assert h.object_ref is None, "CPU tensor (object_ref set) must not go through NCCL. Check localize routing."
-            tensor = self.get(h.base if isinstance(h, TensorSpan) else h)
-            if isinstance(h, TensorSpan):
-                tensor = tensor[h.start : h.end]  # exact-row routing: ship only the view's rows
+        for item in items:
+            key, start, stop = (item, None, None) if isinstance(item, str) else item
+            tensor = self._store[key].detach()
+            if start is not None:
+                tensor = tensor[start:stop]
             self._global_pg.send([tensor.contiguous()], dst_rank, 0).wait()
 
     def _nccl_recv(

--- a/unirl/distributed/tensor/backend/colocate_store/transport.py
+++ b/unirl/distributed/tensor/backend/colocate_store/transport.py
@@ -23,8 +23,7 @@ from typing import Any, List
 import ray
 import torch
 
-from unirl.distributed.tensor.backend.colocate_store.handle import ColocateTensorHandle
-from unirl.distributed.tensor.transport import TensorSpan, TensorRef, WorkerLocalTransport, cat_rows
+from unirl.distributed.tensor.transport import TensorRef, WorkerLocalTransport, cat_rows
 
 
 class ColocateStoreTransport(WorkerLocalTransport):
@@ -37,25 +36,26 @@ class ColocateStoreTransport(WorkerLocalTransport):
     def store(self) -> Any:
         return self._store
 
-    def _resolve_handle(self, handle: Any) -> torch.Tensor:
-        if isinstance(handle, TensorSpan):
-            return self._resolve_handle(handle.base)[handle.start : handle.end]
-        if handle.object_ref is not None:
-            return ray.get(handle.object_ref).detach()
-        if handle.source_id != self._store.worker_id:
+    def _resolve_span(self, span: Any) -> torch.Tensor:
+        h = span.handle
+        if h.object_ref is not None:
+            base = ray.get(h.object_ref).detach()
+        elif h.source_id != self._store.worker_id:
             raise RuntimeError(
-                f"ColocateStoreTransport: handle from '{handle.source_id}' is not local to "
+                f"ColocateStoreTransport: handle from '{h.source_id}' is not local to "
                 f"'{self._store.worker_id}'. localize should have transferred it."
             )
-        return self._store.get(handle)
+        else:
+            base = self._store.get(h)
+        return base[span.start : span.stop]
 
     def put(self, tensor: torch.Tensor) -> Any:
         return self._store.put(tensor)
 
-    def get(self, refs: List[Any]) -> torch.Tensor:
-        if not refs:
-            raise ValueError("ColocateStoreTransport.get: empty refs list")
-        return cat_rows([self._resolve_handle(h) for h in refs])
+    def get(self, spans: List[Any]) -> torch.Tensor:
+        if not spans:
+            raise ValueError("ColocateStoreTransport.get: empty spans list")
+        return cat_rows([self._resolve_span(s) for s in spans])
 
     def is_ref(self, value: Any) -> bool:
         return isinstance(value, TensorRef)
@@ -78,7 +78,9 @@ class ColocateStoreTransport(WorkerLocalTransport):
         self._store.setup_global_pg(global_rank, world_size)
 
     def nccl_send(self, dst_rank: int, handles: List[Any]) -> None:
-        self._store._nccl_send(dst_rank, handles)
+        # Each ref is a span → send ONLY its [start:stop) rows (exact-row routing).
+        items = [(s.handle.store_key, s.start, s.stop) for s in handles]
+        self._store._nccl_send(dst_rank, items)
 
     def nccl_recv(self, src_rank: int, shapes: List[tuple], dtypes: List[torch.dtype]) -> List[Any]:
         return self._store._nccl_recv(src_rank, shapes, dtypes)

--- a/unirl/distributed/tensor/backend/colocate_store/transport.py
+++ b/unirl/distributed/tensor/backend/colocate_store/transport.py
@@ -23,8 +23,8 @@ from typing import Any, List
 import ray
 import torch
 
-from unirl.distributed.tensor.backend.colocate_store.handle import TensorHandle
-from unirl.distributed.tensor.transport import HandleView, TensorMeta, WorkerLocalTransport, cat_rows
+from unirl.distributed.tensor.backend.colocate_store.handle import ColocateTensorHandle
+from unirl.distributed.tensor.transport import TensorSpan, TensorRef, WorkerLocalTransport, cat_rows
 
 
 class ColocateStoreTransport(WorkerLocalTransport):
@@ -38,7 +38,7 @@ class ColocateStoreTransport(WorkerLocalTransport):
         return self._store
 
     def _resolve_handle(self, handle: Any) -> torch.Tensor:
-        if isinstance(handle, HandleView):
+        if isinstance(handle, TensorSpan):
             return self._resolve_handle(handle.base)[handle.start : handle.end]
         if handle.object_ref is not None:
             return ray.get(handle.object_ref).detach()
@@ -58,7 +58,7 @@ class ColocateStoreTransport(WorkerLocalTransport):
         return cat_rows([self._resolve_handle(h) for h in refs])
 
     def is_ref(self, value: Any) -> bool:
-        return isinstance(value, TensorMeta)
+        return isinstance(value, TensorRef)
 
     # ── lifecycle ──
 

--- a/unirl/distributed/tensor/backend/colocate_store/transport.py
+++ b/unirl/distributed/tensor/backend/colocate_store/transport.py
@@ -24,7 +24,7 @@ import ray
 import torch
 
 from unirl.distributed.tensor.backend.colocate_store.handle import TensorHandle
-from unirl.distributed.tensor.transport import TensorMeta, WorkerLocalTransport
+from unirl.distributed.tensor.transport import HandleView, TensorMeta, WorkerLocalTransport, cat_rows
 
 
 class ColocateStoreTransport(WorkerLocalTransport):
@@ -37,7 +37,9 @@ class ColocateStoreTransport(WorkerLocalTransport):
     def store(self) -> Any:
         return self._store
 
-    def _resolve_handle(self, handle: TensorHandle) -> torch.Tensor:
+    def _resolve_handle(self, handle: Any) -> torch.Tensor:
+        if isinstance(handle, HandleView):
+            return self._resolve_handle(handle.base)[handle.start : handle.end]
         if handle.object_ref is not None:
             return ray.get(handle.object_ref).detach()
         if handle.source_id != self._store.worker_id:
@@ -53,8 +55,7 @@ class ColocateStoreTransport(WorkerLocalTransport):
     def get(self, refs: List[Any]) -> torch.Tensor:
         if not refs:
             raise ValueError("ColocateStoreTransport.get: empty refs list")
-        parts = [self._resolve_handle(h) for h in refs]
-        return parts[0] if len(parts) == 1 else torch.cat(parts, dim=0)
+        return cat_rows([self._resolve_handle(h) for h in refs])
 
     def is_ref(self, value: Any) -> bool:
         return isinstance(value, TensorMeta)

--- a/unirl/distributed/tensor/backend/colocate_store/transport.py
+++ b/unirl/distributed/tensor/backend/colocate_store/transport.py
@@ -23,7 +23,8 @@ from typing import Any, List
 import ray
 import torch
 
-from unirl.distributed.tensor.transport import TensorRef, WorkerLocalTransport, cat_rows
+from unirl.distributed.tensor.backend.colocate_store.handle import ColocateTensorHandle
+from unirl.distributed.tensor.transport import TensorRef, TensorSpan, WorkerLocalTransport, cat_rows
 
 
 class ColocateStoreTransport(WorkerLocalTransport):
@@ -36,7 +37,7 @@ class ColocateStoreTransport(WorkerLocalTransport):
     def store(self) -> Any:
         return self._store
 
-    def _resolve_span(self, span: Any) -> torch.Tensor:
+    def _resolve_span(self, span: TensorSpan[ColocateTensorHandle]) -> torch.Tensor:
         h = span.handle
         if h.object_ref is not None:
             base = ray.get(h.object_ref).detach()
@@ -52,7 +53,7 @@ class ColocateStoreTransport(WorkerLocalTransport):
     def put(self, tensor: torch.Tensor) -> Any:
         return self._store.put(tensor)
 
-    def get(self, spans: List[Any]) -> torch.Tensor:
+    def get(self, spans: List[TensorSpan[ColocateTensorHandle]]) -> torch.Tensor:
         if not spans:
             raise ValueError("ColocateStoreTransport.get: empty spans list")
         return cat_rows([self._resolve_span(s) for s in spans])

--- a/unirl/distributed/tensor/backend/gpu_store/handle.py
+++ b/unirl/distributed/tensor/backend/gpu_store/handle.py
@@ -1,4 +1,4 @@
-"""TensorHandle — tensor reference for the Single Controller.
+"""GPUTensorHandle — tensor reference for the Single Controller.
 
 A reference-counted handle to a single tensor stored in a worker. It manages its
 own GC via weakref.finalize and flows between worker and controller via Ray RPC
@@ -19,7 +19,7 @@ from torch import Tensor
 logger = logging.getLogger(__name__)
 
 
-class TensorHandle:
+class GPUTensorHandle:
     """Handle to a single tensor stored in a worker.
 
     Two phases of life:
@@ -66,23 +66,23 @@ class TensorHandle:
         no decref RPC needed.
         """
         assert not self._finalized, (
-            f"TensorHandle {self.store_key!r} is already bound. rebind() must only be called once."
+            f"GPUTensorHandle {self.store_key!r} is already bound. rebind() must only be called once."
         )
         self._finalized = True
         self.worker_handle = worker_handle
         if self.object_ref is None:
             # CUDA tensor: register finalizer for decref RPC
-            weakref.finalize(self, TensorHandle._release, worker_handle, self.store_key)
+            weakref.finalize(self, GPUTensorHandle._release, worker_handle, self.store_key)
 
     # ── Remote operations ──
 
     def remote_op_async(self, op: str, *args) -> Any:
         """Fire remote tensor_op on the worker, return ObjectRef (does not wait)."""
-        assert self.worker_handle is not None, "TensorHandle not bound"
+        assert self.worker_handle is not None, "GPUTensorHandle not bound"
         return self.worker_handle.transport_op.remote("tensor_op", self, op, *args)
 
-    def remote_op(self, op: str, *args) -> TensorHandle:
-        """Execute remote tensor_op synchronously, return new bound TensorHandle."""
+    def remote_op(self, op: str, *args) -> GPUTensorHandle:
+        """Execute remote tensor_op synchronously, return new bound GPUTensorHandle."""
         new_h = ray.get(self.remote_op_async(op, *args))
         new_h.rebind(self.worker_handle)
         return new_h
@@ -91,35 +91,35 @@ class TensorHandle:
         """Fetch the actual tensor to controller CPU."""
         if self.object_ref is not None:
             return ray.get(self.object_ref)
-        assert self.worker_handle is not None, "TensorHandle not bound to worker"
+        assert self.worker_handle is not None, "GPUTensorHandle not bound to worker"
         return ray.get(self.worker_handle.transport_op.remote("get_cpu", self))
 
     # ── Copy protocols ──
 
-    def __copy__(self) -> TensorHandle:
+    def __copy__(self) -> GPUTensorHandle:
         if self.worker_handle is not None and self.object_ref is None:
             # CUDA tensor: explicit incref to keep tensor alive in the worker
             self.worker_handle.transport_op.remote("incref", self.store_key)
-        clone = TensorHandle(
+        clone = GPUTensorHandle(
             self.store_key, self.source_id, self.shape, self.dtype, self.device, object_ref=self.object_ref
         )
         if self.worker_handle is not None:
             clone.rebind(self.worker_handle)
         return clone
 
-    def __deepcopy__(self, memo) -> TensorHandle:
+    def __deepcopy__(self, memo) -> GPUTensorHandle:
         clone = self.__copy__()
         memo[id(self)] = clone
         return clone
 
-    def routing_copy(self) -> TensorHandle:
+    def routing_copy(self) -> GPUTensorHandle:
         """A bare, unbound same-fields copy used as an id()-keyed transfer placeholder.
 
         Unlike __copy__ this does NOT incref or rebind — it is a disposable token the
         controller plants in a shard tree and matches by identity after NCCL recv, so
         dropping it must not touch the source tensor's ref count.
         """
-        return TensorHandle(
+        return GPUTensorHandle(
             self.store_key, self.source_id, self.shape, self.dtype, self.device, object_ref=self.object_ref
         )
 
@@ -163,4 +163,4 @@ class TensorHandle:
 
     def __repr__(self) -> str:
         bound = "bound" if self.worker_handle else "unbound"
-        return f"TensorHandle({self.shape}, {self.dtype}, source_id={self.source_id}, {bound})"
+        return f"GPUTensorHandle({self.shape}, {self.dtype}, source_id={self.source_id}, {bound})"

--- a/unirl/distributed/tensor/backend/gpu_store/transport.py
+++ b/unirl/distributed/tensor/backend/gpu_store/transport.py
@@ -88,8 +88,8 @@ class GPUStoreTransport(WorkerLocalTransport):
         borrow_map = self._batch_borrow(all_handles)
         out: Dict[str, torch.Tensor] = {}
         for k, m in metas.items():
-            parts = [self._resolve_handle(h, borrow_map) for h in m.refs]
-            out[k] = parts[0] if len(parts) == 1 else torch.cat(parts, dim=0)
+            resolved = {i: self._resolve_handle(h, borrow_map) for i, h in enumerate(m.refs)}
+            out[k] = m.assemble(resolved)
         return out
 
     def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorMeta]:

--- a/unirl/distributed/tensor/backend/gpu_store/transport.py
+++ b/unirl/distributed/tensor/backend/gpu_store/transport.py
@@ -58,7 +58,7 @@ class GPUStoreTransport(WorkerLocalTransport):
             return {}
         return dict(zip(unique, ray.get(self._tw.batch_borrow.remote(unique))))
 
-    def _resolve_span(self, span: Any, borrow_map: Dict[str, tuple]) -> torch.Tensor:
+    def _resolve_span(self, span: TensorSpan[GPUTensorHandle], borrow_map: Dict[str, tuple]) -> torch.Tensor:
         # Resolve the handle (cached per store_key), then slice the span's rows —
         # the slice is a zero-copy view of the open IPC mapping.
         h = span.handle
@@ -83,7 +83,7 @@ class GPUStoreTransport(WorkerLocalTransport):
     def put(self, tensor: torch.Tensor) -> Any:
         return self.put_batch({"_": tensor})["_"].spans[0].handle
 
-    def get(self, spans: List[Any]) -> torch.Tensor:
+    def get(self, spans: List[TensorSpan[GPUTensorHandle]]) -> torch.Tensor:
         if not spans:
             raise ValueError("GPUStoreTransport.get: empty spans list")
         borrow_map = self._batch_borrow([s.handle for s in spans])

--- a/unirl/distributed/tensor/backend/gpu_store/transport.py
+++ b/unirl/distributed/tensor/backend/gpu_store/transport.py
@@ -18,8 +18,8 @@ from typing import Any, Dict, List
 import ray
 import torch
 
-from unirl.distributed.tensor.backend.gpu_store.handle import TensorHandle
-from unirl.distributed.tensor.transport import HandleView, TensorMeta, WorkerLocalTransport, cat_rows
+from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
+from unirl.distributed.tensor.transport import TensorSpan, TensorRef, WorkerLocalTransport, cat_rows
 
 
 class GPUStoreTransport(WorkerLocalTransport):
@@ -39,14 +39,14 @@ class GPUStoreTransport(WorkerLocalTransport):
         self._tw = tw
 
     def is_ref(self, value: Any) -> bool:
-        return isinstance(value, TensorMeta)
+        return isinstance(value, TensorRef)
 
     # ── resolve helpers: batched borrow + zero-copy IPC views ──
 
-    def _batch_borrow(self, handles: List[TensorHandle]) -> Dict[str, tuple]:
+    def _batch_borrow(self, handles: List[GPUTensorHandle]) -> Dict[str, tuple]:
         """One ``batch_borrow`` RPC for all not-yet-open CUDA store_keys.
 
-        ``HandleView`` refs borrow their BASE key once — the dict.fromkeys dedup
+        ``TensorSpan`` refs borrow their BASE key once — the dict.fromkeys dedup
         means N views of one block still cost a single IPC open.
         """
         unique = list(
@@ -59,7 +59,7 @@ class GPUStoreTransport(WorkerLocalTransport):
         return dict(zip(unique, ray.get(self._tw.batch_borrow.remote(unique))))
 
     def _resolve_handle(self, handle: Any, borrow_map: Dict[str, tuple]) -> torch.Tensor:
-        if isinstance(handle, HandleView):
+        if isinstance(handle, TensorSpan):
             # Resolve the base once (cached), slice the view's rows — the slice
             # is a zero-copy view of the open IPC mapping.
             return self._resolve_handle(handle.base, borrow_map)[handle.start : handle.end]
@@ -90,12 +90,12 @@ class GPUStoreTransport(WorkerLocalTransport):
 
     # ── batched resolve / pack (the Worker's path) ──
 
-    def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
+    def get_batch(self, metas: Dict[str, TensorRef]) -> Dict[str, torch.Tensor]:
         all_handles = [h for m in metas.values() for h in m.refs]
         borrow_map = self._batch_borrow(all_handles)
         return {k: cat_rows([self._resolve_handle(h, borrow_map) for h in m.refs]) for k, m in metas.items()}
 
-    def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorMeta]:
+    def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorRef]:
         items = list(tensors.items())
 
         # Pass 1: one batch_allocate for the unique CUDA tensors (by id).
@@ -104,7 +104,7 @@ class GPUStoreTransport(WorkerLocalTransport):
             if isinstance(t, torch.Tensor) and t.is_cuda:
                 cuda_unique.setdefault(id(t), t)
 
-        handle_map: Dict[int, TensorHandle] = {}
+        handle_map: Dict[int, GPUTensorHandle] = {}
         if cuda_unique:
             tl = list(cuda_unique.values())
             allocs = ray.get(self._tw.batch_allocate.remote([(tuple(t.shape), t.dtype) for t in tl]))
@@ -120,28 +120,28 @@ class GPUStoreTransport(WorkerLocalTransport):
                 del v, s  # counter 1→0
             ray.get(self._tw.batch_write_done.remote([sk for sk, _, _ in allocs]))
             for t, (sk, _, _) in zip(tl, allocs):
-                handle_map[id(t)] = TensorHandle(
+                handle_map[id(t)] = GPUTensorHandle(
                     store_key=sk, source_id=self.worker_id, shape=tuple(t.shape), dtype=t.dtype, device=self.device
                 )
 
-        # Pass 2: one TensorMeta per key; duplicate output tensors share a
+        # Pass 2: one TensorRef per key; duplicate output tensors share a
         # store_key but get distinct handles (independent rebind/GC) + batch_incref.
         emitted: set = set()
         extra_incref: list = []
-        result: Dict[str, TensorMeta] = {}
+        result: Dict[str, TensorRef] = {}
         for k, t in items:
             if isinstance(t, torch.Tensor) and t.is_cuda:
                 h = handle_map[id(t)]
                 if id(t) in emitted:
                     extra_incref.append(h.store_key)
-                    handle = TensorHandle(
+                    handle = GPUTensorHandle(
                         store_key=h.store_key, source_id=h.source_id, shape=h.shape, dtype=h.dtype, device=h.device
                     )
                 else:
                     emitted.add(id(t))
                     handle = h
             elif isinstance(t, torch.Tensor):  # CPU tensor → Ray plasma
-                handle = TensorHandle(
+                handle = GPUTensorHandle(
                     store_key=None,
                     source_id=self.worker_id,
                     shape=tuple(t.shape),
@@ -153,7 +153,7 @@ class GPUStoreTransport(WorkerLocalTransport):
                 result[k] = t
                 continue
             bs = handle.shape[0] if handle.shape else 1
-            result[k] = TensorMeta(
+            result[k] = TensorRef(
                 refs=[handle], sizes=[bs], shape=tuple(handle.shape), dtype=handle.dtype, device=str(handle.device)
             )
         if extra_incref:
@@ -188,10 +188,10 @@ class GPUStoreTransport(WorkerLocalTransport):
         ray.get(self._tw.setup_global_pg.remote(global_rank, world_size))
 
     def nccl_send(self, dst_rank: int, handles: List[Any]) -> None:
-        # HandleView → send ONLY its [start:end) rows (exact-row routing);
+        # TensorSpan → send ONLY its [start:end) rows (exact-row routing);
         # whole handles send the full block (range None).
         items = [
-            (h.store_key, h.start, h.end) if isinstance(h, HandleView) else (h.store_key, None, None)
+            (h.store_key, h.start, h.end) if isinstance(h, TensorSpan) else (h.store_key, None, None)
             for h in handles
         ]
         ray.get(self._tw._nccl_send.remote(dst_rank, items))

--- a/unirl/distributed/tensor/backend/gpu_store/transport.py
+++ b/unirl/distributed/tensor/backend/gpu_store/transport.py
@@ -155,7 +155,10 @@ class GPUStoreTransport(WorkerLocalTransport):
                 continue
             bs = handle.shape[0] if handle.shape else 1
             result[k] = TensorRef(
-                spans=[TensorSpan(handle, 0, bs)], shape=tuple(handle.shape), dtype=handle.dtype, device=str(handle.device)
+                spans=[TensorSpan(handle, 0, bs)],
+                shape=tuple(handle.shape),
+                dtype=handle.dtype,
+                device=str(handle.device),
             )
         if extra_incref:
             self._tw.batch_incref.remote(extra_incref)

--- a/unirl/distributed/tensor/backend/gpu_store/transport.py
+++ b/unirl/distributed/tensor/backend/gpu_store/transport.py
@@ -19,7 +19,7 @@ import ray
 import torch
 
 from unirl.distributed.tensor.backend.gpu_store.handle import TensorHandle
-from unirl.distributed.tensor.transport import TensorMeta, WorkerLocalTransport
+from unirl.distributed.tensor.transport import HandleView, TensorMeta, WorkerLocalTransport, cat_rows
 
 
 class GPUStoreTransport(WorkerLocalTransport):
@@ -44,7 +44,11 @@ class GPUStoreTransport(WorkerLocalTransport):
     # ── resolve helpers: batched borrow + zero-copy IPC views ──
 
     def _batch_borrow(self, handles: List[TensorHandle]) -> Dict[str, tuple]:
-        """One ``batch_borrow`` RPC for all not-yet-open CUDA store_keys."""
+        """One ``batch_borrow`` RPC for all not-yet-open CUDA store_keys.
+
+        ``HandleView`` refs borrow their BASE key once — the dict.fromkeys dedup
+        means N views of one block still cost a single IPC open.
+        """
         unique = list(
             dict.fromkeys(
                 h.store_key for h in handles if h.object_ref is None and h.store_key not in self._resolved_map
@@ -54,7 +58,11 @@ class GPUStoreTransport(WorkerLocalTransport):
             return {}
         return dict(zip(unique, ray.get(self._tw.batch_borrow.remote(unique))))
 
-    def _resolve_handle(self, handle: TensorHandle, borrow_map: Dict[str, tuple]) -> torch.Tensor:
+    def _resolve_handle(self, handle: Any, borrow_map: Dict[str, tuple]) -> torch.Tensor:
+        if isinstance(handle, HandleView):
+            # Resolve the base once (cached), slice the view's rows — the slice
+            # is a zero-copy view of the open IPC mapping.
+            return self._resolve_handle(handle.base, borrow_map)[handle.start : handle.end]
         if handle.object_ref is not None:
             return ray.get(handle.object_ref).detach()
         cached = self._resolved_map.get(handle.store_key)
@@ -78,19 +86,14 @@ class GPUStoreTransport(WorkerLocalTransport):
         if not refs:
             raise ValueError("GPUStoreTransport.get: empty refs list")
         borrow_map = self._batch_borrow(refs)
-        parts = [self._resolve_handle(h, borrow_map) for h in refs]
-        return parts[0] if len(parts) == 1 else torch.cat(parts, dim=0)
+        return cat_rows([self._resolve_handle(h, borrow_map) for h in refs])
 
     # ── batched resolve / pack (the Worker's path) ──
 
     def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
         all_handles = [h for m in metas.values() for h in m.refs]
         borrow_map = self._batch_borrow(all_handles)
-        out: Dict[str, torch.Tensor] = {}
-        for k, m in metas.items():
-            resolved = {i: self._resolve_handle(h, borrow_map) for i, h in enumerate(m.refs)}
-            out[k] = m.assemble(resolved)
-        return out
+        return {k: cat_rows([self._resolve_handle(h, borrow_map) for h in m.refs]) for k, m in metas.items()}
 
     def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorMeta]:
         items = list(tensors.items())
@@ -185,7 +188,13 @@ class GPUStoreTransport(WorkerLocalTransport):
         ray.get(self._tw.setup_global_pg.remote(global_rank, world_size))
 
     def nccl_send(self, dst_rank: int, handles: List[Any]) -> None:
-        ray.get(self._tw._nccl_send.remote(dst_rank, [h.store_key for h in handles]))
+        # HandleView → send ONLY its [start:end) rows (exact-row routing);
+        # whole handles send the full block (range None).
+        items = [
+            (h.store_key, h.start, h.end) if isinstance(h, HandleView) else (h.store_key, None, None)
+            for h in handles
+        ]
+        ray.get(self._tw._nccl_send.remote(dst_rank, items))
 
     def nccl_recv(self, src_rank: int, shapes: List[tuple], dtypes: List[torch.dtype]) -> List[Any]:
         return ray.get(self._tw._nccl_recv.remote(src_rank, shapes, dtypes))

--- a/unirl/distributed/tensor/backend/gpu_store/transport.py
+++ b/unirl/distributed/tensor/backend/gpu_store/transport.py
@@ -19,7 +19,7 @@ import ray
 import torch
 
 from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
-from unirl.distributed.tensor.transport import TensorSpan, TensorRef, WorkerLocalTransport, cat_rows
+from unirl.distributed.tensor.transport import TensorRef, TensorSpan, WorkerLocalTransport, cat_rows
 
 
 class GPUStoreTransport(WorkerLocalTransport):
@@ -46,8 +46,8 @@ class GPUStoreTransport(WorkerLocalTransport):
     def _batch_borrow(self, handles: List[GPUTensorHandle]) -> Dict[str, tuple]:
         """One ``batch_borrow`` RPC for all not-yet-open CUDA store_keys.
 
-        ``TensorSpan`` refs borrow their BASE key once — the dict.fromkeys dedup
-        means N views of one block still cost a single IPC open.
+        Borrowing is block-level: callers pass span handles, so N spans of one
+        block dedup (``dict.fromkeys``) to a single IPC open.
         """
         unique = list(
             dict.fromkeys(
@@ -58,42 +58,43 @@ class GPUStoreTransport(WorkerLocalTransport):
             return {}
         return dict(zip(unique, ray.get(self._tw.batch_borrow.remote(unique))))
 
-    def _resolve_handle(self, handle: Any, borrow_map: Dict[str, tuple]) -> torch.Tensor:
-        if isinstance(handle, TensorSpan):
-            # Resolve the base once (cached), slice the view's rows — the slice
-            # is a zero-copy view of the open IPC mapping.
-            return self._resolve_handle(handle.base, borrow_map)[handle.start : handle.end]
-        if handle.object_ref is not None:
-            return ray.get(handle.object_ref).detach()
-        cached = self._resolved_map.get(handle.store_key)
-        if cached is not None:
-            return cached
-        ipc_h, shape, stride = borrow_map[handle.store_key]
-        storage = torch.UntypedStorage._new_shared_cuda(*ipc_h)
-        view = torch.empty(0, dtype=handle.dtype, device=self.device)
-        view.set_(storage, 0, shape, stride)  # offset=0; TW stores contiguous
-        self._open_storages.append(storage)
-        resolved = view.detach()
-        self._resolved_map[handle.store_key] = resolved
-        return resolved
+    def _resolve_span(self, span: Any, borrow_map: Dict[str, tuple]) -> torch.Tensor:
+        # Resolve the handle (cached per store_key), then slice the span's rows —
+        # the slice is a zero-copy view of the open IPC mapping.
+        h = span.handle
+        if h.object_ref is not None:
+            base = ray.get(h.object_ref).detach()
+        else:
+            cached = self._resolved_map.get(h.store_key)
+            if cached is not None:
+                base = cached
+            else:
+                ipc_h, shape, stride = borrow_map[h.store_key]
+                storage = torch.UntypedStorage._new_shared_cuda(*ipc_h)
+                view = torch.empty(0, dtype=h.dtype, device=self.device)
+                view.set_(storage, 0, shape, stride)  # offset=0; TW stores contiguous
+                self._open_storages.append(storage)
+                base = view.detach()
+                self._resolved_map[h.store_key] = base
+        return base[span.start : span.stop]
 
     # ── single-tensor primitives (used by transform / dehydrate defaults) ──
 
     def put(self, tensor: torch.Tensor) -> Any:
-        return self.put_batch({"_": tensor})["_"].refs[0]
+        return self.put_batch({"_": tensor})["_"].spans[0].handle
 
-    def get(self, refs: List[Any]) -> torch.Tensor:
-        if not refs:
-            raise ValueError("GPUStoreTransport.get: empty refs list")
-        borrow_map = self._batch_borrow(refs)
-        return cat_rows([self._resolve_handle(h, borrow_map) for h in refs])
+    def get(self, spans: List[Any]) -> torch.Tensor:
+        if not spans:
+            raise ValueError("GPUStoreTransport.get: empty spans list")
+        borrow_map = self._batch_borrow([s.handle for s in spans])
+        return cat_rows([self._resolve_span(s, borrow_map) for s in spans])
 
     # ── batched resolve / pack (the Worker's path) ──
 
     def get_batch(self, metas: Dict[str, TensorRef]) -> Dict[str, torch.Tensor]:
-        all_handles = [h for m in metas.values() for h in m.refs]
+        all_handles = [s.handle for m in metas.values() for s in m.spans]
         borrow_map = self._batch_borrow(all_handles)
-        return {k: cat_rows([self._resolve_handle(h, borrow_map) for h in m.refs]) for k, m in metas.items()}
+        return {k: cat_rows([self._resolve_span(s, borrow_map) for s in m.spans]) for k, m in metas.items()}
 
     def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorRef]:
         items = list(tensors.items())
@@ -154,7 +155,7 @@ class GPUStoreTransport(WorkerLocalTransport):
                 continue
             bs = handle.shape[0] if handle.shape else 1
             result[k] = TensorRef(
-                refs=[handle], sizes=[bs], shape=tuple(handle.shape), dtype=handle.dtype, device=str(handle.device)
+                spans=[TensorSpan(handle, 0, bs)], shape=tuple(handle.shape), dtype=handle.dtype, device=str(handle.device)
             )
         if extra_incref:
             self._tw.batch_incref.remote(extra_incref)
@@ -188,12 +189,8 @@ class GPUStoreTransport(WorkerLocalTransport):
         ray.get(self._tw.setup_global_pg.remote(global_rank, world_size))
 
     def nccl_send(self, dst_rank: int, handles: List[Any]) -> None:
-        # TensorSpan → send ONLY its [start:end) rows (exact-row routing);
-        # whole handles send the full block (range None).
-        items = [
-            (h.store_key, h.start, h.end) if isinstance(h, TensorSpan) else (h.store_key, None, None)
-            for h in handles
-        ]
+        # Each ref is a span → send ONLY its [start:stop) rows (exact-row routing).
+        items = [(s.handle.store_key, s.start, s.stop) for s in handles]
         ray.get(self._tw._nccl_send.remote(dst_rank, items))
 
     def nccl_recv(self, src_rank: int, shapes: List[tuple], dtypes: List[torch.dtype]) -> List[Any]:

--- a/unirl/distributed/tensor/backend/gpu_store/worker.py
+++ b/unirl/distributed/tensor/backend/gpu_store/worker.py
@@ -7,7 +7,7 @@ Responsibilities:
   - Tensor storage with reference counting (_store, _ref_counts)
   - IPC handle management (_share_cuda_() only called here, never in Worker)
   - NCCL cross-GPU transfers (global ProcessGroup)
-  - tensor_op / get_tensor_cpu for TensorHandle remote operations
+  - tensor_op / get_tensor_cpu for GPUTensorHandle remote operations
 
 Put path (Worker → TW):
   1. Worker calls batch_allocate([(shape, dtype), ...]) → [(store_key, ipc_h, stride), ...]
@@ -36,7 +36,7 @@ import torch
 import torch.distributed as dist
 from torch import Tensor
 
-from unirl.distributed.tensor.backend.gpu_store.handle import TensorHandle
+from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
 
 
 class TensorWorker:
@@ -116,7 +116,7 @@ class TensorWorker:
     def batch_write_done(self, store_keys: List[str]) -> None:
         """Move bufs from _pending into _store after Worker finishes writing.
 
-        Must be called synchronously (ray.get) before returning TensorHandle to
+        Must be called synchronously (ray.get) before returning GPUTensorHandle to
         controller — otherwise a concurrent borrow would KeyError on the key.
         """
         with self._lock:
@@ -146,7 +146,7 @@ class TensorWorker:
     # ── Reference counting ──
 
     def incref(self, key: str) -> None:
-        """Increment reference count. Called by TensorHandle __copy__ on controller."""
+        """Increment reference count. Called by GPUTensorHandle __copy__ on controller."""
         with self._lock:
             if key not in self._ref_counts:
                 raise KeyError(f"TensorWorker: cannot incref unknown key '{key}'")
@@ -167,7 +167,7 @@ class TensorWorker:
     def decref(self, key: str) -> None:
         """Decrement reference count. If zero, release the storage.
 
-        Called by TensorHandle._release (GC finalizer on controller side).
+        Called by GPUTensorHandle._release (GC finalizer on controller side).
 
         ipc_collect() is triggered lazily: only after _ipc_collect_count tensors
         freed OR _ipc_collect_bytes of cumulative VRAM freed, whichever comes first.
@@ -201,12 +201,12 @@ class TensorWorker:
                 raise KeyError(f"TensorWorker: unknown key '{key}'")
             return self._ref_counts[key]
 
-    # ── Tensor operations (called by TensorHandle.remote_op / TensorMeta.local) ──
+    # ── Tensor operations (called by GPUTensorHandle.remote_op / TensorRef.local) ──
 
-    def tensor_op(self, handle: TensorHandle, op: str, *op_args) -> TensorHandle:
+    def tensor_op(self, handle: GPUTensorHandle, op: str, *op_args) -> GPUTensorHandle:
         """Execute a tensor operation directly in _store (no IPC needed).
 
-        Returns a new unbound TensorHandle (caller must rebind).
+        Returns a new unbound GPUTensorHandle (caller must rebind).
         """
         if handle.object_ref is not None:
             t = ray.get(handle.object_ref)
@@ -229,12 +229,12 @@ class TensorWorker:
             self._counter += 1
             self._store[key] = result
             self._ref_counts[key] = 1
-        return TensorHandle(
+        return GPUTensorHandle(
             store_key=key, source_id=self.source_id, shape=tuple(result.shape), dtype=result.dtype, device=self.device
         )
 
-    def get_tensor_cpu(self, handle: TensorHandle) -> Tensor:
-        """Return tensor as CPU tensor (for TensorMeta.local())."""
+    def get_tensor_cpu(self, handle: GPUTensorHandle) -> Tensor:
+        """Return tensor as CPU tensor (for TensorRef.local())."""
         if handle.object_ref is not None:
             return ray.get(handle.object_ref)
         with self._lock:
@@ -286,7 +286,7 @@ class TensorWorker:
     def _nccl_send(self, dst_rank: int, items: List) -> None:
         """Send stored tensors (or row ranges of them) to dst_rank via NCCL.
 
-        Each item is ``(store_key, start, end)`` — a ``HandleView`` routing copy
+        Each item is ``(store_key, start, end)`` — a ``TensorSpan`` routing copy
         ships only its ``[start:end)`` rows; ``(key, None, None)`` sends the whole
         block. Bare ``str`` items are accepted for backward compatibility.
         """
@@ -299,7 +299,7 @@ class TensorWorker:
                 tensor = tensor[start:end]
             self._global_pg.send([tensor.contiguous()], dst_rank, 0).wait()
 
-    def _nccl_recv(self, src_rank: int, shapes: List[tuple], dtypes: List[torch.dtype]) -> List[TensorHandle]:
+    def _nccl_recv(self, src_rank: int, shapes: List[tuple], dtypes: List[torch.dtype]) -> List[GPUTensorHandle]:
         """Receive tensors from src_rank via NCCL, store in _store.
 
         Returns unbound TensorHandles (caller must rebind to this TW).
@@ -315,6 +315,6 @@ class TensorWorker:
                 self._store[key] = buf
                 self._ref_counts[key] = 1
             handles.append(
-                TensorHandle(store_key=key, source_id=self.source_id, shape=shape, dtype=dtype, device=self.device)
+                GPUTensorHandle(store_key=key, source_id=self.source_id, shape=shape, dtype=dtype, device=self.device)
             )
         return handles

--- a/unirl/distributed/tensor/backend/gpu_store/worker.py
+++ b/unirl/distributed/tensor/backend/gpu_store/worker.py
@@ -283,12 +283,20 @@ class TensorWorker:
         )
         self._global_pg = dist.ProcessGroupNCCL(store, global_rank, global_world_size)
 
-    def _nccl_send(self, dst_rank: int, store_keys: List[str]) -> None:
-        """Send tensors identified by store_keys to dst_rank via NCCL."""
+    def _nccl_send(self, dst_rank: int, items: List) -> None:
+        """Send stored tensors (or row ranges of them) to dst_rank via NCCL.
+
+        Each item is ``(store_key, start, end)`` — a ``HandleView`` routing copy
+        ships only its ``[start:end)`` rows; ``(key, None, None)`` sends the whole
+        block. Bare ``str`` items are accepted for backward compatibility.
+        """
         assert self._global_pg is not None, "Global PG not initialized."
-        for key in store_keys:
+        for item in items:
+            key, start, end = (item, None, None) if isinstance(item, str) else item
             with self._lock:
                 tensor = self._store[key]
+            if start is not None:
+                tensor = tensor[start:end]
             self._global_pg.send([tensor.contiguous()], dst_rank, 0).wait()
 
     def _nccl_recv(self, src_rank: int, shapes: List[tuple], dtypes: List[torch.dtype]) -> List[TensorHandle]:

--- a/unirl/distributed/tensor/backend/transfer_queue/transport.py
+++ b/unirl/distributed/tensor/backend/transfer_queue/transport.py
@@ -152,7 +152,7 @@ class TQTransport(TensorTransport):
 
         return _run_async_in_temp_loop(_put)
 
-    def get(self, spans: List[Any]) -> torch.Tensor:
+    def get(self, spans: List[TensorSpan[TQTensorHandle]]) -> torch.Tensor:
         async def _get() -> torch.Tensor:
             # Each ref is a span: fetch its handle's row-block, then slice locally.
             handles = [s.handle for s in spans]

--- a/unirl/distributed/tensor/backend/transfer_queue/transport.py
+++ b/unirl/distributed/tensor/backend/transfer_queue/transport.py
@@ -15,8 +15,8 @@ from unirl.distributed.tensor.backend.transfer_queue.runtime import (
     _run_async_in_temp_loop,
 )
 from unirl.distributed.tensor.transport import (
-    HandleView,
-    TensorMeta,
+    TensorSpan,
+    TensorRef,
     TensorTransport,
     TensorTransportRuntime,
     cat_rows,
@@ -29,10 +29,10 @@ class TQTensorHandle:
     field name it occupies in its originating put, and its original shape.
 
     Wrapping the upstream meta (rather than dropping it straight into
-    ``TensorMeta.refs``) keeps three contracts that worker-local handles satisfy
+    ``TensorRef.refs``) keeps three contracts that worker-local handles satisfy
     for free:
 
-    * **Uniform ref interface.** Every ``TensorMeta.refs`` element exposes
+    * **Uniform ref interface.** Every ``TensorRef.refs`` element exposes
       ``.local()``, so driver-side hydration (``_hydrate_tensor_meta``) resolves a
       worker-local ``TensorHandle`` and a global TQ ref the same way.
     * **Field identity travels with the ref.** ``Worker.call`` keys put/get by
@@ -154,11 +154,11 @@ class TQTransport(TensorTransport):
 
     def get(self, refs: List[Any]) -> torch.Tensor:
         async def _get() -> torch.Tensor:
-            # HandleView refs fetch their base row-block, then slice locally.
-            bases = [h.base if isinstance(h, HandleView) else h for h in refs]
+            # TensorSpan refs fetch their base row-block, then slice locally.
+            bases = [h.base if isinstance(h, TensorSpan) else h for h in refs]
             tensors = await self._fetch(bases)
             parts = [
-                t[h.start : h.end] if isinstance(h, HandleView) else t
+                t[h.start : h.end] if isinstance(h, TensorSpan) else t
                 for h, t in zip(refs, tensors)
             ]
             return cat_rows(parts)
@@ -166,13 +166,13 @@ class TQTransport(TensorTransport):
         return _run_async_in_temp_loop(_get)
 
     def is_ref(self, value: Any) -> bool:
-        return isinstance(value, TensorMeta)
+        return isinstance(value, TensorRef)
 
-    def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorMeta]:
+    def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorRef]:
         if not tensors:
             return {}
 
-        async def _put_batch() -> Dict[str, TensorMeta]:
+        async def _put_batch() -> Dict[str, TensorRef]:
             # Group keys by leading-dim batch size: a TensorDict requires one
             # uniform batch_size, so a mixed-dim object (e.g. a rollout's 96-row
             # per-sample tensors alongside an 11-step trajectory) must split into
@@ -189,7 +189,7 @@ class TQTransport(TensorTransport):
                     raise TypeError(f"TQTransport.put_batch: unsupported type {type(t).__name__} for key {k!r}")
                 groups.setdefault(_bs(t), []).append(k)
 
-            result: Dict[str, TensorMeta] = {}
+            result: Dict[str, TensorRef] = {}
             for bs, keys in groups.items():
                 d: dict = {}
                 for k in keys:
@@ -200,7 +200,7 @@ class TQTransport(TensorTransport):
                 for k in keys:
                     t = tensors[k]
                     is_tensor = isinstance(t, torch.Tensor)
-                    result[k] = TensorMeta(
+                    result[k] = TensorRef(
                         refs=[
                             TQTensorHandle(
                                 meta=put_meta.select_fields([k]),
@@ -217,7 +217,7 @@ class TQTransport(TensorTransport):
 
         return _run_async_in_temp_loop(_put_batch)
 
-    def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
+    def get_batch(self, metas: Dict[str, TensorRef]) -> Dict[str, torch.Tensor]:
         if not metas:
             return {}
 
@@ -227,7 +227,7 @@ class TQTransport(TensorTransport):
             # in _fetch, then regroup back per consumer key (cat a key's multiple
             # refs). Extracting by handle.field — not by the consumer's positional
             # key — is what lets a producer's output 'i' resolve under the
-            # consumer's input 'j'. HandleView refs fetch their base block and
+            # consumer's input 'j'. TensorSpan refs fetch their base block and
             # slice locally before the per-key cat.
             handles: List[TQTensorHandle] = []
             views: List[Any] = []
@@ -235,12 +235,12 @@ class TQTransport(TensorTransport):
             for k, m in metas.items():
                 for h in m.refs:
                     views.append(h)
-                    handles.append(h.base if isinstance(h, HandleView) else h)
+                    handles.append(h.base if isinstance(h, TensorSpan) else h)
                     owners.append(k)
             tensors = await self._fetch(handles)
             parts: Dict[str, list] = defaultdict(list)
             for k, h, t in zip(owners, views, tensors):
-                parts[k].append(t[h.start : h.end] if isinstance(h, HandleView) else t)
+                parts[k].append(t[h.start : h.end] if isinstance(h, TensorSpan) else t)
             return {k: cat_rows(lst) for k, lst in parts.items()}
 
         return _run_async_in_temp_loop(_get_batch)

--- a/unirl/distributed/tensor/backend/transfer_queue/transport.py
+++ b/unirl/distributed/tensor/backend/transfer_queue/transport.py
@@ -15,8 +15,8 @@ from unirl.distributed.tensor.backend.transfer_queue.runtime import (
     _run_async_in_temp_loop,
 )
 from unirl.distributed.tensor.transport import (
-    TensorSpan,
     TensorRef,
+    TensorSpan,
     TensorTransport,
     TensorTransportRuntime,
     cat_rows,
@@ -29,10 +29,10 @@ class TQTensorHandle:
     field name it occupies in its originating put, and its original shape.
 
     Wrapping the upstream meta (rather than dropping it straight into
-    ``TensorRef.refs``) keeps three contracts that worker-local handles satisfy
+    ``TensorRef.spans``) keeps three contracts that worker-local handles satisfy
     for free:
 
-    * **Uniform ref interface.** Every ``TensorRef.refs`` element exposes
+    * **Uniform ref interface.** Every ``TensorRef.spans`` element exposes
       ``.local()``, so driver-side hydration (``_hydrate_tensor_meta``) resolves a
       worker-local ``TensorHandle`` and a global TQ ref the same way.
     * **Field identity travels with the ref.** ``Worker.call`` keys put/get by
@@ -152,15 +152,12 @@ class TQTransport(TensorTransport):
 
         return _run_async_in_temp_loop(_put)
 
-    def get(self, refs: List[Any]) -> torch.Tensor:
+    def get(self, spans: List[Any]) -> torch.Tensor:
         async def _get() -> torch.Tensor:
-            # TensorSpan refs fetch their base row-block, then slice locally.
-            bases = [h.base if isinstance(h, TensorSpan) else h for h in refs]
-            tensors = await self._fetch(bases)
-            parts = [
-                t[h.start : h.end] if isinstance(h, TensorSpan) else t
-                for h, t in zip(refs, tensors)
-            ]
+            # Each ref is a span: fetch its handle's row-block, then slice locally.
+            handles = [s.handle for s in spans]
+            tensors = await self._fetch(handles)
+            parts = [t[s.start : s.stop] for s, t in zip(spans, tensors)]
             return cat_rows(parts)
 
         return _run_async_in_temp_loop(_get)
@@ -201,14 +198,17 @@ class TQTransport(TensorTransport):
                     t = tensors[k]
                     is_tensor = isinstance(t, torch.Tensor)
                     result[k] = TensorRef(
-                        refs=[
-                            TQTensorHandle(
-                                meta=put_meta.select_fields([k]),
-                                field=k,
-                                orig_shape=tuple(t.shape) if is_tensor else None,
+                        spans=[
+                            TensorSpan(
+                                TQTensorHandle(
+                                    meta=put_meta.select_fields([k]),
+                                    field=k,
+                                    orig_shape=tuple(t.shape) if is_tensor else None,
+                                ),
+                                0,
+                                bs,
                             )
                         ],
-                        sizes=[bs],
                         shape=tuple(t.shape) if is_tensor else None,
                         dtype=t.dtype if is_tensor else None,
                         device=str(t.device) if is_tensor else None,
@@ -222,25 +222,25 @@ class TQTransport(TensorTransport):
             return {}
 
         async def _get_batch() -> Dict[str, torch.Tensor]:
-            # Flatten every key's refs into one handle list (each handle carries
+            # Flatten every key's spans into one handle list (each handle carries
             # its own producer field + original shape), fetch them grouped-by-put
             # in _fetch, then regroup back per consumer key (cat a key's multiple
-            # refs). Extracting by handle.field — not by the consumer's positional
+            # spans). Extracting by handle.field — not by the consumer's positional
             # key — is what lets a producer's output 'i' resolve under the
-            # consumer's input 'j'. TensorSpan refs fetch their base block and
-            # slice locally before the per-key cat.
+            # consumer's input 'j'. Each span fetches its handle block and slices
+            # locally before the per-key cat.
             handles: List[TQTensorHandle] = []
-            views: List[Any] = []
+            spans_list: List[Any] = []
             owners: List[str] = []
             for k, m in metas.items():
-                for h in m.refs:
-                    views.append(h)
-                    handles.append(h.base if isinstance(h, TensorSpan) else h)
+                for s in m.spans:
+                    spans_list.append(s)
+                    handles.append(s.handle)
                     owners.append(k)
             tensors = await self._fetch(handles)
             parts: Dict[str, list] = defaultdict(list)
-            for k, h, t in zip(owners, views, tensors):
-                parts[k].append(t[h.start : h.end] if isinstance(h, TensorSpan) else t)
+            for k, s, t in zip(owners, spans_list, tensors):
+                parts[k].append(t[s.start : s.stop])
             return {k: cat_rows(lst) for k, lst in parts.items()}
 
         return _run_async_in_temp_loop(_get_batch)

--- a/unirl/distributed/tensor/backend/transfer_queue/transport.py
+++ b/unirl/distributed/tensor/backend/transfer_queue/transport.py
@@ -15,9 +15,11 @@ from unirl.distributed.tensor.backend.transfer_queue.runtime import (
     _run_async_in_temp_loop,
 )
 from unirl.distributed.tensor.transport import (
+    HandleView,
     TensorMeta,
     TensorTransport,
     TensorTransportRuntime,
+    cat_rows,
 )
 
 
@@ -152,8 +154,14 @@ class TQTransport(TensorTransport):
 
     def get(self, refs: List[Any]) -> torch.Tensor:
         async def _get() -> torch.Tensor:
-            tensors = await self._fetch(refs)
-            return tensors[0] if len(tensors) == 1 else torch.cat(tensors, dim=0)
+            # HandleView refs fetch their base row-block, then slice locally.
+            bases = [h.base if isinstance(h, HandleView) else h for h in refs]
+            tensors = await self._fetch(bases)
+            parts = [
+                t[h.start : h.end] if isinstance(h, HandleView) else t
+                for h, t in zip(refs, tensors)
+            ]
+            return cat_rows(parts)
 
         return _run_async_in_temp_loop(_get)
 
@@ -212,13 +220,6 @@ class TQTransport(TensorTransport):
     def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
         if not metas:
             return {}
-        viewed = {k: m for k, m in metas.items() if getattr(m, "view_plan", None) is not None}
-        if viewed:
-            plain = {k: m for k, m in metas.items() if k not in viewed}
-            out = self.get_batch(plain) if plain else {}
-            for k, m in viewed.items():
-                out[k] = m.materialize(backend=self)
-            return out
 
         async def _get_batch() -> Dict[str, torch.Tensor]:
             # Flatten every key's refs into one handle list (each handle carries
@@ -226,18 +227,21 @@ class TQTransport(TensorTransport):
             # in _fetch, then regroup back per consumer key (cat a key's multiple
             # refs). Extracting by handle.field — not by the consumer's positional
             # key — is what lets a producer's output 'i' resolve under the
-            # consumer's input 'j'.
+            # consumer's input 'j'. HandleView refs fetch their base block and
+            # slice locally before the per-key cat.
             handles: List[TQTensorHandle] = []
+            views: List[Any] = []
             owners: List[str] = []
             for k, m in metas.items():
                 for h in m.refs:
-                    handles.append(h)
+                    views.append(h)
+                    handles.append(h.base if isinstance(h, HandleView) else h)
                     owners.append(k)
             tensors = await self._fetch(handles)
             parts: Dict[str, list] = defaultdict(list)
-            for k, t in zip(owners, tensors):
-                parts[k].append(t)
-            return {k: (lst[0] if len(lst) == 1 else torch.cat(lst, dim=0)) for k, lst in parts.items()}
+            for k, h, t in zip(owners, views, tensors):
+                parts[k].append(t[h.start : h.end] if isinstance(h, HandleView) else t)
+            return {k: cat_rows(lst) for k, lst in parts.items()}
 
         return _run_async_in_temp_loop(_get_batch)
 

--- a/unirl/distributed/tensor/backend/transfer_queue/transport.py
+++ b/unirl/distributed/tensor/backend/transfer_queue/transport.py
@@ -212,6 +212,13 @@ class TQTransport(TensorTransport):
     def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
         if not metas:
             return {}
+        viewed = {k: m for k, m in metas.items() if getattr(m, "view_plan", None) is not None}
+        if viewed:
+            plain = {k: m for k, m in metas.items() if k not in viewed}
+            out = self.get_batch(plain) if plain else {}
+            for k, m in viewed.items():
+                out[k] = m.materialize(backend=self)
+            return out
 
         async def _get_batch() -> Dict[str, torch.Tensor]:
             # Flatten every key's refs into one handle list (each handle carries

--- a/unirl/distributed/tensor/batch.py
+++ b/unirl/distributed/tensor/batch.py
@@ -463,10 +463,10 @@ def _concat_packed_data(values: List[Optional[torch.Tensor]]) -> Optional[torch.
     if not non_none:
         return None
     if all(isinstance(v, Batch) for v in non_none):
-        # Transport placeholders (e.g. TensorMeta returned from a DP_SCATTER
+        # Transport placeholders (e.g. TensorRef returned from a DP_SCATTER
         # dispatch) carry routing handles, not real tensors — defer to their own
         # concat, exactly like _concat_value's Batch branch. A raw torch.cat
-        # would choke on them ("expected Tensor ... but got TensorMeta").
+        # would choke on them ("expected Tensor ... but got TensorRef").
         return type(non_none[0]).concat(non_none)
     return torch.cat(non_none, dim=0)
 
@@ -507,7 +507,7 @@ def _select_packed_data(
             return value.select_segments([])
         return value[:0].clone()
     if hasattr(value, "select_segments"):
-        # TensorMeta: token-range gather as a lazy segment view (no data motion).
+        # TensorRef: token-range gather as a lazy segment view (no data motion).
         return value.select_segments(
             [(int(cu[i].item()), int(cu[i + 1].item())) for i in indices]
         )
@@ -875,7 +875,7 @@ class Batch:
 
         The precomputed-values sibling of :meth:`map` (which takes a per-field
         ``fn``). For the generic transport-layer tree-walkers that rebuild a
-        ``Batch`` from already-transformed field values — TensorMeta<->Tensor
+        ``Batch`` from already-transformed field values — TensorRef<->Tensor
         swaps and ref rerouting, representation-only changes that don't alter the
         batch dimension or per-sample lengths — so the framework-managed
         ``_packed_cu_seqlens`` carries over unchanged. Without this carry, those

--- a/unirl/distributed/tensor/batch.py
+++ b/unirl/distributed/tensor/batch.py
@@ -508,9 +508,7 @@ def _select_packed_data(
         return value[:0].clone()
     if hasattr(value, "select_segments"):
         # TensorRef: token-range gather as a lazy segment view (no data motion).
-        return value.select_segments(
-            [(int(cu[i].item()), int(cu[i + 1].item())) for i in indices]
-        )
+        return value.select_segments([(int(cu[i].item()), int(cu[i + 1].item())) for i in indices])
     chunks = [value[int(cu[i].item()) : int(cu[i + 1].item())] for i in indices]
     return torch.cat(chunks, dim=0)
 

--- a/unirl/distributed/tensor/batch.py
+++ b/unirl/distributed/tensor/batch.py
@@ -503,7 +503,14 @@ def _select_packed_data(
             "construct via the regular dataclass __init__ with per-sample lists."
         )
     if not indices:
+        if hasattr(value, "select_segments"):
+            return value.select_segments([])
         return value[:0].clone()
+    if hasattr(value, "select_segments"):
+        # TensorMeta: token-range gather as a lazy segment view (no data motion).
+        return value.select_segments(
+            [(int(cu[i].item()), int(cu[i + 1].item())) for i in indices]
+        )
     chunks = [value[int(cu[i].item()) : int(cu[i + 1].item())] for i in indices]
     return torch.cat(chunks, dim=0)
 

--- a/unirl/distributed/tensor/factory.py
+++ b/unirl/distributed/tensor/factory.py
@@ -1,7 +1,7 @@
 """build_transport — construct the per-Worker TensorTransport for a backend kind.
 
 Called inside the Worker actor process (so the installed
-``TensorTransportRuntime`` singleton lives where ``TensorMeta.local()`` runs).
+``TensorTransportRuntime`` singleton lives where ``TensorRef.local()`` runs).
 Backend dependencies differ: colocate builds an in-process ``TensorStore``; gpu
 needs a ``TensorWorker`` handle (``tw``) injected by ``DevicePool``; transfer
 queue bootstraps its per-process TQ client here from the driver's ``tq_handoff``.

--- a/unirl/distributed/tensor/grad_context.py
+++ b/unirl/distributed/tensor/grad_context.py
@@ -15,7 +15,7 @@ Usage::
 
 The framework issues _auto_backward RPCs automatically on __exit__.
 Gradients are accumulated worker-side using PyTorch's native .grad += mechanism,
-supporting fan-out (same TensorMeta used as input to multiple RPCs).
+supporting fan-out (same TensorRef used as input to multiple RPCs).
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
-from unirl.distributed.tensor.transport import TensorMeta
+from unirl.distributed.tensor.transport import TensorRef
 
 if TYPE_CHECKING:
     from unirl.distributed.group.dispatch import Dispatch
@@ -54,14 +54,14 @@ class RPCBackwardNode:
     input_metas and output_metas are ordered lists — index i corresponds to
     _grad_inputs[call_id][i] and _grad_outputs[call_id][i] on the worker side.
     Both sides use the same depth-first sorted-key traversal via
-    collect_leaves(x, TensorMeta) / collect_leaves(x, Tensor) to guarantee alignment.
+    collect_leaves(x, TensorRef) / collect_leaves(x, Tensor) to guarantee alignment.
     """
 
     role_proxy: "Handle"
     call_id: str  # key prefix for worker _grad_inputs/_grad_outputs
     dispatch_mode: "Dispatch"  # backward dispatch mode (always DP_SCATTER currently)
-    input_metas: List["TensorMeta"]  # forward input TensorMetas, in traversal order
-    output_metas: List["TensorMeta"]  # forward output TensorMetas, in traversal order
+    input_metas: List["TensorRef"]  # forward input TensorMetas, in traversal order
+    output_metas: List["TensorRef"]  # forward output TensorMetas, in traversal order
 
 
 # ── GradContext ────────────────────────────────────────────────────────────────
@@ -140,8 +140,8 @@ def _run_backward(ctx: GradContext) -> None:
 def _run_auto_backward(node: RPCBackwardNode) -> None:
     """Call _auto_backward proxy on workers using node's dispatch_mode.
 
-    out_grads and in_grads are tuples of Optional[TensorMeta].  pytree_chunk
-    recurses into tuple elements, so each TensorMeta is chunked by dp_size
+    out_grads and in_grads are tuples of Optional[TensorRef].  pytree_chunk
+    recurses into tuple elements, so each TensorRef is chunked by dp_size
     giving worker_i its own grad shard.  pytree_cat does the inverse on
     return values.  No manual per-worker dispatch needed.
     """

--- a/unirl/distributed/tensor/pytree.py
+++ b/unirl/distributed/tensor/pytree.py
@@ -3,7 +3,7 @@
 ``pytree_chunk`` shards one same-structured tree into ``N`` per-rank trees;
 ``pytree_cat`` merges ``N`` same-structured trees back into one (the inverse
 pair). Both recurse over the same node types (``Tensor`` / ``ndarray`` /
-``list`` / ``tuple`` / ``dict`` / ``Batch`` / ``TensorMeta``) and operate
+``list`` / ``tuple`` / ``dict`` / ``Batch`` / ``TensorRef``) and operate
 along axis 0.
 
 ``infer_batch_size`` is the companion that derives the ``batch_size`` argument
@@ -23,9 +23,9 @@ from typing import Any, Optional
 import numpy as np
 import torch
 
-from unirl.distributed.tensor.backend.colocate_store.handle import TensorHandle
+from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
 from unirl.distributed.tensor.batch import Batch
-from unirl.distributed.tensor.transport import TensorMeta
+from unirl.distributed.tensor.transport import TensorRef
 from unirl.distributed.utils import Broadcast
 
 # ── Batch-size inference ──
@@ -38,7 +38,7 @@ def _value_batch_size(value) -> Optional[int]:
     inferred size lines up with what actually gets chunked:
 
       - ``Broadcast`` → skipped (never contributes a size)
-      - ``Tensor`` / ``ndarray`` / ``TensorHandle`` / ``TensorMeta`` →
+      - ``Tensor`` / ``ndarray`` / ``TensorHandle`` / ``TensorRef`` →
         ``shape[0]`` (0-dim scalars contribute nothing)
       - ``list`` → ``len`` (per-sample batch)
       - ``Batch`` → its own ``batch_size`` (concat-field aligned)
@@ -53,8 +53,8 @@ def _value_batch_size(value) -> Optional[int]:
     """
     if isinstance(value, Broadcast):
         return None
-    if isinstance(value, (torch.Tensor, np.ndarray, TensorHandle, TensorMeta)):
-        # ``TensorMeta.shape`` is Optional and 0-dim tensors have an empty
+    if isinstance(value, (torch.Tensor, np.ndarray, GPUTensorHandle, TensorRef)):
+        # ``TensorRef.shape`` is Optional and 0-dim tensors have an empty
         # shape — both mean "no batch axis".
         shape = value.shape
         return int(shape[0]) if shape else None
@@ -104,7 +104,7 @@ def pytree_chunk(value, dp_size: int, batch_size: int) -> list:
       - ``Broadcast(x)`` → ``[x] * dp_size``  (explicit opt-out of splitting)
       - ``Tensor`` → chunk along dim 0 (must be divisible)
       - ``ndarray`` → split along axis 0 (must be divisible)
-      - ``TensorMeta`` → chunk refs across ``dp_size`` (requires divisibility)
+      - ``TensorRef`` → chunk refs across ``dp_size`` (requires divisibility)
       - ``list`` → slice into equal parts (must be divisible)
       - ``tuple`` → recurse element-wise, reassemble per-shard tuples
       - ``dict`` → recurse into values, reassemble per-shard dicts
@@ -135,7 +135,7 @@ def pytree_chunk(value, dp_size: int, batch_size: int) -> list:
         chunk_size = batch_size // dp_size
         return [value[i * chunk_size : (i + 1) * chunk_size] for i in range(dp_size)]
 
-    elif isinstance(value, TensorMeta):
+    elif isinstance(value, TensorRef):
         total = value.shape[0]
         if total != batch_size:
             return [value] * dp_size
@@ -143,7 +143,7 @@ def pytree_chunk(value, dp_size: int, batch_size: int) -> list:
             raise ValueError(f"batch_size={batch_size} not divisible by dp_size={dp_size}")
         n_refs = len(value.refs)
         if n_refs % dp_size != 0:
-            raise ValueError(f"TensorMeta has {n_refs} refs, not divisible by dp_size={dp_size}")
+            raise ValueError(f"TensorRef has {n_refs} refs, not divisible by dp_size={dp_size}")
         refs_per_shard = n_refs // dp_size
         parts = []
         for i in range(dp_size):
@@ -153,7 +153,7 @@ def pytree_chunk(value, dp_size: int, batch_size: int) -> list:
             shard_sizes = value.sizes[start:end]
             shard_total = sum(shard_sizes)
             parts.append(
-                TensorMeta(
+                TensorRef(
                     refs=shard_refs,
                     sizes=shard_sizes,
                     shape=(shard_total, *value.shape[1:]) if value.shape else None,
@@ -200,7 +200,7 @@ def pytree_cat(results: list) -> Any:
 
     Rules:
       - ``Tensor`` → ``torch.cat`` along dim 0
-      - ``TensorMeta`` → merge all refs into one ``TensorMeta``
+      - ``TensorRef`` → merge all refs into one ``TensorRef``
       - ``ndarray`` → ``np.concatenate`` along axis 0
       - ``list`` → flatten (concatenate lists)
       - ``tuple`` → recurse element-wise (record-style), return tuple
@@ -218,14 +218,14 @@ def pytree_cat(results: list) -> Any:
         return None
     elif isinstance(first, torch.Tensor):
         return torch.cat(results, dim=0)
-    elif isinstance(first, TensorMeta):
+    elif isinstance(first, TensorRef):
         all_refs = []
         all_sizes = []
         for m in results:
             all_refs.extend(m.refs)
             all_sizes.extend(m.sizes)
         total = sum(all_sizes)
-        return TensorMeta(
+        return TensorRef(
             refs=all_refs,
             sizes=all_sizes,
             shape=(total, *first.shape[1:]) if first.shape else None,

--- a/unirl/distributed/tensor/pytree.py
+++ b/unirl/distributed/tensor/pytree.py
@@ -141,21 +141,19 @@ def pytree_chunk(value, dp_size: int, batch_size: int) -> list:
             return [value] * dp_size
         if batch_size % dp_size != 0:
             raise ValueError(f"batch_size={batch_size} not divisible by dp_size={dp_size}")
-        n_refs = len(value.refs)
-        if n_refs % dp_size != 0:
-            raise ValueError(f"TensorRef has {n_refs} refs, not divisible by dp_size={dp_size}")
-        refs_per_shard = n_refs // dp_size
+        n_spans = len(value.spans)
+        if n_spans % dp_size != 0:
+            raise ValueError(f"TensorRef has {n_spans} spans, not divisible by dp_size={dp_size}")
+        spans_per_shard = n_spans // dp_size
         parts = []
         for i in range(dp_size):
-            start = i * refs_per_shard
-            end = start + refs_per_shard
-            shard_refs = value.refs[start:end]
-            shard_sizes = value.sizes[start:end]
-            shard_total = sum(shard_sizes)
+            start = i * spans_per_shard
+            end = start + spans_per_shard
+            shard_spans = value.spans[start:end]
+            shard_total = sum(s.stop - s.start for s in shard_spans)
             parts.append(
                 TensorRef(
-                    refs=shard_refs,
-                    sizes=shard_sizes,
+                    spans=shard_spans,
                     shape=(shard_total, *value.shape[1:]) if value.shape else None,
                     dtype=value.dtype,
                     device=value.device,
@@ -219,15 +217,12 @@ def pytree_cat(results: list) -> Any:
     elif isinstance(first, torch.Tensor):
         return torch.cat(results, dim=0)
     elif isinstance(first, TensorRef):
-        all_refs = []
-        all_sizes = []
+        all_spans = []
         for m in results:
-            all_refs.extend(m.refs)
-            all_sizes.extend(m.sizes)
-        total = sum(all_sizes)
+            all_spans.extend(m.spans)
+        total = sum(s.stop - s.start for s in all_spans)
         return TensorRef(
-            refs=all_refs,
-            sizes=all_sizes,
+            spans=all_spans,
             shape=(total, *first.shape[1:]) if first.shape else None,
             dtype=first.dtype,
             device=first.device,

--- a/unirl/distributed/tensor/transport.py
+++ b/unirl/distributed/tensor/transport.py
@@ -1,14 +1,14 @@
 """TensorTransport: backend-agnostic tensor storage and retrieval.
 
-``TensorMeta`` is the universal tensor proxy — a ``Batch`` subclass that
+``TensorRef`` is the universal tensor proxy — a ``Batch`` subclass that
 holds per-handle opaque refs and their sizes. Each ref is either a backend
-handle from one ``put()`` call or a :class:`HandleView` (a row/unit-range
+handle from one ``put()`` call or a :class:`TensorSpan` (a row/unit-range
 view of such a handle); ``sizes[i]`` records how many rows ref ``i``
 covers. ``concat`` merges ref/size lists; ``batch_size`` is ``sum(sizes)``.
-Per-row ``select`` / ``slice`` builds ``HandleView`` refs — no data motion,
+Per-row ``select`` / ``slice`` builds ``TensorSpan`` refs — no data motion,
 no hydration.
 
-``TensorMeta`` also serves as a compute proxy: ``transform``, ``reshape``,
+``TensorRef`` also serves as a compute proxy: ``transform``, ``reshape``,
 ``permute``, ``local`` delegate to the active backend.
 
 ``TensorTransport`` is the ABC every backend implements: per-tensor ``put`` /
@@ -38,10 +38,10 @@ from unirl.distributed.tensor.batch import Batch, concat_field, shared_field
 logger = logging.getLogger(__name__)
 
 
-class HandleView:
+class TensorSpan:
     """A unit-range (row/token) view of a parent ref — the addressing primitive.
 
-    ``TensorMeta`` selection/permutation emits these instead of moving data:
+    ``TensorRef`` selection/permutation emits these instead of moving data:
     a view addresses ``base[start:end)`` along dim 0 while the bytes stay in
     the producing worker's store. Backends resolve a view by resolving the
     base and slicing (zero-copy on the IPC/store path); ``localize`` ships
@@ -53,19 +53,19 @@ class HandleView:
     (and the parent itself) is gone. Views carry no finalizer, no store_key
     of their own, and trigger no extra decref RPCs.
 
-    Nested views flatten at construction (``HandleView(HandleView(b,2,8),1,3)``
-    is ``HandleView(b,3,5)``), so ``base`` is always a backend handle.
+    Nested views flatten at construction (``TensorSpan(TensorSpan(b,2,8),1,3)``
+    is ``TensorSpan(b,3,5)``), so ``base`` is always a backend handle.
     """
 
     __slots__ = ("base", "start", "end")
 
     def __init__(self, base: Any, start: int, end: int) -> None:
         start, end = int(start), int(end)
-        if isinstance(base, HandleView):
+        if isinstance(base, TensorSpan):
             start, end = base.start + start, base.start + end
             base = base.base
         if not (0 <= start <= end):
-            raise ValueError(f"HandleView range [{start}, {end}) is invalid")
+            raise ValueError(f"TensorSpan range [{start}, {end}) is invalid")
         self.base = base
         self.start = start
         self.end = end
@@ -100,14 +100,14 @@ class HandleView:
     def local(self) -> torch.Tensor:
         return self.base.local()[self.start : self.end]
 
-    def routing_copy(self) -> "HandleView":
+    def routing_copy(self) -> "TensorSpan":
         """Bare placeholder for localize's id()-keyed NCCL substitution.
 
         Carries the base's routing copy plus this view's range so the send
         side can slice — dropping it must not touch the parent's ref count
         (the parent's routing_copy is equally bare).
         """
-        return HandleView(self.base.routing_copy(), self.start, self.end)
+        return TensorSpan(self.base.routing_copy(), self.start, self.end)
 
     def __getstate__(self) -> dict:
         return {"base": self.base, "start": self.start, "end": self.end}
@@ -118,7 +118,7 @@ class HandleView:
         self.end = state["end"]
 
     def __repr__(self) -> str:
-        return f"HandleView({self.base!r}[{self.start}:{self.end}])"
+        return f"TensorSpan({self.base!r}[{self.start}:{self.end}])"
 
 
 def cat_rows(parts: List[torch.Tensor]) -> torch.Tensor:
@@ -149,11 +149,11 @@ def cat_rows(parts: List[torch.Tensor]) -> torch.Tensor:
 
 
 @dataclass
-class TensorMeta(Batch):
+class TensorRef(Batch):
     """Per-handle tensor proxy.
 
     Each element in ``refs`` is an opaque handle from a single ``put()``
-    call or a :class:`HandleView` over one; ``sizes[i]`` records how many
+    call or a :class:`TensorSpan` over one; ``sizes[i]`` records how many
     rows ref ``i`` covers. ``batch_size`` is ``sum(sizes)``, not
     ``len(refs)``.
     """
@@ -163,7 +163,7 @@ class TensorMeta(Batch):
     shape: Optional[Tuple[int, ...]] = shared_field(default=None)
     dtype: Optional[torch.dtype] = shared_field(default=None)
     device: Optional[str] = shared_field(default=None)
-    grad: Optional["TensorMeta"] = shared_field(default=None)
+    grad: Optional["TensorRef"] = shared_field(default=None)
     retain_grad_flag: bool = shared_field(default=False)
 
     @property
@@ -171,7 +171,7 @@ class TensorMeta(Batch):
         return sum(self.sizes) if self.sizes else 0
 
     @classmethod
-    def concat(cls, items: "list[TensorMeta]") -> "TensorMeta":
+    def concat(cls, items: "list[TensorRef]") -> "TensorRef":
         refs: List[Any] = []
         sizes: List[int] = []
         for m in items:
@@ -179,7 +179,7 @@ class TensorMeta(Batch):
             sizes.extend(m.sizes)
         first = items[0]
         total = sum(sizes)
-        return TensorMeta(
+        return TensorRef(
             refs=refs,
             sizes=sizes,
             shape=(total, *first.shape[1:]) if first.shape else None,
@@ -187,7 +187,7 @@ class TensorMeta(Batch):
             device=first.device,
         )
 
-    def select(self, indices) -> "TensorMeta":
+    def select(self, indices) -> "TensorRef":
         """Re-index along the unit axis by building ref VIEWS (no data motion)."""
         idx = [int(i) for i in (indices.tolist() if hasattr(indices, "tolist") else indices)]
         return self.select_units(idx)
@@ -212,20 +212,20 @@ class TensorMeta(Batch):
             g0 += take
         return pieces
 
-    def _from_pieces(self, pieces: List[Tuple[int, int, int]]) -> "TensorMeta":
+    def _from_pieces(self, pieces: List[Tuple[int, int, int]]) -> "TensorRef":
         """Build the selected meta: whole-ref pieces pass the ref through untouched
         (a boundary-aligned selection costs nothing); partial pieces become
-        :class:`HandleView` refs (nested views flatten in the ctor)."""
+        :class:`TensorSpan` refs (nested views flatten in the ctor)."""
         refs: List[Any] = []
         sizes: List[int] = []
         for r, s, e in pieces:
             if s == 0 and e == int(self.sizes[r]):
                 refs.append(self.refs[r])
             else:
-                refs.append(HandleView(self.refs[r], s, e))
+                refs.append(TensorSpan(self.refs[r], s, e))
             sizes.append(e - s)
         total = sum(sizes)
-        return TensorMeta(
+        return TensorRef(
             refs=refs,
             sizes=sizes,
             shape=(total, *self.shape[1:]) if self.shape else None,
@@ -233,7 +233,7 @@ class TensorMeta(Batch):
             device=self.device,
         )
 
-    def select_units(self, idx: List[int]) -> "TensorMeta":
+    def select_units(self, idx: List[int]) -> "TensorRef":
         """Arbitrary re-index (gather/permute) as lazy ref views."""
         offsets = self._offsets()
         # Coalesce consecutive indices into ranges, then map ranges to pieces.
@@ -247,7 +247,7 @@ class TensorMeta(Batch):
             i = j
         return self._from_pieces(pieces)
 
-    def select_segments(self, segments: List[Tuple[int, int]]) -> "TensorMeta":
+    def select_segments(self, segments: List[Tuple[int, int]]) -> "TensorRef":
         """Re-index by global (start, end) unit ranges (PACKED token ranges)."""
         offsets = self._offsets()
         pieces: List[Tuple[int, int, int]] = []
@@ -255,14 +255,14 @@ class TensorMeta(Batch):
             pieces.extend(self._pieces_for_range(int(g0), int(g1), offsets))
         return self._from_pieces(pieces)
 
-    def with_refs(self, refs: List[Any]) -> "TensorMeta":
+    def with_refs(self, refs: List[Any]) -> "TensorRef":
         """Clone with substituted (routed) refs, preserving sizes/shape.
 
         ``localize`` rebuilds metas after routing; ``from_handles`` would
         re-derive sizes from ``ref.shape[0]`` — equivalent, but this keeps the
         substitution structural (same ref count, same sizes, no re-derivation).
         """
-        return TensorMeta(
+        return TensorRef(
             refs=list(refs),
             sizes=list(self.sizes),
             shape=self.shape,
@@ -270,41 +270,41 @@ class TensorMeta(Batch):
             device=self.device,
         )
 
-    def _slice_by_refs(self, start: int, end: int) -> "TensorMeta":
+    def _slice_by_refs(self, start: int, end: int) -> "TensorRef":
         """Contiguous row range ``[start:end)`` — the structural inverse of concat.
 
         A range on ref boundaries hands the refs back untouched (the exact
         inverse of the DP collect→re-dispatch round-trip); an intra-ref range
-        wraps the boundary refs in :class:`HandleView` — same code path, the
+        wraps the boundary refs in :class:`TensorSpan` — same code path, the
         whole-piece pass-through in ``_from_pieces`` is what preserves the
         zero-cost aligned case.
         """
         return self.select_segments([(int(start), int(end))])
 
-    def slice(self, start, end) -> "TensorMeta":
+    def slice(self, start, end) -> "TensorRef":
         # CONCAT path: Batch.slice → _slice_value → value.slice(start, end).
         return self._slice_by_refs(start, end)
 
-    def __getitem__(self, key) -> "TensorMeta":
+    def __getitem__(self, key) -> "TensorRef":
         # PACKED path: _slice_packed_data does ``value[cu[start]:cu[end]]``.
         if isinstance(key, slice):
             if key.step not in (None, 1):
-                raise NotImplementedError("TensorMeta supports only contiguous (step=1) slicing")
+                raise NotImplementedError("TensorRef supports only contiguous (step=1) slicing")
             lo = 0 if key.start is None else int(key.start)
             hi = self.batch_size if key.stop is None else int(key.stop)
             return self._slice_by_refs(lo, hi)
-        raise NotImplementedError(f"TensorMeta indexing supports slices only, got {type(key).__name__}")
+        raise NotImplementedError(f"TensorRef indexing supports slices only, got {type(key).__name__}")
 
-    def transform(self, fn: Callable[[torch.Tensor], torch.Tensor]) -> "TensorMeta":
+    def transform(self, fn: Callable[[torch.Tensor], torch.Tensor]) -> "TensorRef":
         backend = TensorTransportRuntime.current()
         if backend is None:
             raise RuntimeError("No TensorTransport backend installed")
         return backend.transform(self, fn)
 
-    def reshape(self, *shape: int) -> "TensorMeta":
+    def reshape(self, *shape: int) -> "TensorRef":
         return self.transform(lambda t: t.reshape(*shape))
 
-    def permute(self, *dims: int) -> "TensorMeta":
+    def permute(self, *dims: int) -> "TensorRef":
         return self.transform(lambda t: t.permute(*dims))
 
     def local(self) -> torch.Tensor:
@@ -314,7 +314,7 @@ class TensorMeta(Batch):
         """Fetch this meta into a real tensor (driver- or worker-side).
 
         With a backend: one ``get`` over the refs (backends resolve
-        :class:`HandleView` refs by resolving the base and slicing). Without:
+        :class:`TensorSpan` refs by resolving the base and slicing). Without:
         per-ref ``local()`` round-trips assembled via :func:`cat_rows` (its
         ragged right-pad contract applies to 2D+ per-shard-padded fields).
         """
@@ -326,12 +326,12 @@ class TensorMeta(Batch):
             return backend.get(self.refs)
         return cat_rows([r.local() for r in self.refs])
 
-    def retain_grad(self) -> "TensorMeta":
+    def retain_grad(self) -> "TensorRef":
         self.retain_grad_flag = True
         return self
 
     @classmethod
-    def from_handles(cls, handles: list) -> "TensorMeta":
+    def from_handles(cls, handles: list) -> "TensorRef":
         return cls(
             refs=handles,
             sizes=[h.shape[0] for h in handles],
@@ -484,16 +484,16 @@ class TensorTransport(abc.ABC):
 
     @abc.abstractmethod
     def is_ref(self, value: Any) -> bool:
-        """True if *value* is a ``TensorMeta`` produced by this backend."""
+        """True if *value* is a ``TensorRef`` produced by this backend."""
         ...
 
-    def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorMeta]:
+    def put_batch(self, tensors: Dict[str, torch.Tensor]) -> Dict[str, TensorRef]:
         """Store multiple named tensors. Default: iterate per key."""
-        result: Dict[str, TensorMeta] = {}
+        result: Dict[str, TensorRef] = {}
         for k, t in tensors.items():
             ref = self.put(t)
             bs = int(t.shape[0]) if isinstance(t, torch.Tensor) and t.dim() > 0 else 1
-            result[k] = TensorMeta(
+            result[k] = TensorRef(
                 refs=[ref],
                 sizes=[bs],
                 shape=tuple(t.shape) if isinstance(t, torch.Tensor) else None,
@@ -502,12 +502,12 @@ class TensorTransport(abc.ABC):
             )
         return result
 
-    def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
+    def get_batch(self, metas: Dict[str, TensorRef]) -> Dict[str, torch.Tensor]:
         """Fetch multiple named tensors. Default: iterate per key."""
         return {k: self.get(m.refs) for k, m in metas.items()}
 
-    def transform(self, meta: TensorMeta, fn: Callable[[torch.Tensor], torch.Tensor]) -> TensorMeta:
-        """Apply fn to the remote tensor, return new TensorMeta.
+    def transform(self, meta: TensorRef, fn: Callable[[torch.Tensor], torch.Tensor]) -> TensorRef:
+        """Apply fn to the remote tensor, return new TensorRef.
 
         Default: hydrate -> apply fn -> dehydrate (round-trip through local
         memory). Backends with remote compute (TensorStore) can override to
@@ -517,7 +517,7 @@ class TensorTransport(abc.ABC):
         result = fn(tensor)
         ref = self.put(result)
         bs = int(result.shape[0]) if result.dim() > 0 else 1
-        return TensorMeta(
+        return TensorRef(
             refs=[ref],
             sizes=[bs],
             shape=tuple(result.shape),
@@ -546,16 +546,16 @@ class TensorTransport(abc.ABC):
     # ---- dehydrate / hydrate ------------------------------------------------
 
     def dehydrate(self, value: Any) -> Any:
-        """Replace tensors with ``TensorMeta`` refs.
+        """Replace tensors with ``TensorRef`` refs.
 
-        - ``torch.Tensor`` -> returns ``TensorMeta``
+        - ``torch.Tensor`` -> returns ``TensorRef``
         - ``Batch`` / ``dict`` / ``list`` -> mutates in place, returns *value*
         - anything else -> returns *value* unchanged
         """
         if isinstance(value, torch.Tensor):
             ref = self.put(value)
             bs = int(value.shape[0]) if value.dim() > 0 else 1
-            return TensorMeta(
+            return TensorRef(
                 refs=[ref],
                 sizes=[bs],
                 shape=tuple(value.shape),
@@ -575,16 +575,16 @@ class TensorTransport(abc.ABC):
         return value
 
     def hydrate(self, value: Any, fields: Optional[Set[str]] = None) -> Any:
-        """Replace ``TensorMeta`` refs with tensors.
+        """Replace ``TensorRef`` refs with tensors.
 
-        - ``TensorMeta`` -> returns ``torch.Tensor``
+        - ``TensorRef`` -> returns ``torch.Tensor``
         - ``Batch`` / ``dict`` / ``list`` -> mutates in place, returns *value*
         - anything else -> returns *value* unchanged
 
         If *fields* is given, only dotted-path keys matching a prefix in
-        *fields* are hydrated; the rest stay as ``TensorMeta``.
+        *fields* are hydrated; the rest stay as ``TensorRef``.
         """
-        if isinstance(value, TensorMeta):
+        if isinstance(value, TensorRef):
             return value.materialize(backend=self)
 
         filter_fn: Optional[Callable[[str], bool]] = None
@@ -593,9 +593,9 @@ class TensorTransport(abc.ABC):
             def filter_fn(key):
                 return any(key == f or key.startswith(f + ".") for f in fields)
 
-        meta_map: Dict[str, TensorMeta] = {}
+        meta_map: Dict[str, TensorRef] = {}
         setters: Dict[str, Callable[[Any], None]] = {}
-        _collect_leaves(value, "", TensorMeta, meta_map, setters, filter_fn)
+        _collect_leaves(value, "", TensorRef, meta_map, setters, filter_fn)
         if not meta_map:
             return value
 
@@ -631,7 +631,7 @@ def map_tree(obj: Any, leaf_fn: Callable[[Any], Any]) -> Any:
     first; if it returns a *different* object that replaces the node and recursion
     stops there. Otherwise containers are rebuilt structurally — ``Batch`` via
     :meth:`Batch._rebuild` (preserving framework-managed ``_packed_cu_seqlens``),
-    ``tuple`` / ``list`` / ``dict`` element-wise. ``TensorMeta`` is an atomic leaf
+    ``tuple`` / ``list`` / ``dict`` element-wise. ``TensorRef`` is an atomic leaf
     (never recursed into, despite being a ``Batch`` subclass); any other
     non-container value passes through. Functional (returns new trees), so it works
     on immutable tuples and lets each caller's ``leaf_fn`` decide what to swap.
@@ -639,7 +639,7 @@ def map_tree(obj: Any, leaf_fn: Callable[[Any], Any]) -> Any:
     new = leaf_fn(obj)
     if new is not obj:
         return new
-    if isinstance(obj, TensorMeta):
+    if isinstance(obj, TensorRef):
         return obj
     if isinstance(obj, Batch):
         return obj._rebuild({f.name: map_tree(getattr(obj, f.name), leaf_fn) for f in dc_fields(obj)})
@@ -726,8 +726,8 @@ class WorkerLocalTransport(TensorTransport):
             return routing
 
         def unwrap(obj: Any, dst_worker_id: str, dst_device_id: int) -> Any:
-            if isinstance(obj, TensorMeta):
-                # HandleView refs route like any ref (source_id/shape delegate
+            if isinstance(obj, TensorRef):
+                # TensorSpan refs route like any ref (source_id/shape delegate
                 # to the base); a foreign view ships ONLY its [start:end) rows —
                 # the send side slices by the routing copy's range.
                 return obj.with_refs([route(h, dst_worker_id, dst_device_id) for h in obj.refs])
@@ -765,7 +765,7 @@ class WorkerLocalTransport(TensorTransport):
                 subs[id(old_h)] = new_h
 
         def substitute(obj: Any) -> Any:
-            if isinstance(obj, TensorMeta):
+            if isinstance(obj, TensorRef):
                 return obj.with_refs([subs.get(id(h), h) for h in obj.refs])
             return obj
 
@@ -795,7 +795,7 @@ class TransportSession:
         self._pending: List[Tuple[Dict[str, torch.Tensor], Dict[str, Callable[[Any], None]]]] = []
 
     def dehydrate(self, value: Any) -> Any:
-        """Replace tensors with ``TensorMeta`` refs (deferred flush).
+        """Replace tensors with ``TensorRef`` refs (deferred flush).
 
         Bare ``torch.Tensor`` is handled immediately (caller needs return
         value). ``Batch`` / ``dict`` / ``list`` are collected; the actual
@@ -845,8 +845,8 @@ class TensorTransportRuntime:
 
 
 __all__ = [
-    "HandleView",
-    "TensorMeta",
+    "TensorSpan",
+    "TensorRef",
     "TensorTransport",
     "TensorTransportRuntime",
     "TransportSession",

--- a/unirl/distributed/tensor/transport.py
+++ b/unirl/distributed/tensor/transport.py
@@ -107,7 +107,7 @@ class HandleView:
         side can slice — dropping it must not touch the parent's ref count
         (the parent's routing_copy is equally bare).
         """
-        return HandleView(self.base.routing_copy(), self.start - 0, self.end - 0)
+        return HandleView(self.base.routing_copy(), self.start, self.end)
 
     def __getstate__(self) -> dict:
         return {"base": self.base, "start": self.start, "end": self.end}

--- a/unirl/distributed/tensor/transport.py
+++ b/unirl/distributed/tensor/transport.py
@@ -53,9 +53,18 @@ class TensorMeta(Batch):
     device: Optional[str] = shared_field(default=None)
     grad: Optional["TensorMeta"] = shared_field(default=None)
     retain_grad_flag: bool = shared_field(default=False)
+    # Row/segment VIEW over the refs (the permutation primitive): an ordered
+    # list of ``(ref_idx, start, end)`` segments in ref-local units (rows for
+    # CONCAT fields, tokens for PACKED fields). None = the legacy identity
+    # view (all of every ref, in ref order). A view keeps the data remote —
+    # selection/permutation across the dispatch boundary no longer needs
+    # driver-side hydration; segments are gathered lazily at materialize().
+    view_plan: Optional[List[Tuple[int, int, int]]] = shared_field(default=None)
 
     @property
     def batch_size(self) -> int:
+        if self.view_plan is not None:
+            return sum(int(e) - int(s) for _, s, e in self.view_plan)
         return sum(self.sizes) if self.sizes else 0
 
     @classmethod
@@ -75,8 +84,87 @@ class TensorMeta(Batch):
             device=first.device,
         )
 
-    def select(self, indices):
-        raise NotImplementedError("TensorMeta does not support select — hydrate first")
+    def select(self, indices) -> "TensorMeta":
+        """Re-index along the unit axis by building a segment VIEW (no data motion)."""
+        idx = [int(i) for i in (indices.tolist() if hasattr(indices, "tolist") else indices)]
+        return self.select_units(idx)
+
+    def _identity_plan(self) -> List[Tuple[int, int, int]]:
+        return [(r, 0, int(n)) for r, n in enumerate(self.sizes)]
+
+    def _resolve_unit(self, g: int) -> Tuple[int, int]:
+        """Global unit index (in THIS view's order) -> (ref_idx, ref-local unit)."""
+        plan = self.view_plan if self.view_plan is not None else self._identity_plan()
+        off = 0
+        for r, s, e in plan:
+            n = int(e) - int(s)
+            if g < off + n:
+                return int(r), int(s) + (g - off)
+            off += n
+        raise IndexError(f"unit {g} out of range for view of size {off}")
+
+    def select_units(self, idx: List[int]) -> "TensorMeta":
+        """Arbitrary re-index (gather/permute) as a lazy segment view."""
+        pairs = [self._resolve_unit(int(g)) for g in idx]
+        plan: List[Tuple[int, int, int]] = []
+        for r, u in pairs:
+            if plan and plan[-1][0] == r and plan[-1][2] == u:
+                plan[-1] = (r, plan[-1][1], u + 1)  # extend the run
+            else:
+                plan.append((r, u, u + 1))
+        return self._with_plan(plan)
+
+    def select_segments(self, segments: List[Tuple[int, int]]) -> "TensorMeta":
+        """Re-index by global (start, end) unit ranges (PACKED token ranges)."""
+        plan: List[Tuple[int, int, int]] = []
+        for g0, g1 in segments:
+            g0, g1 = int(g0), int(g1)
+            while g0 < g1:
+                r, u = self._resolve_unit(g0)
+                # extend within the same source segment as far as possible
+                src_plan = self.view_plan if self.view_plan is not None else self._identity_plan()
+                # find the containing segment's end in ref-local units
+                off = 0
+                seg_end = None
+                for rr, ss, ee in src_plan:
+                    n = int(ee) - int(ss)
+                    if g0 < off + n:
+                        seg_end = int(ee)
+                        break
+                    off += n
+                take = min(g1 - g0, seg_end - u)
+                if plan and plan[-1][0] == r and plan[-1][2] == u:
+                    plan[-1] = (r, plan[-1][1], u + take)
+                else:
+                    plan.append((r, u, u + take))
+                g0 += take
+        return self._with_plan(plan)
+
+    def _with_plan(self, plan: List[Tuple[int, int, int]]) -> "TensorMeta":
+        total = sum(int(e) - int(s) for _, s, e in plan)
+        return TensorMeta(
+            refs=list(self.refs),
+            sizes=list(self.sizes),
+            shape=(total, *self.shape[1:]) if self.shape else None,
+            dtype=self.dtype,
+            device=self.device,
+            view_plan=plan,
+        )
+
+    def with_refs(self, refs: List[Any]) -> "TensorMeta":
+        """Clone with substituted (routed) refs, PRESERVING the view plan.
+
+        ``localize`` rebuilds metas after routing; ``from_handles`` would drop
+        the plan and re-derive sizes — views must survive the trip.
+        """
+        return TensorMeta(
+            refs=list(refs),
+            sizes=list(self.sizes),
+            shape=self.shape,
+            dtype=self.dtype,
+            device=self.device,
+            view_plan=None if self.view_plan is None else list(self.view_plan),
+        )
 
     def _slice_by_refs(self, start: int, end: int) -> "TensorMeta":
         """Partition refs for the row range ``[start:end)`` — inverse of concat.
@@ -91,6 +179,9 @@ class TensorMeta(Batch):
         hydration first.
         """
         start, end = int(start), int(end)
+        if self.view_plan is not None:
+            # Views slice anywhere: just trim the segment list.
+            return self.select_segments([(start, end)])
         offsets = [0]
         for s in self.sizes:
             offsets.append(offsets[-1] + int(s))
@@ -98,10 +189,9 @@ class TensorMeta(Batch):
             i0 = offsets.index(start)
             i1 = offsets.index(end)
         except ValueError:
-            raise NotImplementedError(
-                f"TensorMeta slice [{start}:{end}] does not align to ref boundaries "
-                f"{offsets}; intra-handle slicing requires hydration first."
-            )
+            # Misaligned range on a non-view: degrade gracefully to a segment
+            # view instead of demanding hydration (the data stays remote).
+            return self.select_segments([(start, end)])
         refs = list(self.refs[i0:i1])
         sizes = list(self.sizes[i0:i1])
         total = sum(int(s) for s in sizes)
@@ -140,10 +230,66 @@ class TensorMeta(Batch):
         return self.transform(lambda t: t.permute(*dims))
 
     def local(self) -> torch.Tensor:
-        backend = TensorTransportRuntime.current()
+        return self.materialize()
+
+    def materialize(self, backend: "Optional[TensorTransport]" = None) -> torch.Tensor:
+        """Fetch + assemble this (possibly viewed) meta into a real tensor.
+
+        Legacy metas (no plan) keep the exact old path: ``backend.get(refs)``.
+        Views fetch each NEEDED ref once, then gather the plan's segments in
+        order. Trailing-dim CONTRACT for views: refs may be padded to
+        different widths per producing shard (e.g. per-worker prompt blocks);
+        segments crossing such refs are right-padded with zeros to the max
+        width — consumers of 2D+ per-shard-padded fields must be mask-driven
+        (the convention TextTokenCondition.concat already establishes).
+        """
         if backend is None:
-            raise RuntimeError("No TensorTransport backend installed")
-        return backend.get(self.refs)
+            backend = TensorTransportRuntime.current()
+        def fetch(ref):
+            if backend is not None:
+                return backend.get([ref])
+            return ref.local()
+        if self.view_plan is None and backend is not None:
+            return backend.get(self.refs)
+        resolved = {}
+        if self.view_plan is None:
+            resolved = {i: fetch(r) for i, r in enumerate(self.refs)}
+        else:
+            for r in sorted({r for r, _, _ in self.view_plan}):
+                resolved[r] = fetch(self.refs[r])
+        return self.assemble(resolved)
+
+    def assemble(self, resolved: "Dict[int, torch.Tensor]") -> torch.Tensor:
+        """Assemble pre-fetched per-ref tensors into this meta's tensor.
+
+        ``resolved`` maps ref index -> that ref's full tensor (only the refs a
+        view actually needs must be present). Legacy metas concatenate in ref
+        order. Views gather their plan segments in order; trailing-dim CONTRACT:
+        segments crossing refs padded to different widths are right-padded with
+        zeros to the max width — consumers of 2D+ per-shard-padded fields must
+        be mask-driven (the TextTokenCondition.concat convention).
+        """
+        if self.view_plan is None:
+            parts = [resolved[i] for i in range(len(self.refs))]
+            return parts[0] if len(parts) == 1 else torch.cat(parts, dim=0)
+        if not self.view_plan:
+            base = next(iter(resolved.values()), None)
+            return base[:0] if base is not None else torch.empty(0)
+        parts = [resolved[r][s:e] for r, s, e in self.view_plan]
+        if len(parts) == 1:
+            return parts[0]
+        if parts[0].dim() >= 2:
+            widths = {int(t.shape[1]) for t in parts}
+            if len(widths) > 1:
+                target = max(widths)
+                padded = []
+                for t in parts:
+                    if int(t.shape[1]) < target:
+                        pad = t.new_zeros((t.shape[0], target - t.shape[1]) + tuple(t.shape[2:]))
+                        t = torch.cat([t, pad], dim=1)
+                    padded.append(t)
+                parts = padded
+        return torch.cat(parts, dim=0)
 
     def retain_grad(self) -> "TensorMeta":
         self.retain_grad_flag = True
@@ -323,7 +469,15 @@ class TensorTransport(abc.ABC):
 
     def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
         """Fetch multiple named tensors. Default: iterate per key."""
-        return {k: self.get(m.refs) for k, m in metas.items()}
+        out: Dict[str, torch.Tensor] = {}
+        for k, m in metas.items():
+            if getattr(m, "view_plan", None) is not None:
+                # Segment views assemble themselves (plan-ordered gather with
+                # the documented ragged right-pad contract).
+                out[k] = m.materialize(backend=self)
+            else:
+                out[k] = self.get(m.refs)
+        return out
 
     def transform(self, meta: TensorMeta, fn: Callable[[torch.Tensor], torch.Tensor]) -> TensorMeta:
         """Apply fn to the remote tensor, return new TensorMeta.
@@ -404,7 +558,7 @@ class TensorTransport(abc.ABC):
         *fields* are hydrated; the rest stay as ``TensorMeta``.
         """
         if isinstance(value, TensorMeta):
-            return self.get(value.refs)
+            return value.materialize(backend=self)
 
         filter_fn: Optional[Callable[[str], bool]] = None
         if fields is not None:
@@ -418,7 +572,11 @@ class TensorTransport(abc.ABC):
         if not meta_map:
             return value
 
-        tensors = self.get_batch(meta_map)
+        viewed = {k: m for k, m in meta_map.items() if m.view_plan is not None}
+        plain = {k: m for k, m in meta_map.items() if m.view_plan is None}
+        tensors = self.get_batch(plain) if plain else {}
+        for key, meta in viewed.items():
+            tensors[key] = meta.materialize(backend=self)
         for key, tensor in tensors.items():
             if key in setters:
                 setters[key](tensor)
@@ -546,7 +704,9 @@ class WorkerLocalTransport(TensorTransport):
 
         def unwrap(obj: Any, dst_worker_id: str, dst_device_id: int) -> Any:
             if isinstance(obj, TensorMeta):
-                return TensorMeta.from_handles([route(h, dst_worker_id, dst_device_id) for h in obj.refs])
+                # with_refs (NOT from_handles): a permuted shard is a segment
+                # VIEW over the refs — the plan must survive routing.
+                return obj.with_refs([route(h, dst_worker_id, dst_device_id) for h in obj.refs])
             return obj
 
         routed: list = []
@@ -582,7 +742,7 @@ class WorkerLocalTransport(TensorTransport):
 
         def substitute(obj: Any) -> Any:
             if isinstance(obj, TensorMeta):
-                return TensorMeta.from_handles([subs.get(id(h), h) for h in obj.refs])
+                return obj.with_refs([subs.get(id(h), h) for h in obj.refs])
             return obj
 
         return [(map_tree(a, substitute), map_tree(k, substitute)) for a, k in routed]

--- a/unirl/distributed/tensor/transport.py
+++ b/unirl/distributed/tensor/transport.py
@@ -1,12 +1,12 @@
 """TensorTransport: backend-agnostic tensor storage and retrieval.
 
 ``TensorRef`` is the universal tensor proxy — a ``Batch`` subclass that
-holds per-handle opaque refs and their sizes. Each ref is either a backend
-handle from one ``put()`` call or a :class:`TensorSpan` (a row/unit-range
-view of such a handle); ``sizes[i]`` records how many rows ref ``i``
-covers. ``concat`` merges ref/size lists; ``batch_size`` is ``sum(sizes)``.
-Per-row ``select`` / ``slice`` builds ``TensorSpan`` refs — no data motion,
-no hydration.
+holds an ordered list of :class:`TensorSpan`, each a contiguous row-window
+over one backend handle (from a single ``put()`` call). ``spans`` is the
+concat axis; per-span row counts derive ``sizes`` and ``batch_size`` (no
+stored size array). Per-row ``select`` / ``slice`` builds new spans — no data
+motion, no hydration. A :class:`TensorSpan` is generic over its handle type,
+bound by the :class:`TensorHandle` protocol.
 
 ``TensorRef`` also serves as a compute proxy: ``transform``, ``reshape``,
 ``permute``, ``local`` delegate to the active backend.
@@ -28,7 +28,21 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import fields as dc_fields
-from typing import Any, Callable, ClassVar, Dict, Iterator, List, Optional, Set, Tuple
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    TypeVar,
+    runtime_checkable,
+)
 
 import ray
 import torch
@@ -38,7 +52,24 @@ from unirl.distributed.tensor.batch import Batch, concat_field, shared_field
 logger = logging.getLogger(__name__)
 
 
-class TensorSpan:
+@runtime_checkable
+class TensorHandle(Protocol):
+    """The minimal handle contract a :class:`TensorSpan` resolves through.
+
+    The worker-local store handle (``GPUTensorHandle`` / ``ColocateTensorHandle``)
+    and the global ``TQTensorHandle`` both satisfy it structurally. The
+    worker-local-only surface (``store_key`` / ``source_id`` / ``object_ref`` /
+    ``routing_copy``) is reached via ``span.handle`` in the backends that need it,
+    never off the span — so it is intentionally absent from this protocol.
+    """
+
+    def local(self) -> torch.Tensor: ...
+
+
+T = TypeVar("T", bound=TensorHandle)
+
+
+class TensorSpan(Generic[T]):
     """A contiguous half-open ``[start:stop)`` row-window over one handle — the addressing primitive.
 
     ``TensorRef`` selection/permutation emits these instead of moving data:
@@ -58,8 +89,9 @@ class TensorSpan:
     """
 
     __slots__ = ("handle", "start", "stop")
+    handle: T
 
-    def __init__(self, handle: Any, start: int, stop: int) -> None:
+    def __init__(self, handle: T | "TensorSpan[T]", start: int, stop: int) -> None:
         start, stop = int(start), int(stop)
         if isinstance(handle, TensorSpan):
             start, stop = handle.start + start, handle.start + stop
@@ -77,19 +109,9 @@ class TensorSpan:
     def __len__(self) -> int:
         return self.stop - self.start
 
-    # ── delegated identity (what transports/localize read off a span) ──
-
-    @property
-    def source_id(self):
-        return self.handle.source_id
-
-    @property
-    def object_ref(self):
-        return getattr(self.handle, "object_ref", None)
-
-    @property
-    def store_key(self):
-        return self.handle.store_key
+    # ── delegated metadata: shape (sliced) / dtype / device — read by nccl_recv
+    #    and repr. Handle-specific identity (store_key/source_id/object_ref) is
+    #    reached via ``span.handle`` in the worker-local backends, not off the span.
 
     @property
     def shape(self) -> tuple:
@@ -846,6 +868,7 @@ class TensorTransportRuntime:
 
 
 __all__ = [
+    "TensorHandle",
     "TensorSpan",
     "TensorRef",
     "TensorTransport",

--- a/unirl/distributed/tensor/transport.py
+++ b/unirl/distributed/tensor/transport.py
@@ -1,11 +1,12 @@
 """TensorTransport: backend-agnostic tensor storage and retrieval.
 
 ``TensorMeta`` is the universal tensor proxy — a ``Batch`` subclass that
-holds per-handle opaque refs and their sizes. Each ref corresponds to one
-``put()`` call; ``sizes[i]`` records how many rows that ref covers.
-``concat`` merges ref/size lists; ``batch_size`` is ``sum(sizes)``.
-Per-row ``select`` / ``slice`` is not supported on dehydrated data —
-hydrate first.
+holds per-handle opaque refs and their sizes. Each ref is either a backend
+handle from one ``put()`` call or a :class:`HandleView` (a row/unit-range
+view of such a handle); ``sizes[i]`` records how many rows ref ``i``
+covers. ``concat`` merges ref/size lists; ``batch_size`` is ``sum(sizes)``.
+Per-row ``select`` / ``slice`` builds ``HandleView`` refs — no data motion,
+no hydration.
 
 ``TensorMeta`` also serves as a compute proxy: ``transform``, ``reshape``,
 ``permute``, ``local`` delegate to the active backend.
@@ -37,13 +38,124 @@ from unirl.distributed.tensor.batch import Batch, concat_field, shared_field
 logger = logging.getLogger(__name__)
 
 
+class HandleView:
+    """A unit-range (row/token) view of a parent ref — the addressing primitive.
+
+    ``TensorMeta`` selection/permutation emits these instead of moving data:
+    a view addresses ``base[start:end)`` along dim 0 while the bytes stay in
+    the producing worker's store. Backends resolve a view by resolving the
+    base and slicing (zero-copy on the IPC/store path); ``localize`` ships
+    only the ``[start:end)`` rows cross-device, not the whole base block.
+
+    Lifecycle: a view holds a PYTHON REFERENCE to the parent ref object, so
+    CPython's own reference counting aggregates all views' lifetimes onto the
+    parent — the parent's single GC finalizer fires only when the last view
+    (and the parent itself) is gone. Views carry no finalizer, no store_key
+    of their own, and trigger no extra decref RPCs.
+
+    Nested views flatten at construction (``HandleView(HandleView(b,2,8),1,3)``
+    is ``HandleView(b,3,5)``), so ``base`` is always a backend handle.
+    """
+
+    __slots__ = ("base", "start", "end")
+
+    def __init__(self, base: Any, start: int, end: int) -> None:
+        start, end = int(start), int(end)
+        if isinstance(base, HandleView):
+            start, end = base.start + start, base.start + end
+            base = base.base
+        if not (0 <= start <= end):
+            raise ValueError(f"HandleView range [{start}, {end}) is invalid")
+        self.base = base
+        self.start = start
+        self.end = end
+
+    # ── delegated identity (what transports/localize read off a ref) ──
+
+    @property
+    def source_id(self):
+        return self.base.source_id
+
+    @property
+    def object_ref(self):
+        return getattr(self.base, "object_ref", None)
+
+    @property
+    def store_key(self):
+        return self.base.store_key
+
+    @property
+    def shape(self) -> tuple:
+        base_shape = tuple(self.base.shape)
+        return (self.end - self.start, *base_shape[1:])
+
+    @property
+    def dtype(self):
+        return self.base.dtype
+
+    @property
+    def device(self):
+        return self.base.device
+
+    def local(self) -> torch.Tensor:
+        return self.base.local()[self.start : self.end]
+
+    def routing_copy(self) -> "HandleView":
+        """Bare placeholder for localize's id()-keyed NCCL substitution.
+
+        Carries the base's routing copy plus this view's range so the send
+        side can slice — dropping it must not touch the parent's ref count
+        (the parent's routing_copy is equally bare).
+        """
+        return HandleView(self.base.routing_copy(), self.start - 0, self.end - 0)
+
+    def __getstate__(self) -> dict:
+        return {"base": self.base, "start": self.start, "end": self.end}
+
+    def __setstate__(self, state: dict) -> None:
+        self.base = state["base"]
+        self.start = state["start"]
+        self.end = state["end"]
+
+    def __repr__(self) -> str:
+        return f"HandleView({self.base!r}[{self.start}:{self.end}])"
+
+
+def cat_rows(parts: List[torch.Tensor]) -> torch.Tensor:
+    """Concatenate per-ref tensors along dim 0 — the single assembly funnel.
+
+    Trailing-dim CONTRACT: parts may be padded to different widths per
+    producing shard (e.g. per-worker prompt blocks); 2D+ parts are
+    right-padded with zeros to the max width before the cat — consumers of
+    2D+ per-shard-padded fields must be mask-driven (the convention
+    ``TextTokenCondition.concat`` already establishes).
+    """
+    if not parts:
+        return torch.empty(0)
+    if len(parts) == 1:
+        return parts[0]
+    if parts[0].dim() >= 2:
+        widths = {int(t.shape[1]) for t in parts}
+        if len(widths) > 1:
+            target = max(widths)
+            padded = []
+            for t in parts:
+                if int(t.shape[1]) < target:
+                    pad = t.new_zeros((t.shape[0], target - t.shape[1]) + tuple(t.shape[2:]))
+                    t = torch.cat([t, pad], dim=1)
+                padded.append(t)
+            parts = padded
+    return torch.cat(parts, dim=0)
+
+
 @dataclass
 class TensorMeta(Batch):
     """Per-handle tensor proxy.
 
     Each element in ``refs`` is an opaque handle from a single ``put()``
-    call; ``sizes[i]`` records how many rows that handle covers.
-    ``batch_size`` is ``sum(sizes)``, not ``len(refs)``.
+    call or a :class:`HandleView` over one; ``sizes[i]`` records how many
+    rows ref ``i`` covers. ``batch_size`` is ``sum(sizes)``, not
+    ``len(refs)``.
     """
 
     refs: List[Any] = concat_field(default_factory=list)
@@ -53,18 +165,9 @@ class TensorMeta(Batch):
     device: Optional[str] = shared_field(default=None)
     grad: Optional["TensorMeta"] = shared_field(default=None)
     retain_grad_flag: bool = shared_field(default=False)
-    # Row/segment VIEW over the refs (the permutation primitive): an ordered
-    # list of ``(ref_idx, start, end)`` segments in ref-local units (rows for
-    # CONCAT fields, tokens for PACKED fields). None = the legacy identity
-    # view (all of every ref, in ref order). A view keeps the data remote —
-    # selection/permutation across the dispatch boundary no longer needs
-    # driver-side hydration; segments are gathered lazily at materialize().
-    view_plan: Optional[List[Tuple[int, int, int]]] = shared_field(default=None)
 
     @property
     def batch_size(self) -> int:
-        if self.view_plan is not None:
-            return sum(int(e) - int(s) for _, s, e in self.view_plan)
         return sum(self.sizes) if self.sizes else 0
 
     @classmethod
@@ -85,116 +188,43 @@ class TensorMeta(Batch):
         )
 
     def select(self, indices) -> "TensorMeta":
-        """Re-index along the unit axis by building a segment VIEW (no data motion)."""
+        """Re-index along the unit axis by building ref VIEWS (no data motion)."""
         idx = [int(i) for i in (indices.tolist() if hasattr(indices, "tolist") else indices)]
         return self.select_units(idx)
 
-    def _identity_plan(self) -> List[Tuple[int, int, int]]:
-        return [(r, 0, int(n)) for r, n in enumerate(self.sizes)]
-
-    def _resolve_unit(self, g: int) -> Tuple[int, int]:
-        """Global unit index (in THIS view's order) -> (ref_idx, ref-local unit)."""
-        plan = self.view_plan if self.view_plan is not None else self._identity_plan()
-        off = 0
-        for r, s, e in plan:
-            n = int(e) - int(s)
-            if g < off + n:
-                return int(r), int(s) + (g - off)
-            off += n
-        raise IndexError(f"unit {g} out of range for view of size {off}")
-
-    def select_units(self, idx: List[int]) -> "TensorMeta":
-        """Arbitrary re-index (gather/permute) as a lazy segment view."""
-        pairs = [self._resolve_unit(int(g)) for g in idx]
-        plan: List[Tuple[int, int, int]] = []
-        for r, u in pairs:
-            if plan and plan[-1][0] == r and plan[-1][2] == u:
-                plan[-1] = (r, plan[-1][1], u + 1)  # extend the run
-            else:
-                plan.append((r, u, u + 1))
-        return self._with_plan(plan)
-
-    def select_segments(self, segments: List[Tuple[int, int]]) -> "TensorMeta":
-        """Re-index by global (start, end) unit ranges (PACKED token ranges)."""
-        plan: List[Tuple[int, int, int]] = []
-        for g0, g1 in segments:
-            g0, g1 = int(g0), int(g1)
-            while g0 < g1:
-                r, u = self._resolve_unit(g0)
-                # extend within the same source segment as far as possible
-                src_plan = self.view_plan if self.view_plan is not None else self._identity_plan()
-                # find the containing segment's end in ref-local units
-                off = 0
-                seg_end = None
-                for rr, ss, ee in src_plan:
-                    n = int(ee) - int(ss)
-                    if g0 < off + n:
-                        seg_end = int(ee)
-                        break
-                    off += n
-                take = min(g1 - g0, seg_end - u)
-                if plan and plan[-1][0] == r and plan[-1][2] == u:
-                    plan[-1] = (r, plan[-1][1], u + take)
-                else:
-                    plan.append((r, u, u + take))
-                g0 += take
-        return self._with_plan(plan)
-
-    def _with_plan(self, plan: List[Tuple[int, int, int]]) -> "TensorMeta":
-        total = sum(int(e) - int(s) for _, s, e in plan)
-        return TensorMeta(
-            refs=list(self.refs),
-            sizes=list(self.sizes),
-            shape=(total, *self.shape[1:]) if self.shape else None,
-            dtype=self.dtype,
-            device=self.device,
-            view_plan=plan,
-        )
-
-    def with_refs(self, refs: List[Any]) -> "TensorMeta":
-        """Clone with substituted (routed) refs, PRESERVING the view plan.
-
-        ``localize`` rebuilds metas after routing; ``from_handles`` would drop
-        the plan and re-derive sizes — views must survive the trip.
-        """
-        return TensorMeta(
-            refs=list(refs),
-            sizes=list(self.sizes),
-            shape=self.shape,
-            dtype=self.dtype,
-            device=self.device,
-            view_plan=None if self.view_plan is None else list(self.view_plan),
-        )
-
-    def _slice_by_refs(self, start: int, end: int) -> "TensorMeta":
-        """Partition refs for the row range ``[start:end)`` — inverse of concat.
-
-        ``concat`` stacks per-source ref/size lists, so a range that lands on
-        ref boundaries hands the corresponding refs back untouched: the exact
-        structural inverse of the DP collect→re-dispatch round-trip that built
-        this handle. Both callers pass a range in the same unit as ``sizes``
-        (CONCAT: per-sample rows; PACKED: token offsets via ``cu_seqlens``), so
-        a round-trip range always aligns. An arbitrary intra-ref range has no
-        representation here — the data is remote and opaque — and still needs
-        hydration first.
-        """
-        start, end = int(start), int(end)
-        if self.view_plan is not None:
-            # Views slice anywhere: just trim the segment list.
-            return self.select_segments([(start, end)])
+    def _offsets(self) -> List[int]:
         offsets = [0]
         for s in self.sizes:
             offsets.append(offsets[-1] + int(s))
-        try:
-            i0 = offsets.index(start)
-            i1 = offsets.index(end)
-        except ValueError:
-            # Misaligned range on a non-view: degrade gracefully to a segment
-            # view instead of demanding hydration (the data stays remote).
-            return self.select_segments([(start, end)])
-        refs = list(self.refs[i0:i1])
-        sizes = list(self.sizes[i0:i1])
-        total = sum(int(s) for s in sizes)
+        return offsets
+
+    def _pieces_for_range(self, g0: int, g1: int, offsets: List[int]) -> List[Tuple[int, int, int]]:
+        """Global unit range [g0, g1) -> ordered (ref_idx, local_start, local_end) pieces."""
+        if not (0 <= g0 <= g1 <= offsets[-1]):
+            raise IndexError(f"unit range [{g0}, {g1}) out of bounds for size {offsets[-1]}")
+        pieces: List[Tuple[int, int, int]] = []
+        r = 0
+        while g0 < g1:
+            while offsets[r + 1] <= g0:
+                r += 1
+            take = min(g1, offsets[r + 1]) - g0
+            pieces.append((r, g0 - offsets[r], g0 - offsets[r] + take))
+            g0 += take
+        return pieces
+
+    def _from_pieces(self, pieces: List[Tuple[int, int, int]]) -> "TensorMeta":
+        """Build the selected meta: whole-ref pieces pass the ref through untouched
+        (a boundary-aligned selection costs nothing); partial pieces become
+        :class:`HandleView` refs (nested views flatten in the ctor)."""
+        refs: List[Any] = []
+        sizes: List[int] = []
+        for r, s, e in pieces:
+            if s == 0 and e == int(self.sizes[r]):
+                refs.append(self.refs[r])
+            else:
+                refs.append(HandleView(self.refs[r], s, e))
+            sizes.append(e - s)
+        total = sum(sizes)
         return TensorMeta(
             refs=refs,
             sizes=sizes,
@@ -202,6 +232,54 @@ class TensorMeta(Batch):
             dtype=self.dtype,
             device=self.device,
         )
+
+    def select_units(self, idx: List[int]) -> "TensorMeta":
+        """Arbitrary re-index (gather/permute) as lazy ref views."""
+        offsets = self._offsets()
+        # Coalesce consecutive indices into ranges, then map ranges to pieces.
+        pieces: List[Tuple[int, int, int]] = []
+        i = 0
+        while i < len(idx):
+            j = i + 1
+            while j < len(idx) and idx[j] == idx[j - 1] + 1:
+                j += 1
+            pieces.extend(self._pieces_for_range(int(idx[i]), int(idx[j - 1]) + 1, offsets))
+            i = j
+        return self._from_pieces(pieces)
+
+    def select_segments(self, segments: List[Tuple[int, int]]) -> "TensorMeta":
+        """Re-index by global (start, end) unit ranges (PACKED token ranges)."""
+        offsets = self._offsets()
+        pieces: List[Tuple[int, int, int]] = []
+        for g0, g1 in segments:
+            pieces.extend(self._pieces_for_range(int(g0), int(g1), offsets))
+        return self._from_pieces(pieces)
+
+    def with_refs(self, refs: List[Any]) -> "TensorMeta":
+        """Clone with substituted (routed) refs, preserving sizes/shape.
+
+        ``localize`` rebuilds metas after routing; ``from_handles`` would
+        re-derive sizes from ``ref.shape[0]`` — equivalent, but this keeps the
+        substitution structural (same ref count, same sizes, no re-derivation).
+        """
+        return TensorMeta(
+            refs=list(refs),
+            sizes=list(self.sizes),
+            shape=self.shape,
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+    def _slice_by_refs(self, start: int, end: int) -> "TensorMeta":
+        """Contiguous row range ``[start:end)`` — the structural inverse of concat.
+
+        A range on ref boundaries hands the refs back untouched (the exact
+        inverse of the DP collect→re-dispatch round-trip); an intra-ref range
+        wraps the boundary refs in :class:`HandleView` — same code path, the
+        whole-piece pass-through in ``_from_pieces`` is what preserves the
+        zero-cost aligned case.
+        """
+        return self.select_segments([(int(start), int(end))])
 
     def slice(self, start, end) -> "TensorMeta":
         # CONCAT path: Batch.slice → _slice_value → value.slice(start, end).
@@ -233,63 +311,20 @@ class TensorMeta(Batch):
         return self.materialize()
 
     def materialize(self, backend: "Optional[TensorTransport]" = None) -> torch.Tensor:
-        """Fetch + assemble this (possibly viewed) meta into a real tensor.
+        """Fetch this meta into a real tensor (driver- or worker-side).
 
-        Legacy metas (no plan) keep the exact old path: ``backend.get(refs)``.
-        Views fetch each NEEDED ref once, then gather the plan's segments in
-        order. Trailing-dim CONTRACT for views: refs may be padded to
-        different widths per producing shard (e.g. per-worker prompt blocks);
-        segments crossing such refs are right-padded with zeros to the max
-        width — consumers of 2D+ per-shard-padded fields must be mask-driven
-        (the convention TextTokenCondition.concat already establishes).
+        With a backend: one ``get`` over the refs (backends resolve
+        :class:`HandleView` refs by resolving the base and slicing). Without:
+        per-ref ``local()`` round-trips assembled via :func:`cat_rows` (its
+        ragged right-pad contract applies to 2D+ per-shard-padded fields).
         """
         if backend is None:
             backend = TensorTransportRuntime.current()
-        def fetch(ref):
-            if backend is not None:
-                return backend.get([ref])
-            return ref.local()
-        if self.view_plan is None and backend is not None:
+        if not self.refs:
+            return torch.empty(0)
+        if backend is not None:
             return backend.get(self.refs)
-        resolved = {}
-        if self.view_plan is None:
-            resolved = {i: fetch(r) for i, r in enumerate(self.refs)}
-        else:
-            for r in sorted({r for r, _, _ in self.view_plan}):
-                resolved[r] = fetch(self.refs[r])
-        return self.assemble(resolved)
-
-    def assemble(self, resolved: "Dict[int, torch.Tensor]") -> torch.Tensor:
-        """Assemble pre-fetched per-ref tensors into this meta's tensor.
-
-        ``resolved`` maps ref index -> that ref's full tensor (only the refs a
-        view actually needs must be present). Legacy metas concatenate in ref
-        order. Views gather their plan segments in order; trailing-dim CONTRACT:
-        segments crossing refs padded to different widths are right-padded with
-        zeros to the max width — consumers of 2D+ per-shard-padded fields must
-        be mask-driven (the TextTokenCondition.concat convention).
-        """
-        if self.view_plan is None:
-            parts = [resolved[i] for i in range(len(self.refs))]
-            return parts[0] if len(parts) == 1 else torch.cat(parts, dim=0)
-        if not self.view_plan:
-            base = next(iter(resolved.values()), None)
-            return base[:0] if base is not None else torch.empty(0)
-        parts = [resolved[r][s:e] for r, s, e in self.view_plan]
-        if len(parts) == 1:
-            return parts[0]
-        if parts[0].dim() >= 2:
-            widths = {int(t.shape[1]) for t in parts}
-            if len(widths) > 1:
-                target = max(widths)
-                padded = []
-                for t in parts:
-                    if int(t.shape[1]) < target:
-                        pad = t.new_zeros((t.shape[0], target - t.shape[1]) + tuple(t.shape[2:]))
-                        t = torch.cat([t, pad], dim=1)
-                    padded.append(t)
-                parts = padded
-        return torch.cat(parts, dim=0)
+        return cat_rows([r.local() for r in self.refs])
 
     def retain_grad(self) -> "TensorMeta":
         self.retain_grad_flag = True
@@ -469,15 +504,7 @@ class TensorTransport(abc.ABC):
 
     def get_batch(self, metas: Dict[str, TensorMeta]) -> Dict[str, torch.Tensor]:
         """Fetch multiple named tensors. Default: iterate per key."""
-        out: Dict[str, torch.Tensor] = {}
-        for k, m in metas.items():
-            if getattr(m, "view_plan", None) is not None:
-                # Segment views assemble themselves (plan-ordered gather with
-                # the documented ragged right-pad contract).
-                out[k] = m.materialize(backend=self)
-            else:
-                out[k] = self.get(m.refs)
-        return out
+        return {k: self.get(m.refs) for k, m in metas.items()}
 
     def transform(self, meta: TensorMeta, fn: Callable[[torch.Tensor], torch.Tensor]) -> TensorMeta:
         """Apply fn to the remote tensor, return new TensorMeta.
@@ -572,11 +599,7 @@ class TensorTransport(abc.ABC):
         if not meta_map:
             return value
 
-        viewed = {k: m for k, m in meta_map.items() if m.view_plan is not None}
-        plain = {k: m for k, m in meta_map.items() if m.view_plan is None}
-        tensors = self.get_batch(plain) if plain else {}
-        for key, meta in viewed.items():
-            tensors[key] = meta.materialize(backend=self)
+        tensors = self.get_batch(meta_map)
         for key, tensor in tensors.items():
             if key in setters:
                 setters[key](tensor)
@@ -704,8 +727,9 @@ class WorkerLocalTransport(TensorTransport):
 
         def unwrap(obj: Any, dst_worker_id: str, dst_device_id: int) -> Any:
             if isinstance(obj, TensorMeta):
-                # with_refs (NOT from_handles): a permuted shard is a segment
-                # VIEW over the refs — the plan must survive routing.
+                # HandleView refs route like any ref (source_id/shape delegate
+                # to the base); a foreign view ships ONLY its [start:end) rows —
+                # the send side slices by the routing copy's range.
                 return obj.with_refs([route(h, dst_worker_id, dst_device_id) for h in obj.refs])
             return obj
 
@@ -821,10 +845,12 @@ class TensorTransportRuntime:
 
 
 __all__ = [
+    "HandleView",
     "TensorMeta",
     "TensorTransport",
     "TensorTransportRuntime",
     "TransportSession",
     "WorkerLocalTransport",
+    "cat_rows",
     "map_tree",
 ]

--- a/unirl/distributed/tensor/transport.py
+++ b/unirl/distributed/tensor/transport.py
@@ -39,86 +39,93 @@ logger = logging.getLogger(__name__)
 
 
 class TensorSpan:
-    """A unit-range (row/token) view of a parent ref — the addressing primitive.
+    """A contiguous half-open ``[start:stop)`` row-window over one handle — the addressing primitive.
 
     ``TensorRef`` selection/permutation emits these instead of moving data:
-    a view addresses ``base[start:end)`` along dim 0 while the bytes stay in
-    the producing worker's store. Backends resolve a view by resolving the
-    base and slicing (zero-copy on the IPC/store path); ``localize`` ships
-    only the ``[start:end)`` rows cross-device, not the whole base block.
+    a span addresses ``handle[start:stop)`` along dim 0 while the bytes stay in
+    the producing worker's store. Backends resolve a span by resolving the
+    handle and slicing (zero-copy on the IPC/store path); ``localize`` ships
+    only the ``[start:stop)`` rows cross-device, not the whole handle block.
 
-    Lifecycle: a view holds a PYTHON REFERENCE to the parent ref object, so
-    CPython's own reference counting aggregates all views' lifetimes onto the
-    parent — the parent's single GC finalizer fires only when the last view
-    (and the parent itself) is gone. Views carry no finalizer, no store_key
+    Lifecycle: a span holds a PYTHON REFERENCE to the handle object, so
+    CPython's own reference counting aggregates all spans' lifetimes onto the
+    handle — the handle's single GC finalizer fires only when the last span
+    (and the handle itself) is gone. Spans carry no finalizer, no store_key
     of their own, and trigger no extra decref RPCs.
 
-    Nested views flatten at construction (``TensorSpan(TensorSpan(b,2,8),1,3)``
-    is ``TensorSpan(b,3,5)``), so ``base`` is always a backend handle.
+    Nested spans flatten at construction (``TensorSpan(TensorSpan(h,2,8),1,3)``
+    is ``TensorSpan(h,3,5)``), so ``handle`` is always a backend handle.
     """
 
-    __slots__ = ("base", "start", "end")
+    __slots__ = ("handle", "start", "stop")
 
-    def __init__(self, base: Any, start: int, end: int) -> None:
-        start, end = int(start), int(end)
-        if isinstance(base, TensorSpan):
-            start, end = base.start + start, base.start + end
-            base = base.base
-        if not (0 <= start <= end):
-            raise ValueError(f"TensorSpan range [{start}, {end}) is invalid")
-        self.base = base
+    def __init__(self, handle: Any, start: int, stop: int) -> None:
+        start, stop = int(start), int(stop)
+        if isinstance(handle, TensorSpan):
+            start, stop = handle.start + start, handle.start + stop
+            handle = handle.handle
+        if not (0 <= start <= stop):
+            raise ValueError(f"TensorSpan range [{start}, {stop}) is invalid")
+        self.handle = handle
         self.start = start
-        self.end = end
+        self.stop = stop
 
-    # ── delegated identity (what transports/localize read off a ref) ──
+    @property
+    def nrows(self) -> int:
+        return self.stop - self.start
+
+    def __len__(self) -> int:
+        return self.stop - self.start
+
+    # ── delegated identity (what transports/localize read off a span) ──
 
     @property
     def source_id(self):
-        return self.base.source_id
+        return self.handle.source_id
 
     @property
     def object_ref(self):
-        return getattr(self.base, "object_ref", None)
+        return getattr(self.handle, "object_ref", None)
 
     @property
     def store_key(self):
-        return self.base.store_key
+        return self.handle.store_key
 
     @property
     def shape(self) -> tuple:
-        base_shape = tuple(self.base.shape)
-        return (self.end - self.start, *base_shape[1:])
+        handle_shape = tuple(self.handle.shape)
+        return (self.stop - self.start, *handle_shape[1:])
 
     @property
     def dtype(self):
-        return self.base.dtype
+        return self.handle.dtype
 
     @property
     def device(self):
-        return self.base.device
+        return self.handle.device
 
     def local(self) -> torch.Tensor:
-        return self.base.local()[self.start : self.end]
+        return self.handle.local()[self.start : self.stop]
 
     def routing_copy(self) -> "TensorSpan":
         """Bare placeholder for localize's id()-keyed NCCL substitution.
 
-        Carries the base's routing copy plus this view's range so the send
-        side can slice — dropping it must not touch the parent's ref count
-        (the parent's routing_copy is equally bare).
+        Carries the handle's routing copy plus this span's range so the send
+        side can slice — dropping it must not touch the handle's ref count
+        (the handle's routing_copy is equally bare).
         """
-        return TensorSpan(self.base.routing_copy(), self.start, self.end)
+        return TensorSpan(self.handle.routing_copy(), self.start, self.stop)
 
     def __getstate__(self) -> dict:
-        return {"base": self.base, "start": self.start, "end": self.end}
+        return {"handle": self.handle, "start": self.start, "stop": self.stop}
 
     def __setstate__(self, state: dict) -> None:
-        self.base = state["base"]
+        self.handle = state["handle"]
         self.start = state["start"]
-        self.end = state["end"]
+        self.stop = state["stop"]
 
     def __repr__(self) -> str:
-        return f"TensorSpan({self.base!r}[{self.start}:{self.end}])"
+        return f"TensorSpan({self.handle!r}[{self.start}:{self.stop}])"
 
 
 def cat_rows(parts: List[torch.Tensor]) -> torch.Tensor:
@@ -150,16 +157,15 @@ def cat_rows(parts: List[torch.Tensor]) -> torch.Tensor:
 
 @dataclass
 class TensorRef(Batch):
-    """Per-handle tensor proxy.
+    """The dehydrated-tensor proxy — an ordered list of row-window spans.
 
-    Each element in ``refs`` is an opaque handle from a single ``put()``
-    call or a :class:`TensorSpan` over one; ``sizes[i]`` records how many
-    rows ref ``i`` covers. ``batch_size`` is ``sum(sizes)``, not
-    ``len(refs)``.
+    Each element of ``spans`` is a :class:`TensorSpan` over one backend handle;
+    ``spans`` is the concat axis. Per-span row counts derive ``sizes`` and
+    ``batch_size`` — there is no stored size array. ``batch_size`` is the total
+    row count, not ``len(spans)``.
     """
 
-    refs: List[Any] = concat_field(default_factory=list)
-    sizes: List[int] = concat_field(default_factory=list)
+    spans: List[TensorSpan] = concat_field(default_factory=list)
     shape: Optional[Tuple[int, ...]] = shared_field(default=None)
     dtype: Optional[torch.dtype] = shared_field(default=None)
     device: Optional[str] = shared_field(default=None)
@@ -167,21 +173,22 @@ class TensorRef(Batch):
     retain_grad_flag: bool = shared_field(default=False)
 
     @property
+    def sizes(self) -> List[int]:
+        return [s.stop - s.start for s in self.spans]
+
+    @property
     def batch_size(self) -> int:
-        return sum(self.sizes) if self.sizes else 0
+        return sum(s.stop - s.start for s in self.spans)
 
     @classmethod
     def concat(cls, items: "list[TensorRef]") -> "TensorRef":
-        refs: List[Any] = []
-        sizes: List[int] = []
+        spans: List[TensorSpan] = []
         for m in items:
-            refs.extend(m.refs)
-            sizes.extend(m.sizes)
+            spans.extend(m.spans)
         first = items[0]
-        total = sum(sizes)
+        total = sum(s.stop - s.start for s in spans)
         return TensorRef(
-            refs=refs,
-            sizes=sizes,
+            spans=spans,
             shape=(total, *first.shape[1:]) if first.shape else None,
             dtype=first.dtype,
             device=first.device,
@@ -194,8 +201,8 @@ class TensorRef(Batch):
 
     def _offsets(self) -> List[int]:
         offsets = [0]
-        for s in self.sizes:
-            offsets.append(offsets[-1] + int(s))
+        for s in self.spans:
+            offsets.append(offsets[-1] + (s.stop - s.start))
         return offsets
 
     def _pieces_for_range(self, g0: int, g1: int, offsets: List[int]) -> List[Tuple[int, int, int]]:
@@ -213,21 +220,19 @@ class TensorRef(Batch):
         return pieces
 
     def _from_pieces(self, pieces: List[Tuple[int, int, int]]) -> "TensorRef":
-        """Build the selected meta: whole-ref pieces pass the ref through untouched
-        (a boundary-aligned selection costs nothing); partial pieces become
-        :class:`TensorSpan` refs (nested views flatten in the ctor)."""
-        refs: List[Any] = []
-        sizes: List[int] = []
+        """Build the selected ref: a whole-span piece passes the span through
+        untouched (a boundary-aligned selection costs nothing); a partial piece
+        becomes a new :class:`TensorSpan` (nested spans flatten in the ctor)."""
+        spans: List[TensorSpan] = []
         for r, s, e in pieces:
-            if s == 0 and e == int(self.sizes[r]):
-                refs.append(self.refs[r])
+            src = self.spans[r]
+            if s == 0 and e == src.stop - src.start:
+                spans.append(src)
             else:
-                refs.append(TensorSpan(self.refs[r], s, e))
-            sizes.append(e - s)
-        total = sum(sizes)
+                spans.append(TensorSpan(src, s, e))
+        total = sum(sp.stop - sp.start for sp in spans)
         return TensorRef(
-            refs=refs,
-            sizes=sizes,
+            spans=spans,
             shape=(total, *self.shape[1:]) if self.shape else None,
             dtype=self.dtype,
             device=self.device,
@@ -255,16 +260,14 @@ class TensorRef(Batch):
             pieces.extend(self._pieces_for_range(int(g0), int(g1), offsets))
         return self._from_pieces(pieces)
 
-    def with_refs(self, refs: List[Any]) -> "TensorRef":
-        """Clone with substituted (routed) refs, preserving sizes/shape.
+    def with_spans(self, spans: List[Any]) -> "TensorRef":
+        """Clone with substituted (routed) spans, preserving shape/dtype/device.
 
-        ``localize`` rebuilds metas after routing; ``from_handles`` would
-        re-derive sizes from ``ref.shape[0]`` — equivalent, but this keeps the
-        substitution structural (same ref count, same sizes, no re-derivation).
+        ``localize`` rebuilds refs after routing; this keeps the substitution
+        structural (same span count, derived sizes, no re-derivation).
         """
         return TensorRef(
-            refs=list(refs),
-            sizes=list(self.sizes),
+            spans=list(spans),
             shape=self.shape,
             dtype=self.dtype,
             device=self.device,
@@ -313,18 +316,18 @@ class TensorRef(Batch):
     def materialize(self, backend: "Optional[TensorTransport]" = None) -> torch.Tensor:
         """Fetch this meta into a real tensor (driver- or worker-side).
 
-        With a backend: one ``get`` over the refs (backends resolve
-        :class:`TensorSpan` refs by resolving the base and slicing). Without:
-        per-ref ``local()`` round-trips assembled via :func:`cat_rows` (its
+        With a backend: one ``get`` over the spans (backends resolve a
+        :class:`TensorSpan` by resolving its handle and slicing). Without:
+        per-span ``local()`` round-trips assembled via :func:`cat_rows` (its
         ragged right-pad contract applies to 2D+ per-shard-padded fields).
         """
         if backend is None:
             backend = TensorTransportRuntime.current()
-        if not self.refs:
+        if not self.spans:
             return torch.empty(0)
         if backend is not None:
-            return backend.get(self.refs)
-        return cat_rows([r.local() for r in self.refs])
+            return backend.get(self.spans)
+        return cat_rows([s.local() for s in self.spans])
 
     def retain_grad(self) -> "TensorRef":
         self.retain_grad_flag = True
@@ -332,16 +335,17 @@ class TensorRef(Batch):
 
     @classmethod
     def from_handles(cls, handles: list) -> "TensorRef":
+        """Wrap freshly-put handles as full-range spans — the single wrap chokepoint."""
+        spans = [TensorSpan(h, 0, int(h.shape[0])) for h in handles]
         return cls(
-            refs=handles,
-            sizes=[h.shape[0] for h in handles],
-            shape=(sum(h.shape[0] for h in handles), *handles[0].shape[1:]) if handles else None,
+            spans=spans,
+            shape=(sum(int(h.shape[0]) for h in handles), *handles[0].shape[1:]) if handles else None,
             dtype=handles[0].dtype if handles else None,
             device=str(handles[0].device) if handles else None,
         )
 
     def __len__(self) -> int:
-        return sum(self.sizes) if self.sizes else 0
+        return self.batch_size
 
 
 # ---------------------------------------------------------------------------
@@ -494,8 +498,7 @@ class TensorTransport(abc.ABC):
             ref = self.put(t)
             bs = int(t.shape[0]) if isinstance(t, torch.Tensor) and t.dim() > 0 else 1
             result[k] = TensorRef(
-                refs=[ref],
-                sizes=[bs],
+                spans=[TensorSpan(ref, 0, bs)],
                 shape=tuple(t.shape) if isinstance(t, torch.Tensor) else None,
                 dtype=t.dtype if isinstance(t, torch.Tensor) else None,
                 device=str(t.device) if isinstance(t, torch.Tensor) else None,
@@ -504,7 +507,7 @@ class TensorTransport(abc.ABC):
 
     def get_batch(self, metas: Dict[str, TensorRef]) -> Dict[str, torch.Tensor]:
         """Fetch multiple named tensors. Default: iterate per key."""
-        return {k: self.get(m.refs) for k, m in metas.items()}
+        return {k: self.get(m.spans) for k, m in metas.items()}
 
     def transform(self, meta: TensorRef, fn: Callable[[torch.Tensor], torch.Tensor]) -> TensorRef:
         """Apply fn to the remote tensor, return new TensorRef.
@@ -513,13 +516,12 @@ class TensorTransport(abc.ABC):
         memory). Backends with remote compute (TensorStore) can override to
         execute on the worker without moving data.
         """
-        tensor = self.get(meta.refs)
+        tensor = self.get(meta.spans)
         result = fn(tensor)
         ref = self.put(result)
         bs = int(result.shape[0]) if result.dim() > 0 else 1
         return TensorRef(
-            refs=[ref],
-            sizes=[bs],
+            spans=[TensorSpan(ref, 0, bs)],
             shape=tuple(result.shape),
             dtype=result.dtype,
             device=str(result.device),
@@ -556,8 +558,7 @@ class TensorTransport(abc.ABC):
             ref = self.put(value)
             bs = int(value.shape[0]) if value.dim() > 0 else 1
             return TensorRef(
-                refs=[ref],
-                sizes=[bs],
+                spans=[TensorSpan(ref, 0, bs)],
                 shape=tuple(value.shape),
                 dtype=value.dtype,
                 device=str(value.device),
@@ -715,22 +716,21 @@ class WorkerLocalTransport(TensorTransport):
         """
         foreign: Dict[Tuple[int, int], List[Any]] = {}  # (src_device_id, dst_device_id) → [routing_copy, ...]
 
-        def route(ref: Any, dst_worker_id: str, dst_device_id: int) -> Any:
-            if getattr(ref, "object_ref", None) is not None:
-                return ref  # CPU/plasma → resolvable anywhere
-            if cls._is_local(ref, dst_worker_id, dst_device_id, pool):
-                return ref
-            src_device_id = pool.device_id_of(ref.source_id)
-            routing = ref.routing_copy()
+        def route(span: Any, dst_worker_id: str, dst_device_id: int) -> Any:
+            if getattr(span.handle, "object_ref", None) is not None:
+                return span  # CPU/plasma → resolvable anywhere
+            if cls._is_local(span.handle, dst_worker_id, dst_device_id, pool):
+                return span
+            src_device_id = pool.device_id_of(span.handle.source_id)
+            routing = span.routing_copy()
             foreign.setdefault((src_device_id, dst_device_id), []).append(routing)
             return routing
 
         def unwrap(obj: Any, dst_worker_id: str, dst_device_id: int) -> Any:
             if isinstance(obj, TensorRef):
-                # TensorSpan refs route like any ref (source_id/shape delegate
-                # to the base); a foreign view ships ONLY its [start:end) rows —
-                # the send side slices by the routing copy's range.
-                return obj.with_refs([route(h, dst_worker_id, dst_device_id) for h in obj.refs])
+                # A foreign span ships ONLY its [start:stop) rows — the send side
+                # slices by the routing copy's range (its .shape is sliced).
+                return obj.with_spans([route(s, dst_worker_id, dst_device_id) for s in obj.spans])
             return obj
 
         routed: list = []
@@ -760,13 +760,14 @@ class WorkerLocalTransport(TensorTransport):
         subs: Dict[int, Any] = {}
         for (src_device_id, dst_device_id), new_handles in zip(keys, recv_results):
             dst_worker = pool.slot0_worker(dst_device_id)
-            for old_h, new_h in zip(foreign[(src_device_id, dst_device_id)], new_handles):
+            for old_span, new_h in zip(foreign[(src_device_id, dst_device_id)], new_handles):
                 new_h.rebind(dst_worker)
-                subs[id(old_h)] = new_h
+                # The recv handle holds exactly the sliced rows → full-range span.
+                subs[id(old_span)] = TensorSpan(new_h, 0, int(new_h.shape[0]))
 
         def substitute(obj: Any) -> Any:
             if isinstance(obj, TensorRef):
-                return obj.with_refs([subs.get(id(h), h) for h in obj.refs])
+                return obj.with_spans([subs.get(id(s), s) for s in obj.spans])
             return obj
 
         return [(map_tree(a, substitute), map_tree(k, substitute)) for a, k in routed]
@@ -779,12 +780,12 @@ class WorkerLocalTransport(TensorTransport):
         Default: round-trip get -> op -> put. Backends with on-worker compute
         override to avoid moving data.
         """
-        result = _apply_tensor_op(self.get([handle]), op, *op_args).contiguous()
+        result = _apply_tensor_op(self.get([TensorSpan(handle, 0, int(handle.shape[0]))]), op, *op_args).contiguous()
         return self.put(result)
 
     def get_cpu(self, handle: Any) -> torch.Tensor:
         """Return the stored tensor as a CPU tensor."""
-        return self.get([handle]).cpu()
+        return self.get([TensorSpan(handle, 0, int(handle.shape[0]))]).cpu()
 
 
 class TransportSession:

--- a/unirl/distributed/utils.py
+++ b/unirl/distributed/utils.py
@@ -75,7 +75,7 @@ def collect_leaves(x, leaf_type: Type) -> list:
       - everything else -> skip
 
     Sorting dict/Batch keys ensures deterministic ordering across call sites,
-    which is critical for aligning controller-side collect_leaves(TensorMeta)
+    which is critical for aligning controller-side collect_leaves(TensorRef)
     with worker-side collect_leaves(torch.Tensor) by index.
     """
     result = []

--- a/unirl/train_ar.py
+++ b/unirl/train_ar.py
@@ -40,6 +40,7 @@ def main(cfg: DictConfig) -> None:
         logging_cfg=cfg.get("logging"),
         adv_normalization_scope=cfg.get("adv_normalization_scope", "group"),
         normalize_adv_by_std=bool(cfg.get("normalize_adv_by_std", True)),
+        balance_dp_batch=bool(cfg.get("balance_dp_batch", False)),
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", 60)),
         eval_samples_per_prompt=int(cfg.get("eval_samples_per_prompt", 16)),

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -52,6 +52,7 @@ class ARTrainer(BaseTrainer):
         logging_cfg: Optional[DictConfig] = None,
         adv_normalization_scope: str = "group",
         normalize_adv_by_std: bool = True,
+        balance_dp_batch: bool = False,
         eval_interval: int = 0,
         eval_num_prompts: int = 60,
         eval_samples_per_prompt: int = 16,
@@ -65,6 +66,12 @@ class ARTrainer(BaseTrainer):
         # group std. False = mean-center only (reward - group_mean), NO std division —
         # removes the difficulty bias that over-amplifies low-std (hard) prompts.
         self.normalize_adv_by_std = normalize_adv_by_std
+        # verl trainer.balance_batch parity: driver-side reorder of the rollout
+        # batch so each DP rank receives a similar total-token workload. FSDP
+        # collectives sync all ranks every micro, so a step runs at the SLOWEST
+        # rank's pace — without balancing, the rank that drew the longest
+        # sequences straggles (~+/-11%% rank-total variance at heavy lengths).
+        self.balance_dp_batch = bool(balance_dp_batch)
         # AIME-style periodic eval — avg@k accuracy on the eval prompt set
         # (run.eval_data_path), logged under eval/*. eval_interval=0 disables it.
         self.eval_interval = int(eval_interval)
@@ -160,6 +167,8 @@ class ARTrainer(BaseTrainer):
 
         self._drop_decoded(req, resp, rollout_id=rollout_id)
         (track,) = resp.tracks.values()
+        if self.balance_dp_batch:
+            track = self._balance_track(track)
         result = self.stack.train_track(track, training_progress=float(training_progress))
         self.wandb_logger.log_rollout_step(
             rollout_id,
@@ -169,6 +178,100 @@ class ARTrainer(BaseTrainer):
             trunc_len=getattr(self.sampling_params, "max_new_tokens", None),
         )
         return result, mean_reward
+
+
+    def _hydrate_track(self, track):
+        """Driver-side hydrate of every TensorMeta field so ``Batch.select`` works.
+
+        ``Batch.select`` silently passes unknown leaf types through unchanged and
+        ``TensorMeta.select`` raises — so permuting a track that still carries
+        TensorMeta proxies would desync those fields from the permuted ones.
+        Hydrating first costs one fetch of the per-rollout tensors (~10-20 MB).
+        """
+        from dataclasses import fields as dc_fields
+
+        from unirl.distributed.tensor.batch import Batch
+        from unirl.distributed.tensor.transport import TensorMeta
+
+        def hydrate_ragged(tm):
+            # _hydrate_tensor_meta cats per-worker parts along dim 0, which fails
+            # for 2D fields whose per-shard pad WIDTH differs (each worker padded
+            # its prompt block to its own max). Right-pad parts to the global max
+            # first — the same layout TextTokenCondition.concat produces (real
+            # tokens left, pad right; replay reads real lengths from the mask, so
+            # the pad value is immaterial).
+            if not tm.refs:
+                return None
+            parts = [h.local() for h in tm.refs]
+            if len(parts) == 1:
+                return parts[0]
+            if parts[0].dim() >= 2:
+                widths = {int(p.shape[1]) for p in parts}
+                if len(widths) > 1:
+                    target = max(widths)
+                    padded = []
+                    for p in parts:
+                        if int(p.shape[1]) < target:
+                            pad = p.new_zeros((p.shape[0], target - p.shape[1]) + tuple(p.shape[2:]))
+                            p = torch.cat([p, pad], dim=1)
+                        padded.append(p)
+                    parts = padded
+            return torch.cat(parts, dim=0)
+
+        def walk(value):
+            if isinstance(value, TensorMeta):
+                return hydrate_ragged(value)
+            if isinstance(value, Batch):
+                for f in dc_fields(value):
+                    object.__setattr__(value, f.name, walk(getattr(value, f.name)))
+                return value
+            if isinstance(value, dict):
+                return {k: walk(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [walk(v) for v in value]
+            if isinstance(value, tuple):
+                return tuple(walk(v) for v in value)
+            return value
+
+        return walk(track)
+
+    def _balance_track(self, track):
+        """verl ``_balance_batch`` parity: reorder samples so DP ranks get equal token sums.
+
+        Greedy LPT under an equal-count constraint (DP_SCATTER splits the batch
+        into dp_size EQUAL contiguous chunks): longest sample first, into the
+        eligible bucket with the smallest running token sum. Advantages are
+        computed BEFORE this point (per-group stats already attached per
+        sample), so sample order is free to change — the same invariant verl
+        relies on. Buckets are laid out contiguously in worker order.
+        """
+        lengths = getattr(track.segment, "lengths", None) if track.segment is not None else None
+        if lengths is None:
+            logger.warning("balance_dp_batch: track has no segment lengths; skipping balance.")
+            return track
+        total = int(track.batch_size)
+        dp = int(self.num_devices)
+        if total % dp != 0 or dp <= 1:
+            return track
+        cap = total // dp
+        lens = [int(x) for x in lengths.tolist()]
+        order = sorted(range(total), key=lambda i: (-lens[i], i))
+        buckets = [[] for _ in range(dp)]
+        sums = [0] * dp
+        for i in order:
+            best = min((b for b in range(dp) if len(buckets[b]) < cap), key=lambda b: sums[b])
+            buckets[best].append(i)
+            sums[best] += lens[i]
+        perm = [i for bucket in buckets for i in bucket]
+        track = self._hydrate_track(track)
+        balanced = track.select(perm)
+        logger.info(
+            "balance_dp_batch: rank token sums min=%d max=%d (spread %.1f%%)",
+            min(sums),
+            max(sums),
+            100.0 * (max(sums) - min(sums)) / max(1, sum(sums) // dp),
+        )
+        return balanced
 
     def evaluate(self, rollout_id: int) -> float:
         """Periodic eval — ``avg@k`` accuracy on the eval prompt set (no training).

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -154,7 +154,7 @@ class ARTrainer(BaseTrainer):
             if track.rewards is None:
                 continue
             # Hydrate in place so the wandb reward/advantage stats reuse this
-            # fetch instead of re-pulling the TensorMeta from the worker.
+            # fetch instead of re-pulling the TensorRef from the worker.
             track.rewards = _hydrate_tensor_meta(track.rewards)
             mean_reward = float(track.rewards.to(torch.float32).mean().item())
             break  # single-track for now; revisit if multi-track lands

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -71,7 +71,7 @@ class ARTrainer(BaseTrainer):
         # collectives sync all ranks every micro, so a step runs at the SLOWEST
         # rank's pace — without balancing, the rank that drew the longest
         # sequences straggles (~+/-11%% rank-total variance at heavy lengths).
-        self.balance_dp_batch = bool(balance_dp_batch)
+        self.balance_dp_batch = bool(balance_dp_batch)  # overrides the BaseTrainer default (False)
         # AIME-style periodic eval — avg@k accuracy on the eval prompt set
         # (run.eval_data_path), logged under eval/*. eval_interval=0 disables it.
         self.eval_interval = int(eval_interval)
@@ -167,8 +167,7 @@ class ARTrainer(BaseTrainer):
 
         self._drop_decoded(req, resp, rollout_id=rollout_id)
         (track,) = resp.tracks.values()
-        if self.balance_dp_batch:
-            track = self._balance_track(track)
+        track = self._balance_track(track)  # no-op unless balance_dp_batch
         result = self.stack.train_track(track, training_progress=float(training_progress))
         self.wandb_logger.log_rollout_step(
             rollout_id,
@@ -180,109 +179,6 @@ class ARTrainer(BaseTrainer):
         return result, mean_reward
 
 
-    def _hydrate_track(self, track):
-        """Driver-side hydrate of every TensorMeta field so ``Batch.select`` works.
-
-        ``Batch.select`` silently passes unknown leaf types through unchanged and
-        ``TensorMeta.select`` raises — so permuting a track that still carries
-        TensorMeta proxies would desync those fields from the permuted ones.
-        Hydrating first costs one fetch of the per-rollout tensors (~10-20 MB).
-        """
-        from dataclasses import fields as dc_fields
-
-        from unirl.distributed.tensor.batch import Batch
-        from unirl.distributed.tensor.transport import TensorMeta
-
-        def hydrate_ragged(tm):
-            # _hydrate_tensor_meta cats per-worker parts along dim 0, which fails
-            # for 2D fields whose per-shard pad WIDTH differs (each worker padded
-            # its prompt block to its own max). Right-pad parts to the global max
-            # first — the same layout TextTokenCondition.concat produces (real
-            # tokens left, pad right; replay reads real lengths from the mask, so
-            # the pad value is immaterial).
-            if not tm.refs:
-                return None
-            parts = [h.local() for h in tm.refs]
-            if len(parts) == 1:
-                return parts[0]
-            if parts[0].dim() >= 2:
-                widths = {int(p.shape[1]) for p in parts}
-                if len(widths) > 1:
-                    target = max(widths)
-                    padded = []
-                    for p in parts:
-                        if int(p.shape[1]) < target:
-                            pad = p.new_zeros((p.shape[0], target - p.shape[1]) + tuple(p.shape[2:]))
-                            p = torch.cat([p, pad], dim=1)
-                        padded.append(p)
-                    parts = padded
-            return torch.cat(parts, dim=0)
-
-        def walk(value):
-            if isinstance(value, TensorMeta):
-                return hydrate_ragged(value)
-            if isinstance(value, Batch):
-                for f in dc_fields(value):
-                    object.__setattr__(value, f.name, walk(getattr(value, f.name)))
-                return value
-            if isinstance(value, dict):
-                return {k: walk(v) for k, v in value.items()}
-            if isinstance(value, list):
-                return [walk(v) for v in value]
-            if isinstance(value, tuple):
-                return tuple(walk(v) for v in value)
-            return value
-
-        return walk(track)
-
-    def _balance_track(self, track):
-        """verl ``_balance_batch`` parity: reorder samples so DP ranks get equal token sums.
-
-        Greedy LPT under an equal-count constraint (DP_SCATTER splits the batch
-        into dp_size EQUAL contiguous chunks): longest sample first, into the
-        eligible bucket with the smallest running token sum. Advantages are
-        computed BEFORE this point (per-group stats already attached per
-        sample), so sample order is free to change — the same invariant verl
-        relies on. Buckets are laid out contiguously in worker order.
-        """
-        lengths = getattr(track.segment, "lengths", None) if track.segment is not None else None
-        if lengths is None:
-            logger.warning("balance_dp_batch: track has no segment lengths; skipping balance.")
-            return track
-        total = int(track.batch_size)
-        dp = int(self.num_devices)
-        if total % dp != 0 or dp <= 1:
-            return track
-        cap = total // dp
-        lens = [int(x) for x in lengths.tolist()]
-        if len(lens) != total:
-            logger.warning("balance_dp_batch: lengths (%d) != batch_size (%d); skipping.", len(lens), total)
-            return track
-        # Cheap skip guard (review #45): current-order per-rank token sums in pure
-        # Python — when the spread is already tiny (uniform-length workloads), the
-        # hydrate + reorder + real-tensor dispatch is pure overhead (measured
-        # +9.6s/step on VL geo3k).
-        current = [sum(lens[r * cap : (r + 1) * cap]) for r in range(dp)]
-        avg = sum(current) / dp
-        if avg <= 0 or (max(current) - min(current)) / avg < 0.05:
-            return track
-        order = sorted(range(total), key=lambda i: (-lens[i], i))
-        buckets = [[] for _ in range(dp)]
-        sums = [0] * dp
-        for i in order:
-            best = min((b for b in range(dp) if len(buckets[b]) < cap), key=lambda b: sums[b])
-            buckets[best].append(i)
-            sums[best] += lens[i]
-        perm = [i for bucket in buckets for i in bucket]
-        track = self._hydrate_track(track)
-        balanced = track.select(perm)
-        logger.info(
-            "balance_dp_batch: rank token sums min=%d max=%d (spread %.1f%%)",
-            min(sums),
-            max(sums),
-            100.0 * (max(sums) - min(sums)) / max(1, sum(sums) // dp),
-        )
-        return balanced
 
     def evaluate(self, rollout_id: int) -> float:
         """Periodic eval — ``avg@k`` accuracy on the eval prompt set (no training).

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -255,6 +255,17 @@ class ARTrainer(BaseTrainer):
             return track
         cap = total // dp
         lens = [int(x) for x in lengths.tolist()]
+        if len(lens) != total:
+            logger.warning("balance_dp_batch: lengths (%d) != batch_size (%d); skipping.", len(lens), total)
+            return track
+        # Cheap skip guard (review #45): current-order per-rank token sums in pure
+        # Python — when the spread is already tiny (uniform-length workloads), the
+        # hydrate + reorder + real-tensor dispatch is pure overhead (measured
+        # +9.6s/step on VL geo3k).
+        current = [sum(lens[r * cap : (r + 1) * cap]) for r in range(dp)]
+        avg = sum(current) / dp
+        if avg <= 0 or (max(current) - min(current)) / avg < 0.05:
+            return track
         order = sorted(range(total), key=lambda i: (-lens[i], i))
         buckets = [[] for _ in range(dp)]
         sums = [0] * dp

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -178,8 +178,6 @@ class ARTrainer(BaseTrainer):
         )
         return result, mean_reward
 
-
-
     def evaluate(self, rollout_id: int) -> float:
         """Periodic eval — ``avg@k`` accuracy on the eval prompt set (no training).
 

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -92,18 +92,20 @@ class BaseTrainer:
 
         # DP seqlen balancing (verl trainer.balance_batch parity) — OFF by
         # default; subclasses whose workloads have variable response lengths
-        # (currently ARTrainer) override this from their config. The methods
-        # below are trainer-agnostic: any train_step may call
-        # ``track = self._balance_track(track)`` unconditionally — it no-ops
-        # unless the flag is set, the segment carries per-sample lengths, AND
-        # the current per-rank token spread exceeds 5% (uniform workloads such
-        # as diffusion's fixed-step latents or short multiple-choice answers
-        # would only pay the hydrate/reorder overhead).
+        # (currently ARTrainer) override this from their config.
         self.balance_dp_batch = False
 
         # Reclaim per-rollout transport buffers after every train_step, centrally,
         # so each subclass train loop doesn't have to remember to.
         self._install_train_step_reset_hook()
+
+        # Time the standard step collaborators (rollout / weight_sync / reward /
+        # stack) and surface them as perf/<phase>_time_s, centrally, so every
+        # trainer gets step attribution without per-trainer edits. The machinery
+        # lives with the rest of the logging stack in wandb_logger.
+        from unirl.utils.wandb_logger import install_phase_timing
+
+        install_phase_timing(self)
 
     # ---- transport buffer reclaim (shared by all v2 trainers) --------------
 
@@ -141,8 +143,8 @@ class BaseTrainer:
         """Opt-in DP seqlen balancing — thin policy wrapper over the mechanism.
 
         The mechanism (hydrate + LPT reorder) lives with the data type:
-        :func:`unirl.types.rollout_resp.balance_track_for_dp`. This wrapper only
-        owns the POLICY: the ``balance_dp_batch`` flag (False by default; AR
+        :func:. This wrapper only
+        owns the POLICY: the balance_dp_batch flag (False by default; AR
         workloads with variable response lengths opt in) and the dp size. Safe
         to call unconditionally from any train_step.
         """

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -143,8 +143,8 @@ class BaseTrainer:
         """Opt-in DP seqlen balancing — thin policy wrapper over the mechanism.
 
         The mechanism (hydrate + LPT reorder) lives with the data type:
-        :func:. This wrapper only
-        owns the POLICY: the balance_dp_batch flag (False by default; AR
+        :func:`unirl.types.rollout_resp.balance_track_for_dp`. This wrapper
+        only owns the POLICY: the ``balance_dp_batch`` flag (False by default; AR
         workloads with variable response lengths opt in) and the dp size. Safe
         to call unconditionally from any train_step.
         """

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -90,17 +90,20 @@ class BaseTrainer:
         self.logging_cfg = logging_cfg
         self.wandb_logger = UniRLWandBLogger(enabled=False)
 
+        # DP seqlen balancing (verl trainer.balance_batch parity) — OFF by
+        # default; subclasses whose workloads have variable response lengths
+        # (currently ARTrainer) override this from their config. The methods
+        # below are trainer-agnostic: any train_step may call
+        # ``track = self._balance_track(track)`` unconditionally — it no-ops
+        # unless the flag is set, the segment carries per-sample lengths, AND
+        # the current per-rank token spread exceeds 5% (uniform workloads such
+        # as diffusion's fixed-step latents or short multiple-choice answers
+        # would only pay the hydrate/reorder overhead).
+        self.balance_dp_batch = False
+
         # Reclaim per-rollout transport buffers after every train_step, centrally,
         # so each subclass train loop doesn't have to remember to.
         self._install_train_step_reset_hook()
-
-        # Time the standard step collaborators (rollout / weight_sync / reward /
-        # stack) and surface them as perf/<phase>_time_s, centrally, so every
-        # trainer gets step attribution without per-trainer edits. The machinery
-        # lives with the rest of the logging stack in wandb_logger.
-        from unirl.utils.wandb_logger import install_phase_timing
-
-        install_phase_timing(self)
 
     # ---- transport buffer reclaim (shared by all v2 trainers) --------------
 
@@ -131,6 +134,23 @@ class BaseTrainer:
     def _reset_transport_buffers(self) -> None:
         """Reclaim per-rollout mooncake zero-copy buffers (no-op for other backends)."""
         self.pool.reset_transfer_queue_buffers()
+
+    # ---- DP seqlen balancing (opt-in via balance_dp_batch) -----------------
+
+    def _balance_track(self, track):
+        """Opt-in DP seqlen balancing — thin policy wrapper over the mechanism.
+
+        The mechanism (hydrate + LPT reorder) lives with the data type:
+        :func:`unirl.types.rollout_resp.balance_track_for_dp`. This wrapper only
+        owns the POLICY: the ``balance_dp_batch`` flag (False by default; AR
+        workloads with variable response lengths opt in) and the dp size. Safe
+        to call unconditionally from any train_step.
+        """
+        if not self.balance_dp_batch:
+            return track
+        from unirl.types.rollout_resp import balance_track_for_dp
+
+        return balance_track_for_dp(track, dp_size=int(self.num_devices))
 
     # ---- wandb logging (shared by all v2 trainers) -------------------------
 

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -117,7 +117,7 @@ class BaseTrainer:
         its own ``train`` loop but they all drive one ``train_step`` per rollout, so this
         is the single seam that reclaims per-rollout TQ buffers without per-trainer edits.
         The reset fires once ``train_step`` returns — rewards/advantages materialized, no
-        live ``TensorMeta`` ref into the queue's RDMA buffers remaining.
+        live ``TensorRef`` ref into the queue's RDMA buffers remaining.
         """
         if self.pool.transport_kind not in ("transfer_queue", "tq"):
             return

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -353,7 +353,7 @@ class DiffusionTrainer(BaseTrainer):
             if track.rewards is None:
                 continue
             # Hydrate in place so the wandb reward/advantage stats reuse this
-            # fetch instead of re-pulling the TensorMeta from the worker.
+            # fetch instead of re-pulling the TensorRef from the worker.
             track.rewards = _hydrate_tensor_meta(track.rewards)
             mean_reward = float(track.rewards.to(torch.float32).mean().item())
             break  # single-track for now; revisit if multi-track lands

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -209,7 +209,7 @@ class PETrainer(BaseTrainer):
         reward_req = req.repeat_interleave(n_track // p) if n_track > p and n_track % p == 0 else req
         scored = self.reward.score_and_attach(req=reward_req, track=diff_track)
         # propagate_rewards reshapes child.rewards directly (no hydration), so
-        # turn the worker-returned TensorMeta into a real tensor first.
+        # turn the worker-returned TensorRef into a real tensor first.
         if scored.rewards is not None:
             scored.rewards = _hydrate_tensor_meta(scored.rewards)
         resp.tracks["diffusion"] = scored

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -64,7 +64,7 @@ from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement
 from unirl.distributed.tensor.batch import Batch
-from unirl.distributed.tensor.transport import TensorMeta
+from unirl.distributed.tensor.transport import TensorRef
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer
 from unirl.types.primitives import Texts
@@ -84,27 +84,27 @@ IMAGE_TRACK = "image"
 
 
 def deep_hydrate(obj: Any) -> Any:
-    """Materialize every ``TensorMeta`` leaf in ``obj`` to a real tensor, in place.
+    """Materialize every ``TensorRef`` leaf in ``obj`` to a real tensor, in place.
 
     The anchored single-actor engines return each track as ONE transport handle
     (a single ref spanning all samples), but the train side is num_devices-way DP and
     slices each track into per-rank shards — a single ref can't be intra-handle
     sliced. Hydrating on the driver fixes the mismatch (the DP dispatch then
     re-shards real tensors), but the driver has no ``TensorTransportRuntime``
-    installed, so ``TensorTransport.hydrate`` / ``TensorMeta.local`` are
+    installed, so ``TensorTransport.hydrate`` / ``TensorRef.local`` are
     unavailable here. ``_hydrate_tensor_meta`` instead pulls each leaf through
     its ref's ``.local()`` (a plain ``ray.get`` from the owning worker's store),
     which works from the driver — we walk the nested Batch/dict/list/TUPLE
-    structure and apply it to every ``TensorMeta``.
+    structure and apply it to every ``TensorRef``.
 
     NB: this walks TUPLES too (rebuilding them), unlike ``_collect_leaves``
     which skips them. HunyuanImage3's fused condition stores ``rope_cache`` as a
-    ``tuple`` of two TensorMeta; the DP scatter's driver-side
+    ``tuple`` of two TensorRef; the DP scatter's driver-side
     ``RolloutTrack.concat`` pads that rope (``conditions.concat`` → ``_pad_seq``
     → ``t.ndim``), so the rope MUST be real tensors here. (dp=1 never concats on
     the driver, so it never tripped on this.)
     """
-    if isinstance(obj, TensorMeta):
+    if isinstance(obj, TensorRef):
         return _hydrate_tensor_meta(obj)
     if isinstance(obj, Batch):
         for f in dataclasses.fields(obj):

--- a/unirl/types/media_preview.py
+++ b/unirl/types/media_preview.py
@@ -85,11 +85,11 @@ class MediaPreview(Batch):
 
 
 def _ref_aligned_prefix_len(decoded: Any, min_items: int) -> int:
-    """Smallest sample count >= ``min_items`` landing on a TensorMeta ref boundary.
+    """Smallest sample count >= ``min_items`` landing on a TensorRef ref boundary.
 
     ``decoded`` reaches the driver dehydrated: its tensor leaf (``Images.pixels``
-    / ``Videos.frames``) is a ``TensorMeta`` whose refs partition the batch by DP
-    shard, and ``TensorMeta`` only supports ref-boundary slicing. The cheapest
+    / ``Videos.frames``) is a ``TensorRef`` whose refs partition the batch by DP
+    shard, and ``TensorRef`` only supports ref-boundary slicing. The cheapest
     preview prefix is the first shard boundary covering ``min_items`` samples, so
     media logging hydrates one shard instead of the full decoded batch.
     ``Videos`` ref sizes count frames (PACKED), so shard frame boundaries are
@@ -97,13 +97,13 @@ def _ref_aligned_prefix_len(decoded: Any, min_items: int) -> int:
     full batch size when the leaf is already a real tensor (nothing to save) or a
     boundary cannot be mapped.
     """
-    from unirl.distributed.tensor.transport import TensorMeta
+    from unirl.distributed.tensor.transport import TensorRef
 
     total = len(decoded)
     want = max(1, min(int(min_items), total))
     if isinstance(decoded, Images):
         meta = decoded.pixels
-        if not isinstance(meta, TensorMeta):
+        if not isinstance(meta, TensorRef):
             return total
         rows = 0
         for size in meta.sizes:
@@ -113,7 +113,7 @@ def _ref_aligned_prefix_len(decoded: Any, min_items: int) -> int:
         return total
     meta = decoded.frames
     cu = decoded.cu_seqlens
-    if not isinstance(meta, TensorMeta) or cu is None:
+    if not isinstance(meta, TensorRef) or cu is None:
         return total
     sample_at_frame = {int(v): i for i, v in enumerate(cu.tolist())}
     frames = 0
@@ -166,7 +166,7 @@ def build_media_preview_for_track(
     limit = max(1, int(max_items))
 
     # ``decoded`` reaches the driver dehydrated (its tensor leaf is a
-    # ``TensorMeta`` proxy partitioned by DP shard). Slice to the smallest
+    # ``TensorRef`` proxy partitioned by DP shard). Slice to the smallest
     # ref-boundary prefix covering ``limit`` samples, then hydrate only that
     # shard so we pull one shard instead of the full decoded batch. Both steps
     # are no-ops when the leaf is already a real tensor (e.g. unit tests).

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -381,6 +381,102 @@ def _hydrate_tensor_meta(value: Any) -> Any:
     return torch.cat(tensors, dim=0)
 
 
+def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":
+    """Driver-side hydrate of every TensorMeta field of a track (so ``Batch.select`` works).
+
+    ``Batch.select`` silently passes unknown leaf types through unchanged and
+    ``TensorMeta.select`` raises — so permuting a track that still carries
+    TensorMeta proxies would desync those fields from the permuted ones.
+    Hydrating first costs one fetch of the per-rollout tensors (~10-20 MB).
+    """
+    from dataclasses import fields as dc_fields
+
+    import torch
+
+    from unirl.distributed.tensor.batch import Batch
+    from unirl.distributed.tensor.transport import TensorMeta
+
+    def hydrate_ragged(tm):
+        # _hydrate_tensor_meta cats per-worker parts along dim 0, which fails
+        # for 2D fields whose per-shard pad WIDTH differs (each worker padded
+        # its prompt block to its own max). Right-pad parts to the global max
+        # first — the same layout TextTokenCondition.concat produces (real
+        # tokens left, pad right; replay reads real lengths from the mask, so
+        # the pad value is immaterial).
+        if not tm.refs:
+            return None
+        parts = [h.local() for h in tm.refs]
+        if len(parts) == 1:
+            return parts[0]
+        if parts[0].dim() >= 2:
+            widths = {int(p.shape[1]) for p in parts}
+            if len(widths) > 1:
+                target = max(widths)
+                padded = []
+                for p in parts:
+                    if int(p.shape[1]) < target:
+                        pad = p.new_zeros((p.shape[0], target - p.shape[1]) + tuple(p.shape[2:]))
+                        p = torch.cat([p, pad], dim=1)
+                    padded.append(p)
+                parts = padded
+        return torch.cat(parts, dim=0)
+
+    def walk(value):
+        if isinstance(value, TensorMeta):
+            return hydrate_ragged(value)
+        if isinstance(value, Batch):
+            for f in dc_fields(value):
+                object.__setattr__(value, f.name, walk(getattr(value, f.name)))
+            return value
+        if isinstance(value, dict):
+            return {k: walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [walk(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(walk(v) for v in value)
+        return value
+
+    return walk(track)
+
+def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: float = 0.05) -> "RolloutTrack":
+    """verl ``_balance_batch`` parity: reorder samples so DP ranks get equal token sums.
+
+    Greedy LPT under an equal-count constraint (DP_SCATTER splits the batch
+    into dp_size EQUAL contiguous chunks): longest sample first, into the
+    eligible bucket with the smallest running token sum. Advantages are
+    computed BEFORE this point (per-group stats already attached per
+    sample), so sample order is free to change — the same invariant verl
+    relies on. Buckets are laid out contiguously in worker order.
+    """
+    lengths = getattr(track.segment, "lengths", None) if track.segment is not None else None
+    if lengths is None:
+        logger.warning("balance_dp_batch: track has no segment lengths; skipping balance.")
+        return track
+    total = int(track.batch_size)
+    dp = int(dp_size)
+    if total % dp != 0 or dp <= 1:
+        return track
+    cap = total // dp
+    lens = [int(x) for x in lengths.tolist()]
+    order = sorted(range(total), key=lambda i: (-lens[i], i))
+    buckets = [[] for _ in range(dp)]
+    sums = [0] * dp
+    for i in order:
+        best = min((b for b in range(dp) if len(buckets[b]) < cap), key=lambda b: sums[b])
+        buckets[best].append(i)
+        sums[best] += lens[i]
+    perm = [i for bucket in buckets for i in bucket]
+    track = hydrate_track(track)
+    balanced = track.select(perm)
+    logger.info(
+        "balance_dp_batch: rank token sums min=%d max=%d (spread %.1f%%)",
+        min(sums),
+        max(sums),
+        100.0 * (max(sums) - min(sums)) / max(1, sum(sums) // dp),
+    )
+    return balanced
+
+
 def _track_with_field(track: TR, field_name: str, value: Any) -> TR:
     """Return a copy of ``track`` with one field replaced (other fields preserved)."""
     kwargs: Dict[str, Any] = {f.name: getattr(track, f.name) for f in dc_fields(track)}

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -379,14 +379,9 @@ def _hydrate_tensor_meta(value: Any) -> Any:
         return value
     if not value.refs:
         return None
-    if getattr(value, "view_plan", None) is not None:
-        # Segment views know how to assemble themselves (plan-ordered gather
-        # with the documented ragged right-pad contract).
-        return value.materialize(backend=None)
-    tensors = [h.local() for h in value.refs]
-    if len(tensors) == 1:
-        return tensors[0]
-    return torch.cat(tensors, dim=0)
+    # materialize(None) = per-ref local() fetch + cat_rows (HandleView refs
+    # slice their base; ragged 2D parts follow the documented right-pad contract).
+    return value.materialize(backend=None)
 
 
 def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -271,7 +271,7 @@ class RolloutTrack(Batch):
             return self  # trivially nothing to do
 
         # The reward service runs on workers; its returned ``rewards`` arrives
-        # at the driver as a TensorMeta proxy (Worker._pack_output dehydrates
+        # at the driver as a TensorRef proxy (Worker._pack_output dehydrates
         # every Tensor leaf). Driver-side arithmetic below needs a real Tensor.
         rewards_local = _hydrate_tensor_meta(self.rewards)
 
@@ -362,34 +362,34 @@ def _root_group_per_sample(resp: "RolloutResp", track_name: str) -> List[str]:
 
 
 def _hydrate_tensor_meta(value: Any) -> Any:
-    """Driver-side hydrate of a ``TensorMeta`` proxy back to a real ``torch.Tensor``.
+    """Driver-side hydrate of a ``TensorRef`` proxy back to a real ``torch.Tensor``.
 
     ``Worker._pack_output`` stores every ``torch.Tensor`` leaf in the return
     value into the TensorStore, so fields like ``track.rewards`` arrive at
-    the driver as ``TensorMeta`` proxies even though downstream driver-side
+    the driver as ``TensorRef`` proxies even though downstream driver-side
     code (advantage computation) does arithmetic on them as if they were
     tensors. This helper
     fetches the underlying tensor(s) via each handle's bound worker and cats
     them. Returns the value unchanged when it is already a ``torch.Tensor``
     or ``None``.
     """
-    from unirl.distributed.tensor.transport import TensorMeta
+    from unirl.distributed.tensor.transport import TensorRef
 
-    if not isinstance(value, TensorMeta):
+    if not isinstance(value, TensorRef):
         return value
     if not value.refs:
         return None
-    # materialize(None) = per-ref local() fetch + cat_rows (HandleView refs
+    # materialize(None) = per-ref local() fetch + cat_rows (TensorSpan refs
     # slice their base; ragged 2D parts follow the documented right-pad contract).
     return value.materialize(backend=None)
 
 
 def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":
-    """Driver-side hydrate of every TensorMeta field of a track (so ``Batch.select`` works).
+    """Driver-side hydrate of every TensorRef field of a track (so ``Batch.select`` works).
 
     ``Batch.select`` silently passes unknown leaf types through unchanged and
-    ``TensorMeta.select`` raises — so permuting a track that still carries
-    TensorMeta proxies would desync those fields from the permuted ones.
+    ``TensorRef.select`` raises — so permuting a track that still carries
+    TensorRef proxies would desync those fields from the permuted ones.
     Hydrating first costs one fetch of the per-rollout tensors (~10-20 MB).
     """
     from dataclasses import fields as dc_fields
@@ -397,7 +397,7 @@ def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":
     import torch
 
     from unirl.distributed.tensor.batch import Batch
-    from unirl.distributed.tensor.transport import TensorMeta
+    from unirl.distributed.tensor.transport import TensorRef
 
     def hydrate_ragged(tm):
         # _hydrate_tensor_meta cats per-worker parts along dim 0, which fails
@@ -425,7 +425,7 @@ def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":
         return torch.cat(parts, dim=0)
 
     def walk(value):
-        if isinstance(value, TensorMeta):
+        if isinstance(value, TensorRef):
             return hydrate_ragged(value)
         if isinstance(value, Batch):
             for f in dc_fields(value):
@@ -481,8 +481,8 @@ def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: flo
         buckets[best].append(i)
         sums[best] += lens[i]
     perm = [i for bucket in buckets for i in bucket]
-    # TensorMeta fields now support native select (lazy segment views over the
-    # remote refs — see TensorMeta.select_units), so the permutation needs NO
+    # TensorRef fields now support native select (lazy segment views over the
+    # remote refs — see TensorRef.select_units), so the permutation needs NO
     # driver-side hydration: data stays worker-resident and materializes on the
     # destination worker. hydrate_track() remains available as a utility but is
     # no longer on this path.

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -458,6 +458,18 @@ def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: flo
         return track
     cap = total // dp
     lens = [int(x) for x in lengths.tolist()]
+    if len(lens) != total:
+        logger.warning("balance_dp_batch: lengths (%d) != batch_size (%d); skipping.", len(lens), total)
+        return track
+    # Cheap skip guard: compute the CURRENT-order per-rank token sums in pure
+    # Python — when the spread is already tiny (uniform-length workloads, e.g.
+    # multiple-choice answers or fixed-step diffusion latents), the hydrate +
+    # reorder + real-tensor dispatch is pure overhead (measured +9.6s/step on
+    # VL geo3k).
+    current = [sum(lens[r * cap : (r + 1) * cap]) for r in range(dp)]
+    avg = sum(current) / dp
+    if avg <= 0 or (max(current) - min(current)) / avg < float(min_spread):
+        return track
     order = sorted(range(total), key=lambda i: (-lens[i], i))
     buckets = [[] for _ in range(dp)]
     sums = [0] * dp

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -440,6 +440,7 @@ def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":
 
     return walk(track)
 
+
 def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: float = 0.05) -> "RolloutTrack":
     """verl ``_balance_batch`` parity: reorder samples so DP ranks get equal token sums.
 

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -43,11 +43,10 @@ Pairs with ``RolloutReq`` (in ``unirl/types/rollout_req.py``).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from dataclasses import fields as dc_fields
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Type, TypeVar, Union
-
-import logging
 
 import torch
 
@@ -377,10 +376,10 @@ def _hydrate_tensor_meta(value: Any) -> Any:
 
     if not isinstance(value, TensorRef):
         return value
-    if not value.refs:
+    if not value.spans:
         return None
-    # materialize(None) = per-ref local() fetch + cat_rows (TensorSpan refs
-    # slice their base; ragged 2D parts follow the documented right-pad contract).
+    # materialize(None) = per-span local() fetch + cat_rows (each span slices its
+    # handle; ragged 2D parts follow the documented right-pad contract).
     return value.materialize(backend=None)
 
 
@@ -406,9 +405,9 @@ def hydrate_track(track: "RolloutTrack") -> "RolloutTrack":
         # first — the same layout TextTokenCondition.concat produces (real
         # tokens left, pad right; replay reads real lengths from the mask, so
         # the pad value is immaterial).
-        if not tm.refs:
+        if not tm.spans:
             return None
-        parts = [h.local() for h in tm.refs]
+        parts = [s.local() for s in tm.spans]
         if len(parts) == 1:
             return parts[0]
         if parts[0].dim() >= 2:

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -47,6 +47,8 @@ from dataclasses import dataclass
 from dataclasses import fields as dc_fields
 from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Type, TypeVar, Union
 
+import logging
+
 import torch
 
 from unirl.distributed.tensor.batch import (
@@ -61,6 +63,8 @@ from unirl.types.conditions import Condition
 from unirl.types.media_preview import MediaPreview
 from unirl.types.primitives import Audios, Images, Texts, Videos
 from unirl.types.segments import Segment
+
+logger = logging.getLogger(__name__)
 
 TR = TypeVar("TR", bound="RolloutTrack")
 TT = TypeVar("TT", bound="RolloutResp")
@@ -375,6 +379,10 @@ def _hydrate_tensor_meta(value: Any) -> Any:
         return value
     if not value.refs:
         return None
+    if getattr(value, "view_plan", None) is not None:
+        # Segment views know how to assemble themselves (plan-ordered gather
+        # with the documented ragged right-pad contract).
+        return value.materialize(backend=None)
     tensors = [h.local() for h in value.refs]
     if len(tensors) == 1:
         return tensors[0]
@@ -478,7 +486,11 @@ def balance_track_for_dp(track: "RolloutTrack", *, dp_size: int, min_spread: flo
         buckets[best].append(i)
         sums[best] += lens[i]
     perm = [i for bucket in buckets for i in bucket]
-    track = hydrate_track(track)
+    # TensorMeta fields now support native select (lazy segment views over the
+    # remote refs — see TensorMeta.select_units), so the permutation needs NO
+    # driver-side hydration: data stays worker-resident and materializes on the
+    # destination worker. hydrate_track() remains available as a utility but is
+    # no longer on this path.
     balanced = track.select(perm)
     logger.info(
         "balance_dp_batch: rank token sums min=%d max=%d (spread %.1f%%)",


### PR DESCRIPTION
Part of the verl performance-parity series tracked in #40. Root-cause follow-up to #45.

## Summary
#45's DP balancing needed `hydrate_track`: a driver-side full hydration of every TensorMeta field before `Batch.select`, because selection had no representation on remote refs (`TensorMeta.select` raised; `_slice_by_refs` only cut at ref boundaries). That workaround broke the transport's zero-copy premise (worker → driver → worker bounce), mutated frozen dataclasses in place, left field types history-dependent, and buried a padding convention in a private helper.

This PR adds the missing primitive — selection over remote refs with **zero driver-side data motion** — in two commits that show the design converging:

1. `0dc87a9` — segment views as a side-band `view_plan` on `TensorMeta` (first iteration).
2. `8c7b4b1` — the view moves down to the **ref layer**: `HandleView(base, start, end)`, a unit-range view of a parent ref. This is the final design; `view_plan` and all its special-casing are deleted.

### Final design (`HandleView`)
- `select` / `select_units` / `select_segments` emit `HandleView` refs — a viewed meta is structurally identical to a plain one (`refs + sizes`), so every transport treats refs uniformly (no viewed/plain branches anywhere).
- **Exact-row routing**: `localize` ships only a view's `[start:end)` rows cross-device (`gpu_store` and `colocate` `_nccl_send` slice by the routing copy's range) — a permuted shard no longer drags whole foreign blocks.
- **GC by construction**: a view holds a Python reference to its parent ref; CPython refcounting aggregates all views onto the parent's single finalizer. No per-view finalizer, no extra decref RPCs.
- `cat_rows` is the single assembly funnel. Trailing-dim CONTRACT documented there: parts from refs padded to different widths are right-padded with zeros (the `TextTokenCondition.concat` convention) — consumers of 2D+ per-shard-padded fields must be mask-driven.
- Boundary-aligned selections pass the original ref objects through untouched — the structural inverse of concat stays the zero-cost case; misaligned `slice` wraps only the boundary refs instead of raising.
- Nested views flatten at construction (no indirection chains).
- `balance_track_for_dp` permutes via native `track.select(perm)`: data stays worker-resident and materializes on the destination worker. `hydrate_track` remains a utility but is off the balance path.

## Test Plan
- `tests/test_tensormeta_views.py`: 10 CPU unit tests — permutation + ragged right-pad, aligned pass-through, misaligned wrap, packed token segments, nested-view flattening, `with_refs` size preservation, empty selection, `HandleView` shape/local, `cat_rows` contract.
- 16-GPU e2e gate (`viewbal_e2e`, Qwen3-4B DRPO + balance on, L2 iteration): 5 steps, `ratio_mean` 0.9995–1.0004, rank token spread 0.06%, rewards nominal.
- 8-GPU paired L2↔L3 ablation on both trainers (same node, back-to-back; details in the PR comment): ARTrainer (geo3k VL trainside, balance on) train 11.13 vs 11.76 s, rollout 22.70 vs 23.57 s; DiffusionTrainer (SD3 trainside, colocate backend) step 111.7 vs 112.7 s — no regression, deltas within noise; ratio 1.0000 on both.
