### PR TITLE
refactor(train): token-budget micro-batching by composition (sort-then-slice)

### DIFF
--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -188,11 +188,6 @@ sync:
 stack:
   _target_: unirl.train.stack.TrainStack
   micro_batch_size: 1
-  # verl ppo_max_token_len_per_gpu parity: pack each mini-batch into micro-batches
-  # under a token budget (length-sorted bin packing) instead of fixed-count
-  # slicing; with mbs=1 every sequence ran its own forward/backward. null keeps
-  # the legacy count-based behavior.
-  micro_token_budget: 10240
   max_grad_norm: 1.0
   # 4 disjoint mini-batch optimizer steps per rollout, 128 trajectories each —
   # matches the RELEASED verl run script (run_qwen3_4b.sh: ppo_mini_batch_size=16
@@ -202,6 +197,13 @@ stack:
   # the increasingly off-policy steps 2-4 (π_old frozen per algorithm.
   # old_logp_source). dp=32 → per-worker shard 16 samples, 16%4==0 OK.
   num_updates_per_batch: 4
+  # verl ppo_max_token_len_per_gpu parity: pack each mini-batch into micro-batches
+  # under a token budget (length-sorted bin packing) instead of fixed-count
+  # slicing; with mbs=1 every sequence ran its own forward/backward. Omit
+  # micro_planner (→ default CountPlanner) for the legacy count-based behavior.
+  micro_planner:
+    _target_: unirl.train.stack.TokenBudgetPlanner
+    token_budget: 10240
 
 data_source:
   _target_: unirl.data.data_source.MultimodalRLDataSource

--- a/tests/train/test_packing.py
+++ b/tests/train/test_packing.py
@@ -1,0 +1,253 @@
+"""Unit tests for micro-batch planning (unirl/train/stack.py) + the
+TokenBudgetPlanner seq-mean guard. Pure / CPU-only — no GPU, no FSDP backend.
+
+Run with ``pytest tests/train/test_packing.py`` or directly:
+``python tests/train/test_packing.py``.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+
+from unirl.train.stack import (
+    TokenBudgetPlanner,
+    _arrange_packed,
+    _build_micro_batch_slices,
+    _count_plan,
+    _pack_micros,
+    _pack_micros_2d,
+    _pack_micros_sum,
+    _partition_into_k,
+    _sync_micro_count,
+    _update_ranges,
+)
+
+
+def _range_indices(r):
+    """Sample indices covered by a contiguous (start, end) micro range."""
+    return list(range(r[0], r[1]))
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _flatten(bins):
+    return [i for b in bins for i in b]
+
+
+def _covers(bins, indices):
+    """Every index appears exactly once across the bins."""
+    flat = _flatten(bins)
+    return sorted(flat) == sorted(indices) and len(flat) == len(indices)
+
+
+def _fake_track(lengths):
+    """Minimal RolloutTrack stand-in: just batch_size + segment.lengths."""
+    seg = types.SimpleNamespace(lengths=torch.tensor(lengths, dtype=torch.long))
+    return types.SimpleNamespace(batch_size=len(lengths), segment=seg, conditions={})
+
+
+# --------------------------------------------------------------------------- #
+# update / count partitioning
+# --------------------------------------------------------------------------- #
+def test_update_ranges_even():
+    assert _update_ranges(total_size=8, num_updates=2) == ((0, 4), (4, 8))
+    assert _update_ranges(total_size=12, num_updates=4) == ((0, 3), (3, 6), (6, 9), (9, 12))
+
+
+def test_update_ranges_requires_divisibility():
+    with pytest.raises(ValueError):
+        _update_ranges(total_size=10, num_updates=3)
+
+
+def test_count_micro_slices_cover():
+    sl = _build_micro_batch_slices(total_size=10, micro_batch_size=4)
+    assert sl == ((0, 4), (4, 8), (8, 10))  # last partial, full coverage
+
+
+def test_count_plan_structure():
+    # 8 samples, 2 updates, micro_batch_size 1 -> 2 updates x 4 single-sample micros
+    plan = _count_plan(total=8, num_updates=2, micro_batch_size=1)
+    assert len(plan) == 2
+    assert plan[0] == [(0, 1), (1, 2), (2, 3), (3, 4)]
+    assert plan[1] == [(4, 5), (5, 6), (6, 7), (7, 8)]
+
+
+# --------------------------------------------------------------------------- #
+# token-budget packing — coverage + budget invariants
+# --------------------------------------------------------------------------- #
+DENSE_LENGTHS = [4000, 3500, 300, 250, 200, 180, 150, 120]
+
+
+def test_pack_micros_dense_covers_and_respects_budget():
+    bins = _pack_micros(indices=list(range(8)), lengths=DENSE_LENGTHS, token_budget=10240)
+    assert _covers(bins, list(range(8)))
+    for b in bins:
+        cost = max(DENSE_LENGTHS[i] for i in b) * len(b)
+        assert cost <= 10240 or len(b) == 1  # single oversize seq allowed its own bin
+    # the two long seqs cannot share with the shorts under 10240
+    assert all(b for b in bins)  # no empty bins
+
+
+def test_pack_micros_sum_covers_and_respects_budget():
+    bins = _pack_micros_sum(indices=list(range(8)), lengths=DENSE_LENGTHS, token_budget=8000)
+    assert _covers(bins, list(range(8)))
+    for b in bins:
+        cost = sum(DENSE_LENGTHS[i] for i in b)
+        assert cost <= 8000 or len(b) == 1
+
+
+def test_pack_micros_2d_covers_and_respects_budget():
+    prompt = [1000, 50, 900, 40, 30, 20, 10, 5]
+    resp = [50, 1000, 40, 900, 200, 180, 150, 120]
+    bins = _pack_micros_2d(indices=list(range(8)), prompt_lens=prompt, resp_lens=resp, token_budget=4096)
+    assert _covers(bins, list(range(8)))
+    for b in bins:
+        cost = (max(prompt[i] for i in b) + max(resp[i] for i in b)) * len(b)
+        assert cost <= 4096 or len(b) == 1
+
+
+def test_oversize_sequence_gets_its_own_bin():
+    # one seq longer than the whole budget must still be placed (never dropped)
+    bins = _pack_micros(indices=[0, 1, 2], lengths=[50, 99999, 60], token_budget=1024)
+    assert _covers(bins, [0, 1, 2])
+    big = next(b for b in bins if 1 in b)
+    assert big == [1]
+
+
+def test_pack_micros_rejects_nonpositive_budget():
+    with pytest.raises(ValueError):
+        _pack_micros(indices=[0, 1], lengths=[10, 20], token_budget=0)
+
+
+# --------------------------------------------------------------------------- #
+# exact-K re-partition (NCCL micro-count parity)
+# --------------------------------------------------------------------------- #
+def test_partition_into_k_exact_and_covers():
+    idx = list(range(8))
+    for k in (1, 2, 3, 5, 8):
+        bins = _partition_into_k(indices=idx, lengths=DENSE_LENGTHS, k=k)
+        assert len(bins) == k
+        assert all(len(b) >= 1 for b in bins)  # every bin non-empty
+        assert _covers(bins, idx)
+
+
+def test_partition_into_k_out_of_range():
+    with pytest.raises(ValueError):
+        _partition_into_k(indices=[0, 1, 2], lengths=[1, 2, 3], k=0)
+    with pytest.raises(ValueError):
+        _partition_into_k(indices=[0, 1, 2], lengths=[1, 2, 3], k=4)  # k > n
+
+
+def test_sync_micro_count_noop_without_dist():
+    # torch.distributed not initialized in a unit test -> returns the local count
+    assert _sync_micro_count(7) == 7
+
+
+# --------------------------------------------------------------------------- #
+# plan equivalence: packing only regroups, never changes which samples an update trains on
+# --------------------------------------------------------------------------- #
+def test_packed_arrange_preserves_update_membership():
+    # sort-then-slice: arrange reorders the track but each update's permuted block
+    # must hold exactly its original [u*4, u*4+4) samples (membership unchanged), and
+    # the plan's ranges must contiguously cover that permuted block.
+    lengths = [4000, 3500, 300, 250, 200, 180, 150, 120]
+    track = _fake_track(lengths)
+    out = _arrange_packed(track, num_updates=2, token_budget=10240, cost_model="dense")
+    assert out is not None
+    perm, plan = out
+    assert sorted(perm) == list(range(8))  # a full permutation, no sample lost
+    assert len(plan) == 2
+    for u, update in enumerate(plan):
+        block = list(range(u * 4, (u + 1) * 4))
+        # the permuted positions in this update map back to the original update's samples
+        assert sorted(perm[p] for p in block) == block
+        # ranges contiguously tile the permuted update block
+        covered = [p for m in update for p in _range_indices(m)]
+        assert covered == block
+
+
+def test_sample_share_weights_sum_to_one_per_update():
+    lengths = [4000, 3500, 300, 250, 200, 180, 150, 120]
+    track = _fake_track(lengths)
+    _, plan = _arrange_packed(track, num_updates=2, token_budget=10240, cost_model="dense")
+    for update in plan:
+        update_total = sum(e - s for s, e in update)
+        weights = [(e - s) / update_total for s, e in update]
+        assert update_total == 4
+        assert abs(sum(weights) - 1.0) < 1e-12
+
+
+def test_arrange_packed_falls_back_when_no_lengths():
+    track = types.SimpleNamespace(batch_size=4, segment=None, conditions={})
+    assert _arrange_packed(track, num_updates=2, token_budget=1024, cost_model="dense") is None
+
+
+def test_arrange_packed_picks_up_prompt_from_conditions_dict():
+    # review #42 B2: conditions is a Dict, so prompt lengths must be read via dict
+    # access — otherwise the budget counts response tokens only. With prompt=50,
+    # resp=100 the 2D cost is (50+100)*count<=300 -> <=2 per micro; if the prompt
+    # were ignored it'd be 100*count<=300 -> 3 per micro. The cap distinguishes them.
+    seg = types.SimpleNamespace(lengths=torch.tensor([100, 100, 100, 100], dtype=torch.long))
+    prompt = types.SimpleNamespace(attention_mask=torch.ones(4, 50, dtype=torch.long))
+    track = types.SimpleNamespace(batch_size=4, segment=seg, conditions={"prompt": prompt})
+    out = _arrange_packed(track, num_updates=1, token_budget=300, cost_model="dense")
+    assert out is not None
+    perm, plan = out
+    assert sorted(perm) == [0, 1, 2, 3]
+    assert all((e - s) <= 2 for s, e in plan[0])  # prompt counted -> 2D cap
+
+
+# --------------------------------------------------------------------------- #
+# TokenBudgetPlanner seq-mean guard
+# --------------------------------------------------------------------------- #
+def _algo(mode):
+    return types.SimpleNamespace(loss_agg_mode=mode)
+
+
+def _planner():
+    return TokenBudgetPlanner(token_budget=1024)
+
+
+@pytest.mark.parametrize("mode", ["seq-mean-token-sum-norm", "seq-mean-token-mean"])
+def test_guard_allows_seq_mean(mode):
+    _planner().validate(_algo(mode))  # must not raise
+
+
+@pytest.mark.parametrize("mode", ["token-mean", "something-else", None])
+def test_guard_rejects_non_seq_mean(mode):
+    with pytest.raises(ValueError):
+        _planner().validate(_algo(mode))
+
+
+def test_guard_rejects_algo_without_agg_mode():
+    with pytest.raises(ValueError):
+        _planner().validate(types.SimpleNamespace())  # no loss_agg_mode attr
+
+
+# --------------------------------------------------------------------------- #
+# direct runner (no pytest required)
+# --------------------------------------------------------------------------- #
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        marks = getattr(fn, "pytestmark", [])
+        param_sets = None
+        for m in marks:
+            if m.name == "parametrize":
+                param_sets = m.args[1]
+        cases = [(v,) for v in param_sets] if param_sets is not None else [()]
+        for args in cases:
+            try:
+                fn(*args)
+                print(f"PASS {name}{args if args else ''}")
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                print(f"FAIL {name}{args if args else ''}: {type(exc).__name__}: {exc}")
+    print(f"\n{'OK' if failures == 0 else f'{failures} FAILURE(S)'}")
+    raise SystemExit(1 if failures else 0)

--- a/unirl/algorithms/drpo.py
+++ b/unirl/algorithms/drpo.py
@@ -292,15 +292,6 @@ class DRPO(StageAlgorithm):
             return AlgorithmStepResult(loss=0.0, metrics={}, num_steps_or_tokens=0, has_backward=False)
 
         typed_conds = typed_conditions(conditions, self.conditions_cls)
-        # Per-micro fwd/bwd wall-clock (cuda-synced) -> train/replay_time_s and
-        # train/backward_time_s via metrics aggregation: attributes the train
-        # phase without an external profiler. Sync cost is negligible next to
-        # multi-second micros.
-        import time as _time
-
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        _t0 = _time.perf_counter()
         new_logp = self.stage.replay(
             typed_conds, segment=segment, temperature=self.sampling_temperature
         )  # [total_tokens]
@@ -337,19 +328,11 @@ class DRPO(StageAlgorithm):
             loss = torch.stack([p.sum() for p in parts]).mean() / float(self.horizon)
         else:
             loss = loss_per_elem.mean()
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        _t1 = _time.perf_counter()
         (loss * loss_scale).backward()
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-        _t2 = _time.perf_counter()
 
         metrics: Dict[str, Any] = {
             "policy_loss": float(loss.detach().item()),
             "drpo_epsilon": self.drpo_epsilon,
-            "replay_time_s": _t1 - _t0,
-            "backward_time_s": _t2 - _t1,
             **rollout_replay_logp_absdiff(new_logp, old_logp),
             **{k: float(v.item()) for k, v in ratio_metrics.items()},
         }

--- a/unirl/train/stack.py
+++ b/unirl/train/stack.py
@@ -1,40 +1,46 @@
-"""Single-stage train stack.
+"""Family-agnostic single-stage train stack.
 
-Wraps one :class:`FSDPBackend` (training state: model + optimizer +
-scheduler + EMA) and one :class:`StageAlgorithm` (loss + backward
-against the bundle's trainable module) into a single-stage training
-driver.  One :class:`TrainStack` = one training track.
+:class:`TrainStack` wraps one :class:`FSDPBackend` (training state: model +
+optimizer + scheduler + EMA) and one :class:`StageAlgorithm` (loss + backward
+against the bundle's trainable module) into a single-stage training driver. One
+stack = one training track.
+
+It owns the entire family-agnostic pipeline — device alignment, the π_old anchor
+freeze, the per-update micro-accumulation loop, EMA, metrics — and defers exactly
+ONE decision to an injected :class:`MicroPlanner` (composition, not inheritance):
+how each update's samples are grouped into micro-batches. :class:`CountPlanner`
+(the default) groups by fixed count; :class:`TokenBudgetPlanner` packs by token
+budget. Swapping the strategy is a recipe-level ``micro_planner`` block, no subclass.
 
 Sequencing per :meth:`train_track` call (one rollout)::
 
-    prepare_segment(resp_track)                  # once: freeze the π_old anchor
-    for (start, end) in mini_batch_slices(num_updates_per_batch):
-        train(resp_track.slice(start, end))      # one optimizer step each
+    track, plans = micro_planner.arrange(track)  # reorder (if packing) + plan
+    prepare_segment(track, plans)                # once: freeze the π_old anchor
+    for micros in plans:                         # num_updates_per_batch updates
+        _run_update(track, micros=micros)        # one optimizer step each
     on_rollout_end()                             # once: EMA / rollout boundary
 
+**Sort-then-slice.** Variable-length packing wants to group samples of similar
+length, which would normally force arbitrary index lists threaded through the
+whole pipeline. Instead the planner *reorders the track once up front* (length-sort
+within each update, see :meth:`TokenBudgetPlanner.arrange`) so every micro is again
+a **contiguous** ``(start, end)`` range — exactly the count-based geometry. The
+stack therefore only ever slices, and the anchor reassembly is a plain ordered
+``cat``; all packing-specific logic is isolated to the planner's one ``arrange``
+call (a no-op for :class:`CountPlanner`).
+
 ``num_updates_per_batch`` partitions the rollout batch into that many disjoint
-mini-batches and runs one optimizer step per mini-batch — the FlowGRPO /
-DanceGRPO schedule (``local_batch_size = local_mini_batch_size *
-num_updates_per_batch``). Because ``prepare_segment`` captures the pre-update
-policy once, every step shares the same PPO anchor; this is only correct for
-algorithms with ``supports_multi_update`` (the ctor enforces it). Defaults to 1
-— a single optimizer step over the whole batch, the prior behavior.
-
-Sequencing per :meth:`train` call (one optimizer step)::
-
-    backend.zero_grad()
-    for (start, end) in micro_slices(resp_track.batch_size):
-        algorithm.compute_loss_and_backward(loss_scale=1/N, ...)
-    if has_backward:
-        grad_norm = backend.optimizer_step(max_grad_norm=...)
-    return TrainStepResult(loss, grad_norm, lr, has_backward, micros, metrics)
+updates and runs one optimizer step per update — the FlowGRPO / DanceGRPO
+schedule. Because ``prepare_segment`` captures the pre-update policy once, every
+update shares the same PPO anchor; this is only correct for algorithms with
+``supports_multi_update`` (the ctor enforces it). Defaults to 1.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, replace
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Mapping, Optional, Protocol, Sequence, Tuple, runtime_checkable
 
 import torch
 
@@ -49,20 +55,18 @@ from unirl.utils.misc import aggregate_numeric_metrics
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class TrainStepResult:
-    """Result of one full optimizer step on this stage."""
-
-    loss: float
-    grad_norm: float
-    lr: float
-    has_backward: bool
-    micros: List[AlgorithmStepResult]
-    metrics: Mapping[str, object]
-    # Per-optimizer-step metrics when num_updates_per_batch > 1 (one Mapping per
-    # update, in order); empty for the single-update path. Lets the trainer log
-    # one wandb point per optimizer step instead of averaging the updates.
-    per_update: Tuple[Mapping[str, object], ...] = ()
+# --------------------------------------------------------------------------- #
+# Plan types
+# --------------------------------------------------------------------------- #
+# A plan is built before any forward runs:
+#     Plan       = List[UpdatePlan]   # the whole rollout shard
+#     UpdatePlan = List[Range]        # one optimizer step (= one "update")
+#     Range      = (start, end)       # one micro's CONTIGUOUS sample membership
+# Because packing reorders the track up front (sort-then-slice), a micro is ALWAYS
+# a contiguous range — no index lists.
+Range = Tuple[int, int]
+UpdatePlan = List[Range]
+Plan = List[UpdatePlan]
 
 
 def _positive_int(*, name: str, value: object) -> int:
@@ -72,14 +76,34 @@ def _positive_int(*, name: str, value: object) -> int:
     return resolved
 
 
+def _update_ranges(*, total_size: int, num_updates: int) -> Tuple[Range, ...]:
+    """Partition ``[0, total_size)`` into ``num_updates`` equal contiguous updates.
+
+    One range = one optimizer step. Even divisibility is required: the per-worker
+    batch is fixed (DP sharding is even) and a ragged final update would silently
+    drop samples and desync grad accumulation across DP ranks.
+    """
+    total = _positive_int(name="total_size", value=total_size)
+    n = _positive_int(name="num_updates_per_batch", value=num_updates)
+    if total % n != 0:
+        raise ValueError(
+            f"num_updates_per_batch={n} must evenly divide the per-worker batch "
+            f"size ({total}); got remainder {total % n}. Adjust batch_size, "
+            f"samples_per_prompt, or num_updates_per_batch."
+        )
+    update_size = total // n
+    return tuple((i * update_size, (i + 1) * update_size) for i in range(n))
+
+
 def _build_micro_batch_slices(
     *,
     total_size: int,
     micro_batch_size: int,
-) -> Tuple[Tuple[int, int], ...]:
+) -> Tuple[Range, ...]:
+    """Contiguous fixed-count micro ranges over ``[0, total_size)``."""
     resolved_total_size = _positive_int(name="total_size", value=total_size)
     resolved_micro_batch_size = _positive_int(name="micro_batch_size", value=micro_batch_size)
-    slices: List[Tuple[int, int]] = []
+    slices: List[Range] = []
     start = 0
     while start < resolved_total_size:
         end = min(start + resolved_micro_batch_size, resolved_total_size)
@@ -88,20 +112,29 @@ def _build_micro_batch_slices(
     return tuple(slices)
 
 
-# A micro-batch plan is either a contiguous ``(start, end)`` range (the classic
-# count-based path) or an explicit index list (the token-budget packed path,
-# where samples are length-sorted so a range cannot express the grouping).
-MicroPlan = Union[Tuple[int, int], List[int]]
+def _count_plan(*, total: int, num_updates: int, micro_batch_size: int) -> Plan:
+    """Fixed-count plan: contiguous equal updates, each split into ``micro_batch_size`` micros.
+
+    The diffusion / FlowGRPO "batched" schedule, and the fallback for the LLM path
+    when a segment exposes no per-sample lengths. No collective: every DP rank
+    produces the same update/micro counts because the per-rank batch is evenly
+    sharded.
+    """
+    plan: Plan = []
+    for u_start, u_end in _update_ranges(total_size=total, num_updates=num_updates):
+        plan.append(
+            [
+                (u_start + ms, u_start + me)
+                for ms, me in _build_micro_batch_slices(total_size=u_end - u_start, micro_batch_size=micro_batch_size)
+            ]
+        )
+    return plan
 
 
-def _micro_indices(plan: MicroPlan) -> List[int]:
-    """Absolute sample indices covered by a micro plan."""
-    if isinstance(plan, tuple):
-        return list(range(plan[0], plan[1]))
-    return list(plan)
-
-
-def _build_token_budget_micros_sum(
+# --------------------------------------------------------------------------- #
+# Token-budget bin-packing (verl ppo_max_token_len_per_gpu parity)
+# --------------------------------------------------------------------------- #
+def _pack_micros_sum(
     *,
     indices: Sequence[int],
     lengths: Sequence[int],
@@ -112,7 +145,7 @@ def _build_token_budget_micros_sum(
     verl's ppo_max_token_len_per_gpu accounting. First-fit decreasing.
     """
     if int(token_budget) < 1:
-        raise ValueError(f"micro_token_budget must be >= 1; got {token_budget}")
+        raise ValueError(f"token_budget must be >= 1; got {token_budget}")
     order = sorted(indices, key=lambda i: (-int(lengths[i]), i))
     bins: List[List[int]] = []
     bin_sum: List[int] = []
@@ -131,7 +164,7 @@ def _build_token_budget_micros_sum(
     return bins
 
 
-def _build_token_budget_micros_2d(
+def _pack_micros_2d(
     *,
     indices: Sequence[int],
     prompt_lens: Sequence[int],
@@ -146,7 +179,7 @@ def _build_token_budget_micros_2d(
     once. First-fit decreasing on total length with the exact 2D cost check.
     """
     if int(token_budget) < 1:
-        raise ValueError(f"micro_token_budget must be >= 1; got {token_budget}")
+        raise ValueError(f"token_budget must be >= 1; got {token_budget}")
     order = sorted(indices, key=lambda i: (-(int(prompt_lens[i]) + int(resp_lens[i])), i))
     bins: List[List[int]] = []
     bin_pmax: List[int] = []
@@ -170,7 +203,7 @@ def _build_token_budget_micros_2d(
     return bins
 
 
-def _build_token_budget_micros(
+def _pack_micros(
     *,
     indices: Sequence[int],
     lengths: Sequence[int],
@@ -178,20 +211,16 @@ def _build_token_budget_micros(
 ) -> List[List[int]]:
     """Pack ``indices`` into micro-batches under a dense-compute token budget.
 
-    verl-style token-budget micro-batching (``ppo_max_token_len_per_gpu``)
-    adapted to a DENSE-padded replay: a micro's compute cost is
-    ``max_len_in_micro * batch_size`` (every row pads to the micro max), so the
-    bin constraint is ``max_len * (count + 1) <= token_budget``. First-fit
-    decreasing on length keeps rows of similar length together, which makes the
-    dense pad waste ~0 without needing varlen attention. A sequence longer than
-    the whole budget still gets its own micro (never dropped).
-
-    Replaces the count-based ``micro_batch_size`` slicing: with mbs=1 every
-    sequence is its own forward/backward (massive GPU under-utilization); with
-    a 10k budget and ~1-2k sequences one micro carries ~5-10 packed rows.
+    verl-style token-budget micro-batching (``ppo_max_token_len_per_gpu``) adapted
+    to a DENSE-padded replay: a micro's compute cost is ``max_len_in_micro *
+    batch_size`` (every row pads to the micro max), so the bin constraint is
+    ``max_len * (count + 1) <= token_budget``. First-fit decreasing on length keeps
+    rows of similar length together, which makes the dense pad waste ~0 without
+    needing varlen attention. A sequence longer than the whole budget still gets
+    its own micro (never dropped).
     """
     if int(token_budget) < 1:
-        raise ValueError(f"micro_token_budget must be >= 1; got {token_budget}")
+        raise ValueError(f"token_budget must be >= 1; got {token_budget}")
     order = sorted(indices, key=lambda i: (-int(lengths[i]), i))
     bins: List[List[int]] = []
     bin_max: List[int] = []
@@ -220,12 +249,12 @@ def _partition_into_k(
     """Partition ``indices`` into EXACTLY ``k`` non-empty bins, balancing dense cost.
 
     Used to equalize the micro-batch COUNT across DP ranks (see
-    :func:`_build_token_budget_micros` callers): FSDP forward/backward issues
-    collectives per micro, so every rank must run the same number of micros or
-    NCCL deadlocks. Greedy LPT: longest-first, each item goes to the bin whose
-    dense cost (``max_len * count``) stays smallest after insertion; the first
-    ``k`` items seed the bins so none is empty. May exceed the token budget —
-    the budget is a throughput hint, parity is a correctness requirement.
+    :func:`_arrange_packed`): FSDP forward/backward issues collectives per micro,
+    so every rank must run the same number of micros or NCCL deadlocks. Greedy LPT:
+    longest-first, each item goes to the bin whose dense cost (``max_len * count``)
+    stays smallest after insertion; the first ``k`` items seed the bins so none is
+    empty. May exceed the token budget — the budget is a throughput hint, parity is
+    a correctness requirement.
     """
     if k < 1 or k > len(indices):
         raise ValueError(f"_partition_into_k: k={k} out of range for {len(indices)} samples")
@@ -261,24 +290,234 @@ def _sync_micro_count(local_count: int) -> int:
     return int(t.item())
 
 
-def _build_mini_batch_slices(*, total_size: int, num_updates: int) -> Tuple[Tuple[int, int], ...]:
-    """Partition ``[0, total_size)`` into ``num_updates`` equal contiguous slices.
+def _arrange_packed(
+    resp_track: RolloutTrack,
+    *,
+    num_updates: int,
+    token_budget: int,
+    cost_model: str,
+) -> Optional[Tuple[List[int], Plan]]:
+    """Token-budget packed arrangement (verl ``ppo_max_token_len_per_gpu`` parity).
 
-    One slice = one optimizer step. Even divisibility is required: the per-worker
-    batch is fixed (DP sharding is even) and a ragged final mini-batch would
-    silently drop samples and desync grad accumulation across DP ranks. Mirrors
-    v1's ``local_batch_size = local_mini_batch_size * num_updates_per_batch``.
+    Returns ``(perm, plan)`` where ``perm`` is a permutation of ``[0, total)`` that
+    length-sorts each update's samples and ``plan`` is the resulting CONTIGUOUS
+    range plan over the permuted track — so the caller applies ``track.select(perm)``
+    once and everything downstream slices contiguously (sort-then-slice). Returns
+    ``None`` when the segment exposes no per-sample ``lengths`` so the caller can
+    fall back to a count plan.
+
+    The bins from the FFD packers are index groups; concatenating them in order
+    *is* the permutation, and each bin's size *is* a contiguous range in that
+    permuted order. Update membership is unchanged — each update contributes its own
+    ``[u_start, u_end)`` indices to ``perm`` in order, so the permuted update blocks
+    sit at the same ``[u * M, (u+1) * M)`` positions as the count plan (the
+    accumulated gradient per update is the same set-sum; micro losses are re-weighted
+    by sample share in :meth:`TrainStack._run_update`).
     """
-    total = _positive_int(name="total_size", value=total_size)
-    n = _positive_int(name="num_updates_per_batch", value=num_updates)
-    if total % n != 0:
-        raise ValueError(
-            f"num_updates_per_batch={n} must evenly divide the per-worker batch "
-            f"size ({total}); got remainder {total % n}. Adjust batch_size, "
-            f"samples_per_prompt, or num_updates_per_batch."
+    total = int(resp_track.batch_size)
+    segment = resp_track.segment
+    raw = getattr(segment, "lengths", None) if segment is not None else None
+    if not (isinstance(raw, torch.Tensor) and raw.numel() == total):
+        logger.warning(
+            "token-budget packing requested (budget=%s) but the segment exposes no "
+            "per-sample lengths; falling back to count-based micro-batching.",
+            token_budget,
         )
-    mini_batch_size = total // n
-    return tuple((i * mini_batch_size, (i + 1) * mini_batch_size) for i in range(n))
+        return None
+    resp_lens = [int(x) for x in raw.tolist()]
+    # The dense replay forwards [B, P_max + T_max] with the prompt and response
+    # blocks padded SEPARATELY — pack with the exact 2D cost when prompt lengths are
+    # available (verl's token accounting also covers prompt+response). conditions is
+    # a Dict[str, Condition], so read "prompt" via the dict accessor.
+    prompt_lens: Optional[List[int]] = None
+    conditions = getattr(resp_track, "conditions", None)
+    if isinstance(conditions, dict):
+        prompt = conditions.get("prompt")
+    else:
+        prompt = getattr(conditions, "prompt", None) if conditions is not None else None
+    pmask = getattr(prompt, "attention_mask", None) if prompt is not None else None
+    if isinstance(pmask, torch.Tensor) and pmask.dim() == 2 and int(pmask.shape[0]) == total:
+        prompt_lens = [int(p) for p in pmask.long().sum(dim=-1).tolist()]
+    totals = [r + p for r, p in zip(resp_lens, prompt_lens)] if prompt_lens is not None else list(resp_lens)
+
+    perm: List[int] = []
+    plan: Plan = []
+    cursor = 0
+    n_micros = 0
+    real_tokens = 0
+    padded_tokens = 0
+    for u_start, u_end in _update_ranges(total_size=total, num_updates=num_updates):
+        indices = list(range(u_start, u_end))
+        if cost_model == "sum":
+            bins = _pack_micros_sum(indices=indices, lengths=totals, token_budget=token_budget)
+        elif prompt_lens is not None:
+            bins = _pack_micros_2d(
+                indices=indices, prompt_lens=prompt_lens, resp_lens=resp_lens, token_budget=token_budget
+            )
+        else:
+            bins = _pack_micros(indices=indices, lengths=totals, token_budget=token_budget)
+        # NCCL micro-count parity: FSDP fwd/bwd run collectives per micro, so every
+        # DP rank must execute the SAME number of micros per optimizer step or the
+        # process group deadlocks. Packing is local, so sync to the global max and
+        # re-partition into exactly that many bins.
+        k = _sync_micro_count(len(bins))
+        if k != len(bins):
+            bins = _partition_into_k(indices=indices, lengths=totals, k=k)
+        # Concatenate the bins into the permutation; each bin becomes a contiguous
+        # range in the permuted order.
+        update_plan: UpdatePlan = []
+        for b in bins:
+            perm.extend(b)
+            update_plan.append((cursor, cursor + len(b)))
+            cursor += len(b)
+            n_micros += 1
+            real_tokens += sum(totals[i] for i in b)
+            if cost_model == "sum":
+                padded_tokens += sum(totals[i] for i in b)
+            else:
+                pmax = max(prompt_lens[i] for i in b) if prompt_lens is not None else 0
+                tmax = max(resp_lens[i] for i in b)
+                padded_tokens += (pmax + tmax if prompt_lens is not None else tmax) * len(b)
+        plan.append(update_plan)
+    logger.info(
+        "token-budget packing: %d micros for %d samples (budget=%d), dense efficiency %.0f%% (%d/%d tokens)",
+        n_micros,
+        total,
+        token_budget,
+        100.0 * real_tokens / max(1, padded_tokens),
+        real_tokens,
+        padded_tokens,
+    )
+    return perm, plan
+
+
+# --------------------------------------------------------------------------- #
+# Micro-batch planners — the strategy injected into TrainStack (composition)
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class MicroPlanner(Protocol):
+    """How an update's samples are grouped into micro-batches.
+
+    :meth:`arrange` returns ``(track, plan)``: the track to train on — possibly
+    reordered so packed micros are contiguous (sort-then-slice) — and one
+    :data:`UpdatePlan` of contiguous ranges per optimizer step. :meth:`validate` is
+    the algorithm precondition the grouping needs, checked once when the stack is built.
+    """
+
+    def arrange(
+        self, resp_track: RolloutTrack, *, num_updates: int, micro_batch_size: int
+    ) -> Tuple[RolloutTrack, Plan]: ...
+
+    def validate(self, algorithm: StageAlgorithm) -> None: ...
+
+
+class CountPlanner:
+    """Fixed-count micro-batches: every micro holds ``micro_batch_size`` samples.
+
+    The original ``TrainStack`` behaviour. Uniform-shape latents (diffusion) make a
+    sample COUNT a good proxy for compute, so micros are contiguous equal-count
+    slices and the per-rank micro count is identical across DP ranks — no NCCL
+    micro-count parity collective is needed. Never reorders the track; imposes no
+    algorithm precondition.
+    """
+
+    def arrange(
+        self, resp_track: RolloutTrack, *, num_updates: int, micro_batch_size: int
+    ) -> Tuple[RolloutTrack, Plan]:
+        return resp_track, _count_plan(
+            total=int(resp_track.batch_size),
+            num_updates=num_updates,
+            micro_batch_size=micro_batch_size,
+        )
+
+    def validate(self, algorithm: StageAlgorithm) -> None:
+        return None
+
+
+class TokenBudgetPlanner:
+    """Token-budget packed micro-batches (verl ``ppo_max_token_len_per_gpu``).
+
+    Varlen LLM sequences differ wildly in length, so a fixed sample COUNT is a poor
+    proxy for compute. :meth:`arrange` length-sorts each update's samples and
+    bin-packs them under ``token_budget``, then reorders the track once so those
+    packed micros are contiguous ranges (sort-then-slice — the stack stays a pure
+    contiguous-slice driver). Falls back to fixed-count micros (``micro_batch_size``)
+    when the segment exposes no per-sample lengths.
+
+    ``cost_model`` picks how a micro's cost is accounted against the budget:
+
+    - ``'dense'``: ``(max_prompt + max_resp) * count`` — rectangular replay that
+      pads to the in-micro maxes (``padding_replay``).
+    - ``'sum'``: sum of real tokens — packed varlen replay (``packed_replay``;
+      = verl token accounting).
+    """
+
+    def __init__(self, *, token_budget: int, cost_model: str = "dense") -> None:
+        self.token_budget = _positive_int(name=f"{type(self).__name__}.token_budget", value=token_budget)
+        if cost_model not in ("dense", "sum"):
+            raise ValueError(f"{type(self).__name__}.cost_model must be dense|sum, got {cost_model!r}")
+        self.cost_model = str(cost_model)
+
+    def arrange(
+        self, resp_track: RolloutTrack, *, num_updates: int, micro_batch_size: int
+    ) -> Tuple[RolloutTrack, Plan]:
+        packed = _arrange_packed(
+            resp_track,
+            num_updates=num_updates,
+            token_budget=self.token_budget,
+            cost_model=self.cost_model,
+        )
+        if packed is None:
+            return resp_track, _count_plan(
+                total=int(resp_track.batch_size),
+                num_updates=num_updates,
+                micro_batch_size=micro_batch_size,
+            )
+        perm, plan = packed
+        # One up-front gather reorders the whole track (segment / conditions /
+        # advantages stay sample-aligned) so the packed micros are contiguous.
+        return resp_track.select(perm), plan
+
+    def validate(self, algorithm: StageAlgorithm) -> None:
+        """Guard: token-budget packing is gradient-exact only under seq-mean losses.
+
+        ``_run_update`` weights each micro's loss by its share of SAMPLES, which
+        reproduces the whole-update gradient only when the micro loss is a mean over
+        the micro's SEQUENCES (any ``seq-mean-*`` mode — both
+        ``seq-mean-token-sum-norm`` and ``seq-mean-token-mean`` are
+        grouping-invariant). A token-level mean (``token-mean``) pools tokens across
+        sequences, so regrouping samples into uneven micros changes the gradient.
+        Fail fast rather than silently alter optimization.
+        """
+        mode = getattr(algorithm, "loss_agg_mode", None)
+        if mode is None or not str(mode).startswith("seq-mean"):
+            raise ValueError(
+                f"{type(self).__name__}: token-budget packing requires a sequence-mean loss "
+                f"aggregation (loss_agg_mode starting with 'seq-mean'), because micro losses are "
+                f"weighted by sample share. {type(algorithm).__name__} has loss_agg_mode={mode!r}, "
+                f"which is not grouping-invariant under packing — the update gradient would change. "
+                f"Use loss_agg_mode='seq-mean-token-sum-norm' (or 'seq-mean-token-mean'), or use a "
+                f"CountPlanner (omit micro_planner) for count-based micro-batching."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Results
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class TrainStepResult:
+    """Result of one full optimizer step on this stage."""
+
+    loss: float
+    grad_norm: float
+    lr: float
+    has_backward: bool
+    micros: List[AlgorithmStepResult]
+    metrics: Mapping[str, object]
+    # Per-optimizer-step metrics when num_updates_per_batch > 1 (one Mapping per
+    # update, in order); empty for the single-update path. Lets the trainer log one
+    # wandb point per optimizer step instead of averaging the updates.
+    per_update: Tuple[Mapping[str, object], ...] = ()
 
 
 def _aggregate_update_results(results: List["TrainStepResult"]) -> "TrainStepResult":
@@ -286,8 +525,8 @@ def _aggregate_update_results(results: List["TrainStepResult"]) -> "TrainStepRes
 
     Scalars are averaged across the N optimizer steps (``lr`` is the last,
     post-step value), ``micros`` are concatenated, and algorithm metrics are
-    averaged via :func:`aggregate_numeric_metrics`. Downstream logging then
-    treats the whole rollout as one point, exactly as in the single-update path.
+    averaged via :func:`aggregate_numeric_metrics`. Downstream logging then treats
+    the whole rollout as one point, exactly as in the single-update path.
     """
     if len(results) == 1:
         return results[0]
@@ -305,20 +544,19 @@ def _aggregate_update_results(results: List["TrainStepResult"]) -> "TrainStepRes
 
 
 def _align_track_to_model(resp_track: RolloutTrack, *, device: torch.device) -> None:
-    """Move a track's training inputs onto the model's device — SGLang returns
-    them on CPU via Ray IPC. Uses :meth:`Batch.to_device` (recursive; carries
-    framework-managed ``_packed_cu_seqlens`` and tensors nested in tuples/dicts)
-    on the segment + conditions only, so heavy ``decoded`` / ``media_preview``
-    payloads stay off the GPU. dtype is left to the model, which casts what it
-    feeds the network (see SD3DiffusionStep.predict_noise).
+    """Move a track's training inputs onto the model's device — SGLang returns them
+    on CPU via Ray IPC. Uses :meth:`Batch.to_device` (recursive; carries
+    framework-managed ``_packed_cu_seqlens`` and tensors nested in tuples/dicts) on
+    the segment + conditions only, so heavy ``decoded`` / ``media_preview`` payloads
+    stay off the GPU. dtype is left to the model, which casts what it feeds the
+    network (see SD3DiffusionStep.predict_noise).
 
     Condition values are moved via ``_move_value`` (the same recursive mover
-    ``Batch.to_device`` uses) rather than assuming each value is a ``Batch``:
-    most are (e.g. ``TextTokenCondition``), but multimodal stages also carry
-    raw per-sample ``FieldKind.CONCAT`` lists of tensors (Qwen2.5-VL's
-    ``pixel_values`` / ``image_grid_thw``), which have no ``.to_device`` of
-    their own — ``_move_value`` handles Batch / tensor / list / dict / None
-    uniformly."""
+    ``Batch.to_device`` uses) rather than assuming each value is a ``Batch``: most
+    are (e.g. ``TextTokenCondition``), but multimodal stages also carry raw
+    per-sample ``FieldKind.CONCAT`` lists of tensors (Qwen2.5-VL's ``pixel_values``
+    / ``image_grid_thw``), which have no ``.to_device`` of their own — ``_move_value``
+    handles Batch / tensor / list / dict / None uniformly."""
     if resp_track.segment is not None:
         resp_track.segment = resp_track.segment.to_device(device)
     resp_track.conditions = {k: _move_value(v, device) for k, v in resp_track.conditions.items()}
@@ -326,15 +564,21 @@ def _align_track_to_model(resp_track: RolloutTrack, *, device: torch.device) -> 
         resp_track.advantages = resp_track.advantages.to(device=device)
 
 
+# --------------------------------------------------------------------------- #
+# The stack
+# --------------------------------------------------------------------------- #
 class TrainStack(Remote):
-    """Single-stage stage-driven train stack.
+    """Single-stage stage-driven train stack — family-agnostic.
 
-    One stage only — no track-name dict, no optional-track
-    semantics, no multi-track on_rollout_end fan-out.
+    One stage only — no track-name dict, no optional-track semantics, no multi-track
+    on_rollout_end fan-out. The ONLY family-varying decision — micro-batch grouping —
+    is delegated to an injected ``micro_planner`` (count-based vs token-budget);
+    everything else is shared. Defaults to :class:`CountPlanner` (the historical
+    diffusion behaviour), so the 60+ count-based configs need no ``micro_planner``
+    block.
 
-    Created as a sibling ``Remote`` inside a placement block; takes
-    handles to its FSDPBackend and StageAlgorithm siblings via
-    sibling-handle auto-resolve.
+    Created as a sibling ``Remote`` inside a placement block; takes handles to its
+    FSDPBackend and StageAlgorithm siblings via sibling-handle auto-resolve.
     """
 
     def __init__(
@@ -342,18 +586,18 @@ class TrainStack(Remote):
         *,
         fsdp_backend: FSDPBackend,
         algorithm: StageAlgorithm,
-        micro_batch_size: int,
+        micro_batch_size: int = 1,
         max_grad_norm: float,
         num_updates_per_batch: int = 1,
-        micro_token_budget: Optional[int] = None,
-        micro_cost_model: str = "dense",
+        micro_planner: Optional[MicroPlanner] = None,
     ) -> None:
         super().__init__()
+        cls = type(self).__name__
         if int(micro_batch_size) < 1:
-            raise ValueError(f"TrainStack.micro_batch_size must be >= 1; got {micro_batch_size}.")
+            raise ValueError(f"{cls}.micro_batch_size must be >= 1; got {micro_batch_size}.")
         if float(max_grad_norm) <= 0.0:
-            raise ValueError(f"TrainStack.max_grad_norm must be > 0; got {max_grad_norm}.")
-        self.num_updates_per_batch = _positive_int(name="TrainStack.num_updates_per_batch", value=num_updates_per_batch)
+            raise ValueError(f"{cls}.max_grad_norm must be > 0; got {max_grad_norm}.")
+        self.num_updates_per_batch = _positive_int(name=f"{cls}.num_updates_per_batch", value=num_updates_per_batch)
         if self.num_updates_per_batch > 1 and not getattr(algorithm, "supports_multi_update", False):
             raise ValueError(
                 f"num_updates_per_batch={self.num_updates_per_batch} requires an algorithm whose "
@@ -365,176 +609,32 @@ class TrainStack(Remote):
         self.fsdp_backend = fsdp_backend
         self.algorithm = algorithm
         self.micro_batch_size = int(micro_batch_size)
-        # verl-parity perf knob (ppo_max_token_len_per_gpu analogue): when set and
-        # the segment exposes per-sample ``lengths``, micro-batches are built by
-        # length-sorted token-budget packing (see _build_token_budget_micros)
-        # instead of fixed-count slicing. None preserves the legacy behavior.
-        self.micro_token_budget = None if micro_token_budget is None else _positive_int(
-            name="TrainStack.micro_token_budget", value=micro_token_budget
-        )
-        # 'dense': micro cost = (max_prompt + max_resp) * count — rectangular
-        #          replay that pads to the in-micro maxes.
-        # 'sum':   micro cost = sum of real tokens — packed varlen replay
-        #          (qwen3 packed path; = verl token accounting).
-        if micro_cost_model not in ("dense", "sum"):
-            raise ValueError(f"TrainStack.micro_cost_model must be dense|sum, got {micro_cost_model!r}")
-        self.micro_cost_model = str(micro_cost_model)
         self.max_grad_norm = float(max_grad_norm)
+        # Composition: the micro-batch grouping strategy. None → the historical
+        # fixed-count behaviour. The planner also owns the algorithm precondition its
+        # grouping requires (e.g. token-budget packing needs a seq-mean loss),
+        # checked once here at construction.
+        self.micro_planner: MicroPlanner = micro_planner if micro_planner is not None else CountPlanner()
+        self.micro_planner.validate(algorithm)
 
-    def _optimizer_step_slices(self, total: int) -> List[List[Tuple[int, int]]]:
-        """Single source of truth for how a rollout shard is sliced for training.
-
-        Returns one inner list of absolute ``(start, end)`` micro-batch slices per
-        optimizer step (one per ``num_updates_per_batch`` mini-batch). BOTH the
-        train loop (:meth:`_train_mini_batches` / :meth:`train`) AND
-        :meth:`prepare_segment` consume this, so the π_old anchor is frozen at
-        exactly the ``(mini, micro)`` geometry ``new_logp`` is later computed at —
-        the only way bf16 batch-shape sensitivity cancels and the on-policy ratio
-        is exactly 1 (FlowDPPO on-policy KL exactly 0).
-
-        Invariant: any *cross-sample* statistic (e.g. advantage mean/std) must be
-        computed on the full shard BEFORE this slicing — the trainer does so in
-        ``compute_advantages`` ahead of ``train_track``. Slicing only governs the
-        per-sample forward geometry, never a batch statistic.
-        """
-        steps: List[List[Tuple[int, int]]] = []
-        for mini_start, mini_end in _build_mini_batch_slices(total_size=total, num_updates=self.num_updates_per_batch):
-            steps.append(
-                [
-                    (mini_start + ms, mini_start + me)
-                    for ms, me in _build_micro_batch_slices(
-                        total_size=mini_end - mini_start, micro_batch_size=self.micro_batch_size
-                    )
-                ]
-            )
-        return steps
-
-    def _plan_optimizer_steps(self, resp_track: RolloutTrack) -> List[List[MicroPlan]]:
-        """Plan the per-step micro-batches, preferring token-budget packing.
-
-        Mini-batch (optimizer-step) partitioning is unchanged — contiguous equal
-        slices in sample order. WITHIN each mini-batch, when ``micro_token_budget``
-        is set and the segment exposes per-sample ``lengths``, micros are built by
-        length-sorted dense-cost bin packing (index plans); otherwise the legacy
-        count-based contiguous ranges are used. Sample membership of each
-        optimizer step is identical in both modes — packing only regroups the
-        forward geometry inside a step, never which samples it trains on, so the
-        accumulated gradient per step is the same set-sum either way (micro losses
-        are re-weighted by sample count in :meth:`train`).
-        """
-        total = int(resp_track.batch_size)
-        resp_lens: Optional[List[int]] = None
-        prompt_lens: Optional[List[int]] = None
-        if self.micro_token_budget is not None:
-            segment = resp_track.segment
-            raw = getattr(segment, "lengths", None) if segment is not None else None
-            if isinstance(raw, torch.Tensor) and raw.numel() == total:
-                resp_lens = [int(x) for x in raw.tolist()]
-                # The dense replay forwards [B, P_max + T_max] with the prompt and
-                # response blocks padded SEPARATELY — pack with the exact 2D cost
-                # when prompt lengths are available (verl's token accounting also
-                # covers prompt+response).
-                conditions = getattr(resp_track, "conditions", None)
-                # conditions is a Dict[str, Condition] — getattr never finds "prompt"
-                # (review #42 B2: the 2D packer was unreachable and the budget
-                # counted response tokens only). Use the dict accessor.
-                if isinstance(conditions, dict):
-                    prompt = conditions.get("prompt")
-                else:
-                    prompt = getattr(conditions, "prompt", None) if conditions is not None else None
-                pmask = getattr(prompt, "attention_mask", None) if prompt is not None else None
-                if isinstance(pmask, torch.Tensor) and pmask.dim() == 2 and int(pmask.shape[0]) == total:
-                    prompt_lens = [int(p) for p in pmask.long().sum(dim=-1).tolist()]
-            else:
-                logger.warning(
-                    "TrainStack: micro_token_budget=%s set but segment has no per-sample "
-                    "lengths; falling back to count-based micro_batch_size=%s.",
-                    self.micro_token_budget,
-                    self.micro_batch_size,
-                )
-        if resp_lens is None:
-            return [list(step) for step in self._optimizer_step_slices(total)]
-        totals = (
-            [r + p for r, p in zip(resp_lens, prompt_lens)] if prompt_lens is not None else list(resp_lens)
-        )
-        steps: List[List[MicroPlan]] = []
-        n_micros = 0
-        real_tokens = 0
-        padded_tokens = 0
-        for mini_start, mini_end in _build_mini_batch_slices(total_size=total, num_updates=self.num_updates_per_batch):
-            indices = list(range(mini_start, mini_end))
-            if self.micro_cost_model == "sum":
-                bins = _build_token_budget_micros_sum(
-                    indices=indices,
-                    lengths=totals,
-                    token_budget=self.micro_token_budget,
-                )
-            elif prompt_lens is not None:
-                bins = _build_token_budget_micros_2d(
-                    indices=indices,
-                    prompt_lens=prompt_lens,
-                    resp_lens=resp_lens,
-                    token_budget=self.micro_token_budget,
-                )
-            else:
-                bins = _build_token_budget_micros(
-                    indices=indices,
-                    lengths=totals,
-                    token_budget=self.micro_token_budget,
-                )
-            # NCCL micro-count parity: FSDP fwd/bwd run collectives per micro, so
-            # every DP rank must execute the SAME number of micros per optimizer
-            # step or the process group deadlocks (watchdog kills the job). Packing
-            # is local (depends on this rank's lengths), so sync to the global max
-            # and re-partition into exactly that many bins when short.
-            k = _sync_micro_count(len(bins))
-            if k != len(bins):
-                bins = _partition_into_k(indices=indices, lengths=totals, k=k)
-            steps.append(list(bins))
-            for b in bins:
-                n_micros += 1
-                real_tokens += sum(totals[i] for i in b)
-                if self.micro_cost_model == "sum":
-                    padded_tokens += sum(totals[i] for i in b)
-                else:
-                    pmax = max(prompt_lens[i] for i in b) if prompt_lens is not None else 0
-                    tmax = max(resp_lens[i] for i in b)
-                    padded_tokens += (pmax + tmax if prompt_lens is not None else tmax) * len(b)
-        logger.info(
-            "TrainStack packing: %d micros for %d samples (budget=%d), dense efficiency %.0f%% (%d/%d tokens)",
-            n_micros,
-            total,
-            self.micro_token_budget,
-            100.0 * real_tokens / max(1, padded_tokens),
-            real_tokens,
-            padded_tokens,
-        )
-        return steps
-
-    @staticmethod
-    def _materialize_micro(resp_track: RolloutTrack, plan: MicroPlan) -> RolloutTrack:
-        """Materialize one micro-batch from its plan (range slice or index gather)."""
-        if isinstance(plan, tuple):
-            return resp_track.slice(plan[0], plan[1])
-        return resp_track.select(plan)
-
-    def prepare_segment(self, resp_track: RolloutTrack, *, plans: Optional[List[List[MicroPlan]]] = None) -> None:
+    def prepare_segment(self, resp_track: RolloutTrack, *, plans: Plan) -> None:
         """Freeze the π_old anchor once, before the ``num_updates_per_batch`` loop.
 
         No-op if ``segment`` is None. If the algorithm does NOT replay the anchor
         (``recomputes_anchor() == False`` — e.g. rollout GRPO), the anchor is the
         rollout engine's own emission, so one full-segment call suffices. If it DOES
         replay (replay GRPO; FlowDPPO always, for ``sde_means``), the recomputed
-        ``anchor_fields`` are computed at the SAME mini/micro geometry training will
-        use — driven by the shared :meth:`_optimizer_step_slices` — so the old/new
-        forwards match bf16-element-for-element on those fields. Concretely, the
-        on-policy PPO ratio is exactly 1 only where ``sde_logp`` is replayed (replay
-        GRPO, or FlowDPPO under ``old_logp_source='replay'``), and the on-policy KL is
-        exactly 0 wherever ``sde_means`` is replayed (FlowDPPO always). FlowDPPO-rollout keeps
-        the engine's ``sde_logp``, so its KL is 0 on-policy but its ratio is not
-        pinned to 1. A single slice degenerates to one full-segment call; only the
-        algorithm's declared ``anchor_fields`` are re-sliced and reassembled (no
-        hardcoded field names).
+        ``anchor_fields`` are computed at the SAME micro geometry training will use —
+        the contiguous ranges in ``plans`` (already aligned with the reordered track
+        from :meth:`MicroPlanner.arrange`) — so the old/new forwards match
+        bf16-element-for-element on those fields. Concretely, the on-policy PPO ratio
+        is exactly 1 only where ``sde_logp`` is replayed (replay GRPO, or FlowDPPO
+        under ``old_logp_source='replay'``), and the on-policy KL is exactly 0
+        wherever ``sde_means`` is replayed (FlowDPPO always). A single micro
+        degenerates to one full-segment call; only the algorithm's declared
+        ``anchor_fields`` are re-sliced and reassembled (no hardcoded field names).
+        Because every micro is a contiguous range covering the shard in order, the
+        per-micro field chunks reassemble with a plain ordered ``cat``.
         """
         if resp_track.segment is None:
             return
@@ -542,101 +642,68 @@ class TrainStack(Remote):
         if not algorithm.recomputes_anchor():
             algorithm.prepare_segment(conditions=resp_track.conditions, segment=resp_track.segment)
             return
-        if plans is None:
-            plans = self._plan_optimizer_steps(resp_track)
-        micro_plans: List[MicroPlan] = [plan for step in plans for plan in step]
-        if len(micro_plans) == 1:
+        micro_slices = [r for update in plans for r in update]
+        if len(micro_slices) == 1:
             algorithm.prepare_segment(conditions=resp_track.conditions, segment=resp_track.segment)
             return
-        total = int(resp_track.batch_size)
-        # Per-sample anchor chunks keyed by ORIGINAL index, so index plans (token-
-        # budget packing reorders samples inside a micro) reassemble in track
-        # order. Contiguous range plans land on the same path (their indices are
-        # already in order), so one reassembly covers both modes.
-        collected: Dict[str, List[Optional[torch.Tensor]]] = {
-            field: [None] * total for field in algorithm.anchor_fields
-        }
-        for plan in micro_plans:
-            indices = _micro_indices(plan)
-            micro = self._materialize_micro(resp_track, plan)
+        collected: Dict[str, List[torch.Tensor]] = {field: [] for field in algorithm.anchor_fields}
+        for start, end in micro_slices:
+            micro = resp_track.slice(start, end)
             algorithm.prepare_segment(conditions=micro.conditions, segment=micro.segment)
-            micro_bs = len(indices)
-            micro_lengths = getattr(micro.segment, "lengths", None)
             for field in collected:
                 value = getattr(micro.segment, field, None)
                 if value is None:
                     raise RuntimeError(
-                        f"TrainStack.prepare_segment: {type(algorithm).__name__} declares anchor "
-                        f"field {field!r} but a micro-slice produced None."
+                        f"{type(self).__name__}.prepare_segment: {type(algorithm).__name__} declares "
+                        f"anchor field {field!r} but a micro produced None."
                     )
-                if value.dim() > 0 and int(value.shape[0]) == micro_bs:
-                    chunks = [value[j] .unsqueeze(0) for j in range(micro_bs)]
-                elif (
-                    isinstance(micro_lengths, torch.Tensor)
-                    and value.dim() > 0
-                    and int(value.shape[0]) == int(micro_lengths.sum().item())
-                ):
-                    chunks = list(torch.split(value, [int(n) for n in micro_lengths.tolist()], dim=0))
-                else:
-                    raise RuntimeError(
-                        f"TrainStack.prepare_segment: cannot map anchor field {field!r} of shape "
-                        f"{tuple(value.shape)} back to {micro_bs} samples (lengths="
-                        f"{None if micro_lengths is None else int(micro_lengths.sum().item())})."
-                    )
-                for j, orig in enumerate(indices):
-                    collected[field][orig] = chunks[j]
+                collected[field].append(value)
         for field, parts in collected.items():
-            missing = [i for i, p in enumerate(parts) if p is None]
-            if missing:
-                raise RuntimeError(
-                    f"TrainStack.prepare_segment: anchor field {field!r} missing chunks for "
-                    f"sample indices {missing[:5]}... — micro plans must cover every sample."
-                )
             setattr(resp_track.segment, field, torch.cat(parts, dim=0))
 
-    def train(
+    def _run_update(
         self,
         resp_track: RolloutTrack,
         *,
-        micro_slices: List[MicroPlan],
+        micros: UpdatePlan,
         training_progress: float,
     ) -> TrainStepResult:
-        """Run one optimizer step over the given absolute ``micro_slices``.
+        """Run one optimizer step over the contiguous micro ranges of a single update.
 
-        ``micro_slices`` are absolute ``(start, end)`` ranges into ``resp_track``
-        for one optimizer step, produced by :meth:`_optimizer_step_slices` so the
-        forward geometry matches the π_old anchor frozen by :meth:`prepare_segment`.
+        ``micros`` is one update's worth of ``(start, end)`` ranges produced by
+        :meth:`MicroPlanner.arrange` so the forward geometry matches the π_old anchor
+        frozen by :meth:`prepare_segment`.
         """
         if resp_track.advantages is None:
             raise ValueError(
-                "TrainStack.train: resp_track.advantages is None; "
+                f"{type(self).__name__}._run_update: resp_track.advantages is None; "
                 "upstream advantage pipeline must populate it before training."
             )
-        if not micro_slices:
-            raise ValueError("TrainStack.train: empty micro_slices.")
+        if not micros:
+            raise ValueError(f"{type(self).__name__}._run_update: empty micros.")
 
         bs = int(resp_track.batch_size)
         self.fsdp_backend.zero_grad()
 
-        step_total = sum(len(_micro_indices(plan)) for plan in micro_slices)
-        micros: List[AlgorithmStepResult] = []
+        update_total = sum(end - start for start, end in micros)
+        micro_results: List[AlgorithmStepResult] = []
         total_loss = 0.0
         has_backward = False
 
-        single_micro = len(micro_slices) == 1 and micro_slices[0] == (0, bs)
-        last_micro = len(micro_slices) - 1
-        for i, plan in enumerate(micro_slices):
-            # Defer the per-block gradient reduce-scatter to the last micro-batch
-            # so it runs once per optimizer step instead of once per micro-batch
-            # (no-op unless defer_grad_sync + ZeRO-2). Must precede the backward.
+        single_micro = len(micros) == 1 and micros[0] == (0, bs)
+        last_micro = len(micros) - 1
+        for i, (start, end) in enumerate(micros):
+            # Defer the per-block gradient reduce-scatter to the last micro-batch so
+            # it runs once per optimizer step instead of once per micro-batch (no-op
+            # unless defer_grad_sync + ZeRO-2). Must precede the backward.
             self.fsdp_backend.set_grad_sync(i == last_micro)
-            micro_track = resp_track if single_micro else self._materialize_micro(resp_track, plan)
-            # Sample-count weighting: the algorithm's micro loss is a MEAN over the
-            # micro's sequences (seq-mean agg modes), so the step gradient equals
-            # the mini-batch mean only when each micro is weighted by its share of
-            # samples. With equal count-based micros this reduces to the old
-            # 1/len(micro_slices); with token-budget packing micros vary in size.
-            loss_scale = len(_micro_indices(plan)) / float(step_total)
+            micro_track = resp_track if single_micro else resp_track.slice(start, end)
+            # Sample-share weighting: the algorithm's micro loss is a MEAN over the
+            # micro's sequences (seq-mean agg modes), so the update gradient equals
+            # the whole-update mean only when each micro is weighted by its share of
+            # samples. With equal count-based micros this reduces to 1/len(micros);
+            # with token-budget packing micros vary in size.
+            loss_scale = (end - start) / float(update_total)
             result = self.algorithm.compute_loss_and_backward(
                 conditions=micro_track.conditions,
                 segment=micro_track.segment,
@@ -644,34 +711,39 @@ class TrainStack(Remote):
                 training_progress=training_progress,
                 loss_scale=loss_scale,
             )
-            micros.append(result)
+            micro_results.append(result)
             total_loss += result.loss
             has_backward = has_backward or result.has_backward
 
-        aggregated_metrics: Mapping[str, object] = aggregate_numeric_metrics([r.metrics for r in micros if r.metrics])
+        aggregated_metrics: Mapping[str, object] = aggregate_numeric_metrics(
+            [r.metrics for r in micro_results if r.metrics]
+        )
 
         # Under defer_grad_sync the deferred reduce-scatter only runs inside a
-        # backward that executes after set_grad_sync(True) — the last micro's.
-        # If that micro skipped backward while earlier ones ran, the accumulated
-        # grads were never synced: the optimizer would silently step on empty
-        # grads now, and the stale unsharded accumulation (which zero_grad
-        # cannot reach) would leak into the NEXT step's reduce-scatter. Fail
-        # fast instead — mirrors fsdp_wrap's stray-trainable guard.
-        if has_backward and not micros[-1].has_backward and self.fsdp_backend.grad_sync_deferred:
+        # backward that executes after set_grad_sync(True) — the last micro's. If
+        # that micro skipped backward while earlier ones ran, the accumulated grads
+        # were never synced: the optimizer would silently step on empty grads now,
+        # and the stale unsharded accumulation (which zero_grad cannot reach) would
+        # leak into the NEXT step's reduce-scatter. Fail fast instead — mirrors
+        # fsdp_wrap's stray-trainable guard.
+        if has_backward and not micro_results[-1].has_backward and self.fsdp_backend.grad_sync_deferred:
             raise RuntimeError(
-                "TrainStack.train: defer_grad_sync deferred the gradient reduce-scatter to the "
-                "last micro-batch, but it reported no backward (all-empty micro?) while earlier "
-                "micro-batches did — the accumulated grads were never synced. Disable "
-                "training.fsdp.defer_grad_sync or investigate the empty micro-batch."
+                f"{type(self).__name__}._run_update: defer_grad_sync deferred the gradient "
+                "reduce-scatter to the last micro-batch, but it reported no backward (all-empty "
+                "micro?) while earlier micro-batches did — the accumulated grads were never "
+                "synced. Disable training.fsdp.defer_grad_sync or investigate the empty micro-batch."
             )
 
         if has_backward:
             grad_norm = float(self.fsdp_backend.optimizer_step(max_grad_norm=float(self.max_grad_norm)))
         else:
             grad_norm = 0.0
-            logger.warning("TrainStack.train: no micro-batch reported backward; skipping optimizer step.")
+            logger.warning(
+                "%s._run_update: no micro reported backward; skipping optimizer step.",
+                type(self).__name__,
+            )
         if torch.cuda.is_available():
-            # CUDA memory watermark per optimizer step (leak diagnosis: tp2 path
+            # CUDA memory footprint per optimizer step (leak diagnosis: tp2 path
             # showed progressive OOM). Surfaces as train/cuda_alloc_gb|cuda_reserved_gb.
             aggregated_metrics = {
                 **dict(aggregated_metrics),
@@ -684,7 +756,7 @@ class TrainStack(Remote):
             grad_norm=grad_norm,
             lr=self._current_lr(),
             has_backward=has_backward,
-            micros=micros,
+            micros=micro_results,
             metrics=aggregated_metrics,
         )
 
@@ -699,60 +771,60 @@ class TrainStack(Remote):
         *,
         training_progress: float,
     ) -> TrainStepResult:
-        """Driver-callable: prepare → train (×N) → on_rollout_end on the worker.
+        """Driver-callable: arrange → prepare → run updates (×N) → on_rollout_end.
 
-        Combines the steps so worker-side mutations
-        (``segment.sde_logp`` populated by ``prepare_segment``) flow into
-        the subsequent ``train`` call(s) without round-tripping through the
-        driver. Dispatched ``DP_SCATTER`` so each DP worker receives its shard
-        of ``resp_track``; per-shard loss/grad_norm/metrics merge back via
-        ``pytree_merge``.
+        Combines the steps so worker-side mutations (``segment.sde_logp`` populated
+        by ``prepare_segment``) flow into the subsequent update(s) without
+        round-tripping through the driver. Dispatched ``DP_SCATTER`` so each DP
+        worker receives its shard of ``resp_track``; per-shard loss/grad_norm/metrics
+        merge back via ``pytree_merge``.
 
-        ``prepare_segment`` runs once (freezing the π_old anchor for the whole
-        shard), then ``num_updates_per_batch`` optimizer steps run over disjoint
-        mini-batches, then ``on_rollout_end`` runs once — see
-        :meth:`_train_mini_batches`.
+        ``arrange`` reorders the shard (if packing) and builds the contiguous plan;
+        ``prepare_segment`` then freezes the π_old anchor once at that geometry,
+        ``num_updates_per_batch`` optimizer steps run over disjoint updates, and
+        ``on_rollout_end`` runs once — see :meth:`_run_updates`.
         """
         self._align_track_inputs(resp_track)
-        # Plan once (mini partition + micro packing) and share it between the
+        # Arrange once: reorder the track so packed micros are contiguous (no-op for
+        # CountPlanner) and produce the plan. The SAME (track, plans) feed both the
         # anchor freeze and the train loop so both run the exact same geometry.
-        plans = self._plan_optimizer_steps(resp_track)
+        resp_track, plans = self.micro_planner.arrange(
+            resp_track,
+            num_updates=self.num_updates_per_batch,
+            micro_batch_size=self.micro_batch_size,
+        )
         self.prepare_segment(resp_track, plans=plans)
-        result = self._train_mini_batches(resp_track, plans=plans, training_progress=float(training_progress))
+        result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
         self.on_rollout_end()
         return result
 
-    def _train_mini_batches(
+    def _run_updates(
         self,
         resp_track: RolloutTrack,
         *,
-        plans: Optional[List[List[MicroPlan]]] = None,
+        plans: Plan,
         training_progress: float,
     ) -> TrainStepResult:
-        """Run ``num_updates_per_batch`` optimizer steps over disjoint mini-batches.
+        """Run ``num_updates_per_batch`` optimizer steps over disjoint updates.
 
-        The mini/micro slicing comes from the shared :meth:`_optimizer_step_slices`
-        — the same source :meth:`prepare_segment` froze the π_old anchor at — so
-        every step's ``new_logp`` is computed at exactly the anchor's geometry.
-        ``prepare_segment`` must already have frozen the anchor so all steps train
-        against the same pre-update policy. With a single optimizer step the result
-        passes through unchanged; otherwise the per-step results are reduced into one
-        summary and each step's own metrics are attached on ``per_update`` (see
+        The update/micro grouping comes from :meth:`MicroPlanner.arrange` — the same
+        source :meth:`prepare_segment` froze the π_old anchor at — so every update's
+        ``new_logp`` is computed at exactly the anchor's geometry. ``prepare_segment``
+        must already have frozen the anchor so all updates train against the same
+        pre-update policy. With a single optimizer step the result passes through
+        unchanged; otherwise the per-update results are reduced into one summary and
+        each update's own metrics are attached on ``per_update`` (see
         :func:`_aggregate_update_results`).
         """
-        if plans is None:
-            plans = self._plan_optimizer_steps(resp_track)
-        results = [
-            self.train(resp_track, micro_slices=micros, training_progress=training_progress) for micros in plans
-        ]
+        results = [self._run_update(resp_track, micros=micros, training_progress=training_progress) for micros in plans]
         if len(results) == 1:
             return results[0]
         aggregated = _aggregate_update_results(results)
-        # Attach each optimizer step's own metrics (in order) so the trainer can
-        # log one wandb point per optimizer step — the on-policy update0 and the
-        # off-policy update1 stay distinct series instead of being averaged into
-        # one misleading ``ratio_mean``. Structured data on the result object,
-        # which the DP collect (``pytree_cat``) returns whole, so it rides along.
+        # Attach each optimizer step's own metrics (in order) so the trainer can log
+        # one wandb point per optimizer step — the on-policy update0 and the
+        # off-policy update1 stay distinct series instead of being averaged into one
+        # misleading ``ratio_mean``. Structured data on the result object, which the
+        # DP collect (``pytree_cat``) returns whole, so it rides along.
         per_update = tuple(
             {**dict(r.metrics), "loss": float(r.loss), "grad_norm": float(r.grad_norm), "lr": float(r.lr)}
             for r in results
@@ -775,9 +847,3 @@ class TrainStack(Remote):
             if isinstance(last, list) and last:
                 return float(last[0])
         return 0.0
-
-
-__all__ = [
-    "TrainStack",
-    "TrainStepResult",
-]


### PR DESCRIPTION
Refactor of the token-budget micro-batching from #42 — no behaviour change to the perf feature, just a cleaner design. **Stacked on #42** (base `perf/01-token-budget-packing`); rebase onto main once #42 lands.

## Summary
Two changes, both pure refactor:

**1. Composition instead of a ctor knob.** `TrainStack` now takes an injected `micro_planner` (default `CountPlanner` = the historical fixed-count behaviour). `TokenBudgetPlanner` carries `token_budget` / `cost_model` and owns the seq-mean loss precondition (`validate`, checked once at construction) — so count-based stacks no longer run a guard that only applies to packing. Recipes opt in with a `micro_planner` block; only `qwen3_drpo` does. Replaces the `micro_token_budget` / `micro_cost_model` ctor args.

**2. Sort-then-slice removes the index-plan invasiveness.** The planner reorders the track **once** up front (length-sort within each update, one `track.select`) so every micro is again a **contiguous `(start, end)` range** — exactly the count-based geometry. The stack therefore only ever slices, and the π_old anchor reassembly is a plain ordered `cat`. Gone: the `MicroPlan` range|index-list union, the slice/select branch, and the per-original-index anchor bookkeeping threaded through `prepare_segment`. All packing-specific logic is isolated to `MicroPlanner.arrange` (a no-op for `CountPlanner`). Reorder cost drops from one gather per packed micro to one gather per rollout.

Also drops the `replay_time_s` / `backward_time_s` timing hooks from `unirl/algorithms/drpo.py` — perf scaffolding that doesn't belong in the algorithm hot path (cross-cutting, DRPO-only).

Invariants preserved: update membership unchanged (each update's permuted block holds its original samples → same per-update gradient set-sum), sample-share loss weighting exact, NCCL micro-count parity.

Stays a single `unirl/train/stack.py` module — carving it into a `stack/` package is a further follow-up.

## Test Plan
- `tests/train/test_packing.py` (new, CPU-only): bin coverage/budget invariants, exact-K partition, sort-then-slice membership preservation, sample-share weighting (1e-12), seq-mean guard
- verified on Qwen env: ruff clean, `check_recipe_targets` 1004 `_target_` paths resolve, `test_packing` passes
- behaviour-equivalence: the packed plan trains the same sample set per update as before; `ratio_mean` unaffected (geometry identical to #42)
