### PR TITLE
fix(wandb): restore per-rollout train/* step axis (regressed in #24)

### DIFF
--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -259,7 +259,11 @@ class UniRLWandBLogger:
 
     @property
     def optimizer_step(self) -> int:
-        """Current ``train/`` step-axis value — checkpointed for resume."""
+        """Cumulative optimizer-update count — checkpointed for resume.
+
+        No longer the ``train/`` x-axis (that is now rollout-anchored); this is
+        the running optimizer-update total kept only for resume bookkeeping.
+        """
         return self._optimizer_step
 
     def _handle_init_failure(
@@ -660,7 +664,7 @@ class UniRLWandBLogger:
             rollout_metrics.update(extra_metrics)
         self.log_rollout(step, rollout_metrics)
 
-        self._log_train(results)
+        self._log_train(results, step)
 
         perf: Dict[str, float] = {}
         if step_time_s is not None:
@@ -673,20 +677,33 @@ class UniRLWandBLogger:
     def _log_train(
         self,
         results: Union["TrainStepResult", Dict[str, "TrainStepResult"]],
+        step: int,
     ) -> None:
-        """Emit ``train/*`` points, per optimizer step, single- and multi-track.
+        """Emit ``train/*`` points for one rollout, single- and multi-track.
 
-        Step-axis matrix (``train/step`` == ``self._optimizer_step``):
+        ``train/step`` is anchored to the rollout id (``step`` == ``rollout_id
+        + 1``), so it shares an x-axis with ``rollout/*`` and overlays directly
+        against runs that log one row per rollout. A multi-update recipe
+        (``per_update`` len N>1) no longer scatters N points along the optimizer
+        counter; the N updates fold into a SINGLE rollout row, each update's
+        metrics namespaced ``update{i}/...`` (so ``train/update0/grad_norm`` …
+        ``train/updateN/...`` sit side by side — the on-policy update0 then
+        off-policy drift, readable within one rollout instead of strung along
+        the wandb step axis).
+
+        ``self._optimizer_step`` is advanced by the exact same amount it always
+        was (cumulative optimizer-update count, checkpointed via the
+        :attr:`optimizer_step` property for resume); it simply no longer drives
+        the wandb ``train/step`` x-axis.
 
         - single result, ``per_update`` empty → one aggregate point per backward.
-        - single result, ``per_update`` len N>1 → N points (one per optimizer
-          update), metrics unprefixed (the on-policy update0 then off-policy drift).
+        - single result, ``per_update`` len N>1 → one row, keys ``update{i}/<metric>``.
         - dict results → metrics namespaced ``<track>/<key>``. Cross-track
           per-update merge ONLY when every track's ``per_update`` shares the same
-          length L>1 (one optimizer driving all tracks, e.g. unified_model);
-          otherwise one aggregate point per rollout. This never interleaves the
-          independent optimizers of a per-track recipe (e.g. PE), and is
-          byte-identical to the legacy path for every single-update recipe.
+          length L>1 (one optimizer driving all tracks, e.g. unified_model),
+          keys ``update{i}/<track>/<key>``; otherwise one aggregate point per
+          rollout. This never interleaves the independent optimizers of a
+          per-track recipe (e.g. PE).
         """
         if not self.enabled or not self._initialized:
             return
@@ -696,14 +713,14 @@ class UniRLWandBLogger:
             mergeable = bool(per_update_lens) and len(set(per_update_lens)) == 1 and per_update_lens[0] > 1
             if mergeable:
                 length = per_update_lens[0]
-                for i in range(length):
-                    merged: Dict[str, Any] = {
-                        f"{name}/{key}": value
-                        for name, result in results.items()
-                        for key, value in dict(result.per_update[i]).items()
-                    }
-                    self._optimizer_step += 1
-                    self.log_step(self._optimizer_step, merged)
+                merged: Dict[str, Any] = {
+                    f"update{i}/{name}/{key}": value
+                    for i in range(length)
+                    for name, result in results.items()
+                    for key, value in dict(result.per_update[i]).items()
+                }
+                self._optimizer_step += length
+                self.log_step(step, merged)
                 return
             train_metrics: Dict[str, Any] = {
                 f"{name}/{key}": value
@@ -712,18 +729,22 @@ class UniRLWandBLogger:
             }
             if any(bool(getattr(r, "has_backward", False)) for r in results.values()):
                 self._optimizer_step += 1
-                self.log_step(self._optimizer_step, train_metrics)
+                self.log_step(step, train_metrics)
             return
 
         # Single-track result.
         per_update = getattr(results, "per_update", ()) or ()
         if len(per_update) > 1:
-            for metrics in per_update:
-                self._optimizer_step += 1
-                self.log_step(self._optimizer_step, dict(metrics))
+            merged_single: Dict[str, Any] = {
+                f"update{i}/{key}": value
+                for i, metrics in enumerate(per_update)
+                for key, value in dict(metrics).items()
+            }
+            self._optimizer_step += len(per_update)
+            self.log_step(step, merged_single)
         elif getattr(results, "has_backward", False):
             self._optimizer_step += 1
-            self.log_step(self._optimizer_step, dict(aggregate_stage_results([results])))
+            self.log_step(step, dict(aggregate_stage_results([results])))
 
     def log_progress(
         self,

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -384,7 +384,15 @@ class UniRLWandBLogger:
                 if scalar is None:
                     continue
                 log_dict[metric_key] = scalar
-            wandb.log(log_dict)
+            # Pass the explicit logical step so the per-rollout rollout/train/perf
+            # calls (and the rollout-aligned eval, all at step == rollout_id+1) merge
+            # into ONE wandb history row at _step == rollout, instead of auto-
+            # incrementing _step ~3x/rollout. Gives one data point per step and lets
+            # the run overlay cleanly against per-step loggers (e.g. verl) on the
+            # default Step axis. Every step key shares the rollout_id+1 scale, so
+            # _step stays monotonic. (Builds on the per-update fold above: without it,
+            # the N same-step train calls would overwrite each other.)
+            wandb.log(log_dict, step=int(step))
         except Exception as e:
             print(f"Warning: Failed to log metrics ({step_key}): {e}")
 

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -595,7 +595,15 @@ class UniRLWandBLogger:
                 if wandb_videos:
                     payload[video_key] = wandb_videos
 
-            wandb.log(payload)
+            # `rollout_id` here is ALREADY rollout_id+1 (the caller passes +1, see
+            # base.py `_drop_decoded`), i.e. the same step value this rollout's other
+            # metrics use — so payload["rollout/step"] above is correct, not off by one.
+            # Pass it explicitly so the media row merges into that rollout's _step
+            # instead of auto-incrementing, which would desync from the explicit-step
+            # path used everywhere else in this logger.
+            # INVARIANT: every wandb.log in this logger must pass an explicit step on
+            # the rollout_id+1 scale, or cross-call _step alignment breaks.
+            wandb.log(payload, step=int(rollout_id))
         except Exception as e:
             print(f"Warning: Failed to log generated media: {e}")
 


### PR DESCRIPTION
## Summary

Makes the AR (and any multi-update) wandb logging emit **one data point per step** with all of a rollout's metrics co-located, so a run overlays cleanly against per-step loggers (e.g. verl) on the default Step axis. Two complementary commits:

**1. Fold per-update train metrics into one row (train/* anchored to rollout).**
Multi-update recipes (`per_update` length N>1, e.g. DRPO/GRPO with 4 updates) used to scatter the N updates as N separate `train/*` points along an optimizer-step counter, so `train/step` ran at ~`rollout x N`. Now the N updates fold into a SINGLE row, each namespaced `update{i}/<metric>` (cross-track: `update{i}/<track>/<metric>`), and `train/step` is anchored to `rollout_id + 1` — shared x-axis with `rollout/*`. `self._optimizer_step` is removed (it was only this x-axis).

**2. Merge the per-rollout log calls into one `_step`.**
Even after (1), each rollout still issued ~3 separate `wandb.log` calls — rollout-stats, train, perf — so wandb auto-incremented its internal `_step` ~3x per rollout: reward landed at `_step` 1, train at 2, perf at 3, … The metrics were therefore NOT co-located in a single history row, and the run stretched ~3x along the default **Step** axis versus a per-step logger, breaking cross-run overlay. Passing the explicit logical step to `wandb.log` in `log_with_step` makes all of a rollout's calls (and the rollout-aligned eval, all at `step == rollout_id + 1`) land in ONE history row at `_step == rollout`.

The two parts are interdependent: commit 2 is only safe because commit 1 folded the N train updates into a single call — otherwise the N same-step train `wandb.log` calls would overwrite each other. All step keys (`rollout/step`, `train/step`, `eval/step` via `log_eval(rollout_id+1)`) share the `rollout_id+1` scale, so `_step` stays monotonic.

### Tradeoff

Lost: the per-update points no longer occupy their own x-axis positions (the on-policy `update0` → off-policy `updateN` drift is now the `update0..N/<metric>` series within each rollout row, not a strung-out curve). Gained: one point per step, all rollout metrics in one row, and clean cross-run overlay on the default axis — the goal for the perf / algorithm-alignment comparisons (#40). An alternative (keep per-update points but anchor to a fractional rollout x-axis) was rejected: not isomorphic to single-row baselines.

## Test Plan

- `yaml`/AST parse + offline logic check (monkeypatched `wandb.log`): single-track 4-update → one row, keys `train/update0..3/<metric>`; multi-track mergeable → `update{i}/<track>/<metric>`; counter trajectory preserved where applicable.
- **Live verification** on a 32-GPU AR GRPO run (UniRL_perf, same logger): raw wandb history shows exactly one row per rollout —
  ```
  _step=1  rollout/step=1  train/step=1  | reward + train(update0..3) + perf  (one row)
  _step=2  rollout/step=2  train/step=2  | reward + train(update0..3) + perf
  ```
  `_step == rollout` (1:1), all metrics co-located, vs the pre-fix `_step ≈ 3x rollout` with reward/train/perf in separate rows.

Relates to #40.
