### PR TITLE
refactor(sglang): name the forward-process rollout predicate

### DIFF
--- a/unirl/__init__.py
+++ b/unirl/__init__.py
@@ -12,7 +12,6 @@ _LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     "RewardRequest": ("unirl.types", "RewardRequest"),
     "RewardResponse": ("unirl.types", "RewardResponse"),
     "RewardType": ("unirl.types", "RewardType"),
-    "SamplingRequirements": ("unirl.types.sampling", "SamplingRequirements"),
     # sde
     "get_sigma_schedule": ("unirl.sde", "get_sigma_schedule"),
     # reward

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -33,7 +33,7 @@ batch.
 The dual-adapter mechanics (install / EMA / switch) live in the EMA
 policy owned by the FSDP backend. The algorithm receives the policy
 via constructor injection (``nft_lora_policy=...``, resolved off
-``backend.ema`` by the v2 trainer) and calls its ``with_old_adapter()``
+``backend.ema`` by the v2 trainer) and calls its ``use_shadow()``
 context manager to obtain :math:`old_pred`.
 """
 
@@ -328,7 +328,7 @@ class DiffusionNFT(StageAlgorithm):
             sigma=t_batch,
             params=self.params,
         )
-        # Reference adapter forward, detached. ``with_old_adapter``
+        # Reference adapter forward, detached. ``use_shadow``
         # temporarily activates the EMA-tracked adapter; the surrounding
         # ``no_grad`` keeps autograd off this branch.
         with torch.no_grad(), self.nft_lora_policy.use_shadow():

--- a/unirl/rollout/engine/sglang/_patches/patch_dance.py
+++ b/unirl/rollout/engine/sglang/_patches/patch_dance.py
@@ -10,11 +10,11 @@ This exactly matches UniRL's train-side authority
 ``unirl/sde/kernels.py:DanceSDEStrategy`` (``.step`` / ``.compute_log_prob``)
 that ``logprob_source='replay'`` recomputes against -- keeping the rollout
 transition and the train-side log-prob consistent (iter-0 importance ratios ~1).
-Parity is pinned by ``tests/rollout/sglang/test_flow_sde_parity.py`` (dance case).
+Parity with that authority is verified by hand for now (no automated parity test yet).
 
 This is the ONLY REPLACE patch (all infra patches are additive). It re-vendors
-upstream ``flow_sde_sampling`` with one extra ``elif``; the parity test guards
-re-sync on upstream bumps.
+upstream ``flow_sde_sampling`` with one extra ``elif``, so it must be re-synced by
+hand against the pinned upstream source on any sglang bump.
 """
 
 from __future__ import annotations

--- a/unirl/rollout/engine/sglang/engine.py
+++ b/unirl/rollout/engine/sglang/engine.py
@@ -58,7 +58,7 @@ from unirl.sde.runtime import FlowMatchSchedulePolicy, ensure_req_sigmas
 from unirl.types.noise_recipe import NoiseRecipe
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.rollout_resp import RolloutResp
-from unirl.types.sampling import get_diffusion_params
+from unirl.types.sampling import get_diffusion_params, is_forward_process
 from unirl.utils.dtypes import parse_torch_dtype
 from unirl.utils.peft_merge import adapt_lora_for_sglang
 
@@ -424,11 +424,10 @@ class SGLangRolloutEngine(BaseRolloutEngine):
         # Best-effort emit: whenever the rollout ran SDE-gated steps, try to
         # land SGLang's native per-step log-probs on the segment. Whether they
         # are *used* (vs trainer-side replay) is decided downstream by the
-        # algorithm's ``old_logp_source`` — not by the engine. An empty
-        # ``sde_indices`` (DiffusionNFT / forward-process, num_sde_steps=0 resolves to [])
-        # has no per-step log-probs to emit, so skip the block entirely —
-        # matching the prior behavior for that path.
-        emit_native_logprob = sde_indices is not None and len(sde_indices) > 0
+        # algorithm's ``old_logp_source`` — not by the engine. A forward process
+        # (DiffusionNFT; empty ``sde_indices``) has no per-step log-probs to emit,
+        # so skip the block entirely — matching the prior behavior for that path.
+        emit_native_logprob = not is_forward_process(sde_indices)
 
         return _to_rollout_resp(
             req,

--- a/unirl/rollout/engine/sglang/request.py
+++ b/unirl/rollout/engine/sglang/request.py
@@ -37,7 +37,7 @@ from unirl.config.require import require
 from unirl.rollout.engine.sglang.config import SGLangEngineConfig
 from unirl.types.primitives import Texts
 from unirl.types.rollout_req import RolloutReq
-from unirl.types.sampling import get_diffusion_params
+from unirl.types.sampling import get_diffusion_params, is_forward_process
 
 
 def _deexpand_prompts_from_groups(
@@ -240,10 +240,24 @@ def _to_sglang_kwargs(
     # ``rollout_return_dit_trajectory``, independently of the SDE kernel).
     kwargs["rollout"] = True
     kwargs["rollout_return_dit_trajectory"] = True
-    if sde_indices:
-        # GRPO: per-step SDE noise on the resolved step indices. ``num_sde_steps=0``
-        # resolves to ``[]`` (not ``None``) via ``resolve_sde_indices``, so gate on
-        # non-emptiness, not ``is not None``.
+    if is_forward_process(sde_indices):
+        # DiffusionNFT / forward-process: deterministic ODE rollout — no per-step
+        # SDE noise, so ``rollout_sde_step_indices`` is omitted (the kernel ignores
+        # it for ode and reads the field via ``getattr(..., None)``).
+        #
+        # ``rollout_log_prob_no_const=True`` is REQUIRED whenever
+        # ``rollout_sde_type="ode"``: an ODE step is deterministic, so its
+        # normalized log-prob is undefined and the kernel asserts this flag is set
+        # ("p_ode is always 0, true log_prob is meaningless"). It only makes the
+        # kernel emit a zero-log-prob placeholder, which this path never reads
+        # (``emit_native_logprob`` is False for a forward process). Keep it OFF the
+        # SDE branch below, where True would strip the normalization constants from
+        # GRPO's native log-prob.
+        kwargs["rollout_sde_type"] = "ode"
+        kwargs["rollout_noise_level"] = eta
+        kwargs["rollout_log_prob_no_const"] = True
+    else:
+        # SDE rollout (FlowGRPO et al.): per-step SDE noise on the resolved subset.
         require(
             sde_label is not None,
             "_to_sglang_kwargs: SDE mode requires sde_label (resolved by engine ctor)",
@@ -251,22 +265,6 @@ def _to_sglang_kwargs(
         kwargs["rollout_sde_type"] = sde_label
         kwargs["rollout_noise_level"] = eta
         kwargs["rollout_sde_step_indices"] = sde_indices
-    else:
-        # DiffusionNFT / forward-process: deterministic ODE rollout — no per-step
-        # SDE noise, so ``rollout_sde_step_indices`` is omitted (the kernel
-        # ignores it for ode and reads the field via ``getattr(..., None)``).
-        #
-        # ``rollout_log_prob_no_const=True`` is REQUIRED whenever
-        # ``rollout_sde_type="ode"``: an ODE step is deterministic, so its
-        # normalized log-prob is undefined and the kernel asserts this flag is set
-        # ("p_ode is always 0, true log_prob is meaningless"). It only makes the
-        # kernel emit a zero-log-prob placeholder, which this path never reads
-        # (``emit_native_logprob`` is False when ``sde_indices`` is empty). Keep it
-        # OFF the SDE branch above, where True would strip the normalization
-        # constants from GRPO's native log-prob.
-        kwargs["rollout_sde_type"] = "ode"
-        kwargs["rollout_noise_level"] = eta
-        kwargs["rollout_log_prob_no_const"] = True
 
     if num_outputs_per_prompt is not None:
         kwargs["num_outputs_per_prompt"] = num_outputs_per_prompt

--- a/unirl/types/__init__.py
+++ b/unirl/types/__init__.py
@@ -25,7 +25,6 @@ _LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     "BaseSamplingParams": ("unirl.types.sampling", "BaseSamplingParams"),
     "ComposedSamplingParams": ("unirl.types.sampling", "ComposedSamplingParams"),
     "DiffusionSamplingParams": ("unirl.types.sampling", "DiffusionSamplingParams"),
-    "SamplingRequirements": ("unirl.types.sampling", "SamplingRequirements"),
     "get_diffusion_params": ("unirl.types.sampling", "get_diffusion_params"),
     "TrajectoryStore": ("unirl.types.trajectory_store", "TrajectoryStore"),
 }

--- a/unirl/types/sampling.py
+++ b/unirl/types/sampling.py
@@ -175,26 +175,3 @@ class ComposedSamplingParams(BaseSamplingParams):
         # Each prompt → ar.samples_per_prompt AR outputs, each AR output →
         # diffusion.samples_per_prompt diffusion samples.
         self.samples_per_prompt = int(self.diffusion.samples_per_prompt) * int(self.ar.samples_per_prompt)
-
-
-@dataclass(frozen=True)
-class SamplingRequirements:
-    """Algorithm-declared sampling contract shared with runtime."""
-
-    requires_trajectory: bool = True
-    requires_log_prob: bool = True
-    requires_embeddings: bool = True
-    requires_clean_latents: bool = False
-
-    @property
-    def is_forward_process(self) -> bool:
-        """Whether this is a forward process algorithm (DiffusionNFT)."""
-        return self.requires_clean_latents and not self.requires_trajectory
-
-    def to_dict(self) -> Dict[str, bool]:
-        """Convert core boolean requirements to a plain dictionary."""
-        return {
-            "requires_trajectory": bool(self.requires_trajectory),
-            "requires_log_prob": bool(self.requires_log_prob),
-            "requires_embeddings": bool(self.requires_embeddings),
-        }

--- a/unirl/types/sampling.py
+++ b/unirl/types/sampling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 from unirl.config.require import require
 
@@ -50,6 +50,23 @@ def get_ar_params(sampling: Any) -> Optional["ARSamplingParams"]:
     if isinstance(sampling, ARSamplingParams):
         return sampling
     return None
+
+
+def is_forward_process(sde_indices: Optional[Sequence[int]]) -> bool:
+    """True when the rollout records no SDE steps (deterministic ODE forward process).
+
+    ``sde_indices`` (from :meth:`DiffusionSamplingParams.resolve_sde_indices`) names
+    the denoising steps that draw per-step SDE noise. A non-empty list is an SDE
+    rollout (FlowGRPO et al.); an empty list -- or ``None`` when no SDE params were
+    set -- means every step is deterministic ODE, i.e. the DiffusionNFT-style forward
+    process whose only output of interest is the final clean latent.
+
+    This is the single source of truth for that interpretation: call sites read
+    ``is_forward_process(sde_indices)`` instead of re-deriving it ad hoc from
+    ``not x`` / ``x is None`` / ``len(x) == 0`` (those idioms had drifted apart and
+    caused a trajectory-bandwidth regression once).
+    """
+    return not sde_indices
 
 
 @dataclass


### PR DESCRIPTION
## Summary

DiffusionNFT resolves `sde_indices` to `[]` (no SDE steps) — a deterministic ODE forward process whose only output of interest is the final clean latent. The sglang request/engine path detected this implicitly via mixed idioms (`if sde_indices:`, `x is None`, `len(x) > 0`) with no shared name, and those idioms had drifted apart before (a `[]`-vs-`None` mix caused a trajectory-bandwidth regression).

This introduces a single `is_forward_process(sde_indices)` predicate in `unirl/types/sampling.py` — the one place that interpretation lives — and uses it at the two **decision points**:

- `request.py`: the SDE-vs-ODE branch (now reads forward-process-first).
- `engine.py`: the native-logprob emit gate.

Behavior is unchanged. The **value-carrying** paths that must keep `[]` vs `None` distinct (the `response.py` trajectory trim) are intentionally left as-is — they are value-driven, not forward-process decisions.

It also removes the vestigial `SamplingRequirements` dataclass and its two lazy-export registry entries. It has been dead since the initial release — never instantiated or read anywhere in git history — and its `is_forward_process` property was the *only other* symbol of that name, so dropping it makes the new `is_forward_process(sde_indices)` predicate the genuine single source of truth. The niche it nominally occupied (a centralized algorithm to rollout "requirements" contract) is already filled by `StageAlgorithm`'s wired attributes (`requires_ema_rollout`, `anchor_fields`, `old_logp_source`) plus the runtime `DiffusionSamplingParams`/`sde_indices`, so it was a never-adopted alternative design, not a future API.

Finally, it fixes three stale comment/docstring references (no runtime code touched): `diffusionnft.py` named a nonexistent `with_old_adapter()` context manager (the code calls `use_shadow()`), and `patch_dance.py` claimed parity is pinned by `tests/rollout/sglang/test_flow_sde_parity.py` — a test that does not exist, i.e. a false coverage claim on the only REPLACE monkey-patch. The docstring now states the truth: parity is verified by hand and must be re-synced against the pinned upstream on any sglang bump.

This is follow-up item **#1** flagged in #21.

## Related Issue

Follow-up to #21 (DiffusionNFT EMA-shadow rollout). N/A otherwise.

## Test Plan

- `python -m py_compile` on all changed files — passes.
- Predicate logic (`not sde_indices` over `[]` / `None` / `[0]` / `[3,5,9]`) verified in pure Python (mirrors `tests/types/test_sampling.py`).
- `SamplingRequirements` removal: `git grep SamplingRequirements` shows no remaining references; no orphaned imports (`Dict` still used at line 97); git history (`git log -S`) confirms it was never instantiated.
- Stale-reference fixes are comment/docstring-only: `git grep "with_old_adapter\|test_flow_sde_parity"` shows no matches after the change.

## Compatibility / Risk

- Behavior-preserving refactor: `if is_forward_process(x)` equals `if not x`, and `not is_forward_process(x)` equals `bool(x)` — identical to the prior branch conditions.
- GRPO (non-empty `sde_indices`) and the trainside `models/*/diffusion.py` paths are untouched.
- Removes the public `SamplingRequirements` export from `unirl` / `unirl.types`: zero in-repo consumers and never instantiated in git history (a frozen, never-wired dataclass), so no behavioral dependency. Re-add if a future need arises.
- The stale-reference fixes touch only comments/docstrings — zero runtime impact.

## Reviewer Notes

- AI-assisted. Follow-up #1 from #21's deferred cleanups.
- Scoped deliberately to the sglang **decision points**. The trainside `params.sde_indices or []` idiom (9 model files) is already internally consistent and is left alone to avoid churn.
- Item #2 from #21 (the NFT rollout reusing the GRPO trajectory API, then trimming) is intentionally **not** addressed: sglang's t2i path exposes the final latent *only* through the trajectory return, so that reuse is forced by the engine API, not a removable hack.
- The `SamplingRequirements` removal bundles with this PR because it eliminates the *only other* `is_forward_process`, directly supporting the "single source of truth" goal.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
