### PR TITLE
feat(qwen-vl): packed-varlen replay (packed_replay / padding_replay) (issue #40)

### DIFF
--- a/unirl/models/qwen_vl/ar.py
+++ b/unirl/models/qwen_vl/ar.py
@@ -87,6 +87,13 @@ def _merge_igt(per_sample_igt: Optional[List[Optional[torch.Tensor]]]) -> Option
     return torch.cat(parts, dim=0) if parts else None
 
 
+# Attention backends with a sparse packed kernel (skip cross-sequence blocks) →
+# packed replay always wins. Qwen2.5-VL has no flex support, but gets
+# flash_attention_2 once flash_attn is installed train-side; on plain sdpa,
+# packed is gated on length variance (see packed_replay).
+_SPARSE_PACKED_ATTN = ("flex_attention", "flash_attention_2")
+
+
 class QwenVLARStage(ARStage[QwenVLARConditions]):
     def __init__(self, *, model: QwenVLBundle) -> None:
         self.model = model
@@ -219,6 +226,22 @@ class QwenVLARStage(ARStage[QwenVLARConditions]):
         segment: TextSegment,
         temperature: float = 1.0,
     ) -> torch.Tensor:
+        """Branch: prefer :meth:`packed_replay` (packed-varlen, B > 1), else
+        :meth:`padding_replay` (dense padded default). Returns packed varlen
+        ``[total_tokens]`` aligned with ``segment.log_probs``."""
+        packed = self.packed_replay(conditions, segment=segment, temperature=temperature)
+        if packed is not None:
+            return packed
+        return self.padding_replay(conditions, segment=segment, temperature=temperature)
+
+    def padding_replay(
+        self,
+        conditions: QwenVLARConditions,
+        *,
+        segment: TextSegment,
+        temperature: float = 1.0,
+    ) -> torch.Tensor:
+        """Dense padded ``[B, max_real + T_max]`` replay — the default / fallback path."""
         if conditions.prompt is None or conditions.prompt.input_ids is None:
             raise ValueError("QwenVLARStage.replay: conditions.prompt.input_ids is None")
         if conditions.prompt.attention_mask is None:
@@ -337,6 +360,114 @@ class QwenVLARStage(ARStage[QwenVLARConditions]):
         if not flat:
             return torch.zeros(0, dtype=torch.float32, device=device)
         return torch.cat(flat, dim=0)
+
+    def packed_replay(
+        self,
+        conditions: QwenVLARConditions,
+        *,
+        segment: TextSegment,
+        temperature: float = 1.0,
+    ) -> Optional[torch.Tensor]:
+        """Packed-varlen replay for VL (M-RoPE) — verl remove_padding parity.
+
+        Concatenate every sample's ``prompt + response`` into one zero-padded
+        stream, with per-stream 4-D position ids ``[text_arange; get_rope_index
+        (t,h,w)]``. The text row restarts at 0 per stream, so transformers builds
+        the block-causal mask from it under sdpa (the same packed detection Qwen3
+        relies on; Qwen2.5-VL has no flex_attention support, so no monkey-patch);
+        per-stream M-RoPE positions equal the standalone layout (validated
+        bit-exact), so logp semantics match the dense :meth:`padding_replay`.
+        Returns ``None`` (→ padding fallback) when packing does not apply or
+        would not pay: single sample, missing prompt / lengths, or a
+        low-variance batch (the length-variance gate below — sdpa packed
+        attention regresses on equal-length batches).
+        """
+        if conditions.prompt is None or conditions.prompt.input_ids is None or conditions.prompt.attention_mask is None:
+            return None
+        if segment.tokens is None or segment.cu_seqlens is None or segment.lengths is None:
+            return None
+        device = next(self.model.transformer.parameters()).device
+        prompt_ids = conditions.prompt.input_ids.to(device)
+        prompt_mask = conditions.prompt.attention_mask.to(device)
+        batch_size = int(prompt_ids.shape[0])
+        if batch_size <= 1:
+            return None
+        pv = _merge_pv(conditions.pixel_values)
+        igt = _merge_igt(conditions.image_grid_thw)
+        if pv is not None:
+            pv = pv.to(device)
+        if igt is not None:
+            igt = igt.to(device)
+
+        flat_resp = segment.tokens.to(device=device, dtype=torch.long)
+        lengths = [int(n) for n in segment.lengths.tolist()]
+        igt_list = conditions.image_grid_thw  # per-sample list (a sample may have 0/≥1 images)
+        get_rope_index = self.model.transformer.model.get_rope_index
+        self.model.transformer.model.rope_deltas = None  # avoid stale M-RoPE cache
+
+        real_prompt_lens = prompt_mask.long().sum(dim=-1)  # [B] (right-padded layout)
+
+        # Length-variance gate. On a sparse packed kernel (flash_attention_2 once
+        # flash_attn is installed train-side; Qwen2.5-VL has no flex) packed is
+        # always a win. On plain sdpa, packed attention is the full O((ΣL)²) — a
+        # win only when eliminating padding outweighs it. Measured on 7B: packed
+        # beats padded ~2x on variable-length batches but regresses up to ~1.36x
+        # on equal-length-long ones. So on a non-sparse backend, pack only when
+        # padding waste is substantial (packed tokens <= 0.75 * dense slots);
+        # else fall back to padding.
+        attn_impl = getattr(getattr(self.model.transformer, "config", None), "_attn_implementation", None)
+        if attn_impl not in _SPARSE_PACKED_ATTN:
+            stream_lens = [int(real_prompt_lens[b].item()) + lengths[b] for b in range(batch_size)]
+            if sum(stream_lens) > 0.75 * batch_size * max(stream_lens):
+                return None
+
+        cu_p = [int(c) for c in segment.cu_seqlens.tolist()]
+        streams: List[torch.Tensor] = []
+        pos_parts: List[torch.Tensor] = []
+        pred_parts: List[torch.Tensor] = []
+        offset = 0
+        for b in range(batch_size):
+            n_p = int(real_prompt_lens[b].item())
+            n_r = lengths[b]
+            seq = torch.cat([prompt_ids[b, :n_p], flat_resp[cu_p[b] : cu_p[b] + n_r]])
+            streams.append(seq)
+            # Per-stream 4-D M-RoPE position [text; t; h; w]; text row restarts at
+            # 0 per stream so transformers builds the packed block-causal mask
+            # from it (sdpa). Per-stream get_rope_index == dense per-row (bit-exact).
+            one = seq.unsqueeze(0)
+            grid = igt_list[b] if (igt_list is not None and igt_list[b] is not None) else None
+            if grid is not None:
+                grid = grid.to(device)
+            vision_pos, _ = get_rope_index(one, image_grid_thw=grid, attention_mask=torch.ones_like(one))  # [3,1,n]
+            text_pos = torch.arange(seq.numel(), device=device).unsqueeze(0)  # [1, n]
+            pos_parts.append(torch.cat([text_pos, vision_pos[:, 0, :]], dim=0))  # [4, n]
+            if n_r > 0:
+                pred_parts.append(torch.arange(offset + n_p - 1, offset + n_p - 1 + n_r, device=device))
+            offset += int(seq.numel())
+        packed_ids = torch.cat(streams).unsqueeze(0)  # [1, L]
+        packed_pos = torch.cat(pos_parts, dim=1).unsqueeze(1)  # [4, L] -> [4, 1, L]
+        predict_index = torch.cat(pred_parts) if pred_parts else torch.zeros(0, dtype=torch.long, device=device)
+
+        forward_kwargs: Dict[str, Any] = {
+            "input_ids": packed_ids,
+            "attention_mask": None,  # packed block-causal mask inferred from restarting text positions
+            "position_ids": packed_pos,
+            "use_cache": False,
+            "return_dict": True,
+        }
+        if pv is not None:
+            forward_kwargs["pixel_values"] = pv
+        if igt is not None:
+            forward_kwargs["image_grid_thw"] = igt
+
+        out = self.model.transformer(**forward_kwargs)
+        if predict_index.numel() == 0:
+            return torch.zeros(0, dtype=torch.float32, device=device)
+        pred_logits = out.logits[0].index_select(0, predict_index).float()  # [T_total, V]
+        T = float(temperature) if float(temperature) > 0.0 else 1.0
+        log_probs = F.log_softmax(pred_logits / T, dim=-1)
+        per_token = log_probs.gather(-1, flat_resp.unsqueeze(-1)).squeeze(-1)  # [T_total]
+        return per_token.to(dtype=torch.float32)
 
     def _resolve_stop_ids(
         self,


### PR DESCRIPTION
## Summary
Adds packed-varlen replay to **Qwen-VL** (verl `remove_padding` parity for M-RoPE), mirroring Qwen3's `replay` shape. Part of the verl-parity series (issue #40); independent of #42–#44 (touches only `qwen_vl/ar.py`), so it branches off `main`.

`replay()` becomes a thin branch:
```
replay():  out = packed_replay(...);  return out if out is not None else padding_replay(...)
```
- **`padding_replay`** = the existing dense `[B, max_real + T_max]` path, renamed (more apt — it pads).
- **`packed_replay`** = concat each sample's prompt+response into one zero-padded stream with per-stream 4-D M-RoPE positions `[text; t; h; w]` from `get_rope_index`. The text row restarts per stream, so transformers builds the packed block-causal mask from it under **sdpa** (Qwen2.5-VL has no flex support) — **no monkey-patch**.

### Backend-aware gate (pack only when it's a win)
Packed is a win only with a sparse-block kernel. By `attn_implementation`:
- `flex_attention` / `flash_attention_2` (skip cross-seq blocks) → **always pack**.
- `sdpa`/eager (full `O((ΣL)²)`) → **length-variance gate**: pack only when packed tokens ≤ 0.75 × dense slots, else `padding_replay`.

Qwen-VL has no flex but gains `flash_attention_2` once flash_attn is installed train-side (issue: "Install flash_attn train-side") — then the gate no-ops and packed wins unconditionally.

## Test Plan
Real **Qwen2.5-VL-7B** (sdpa, transformers 4.57.1):
- per-stream `get_rope_index` == dense per-row positions, **bit-exact** (with images).
- text-only / with-image packed vs dense logits: argmax **100%**, no cross-stream leak.
- `packed_replay()` vs `padding_replay()` logp: **max|d| = 0.02** (bf16 noise; leading tokens bit-identical); `replay()` routes to packed for B>1.
- wall-clock (7B): variable-length **0.53×** (packed), equal-length-long **1.36×** (now gated to padding).

Refs: #40, the Qwen3 replay split PR (#52), the train-side flash_attn issue.
