### PR TITLE
feat(bagel): BAGEL-7B-MoT multi-mode RL support (it2i/t2t/i2t/it2t/t2ti)

### DIFF
--- a/examples/diffusion/bagel/bagel_trainside_lora.yaml
+++ b/examples/diffusion/bagel/bagel_trainside_lora.yaml
@@ -133,7 +133,7 @@ algorithm:
   clip_schedule: constant
   # Bagel samples and trains at bs=1 (same micro-geometry), so the rollout's
   # stored sde_logp is a valid pi_old anchor → ratio=1 on update 1 without replay.
-  old_logp_source: native
+  old_logp_source: rollout
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.bagel.conditions.BagelDiffusionConditions

--- a/unirl/models/bagel/__init__.py
+++ b/unirl/models/bagel/__init__.py
@@ -12,6 +12,12 @@ integration mirrors ``unirl.models.hunyuan_image3`` — the diffusion "transform
 is the LLM backbone itself and text conditioning flows through a KV cache rather
 than a separate text encoder.
 
+Five task modes, two stages (rollout + replay each): image-out ``t2i`` / ``it2i``
+(editing) ride :class:`BagelDiffusionStage`; text-out ``t2t`` / ``i2t`` / ``it2t``
+ride :class:`BagelARStage` (the und path, ``ar.py`` + the AR adapters in
+``rl_ops.py``). ``BagelPipeline.generate`` routes via ``stage_config["task"]``
+or infers from the sampling-params type + image-input presence.
+
 Kept flash-attn-free at import time: ``import unirl.models.bagel`` must not pull
 the vendored modeling (which hard-imports ``flash_attn``). The adapter wrappers
 (config / conditions / diffusion / vae / pipeline) are flash-free; ``BagelBundle``
@@ -21,14 +27,20 @@ BagelBundle`` only where a GPU model is constructed. ``rl_ops`` (the RL primitiv
 is flash-free too (torch + diffusers only).
 """
 
-from .conditions import BagelDiffusionConditions
-from .config import BAGEL_MOE_GEN_LORA_TARGETS, BagelPipelineConfig
+from .ar import BagelARParams, BagelARStage, BagelARStep
+from .conditions import BagelARConditions, BagelDiffusionConditions
+from .config import BAGEL_MOE_GEN_LORA_TARGETS, BAGEL_UND_LORA_TARGETS, BagelPipelineConfig
 from .diffusion import BagelDiffusionParams, BagelDiffusionStage, BagelDiffusionStep
 from .pipeline import BagelPipeline
 from .vae import BagelVAEDecodeStage, bagel_latent_geometry, bagel_latent_shape, unpatchify_latent
 
 __all__ = [
     "BAGEL_MOE_GEN_LORA_TARGETS",
+    "BAGEL_UND_LORA_TARGETS",
+    "BagelARConditions",
+    "BagelARParams",
+    "BagelARStage",
+    "BagelARStep",
     "BagelDiffusionConditions",
     "BagelDiffusionParams",
     "BagelDiffusionStage",

--- a/unirl/models/bagel/ar.py
+++ b/unirl/models/bagel/ar.py
@@ -1,0 +1,296 @@
+"""Bagel AR (text-out) stage: typed params + per-token kernel + rollout-level stage.
+
+Serves t2t / i2t / it2t — the conditions' ordered prompt splits decide what the
+context contains; the stage is split-agnostic. Three classes:
+
+- ``BagelARParams`` — request-shape knobs beyond ``ARSamplingParams``
+  (extra ``stop_token_ids``; mirrors ``Qwen3ARParams``).
+- ``BagelARStep`` — per-token sampling kernel (full-softmax log-prob captured
+  BEFORE top-k/top-p truncation, matching replay's untempered convention;
+  verbatim ``Qwen3ARStep`` mechanics).
+- ``BagelARStage`` — implements ``ARStage[BagelARConditions]``. Per sample
+  (navit bs=1): prefill the KV context from the RAW prompt splits via the
+  ``rl_ops`` adapters, then per-token decode (``rl_ops.decode_text``) for
+  rollout, or one teacher-forced grad-capable pass (``rl_ops.score_response``)
+  for replay. Rollout and replay derive the context from the SAME stored splits
+  through the SAME prefill code → prefix K/V parity by construction.
+
+Replay regime: eval() mode with grads enabled (the navit modules dispatch
+``forward_train``/``forward_inference`` on ``self.training``) — identical to
+``BagelDiffusionStage.replay``. The caller owns the grad scope; the stage owns
+only the autocast scope.
+
+This module deliberately avoids importing the vendored modeling (and its hard
+``flash_attn`` dependency) at module load — it reaches the model through the
+bundle instance at call time — so ``import unirl.models.bagel`` stays CPU-clean.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from dataclasses import field as dc_field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from unirl.config.require import require
+from unirl.models.types.ar import ARStage, ARStep
+from unirl.types.sampling import ARSamplingParams
+from unirl.types.segments import TextSegment
+from unirl.utils.dtypes import parse_torch_dtype
+
+from . import rl_ops
+from .conditions import BagelARConditions
+
+if TYPE_CHECKING:
+    from .bundle import BagelBundle
+
+
+@dataclass
+class BagelARParams:
+    """Per-request AR-mode knobs for Bagel.
+
+    ``stop_token_ids`` is unioned with ``new_token_ids['eos_token_id']``
+    (``<|im_end|>``) inside the stage so callers don't repeat the EOS id; the
+    sampling shape (temperature / top_p / top_k / max_new_tokens) rides the
+    shared :class:`ARSamplingParams`.
+    """
+
+    stop_token_ids: List[int] = dc_field(default_factory=list)
+
+
+class BagelARStep(ARStep):
+    """Per-token sampling kernel (``Qwen3ARStep`` mechanics).
+
+    Given logits over the vocabulary at the current position, sample the next
+    token and return its log-probability under the *temperature-scaled* full
+    softmax computed BEFORE top-k/top-p truncation, so it matches replay's
+    ``log_softmax(logits / T)`` without filter masking.
+    """
+
+    def __init__(self, *, temperature: float = 1.0, top_p: float = 1.0, top_k: int = 0) -> None:
+        self.temperature = float(temperature)
+        self.top_p = float(top_p)
+        self.top_k = int(top_k)
+
+    def step(self, logits: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if logits.dim() != 2:
+            raise ValueError(f"BagelARStep.step: expected logits shape [B, vocab], got {tuple(logits.shape)}")
+
+        if self.temperature <= 0.0:
+            # Greedy: argmax under the full (untempered) softmax.
+            log_probs_full = F.log_softmax(logits.float(), dim=-1)
+            token_id = log_probs_full.argmax(dim=-1)
+            log_prob = log_probs_full.gather(-1, token_id.unsqueeze(-1)).squeeze(-1)
+            return token_id, log_prob
+
+        scaled = logits.float() / self.temperature
+
+        # Behavior log-prob under the temperature-scaled distribution, BEFORE
+        # top-k/top-p truncation, so old_logp == replay new_logp at the same
+        # weights (rl_ops.score_response computes log_softmax(logits / T)).
+        log_probs_full = F.log_softmax(scaled, dim=-1)
+
+        if self.top_k > 0 and self.top_k < scaled.shape[-1]:
+            topk_vals, _ = torch.topk(scaled, self.top_k, dim=-1)
+            kth = topk_vals[..., -1, None]
+            scaled = torch.where(scaled < kth, torch.full_like(scaled, float("-inf")), scaled)
+
+        if self.top_p < 1.0:
+            sorted_vals, sorted_idx = torch.sort(scaled, dim=-1, descending=True)
+            cumprob = torch.softmax(sorted_vals, dim=-1).cumsum(dim=-1)
+            cutoff = (cumprob > self.top_p).float()
+            cutoff = torch.cat([torch.zeros_like(cutoff[..., :1]), cutoff[..., :-1]], dim=-1)
+            sorted_vals = sorted_vals.masked_fill(cutoff > 0, float("-inf"))
+            scaled = torch.full_like(scaled, float("-inf")).scatter(-1, sorted_idx, sorted_vals)
+
+        probs = F.softmax(scaled, dim=-1)
+        token_id = torch.multinomial(probs, num_samples=1).squeeze(-1)
+        log_prob = log_probs_full.gather(-1, token_id.unsqueeze(-1)).squeeze(-1)
+        return token_id, log_prob
+
+
+class BagelARStage(ARStage[BagelARConditions]):
+    """Rollout-level AR stage for Bagel (t2t / i2t / it2t).
+
+    Drives the MoT und path through the ``rl_ops`` navit adapters: per-sample
+    context prefill from raw splits, per-token decode with KV cache (rollout),
+    one-shot teacher-forced scoring (replay). Packs per-sample ``(tokens,
+    log_probs)`` into a varlen :class:`TextSegment`.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: "BagelBundle",
+        autocast_precision: str = "bf16",
+        logprob_precision: str = "fp32",
+    ) -> None:
+        self.model = model
+        self.autocast_dtype = parse_torch_dtype(autocast_precision, field_name="BagelARStage.autocast_precision")
+        self.logprob_dtype = parse_torch_dtype(logprob_precision, field_name="BagelARStage.logprob_precision")
+        # A checkpoint trained with freeze_und detaches the und hidden states in
+        # forward_train — a signal the und path was never meant to train. The
+        # inference-path replay is unaffected mechanically, but fail loudly.
+        # (Chain guarded so fake bundles without the full config tree construct.)
+        llm_cfg = getattr(getattr(getattr(model, "model", None), "config", None), "llm_config", None)
+        require(
+            not getattr(llm_cfg, "freeze_und", False),
+            "BagelARStage: llm_config.freeze_und=True — this checkpoint's und path is frozen by design.",
+        )
+
+    def trainable_module(self) -> "torch.nn.Module":
+        """The MoT transformer (``bundle.transformer``) — same root the diffusion
+        stage exposes, so LoRA/FSDP injection is visible to both stages."""
+        return self.model.transformer
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _autocast_ctx(self, device: torch.device):
+        if device.type == "cuda" and self.autocast_dtype in (torch.float16, torch.bfloat16):
+            return torch.autocast("cuda", self.autocast_dtype)
+        return nullcontext()
+
+    def _prefill(self, splits: List[Dict[str, Any]], *, device: torch.device) -> Dict[str, Any]:
+        """Build a fresh KV context from ordered raw splits (rollout AND replay).
+
+        Grad behavior follows the ambient mode: under the rollout ``no_grad`` the
+        prefill is grad-free; under replay's ``enable_grad`` it carries gradients
+        (the und path is the trained surface — see ``BagelARConditions``).
+        """
+        bagel = self.model.model
+        ctx = rl_ops.init_und_context(bagel)
+        for sp in splits:
+            kind = sp.get("kind")
+            if kind == "text":
+                ctx = rl_ops.prefill_text_split(bagel, ctx, text_ids=sp["ids"], device=device)
+            elif kind == "vit":
+                ctx = rl_ops.prefill_vit_split(
+                    bagel, ctx, image_tensor=sp["image"], new_token_ids=self.model.new_token_ids, device=device
+                )
+            else:
+                raise ValueError(f"BagelARStage: unknown prompt split kind {kind!r}; expected 'text' or 'vit'.")
+        return ctx
+
+    def _resolve_stop_ids(self, params: Optional[BagelARParams], sampling_params: ARSamplingParams) -> List[int]:
+        ids: List[int] = []
+        if params is not None and params.stop_token_ids:
+            ids.extend(int(t) for t in params.stop_token_ids)
+        if sampling_params.stop_token_id is not None:
+            ids.append(int(sampling_params.stop_token_id))
+        ids.append(int(self.model.new_token_ids["eos_token_id"]))  # <|im_end|>, as in the vendored gen_text
+        return list(dict.fromkeys(ids))
+
+    # ------------------------------------------------------------------
+    # Rollout
+    # ------------------------------------------------------------------
+
+    def autoregress(
+        self,
+        conditions: BagelARConditions,
+        *,
+        sampling_params: ARSamplingParams,
+        params: Optional[BagelARParams] = None,
+        **_kwargs: Any,
+    ) -> TextSegment:
+        """Run AR generation per sample. Returns a varlen-packed ``TextSegment``."""
+        require(conditions.batch_size > 0, "BagelARStage.autoregress: empty conditions.")
+        bagel = self.model.model
+        device = torch.device(self.model.device)
+        rl_ops.require_inference_dispatch(bagel)
+
+        step = BagelARStep(
+            temperature=float(sampling_params.temperature),
+            top_p=float(sampling_params.top_p),
+            top_k=int(sampling_params.top_k),
+        )
+        stop_ids = self._resolve_stop_ids(params, sampling_params)
+        start_id = int(self.model.new_token_ids["bos_token_id"])
+
+        generated: List[List[int]] = []
+        logps: List[List[float]] = []
+        with torch.no_grad(), self._autocast_ctx(device):
+            for splits in conditions.prompt_splits:
+                ctx = self._prefill(splits, device=device)
+                tokens_i, logps_i = rl_ops.decode_text(
+                    bagel,
+                    ctx,
+                    start_token_id=start_id,
+                    sample_fn=step.step,
+                    max_new_tokens=int(sampling_params.max_new_tokens),
+                    stop_ids=stop_ids,
+                    device=device,
+                )
+                generated.append(tokens_i)
+                logps.append(logps_i)
+
+        return TextSegment.pack(
+            tokens=[torch.tensor(t, dtype=torch.long, device=device) for t in generated],
+            log_probs=[torch.tensor(lp, dtype=torch.float32, device=device) for lp in logps],
+        )
+
+    # ------------------------------------------------------------------
+    # Replay
+    # ------------------------------------------------------------------
+
+    def replay(
+        self,
+        conditions: BagelARConditions,
+        *,
+        segment: TextSegment,
+        temperature: float = 1.0,
+    ) -> torch.Tensor:
+        """Per-token log-prob replay over a stored rollout segment.
+
+        Per sample: grad-capable context re-prefill from the stored splits, then
+        one teacher-forced ``score_response`` pass. Returns packed varlen
+        ``[total_tokens]`` fp32 aligned with ``segment.log_probs``. Caller owns
+        the grad scope and eval() mode; the stage owns the autocast scope.
+        Empty-response samples contribute zero tokens.
+        """
+        if segment.tokens is None or segment.cu_seqlens is None or segment.lengths is None:
+            raise ValueError(
+                "BagelARStage.replay: segment requires tokens with framework-managed "
+                "cu_seqlens (construct via TextSegment.pack)"
+            )
+        require(
+            conditions.batch_size == int(segment.lengths.numel()),
+            f"BagelARStage.replay: conditions batch ({conditions.batch_size}) != "
+            f"segment samples ({int(segment.lengths.numel())}).",
+        )
+        bagel = self.model.model
+        device = next(self.model.transformer.parameters()).device
+        rl_ops.require_inference_dispatch(bagel)
+
+        cu = [int(c) for c in segment.cu_seqlens.tolist()]
+        lengths = [int(n) for n in segment.lengths.tolist()]
+        start_id = int(self.model.new_token_ids["bos_token_id"])
+
+        parts: List[torch.Tensor] = []
+        with self._autocast_ctx(device):
+            for i, splits in enumerate(conditions.prompt_splits):
+                n = lengths[i]
+                if n == 0:
+                    continue
+                response = segment.tokens[cu[i] : cu[i] + n]
+                ctx = self._prefill(splits, device=device)
+                parts.append(
+                    rl_ops.score_response(
+                        bagel,
+                        ctx,
+                        response_ids=response,
+                        start_token_id=start_id,
+                        temperature=float(temperature),
+                        device=device,
+                    )
+                )
+        if not parts:
+            return torch.zeros(0, dtype=self.logprob_dtype, device=device)
+        return torch.cat(parts, dim=0).to(dtype=self.logprob_dtype)
+
+
+__all__ = ["BagelARParams", "BagelARStage", "BagelARStep"]

--- a/unirl/models/bagel/bundle.py
+++ b/unirl/models/bagel/bundle.py
@@ -3,8 +3,10 @@
 Implements the empty :class:`Bundle` Protocol. Pure container of the modules
 BAGEL ships with for text-to-image: one MoT transformer (``Bagel`` wrapping a
 ``Qwen2ForCausalLM`` whose ``Qwen2MoTDecoderLayer`` blocks hold both und and gen
-experts) + one FLUX-style VAE + one tokenizer. The und ViT path is disabled
-(``visual_und=False``) — T2I needs only the gen expert + VAE.
+experts) + one FLUX-style VAE + one tokenizer. The und ViT tower is opt-in
+(``config.enable_vit`` → ``visual_und=True``): pure T2I needs only the gen
+expert + VAE; image-INPUT tasks (it2i editing / i2t / it2t) need the ViT to
+prefill image semantics into the KV context.
 
 LoRA injection / FSDP wrap / autocast lifecycle are owned outside the bundle
 (the train backend), so ``from_config`` only loads + freezes. The trainable
@@ -32,7 +34,14 @@ from .vendor.data.data_utils import add_special_tokens
 from .vendor.data.transforms import ImageTransform
 from .vendor.inferencer import InterleaveInferencer
 from .vendor.modeling.autoencoder import load_ae
-from .vendor.modeling.bagel import Bagel, BagelConfig, Qwen2Config, Qwen2ForCausalLM
+from .vendor.modeling.bagel import (
+    Bagel,
+    BagelConfig,
+    Qwen2Config,
+    Qwen2ForCausalLM,
+    SiglipVisionConfig,
+    SiglipVisionModel,
+)
 from .vendor.modeling.qwen2 import Qwen2Tokenizer
 
 # FSDP wrap block class for the MoT decoder (recipe backend.block_class_names).
@@ -83,7 +92,7 @@ class BagelBundle(Bundle):
 
     @classmethod
     def from_config(cls, config: BagelPipelineConfig) -> "BagelBundle":
-        """Load BAGEL-7B-MoT (gen-only) from a local checkpoint directory.
+        """Load BAGEL-7B-MoT (gen + optional und ViT) from a local checkpoint dir.
 
         Replicates flow_grpo/train_bagel.py:316-414 minus LoRA/optimizer (which
         the train backend owns). Loads the EMA weights via
@@ -111,11 +120,20 @@ class BagelBundle(Bundle):
 
         vae_model, vae_config = load_ae(local_path=os.path.join(model_dir, "ae.safetensors"))
 
+        vit_config = None
+        if config.enable_vit:
+            # Official inference setup (ByteDance-Seed/Bagel app.py @ vendored
+            # commit a2fa77d): no RoPE, drop the last SigLIP layer; the checkpoint
+            # stores the patch embedding as a Linear (converted below, pre-load).
+            vit_config = SiglipVisionConfig.from_json_file(os.path.join(model_dir, "vit_config.json"))
+            vit_config.rope = False
+            vit_config.num_hidden_layers -= 1
+
         bagel_config = BagelConfig(
             visual_gen=True,
-            visual_und=False,
+            visual_und=config.enable_vit,
             llm_config=llm_config,
-            vit_config=None,
+            vit_config=vit_config,
             vae_config=vae_config,
             vit_max_num_patch_per_side=70,
             connector_act="gelu_pytorch_tanh",
@@ -125,7 +143,10 @@ class BagelBundle(Bundle):
 
         with init_empty_weights():
             language_model = Qwen2ForCausalLM(llm_config)
-            model = Bagel(language_model, None, bagel_config)
+            vit_model = SiglipVisionModel(vit_config) if config.enable_vit else None
+            model = Bagel(language_model, vit_model, bagel_config)
+            if config.enable_vit:
+                model.vit_model.vision_model.embeddings.convert_conv2d_to_linear(vit_config, meta=True)
 
         # force_hooks=True attaches accelerate AlignDevicesHooks (matching
         # flow_grpo/train_bagel.py) so the vendored inferencer / generate_image

--- a/unirl/models/bagel/conditions.py
+++ b/unirl/models/bagel/conditions.py
@@ -24,6 +24,15 @@ context is one list element).
 
 ``Condition`` subclass so it is a valid ``RolloutTrack.conditions`` dict value;
 ``to_dict`` emits it under a single ``"bagel"`` key, ``from_dict`` reads it back.
+
+Replay approximation (frozen contexts): the contexts are prefilled under
+``no_grad`` at rollout and reused verbatim by ``replay``. For T2I this is exact
+w.r.t. training — the text prefill routes through the frozen und experts. For
+it2i (editing) the input-image VAE prefill routes through the GEN experts
+(``mode="gen"``, vendor bagel.py:528-534) — the LoRA-trained surface — so the
+stored contexts carry no gradient and go stale across optimizer updates. Ratio
+consistency still holds because old and new log-probs replay against the SAME
+stored contexts; this matches the standard frozen-context treatment.
 """
 
 from __future__ import annotations
@@ -34,6 +43,67 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple
 from unirl.config.require import require
 from unirl.distributed.tensor.batch import concat_field
 from unirl.types.conditions.base import Condition, Modality
+
+
+@dataclass
+class BagelARConditions(Condition):
+    """Per-sample RAW prompt material for the Bagel AR (text-out) stage.
+
+    Unlike :class:`BagelDiffusionConditions` (opaque prefilled KV contexts —
+    valid because the diffusion path trains only the gen experts while the
+    prompt prefill rides the frozen und path), the AR stage trains the und path
+    itself: replay needs gradients THROUGH the prompt prefill, so an opaque
+    no-grad cache cannot be the source of truth. Both ``autoregress`` and
+    ``replay`` re-derive the context from the same stored splits via the same
+    ``rl_ops`` prefill functions — prefix K/V parity by construction.
+
+    ``prompt_splits[i]`` is the ordered list of split descriptors for sample i:
+
+    - ``{"kind": "text", "ids": LongTensor[k]}`` — final token ids INCLUDING the
+      ``bos``/``eos`` (``<|im_start|>``/``<|im_end|>``) wrap that the vendored
+      ``prepare_prompts`` applies, so replay is tokenizer-independent.
+    - ``{"kind": "vit", "image": FloatTensor[3, H, W]}`` — the ``vit_transform``
+      output (final preprocessed pixels), ingested ViT-only (understanding path).
+
+    Covers t2t ``[text]``, i2t ``[vit]``, it2t ``[vit, text]`` and arbitrary
+    future interleaves. ``concat_field`` lists so ``RolloutTrack.slice`` /
+    ``concat`` / ``select`` re-index per sample, exactly like the diffusion
+    conditions.
+    """
+
+    modality: ClassVar[Modality] = Modality.TEXT
+
+    prompt_splits: List[List[Dict[str, Any]]] = concat_field(default_factory=list)
+
+    @property
+    def batch_size(self) -> int:
+        return len(self.prompt_splits)
+
+    @classmethod
+    def for_sample(cls, *, splits: List[Dict[str, Any]]) -> "BagelARConditions":
+        """Build a single-sample conditions (1-element list) from ordered splits."""
+        require(bool(splits), "BagelARConditions.for_sample: splits must be non-empty.")
+        for sp in splits:
+            require(
+                isinstance(sp, dict) and sp.get("kind") in ("text", "vit"),
+                f"BagelARConditions.for_sample: each split must be a dict with kind in ('text', 'vit'); got {sp!r}.",
+            )
+        return cls(prompt_splits=[list(splits)])
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "BagelARConditions":
+        """Read the conditions back from a ``RolloutTrack.conditions`` dict."""
+        bagel_ar = d.get("bagel_ar")
+        if isinstance(bagel_ar, cls):
+            return bagel_ar
+        raise ValueError(
+            "BagelARConditions.from_dict: expected a 'bagel_ar' key holding a "
+            f"BagelARConditions instance; got keys {sorted(d.keys())}."
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Emit as a single ``"bagel_ar"`` entry for ``RolloutTrack.conditions``."""
+        return {"bagel_ar": self}
 
 
 @dataclass
@@ -124,4 +194,4 @@ class BagelDiffusionConditions(Condition):
         return {"bagel": self}
 
 
-__all__ = ["BagelDiffusionConditions"]
+__all__ = ["BagelARConditions", "BagelDiffusionConditions"]

--- a/unirl/models/bagel/config.py
+++ b/unirl/models/bagel/config.py
@@ -11,8 +11,10 @@ consumed by the diffusion stage, the same split SD3 uses between its config and
 ``DiffusionSamplingParams``.
 
 Fixed BAGEL topology constants (``qk_norm``, ``tie_word_embeddings``,
-``layer_module``, ``connector_act``, ``visual_und``) are not exposed here — they
-are not tunable for this checkpoint and live as constants in the bundle.
+``layer_module``, ``connector_act``) are not exposed here — they are not tunable
+for this checkpoint and live as constants in the bundle. ``visual_und`` IS
+exposed (as ``enable_vit``): the und ViT tower is optional and only needed for
+image-input tasks.
 """
 
 from __future__ import annotations
@@ -35,6 +37,18 @@ BAGEL_MOE_GEN_LORA_TARGETS: Tuple[str, ...] = (
     "mlp_moe_gen.down_proj",
 )
 
+# LoRA targets for TEXT-out RL (t2t / i2t / it2t): the und/base projections the
+# MoT routes text (and ViT) tokens through. The gen experts stay frozen.
+BAGEL_UND_LORA_TARGETS: Tuple[str, ...] = (
+    "self_attn.q_proj",
+    "self_attn.k_proj",
+    "self_attn.v_proj",
+    "self_attn.o_proj",
+    "mlp.gate_proj",
+    "mlp.up_proj",
+    "mlp.down_proj",
+)
+
 
 @dataclass
 class BagelPipelineConfig:
@@ -43,7 +57,8 @@ class BagelPipelineConfig:
     BAGEL-7B-MoT is a single MoT transformer that runs both the und
     (understanding) and gen (image-generation) paths on shared weights; only the
     gen expert is trained. The bundle owns one transformer + one FLUX-style VAE +
-    one tokenizer; for text-to-image the und ViT is disabled (``visual_und=False``).
+    one tokenizer; for pure text-to-image the und ViT stays disabled
+    (``enable_vit=False`` → ``visual_und=False``), image-input tasks opt in.
 
     ``device`` may be runtime-injected by the actor after compose; the other
     fields are read once during bundle construction.
@@ -73,6 +88,13 @@ class BagelPipelineConfig:
     vae_downsample: int = 8
     latent_channels: int = 16
 
+    # Load the und ViT tower (``visual_und=True``): SiglipVisionConfig from
+    # ``<ckpt>/vit_config.json`` + SiglipVisionModel/connector/vit_pos_embed
+    # weights from the same ``ema.safetensors``. Required for image-INPUT tasks
+    # (it2i editing / i2t / it2t); the default False keeps the T2I-only
+    # construction byte-identical to before.
+    enable_vit: bool = False
+
     # Trainable module is ``model.language_model`` (the MoT). Used only by
     # dedicated-sync modes; trainside performs no weight sync.
     weight_sync_param_name_prefix: str = "language_model."
@@ -86,4 +108,4 @@ class BagelPipelineConfig:
             self.lora_target_modules = tuple(self.lora_target_modules)
 
 
-__all__ = ["BAGEL_MOE_GEN_LORA_TARGETS", "BagelPipelineConfig"]
+__all__ = ["BAGEL_MOE_GEN_LORA_TARGETS", "BAGEL_UND_LORA_TARGETS", "BagelPipelineConfig"]

--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -115,14 +115,9 @@ class BagelDiffusionParams(DiffusionSamplingParams):
         )
 
 
-def _to_device(d: Dict[str, Any], device: torch.device) -> Dict[str, Any]:
-    """Move every tensor value in a ``prepare_vae_latent*`` dict onto ``device``.
-
-    The vendored ``prepare_vae_latent`` / ``prepare_vae_latent_cfg`` build their
-    packed index tensors on CPU; the MoT forward needs them on the model device.
-    Non-tensor values pass through untouched.
-    """
-    return {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in d.items()}
+# The vendored ``prepare_*`` helpers build their packed index tensors on CPU;
+# the MoT forward needs them on the model device. Shared with the AR adapters.
+_to_device = rl_ops._to_device
 
 
 class BagelDiffusionStep:

--- a/unirl/models/bagel/pipeline.py
+++ b/unirl/models/bagel/pipeline.py
@@ -1,16 +1,26 @@
-"""BagelPipeline — RolloutReq → RolloutResp end-to-end for BAGEL-7B-MoT (T2I).
+"""BagelPipeline — RolloutReq → RolloutResp end-to-end for BAGEL-7B-MoT (T2I / it2i).
 
 Four-tier flow, per-sample (navit ``bs=1``)::
 
-    Texts ─build 3 KV contexts─▶ BagelDiffusionConditions ─diffuse─▶ LatentSegment ─vae_decode─▶ Images
+    Texts [+ Images] ─build 3 KV contexts─▶ BagelDiffusionConditions ─diffuse─▶ LatentSegment ─vae_decode─▶ Images
+
+Also serves the text-out modes (t2t / i2t / it2t, via :class:`BagelARStage`) and
+the composed **t2ti** (native think-then-generate: the AR und path plans a
+``<think>`` caption, then diffusion generates conditioned on it — one bundle, two
+linked tracks).
+
+Task routing (``_resolve_task``): explicit ``req.stage_config["task"]`` wins;
+else ``ComposedSamplingParams`` ⇒ ``t2ti``; ``ARSamplingParams`` ⇒ text-out; an
+``Images`` input ⇒ ``it2i`` (editing), else ``t2i``.
 
 Per prompt the pipeline builds the three KV-cache contexts the sampler needs
-(mirroring ``InterleaveInferencer.interleave_inference`` for plain T2I, ``think=False``,
-no input image):
+(mirroring ``InterleaveInferencer.interleave_inference``, ``think=False``;
+editing input order ``[image, text]``, vendor/inferencer.py:242-253):
 
-- ``gen``      = init + text(prompt)          (conditional)
-- ``cfg_text`` = init snapshot before the text (unconditional / text-CFG)
-- ``cfg_img``  = init + text(prompt)          (== gen for pure T2I)
+- t2i:  ``gen`` = init + text; ``cfg_text`` = init snapshot before the text
+  (unconditional); ``cfg_img`` = init + text (== gen — no image branch).
+- it2i: ``gen`` = init + image(VAE+ViT) + text; ``cfg_text`` = init + image
+  (drop-text branch); ``cfg_img`` = init + text (drop-image branch).
 
 then runs ``diffusion.diffuse`` once per sample, accumulates the per-sample latents
 into one batched ``LatentSegment``, decodes them, and packs one ``"image"`` track.
@@ -35,7 +45,7 @@ from __future__ import annotations
 
 from contextlib import nullcontext
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import torch
 
@@ -43,14 +53,17 @@ from unirl.models.types.pipeline import Pipeline
 from unirl.sde.kernels import FlowSDEStrategy, StepStrategy
 from unirl.sde.runtime import FlowMatchSchedulePolicy
 from unirl.types.noise_recipe import NoiseRecipe
-from unirl.types.primitives import Texts
+from unirl.types.primitives import Images, Texts
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.rollout_resp import RolloutResp, RolloutTrack
-from unirl.types.sampling import get_diffusion_params
+from unirl.types.sampling import ARSamplingParams, ComposedSamplingParams, get_ar_params, get_diffusion_params
 from unirl.types.segments.latent import LatentSegment
+from unirl.types.segments.text import TextSegment
 
-from .conditions import BagelDiffusionConditions
+from .ar import BagelARStage
+from .conditions import BagelARConditions, BagelDiffusionConditions
 from .diffusion import BagelDiffusionParams, BagelDiffusionStage
+from .rl_ops import _to_device
 from .vae import BagelVAEDecodeStage, bagel_latent_shape
 
 if TYPE_CHECKING:
@@ -97,6 +110,13 @@ class BagelPipeline(Pipeline):
             )
         self.diffusion = diffusion
         self.vae_decode = vae_decode if vae_decode is not None else BagelVAEDecodeStage(bundle)
+        # AR (text-out) stage for t2t / i2t / it2t; resolvable via the trainside
+        # engine's ``stage_attrs=["ar"]``. Shares the bundle (same MoT root).
+        self.ar = BagelARStage(
+            model=bundle,
+            autocast_precision=autocast_precision,
+            logprob_precision=logprob_precision,
+        )
         self.autocast_precision = autocast_precision
         # FlowMatch time-shift for the σ schedule policy (read by the hosting engine
         # via build_schedule_policy → ensure_req_sigmas). Bagel uses static shift.
@@ -148,24 +168,138 @@ class BagelPipeline(Pipeline):
             return torch.autocast("cuda", dtype)
         return nullcontext()
 
-    def _build_contexts(self, prompt: str) -> Tuple[Any, Any, Any]:
-        """Build (gen, cfg_text, cfg_img) KV contexts for a plain-T2I prompt.
+    def _resize_input_image(self, image: Any) -> Any:
+        """Canonical input-image preproc (inferencer.py:249): rgb → aspect-preserving
+        stride-8 resize. Every image-input task funnels through this before the
+        VAE/ViT branches so the chain has one home."""
+        from .vendor.data.data_utils import pil_img2rgb
 
-        Mirrors ``InterleaveInferencer.interleave_inference`` (think=False, no
-        image): ``cfg_text`` is the init snapshot taken *before* the prompt text
-        (unconditional); ``gen`` and ``cfg_img`` both ingest the prompt.
+        return self.bundle.vae_transform.resize_transform(pil_img2rgb(image))
+
+    def _extract_input_images(self, req: RolloutReq, task: str, *, n_prompts: Optional[int]) -> List[Any]:
+        """Validated per-sample input PILs for image-input tasks (it2i / i2t / it2t).
+
+        Requires an ``Images`` primitive, a ViT-loaded bundle (``enable_vit``),
+        and — when prompts are present — a matching per-sample count.
+        """
+        images_prim = req.primitives.get("image")
+        if not isinstance(images_prim, Images):
+            raise TypeError(
+                f"BagelPipeline.generate ({task}): req.primitives['image'] must be Images, "
+                f"got {type(images_prim).__name__ if images_prim is not None else 'None'}"
+            )
+        if getattr(self.bundle.model, "vit_model", None) is None:
+            raise ValueError(
+                f"BagelPipeline.generate ({task}): the bundle was built without the und ViT; "
+                "set BagelPipelineConfig.enable_vit=true for image-input tasks."
+            )
+        pil_images = [img.to_pil() for img in images_prim.to_list()]
+        if n_prompts is not None and len(pil_images) != n_prompts:
+            raise ValueError(
+                f"BagelPipeline.generate ({task}): image count {len(pil_images)} != prompt count {n_prompts}"
+            )
+        return pil_images
+
+    def _update_context_image(self, image: Any, gen_context: Any, *, vae: bool, vit: bool) -> Any:
+        """Prefill one input image into a KV context (VAE and/or ViT branch).
+
+        Mirrors the vendored ``InterleaveInferencer.update_context_image``
+        (vendor/inferencer.py:62-96) with explicit device pinning: the vendored
+        ``prepare_vae_images`` / ``prepare_vit_images`` build their tensors on
+        CPU and the bundle's VAE carries no accelerate hooks, so ``padded_images``
+        (and the packed index tensors) must be moved before the cache update.
+        ``image`` is already ``resize_transform``-ed. Caller owns no_grad+autocast.
+        """
+        bagel = self.bundle.model
+        device = torch.device(self.bundle.device)
+        ctx = gen_context
+        if vae:
+            gi, kv_lens, ropes = bagel.prepare_vae_images(
+                curr_kvlens=ctx["kv_lens"],
+                curr_rope=ctx["ropes"],
+                images=[image],
+                transforms=self.bundle.vae_transform,
+                new_token_ids=self.bundle.new_token_ids,
+            )
+            gi = _to_device(gi, device)
+            gi["padded_images"] = gi["padded_images"].to(dtype=self.bundle.vae_dtype)
+            past = bagel.forward_cache_update_vae(self.bundle.vae, ctx["past_key_values"], **gi)
+            ctx = {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
+        if vit:
+            gi, kv_lens, ropes = bagel.prepare_vit_images(
+                curr_kvlens=ctx["kv_lens"],
+                curr_rope=ctx["ropes"],
+                images=[image],
+                transforms=self.bundle.vit_transform,
+                new_token_ids=self.bundle.new_token_ids,
+            )
+            gi = _to_device(gi, device)
+            past = bagel.forward_cache_update_vit(ctx["past_key_values"], **gi)
+            ctx = {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
+        return ctx
+
+    def _build_contexts(self, prompt: str, image: Optional[Any] = None) -> Tuple[Any, Any, Any]:
+        """Build (gen, cfg_text, cfg_img) KV contexts for T2I or editing (it2i).
+
+        Mirrors ``InterleaveInferencer.interleave_inference`` exactly
+        (vendor/inferencer.py:242-253; editing input order ``[image, text]``)::
+
+            t2i  (image=None): gen      = init + text
+                               cfg_text = init                  (unconditional)
+                               cfg_img  = init + text           (no image branch)
+            it2i (image set):  gen      = init + image(VAE+ViT) + text
+                               cfg_text = init + image          (drop-text branch)
+                               cfg_img  = init + text           (drop-image branch)
+
+        ``image`` is a raw PIL image; preprocessing matches inferencer.py:249
+        (``pil_img2rgb`` + ``vae_transform.resize_transform``).
         """
         inf = self.bundle.inferencer
         gen = inf.init_gen_context()
         cfg_img = deepcopy(gen)
         with torch.no_grad(), self._autocast_ctx():
-            cfg_text = deepcopy(gen)  # snapshot before the prompt text → unconditional
+            if image is not None:
+                gen = self._update_context_image(self._resize_input_image(image), gen, vae=True, vit=True)
+            cfg_text = deepcopy(gen)  # snapshot before the prompt text → drop-text branch
             gen = inf.update_context_text(prompt, gen)
             cfg_img = inf.update_context_text(prompt, cfg_img)
         return gen, cfg_text, cfg_img
 
+    @staticmethod
+    def _resolve_task(req: RolloutReq) -> str:
+        """Resolve the task mode: explicit ``stage_config["task"]`` wins, else infer.
+
+        Inference: ``ComposedSamplingParams`` ⇒ ``t2ti`` (think-then-generate);
+        ``ARSamplingParams`` ⇒ text-out (``it2t`` with an ``Images`` input, else
+        ``t2t``; pure ``i2t`` — image, no prompt — must be explicit); diffusion
+        params ⇒ image-out (``it2i`` with an ``Images`` input, else ``t2i``).
+        """
+        task = req.stage_config.get("task")
+        if task is not None:
+            return str(task)
+        if isinstance(req.sampling_params, ComposedSamplingParams):
+            return "t2ti"
+        has_image = isinstance(req.primitives.get("image"), Images)
+        if isinstance(req.sampling_params, ARSamplingParams):
+            return "it2t" if has_image else "t2t"
+        return "it2i" if has_image else "t2i"
+
     def generate(self, req: RolloutReq) -> RolloutResp:
-        """Run BAGEL T2I per-sample and pack one ``"image"`` track."""
+        """Dispatch on the resolved task and pack one track per request."""
+        task = self._resolve_task(req)
+        if task in ("t2i", "it2i"):
+            return self._generate_image(req, task)
+        if task in ("t2t", "i2t", "it2t"):
+            return self._generate_text(req, task)
+        if task == "t2ti":
+            return self._generate_t2ti(req)
+        raise ValueError(
+            f"BagelPipeline.generate: unsupported task {task!r}; "
+            "expected one of 't2i', 'it2i', 't2t', 'i2t', 'it2t', 't2ti'."
+        )
+
+    def _generate_image(self, req: RolloutReq, task: str) -> RolloutResp:
+        """Run BAGEL image-out (t2i / it2i) per-sample and pack one ``"image"`` track."""
         if req.sigmas is None:
             raise ValueError(
                 "BagelPipeline.generate: req.sigmas is None. The hosting engine must call "
@@ -186,14 +320,54 @@ class BagelPipeline(Pipeline):
 
         prompts = list(texts.texts)
         n = len(prompts)
+
+        # it2i: per-sample input images — editing prefills the input image
+        # through BOTH the VAE branch (pixel fidelity) and the ViT branch
+        # (semantics) in _build_contexts.
+        pil_images = self._extract_input_images(req, task, n_prompts=n) if task == "it2i" else None
+
         sample_ids = list(req.sample_ids) if req.sample_ids else [f"s{i}" for i in range(n)]
         image_shape = (int(params.height), int(params.width))
+
+        contexts = [
+            self._build_contexts(prompt, image=pil_images[i] if pil_images is not None else None)
+            for i, prompt in enumerate(prompts)
+        ]
+        segment, conditions, images = self._diffuse_and_decode(
+            contexts, params=params, req=req, image_shape=image_shape
+        )
+
+        return RolloutResp(
+            tracks={
+                "image": RolloutTrack(
+                    sample_ids=sample_ids,
+                    parent_ids=list(req.group_ids) if req.group_ids else None,
+                    conditions=conditions.to_dict(),
+                    segment=segment,
+                    decoded=images,
+                ),
+            }
+        )
+
+    def _diffuse_and_decode(
+        self,
+        contexts: List[Tuple[Any, Any, Any]],
+        *,
+        params: BagelDiffusionParams,
+        req: RolloutReq,
+        image_shape: Tuple[int, int],
+    ) -> Tuple[LatentSegment, BagelDiffusionConditions, Images]:
+        """Diffuse per-sample over prebuilt ``(gen, cfg_text, cfg_img)`` contexts,
+        batch the latents, build the ``BagelDiffusionConditions``, and VAE-decode.
+
+        Shared by image-out (t2i / it2i) and think-then-generate (t2ti). x_T is
+        driver-authored per-sample via :class:`NoiseRecipe` (keyed on the request's
+        sample ids — engine draws its own when no driver recipe is present); the
+        three CFG contexts ride verbatim into the stored conditions for
+        frozen-context replay.
+        """
         device = torch.device(self.bundle.device)
         schedule = req.sigmas.to(device)
-
-        # Driver-authoritative per-sample x_T (NoiseRecipe), [n, seq, C] or None
-        # (engine draws its own — tests / no driver recipe). Per-sample-unique +
-        # per-rollout-fresh via the driver's r{rollout_id}:{sample_id} group ids.
         initial = NoiseRecipe.from_rollout_req(req).resolve(device=device, dtype=torch.float32)
 
         gen_list: List[Any] = []
@@ -201,8 +375,7 @@ class BagelPipeline(Pipeline):
         cfg_img_list: List[Any] = []
         shapes: List[Tuple[int, int]] = []
         segments: List[LatentSegment] = []
-        for i, prompt in enumerate(prompts):
-            gen_ctx, cfg_text_ctx, cfg_img_ctx = self._build_contexts(prompt)
+        for i, (gen_ctx, cfg_text_ctx, cfg_img_ctx) in enumerate(contexts):
             cond_i = BagelDiffusionConditions.for_sample(
                 gen_context=gen_ctx,
                 cfg_text_context=cfg_text_ctx,
@@ -225,18 +398,7 @@ class BagelPipeline(Pipeline):
             image_shapes=shapes,
         )
         images = self.vae_decode.decode(segment, image_shape=image_shape)
-
-        return RolloutResp(
-            tracks={
-                "image": RolloutTrack(
-                    sample_ids=sample_ids,
-                    parent_ids=list(req.group_ids) if req.group_ids else None,
-                    conditions=conditions.to_dict(),
-                    segment=segment,
-                    decoded=images,
-                ),
-            }
-        )
+        return segment, conditions, images
 
     @staticmethod
     def _batch_segments(segments: List[LatentSegment]) -> LatentSegment:
@@ -245,7 +407,9 @@ class BagelPipeline(Pipeline):
         With the per-rollout SDE window (``resolve_sde_indices(rollout_id)`` is shared
         across the group), every sample's ``sde_indices`` / ``indices`` / ``sigmas`` is
         identical, so the shared fields are taken from ``segments[0]`` and only the
-        per-sample ``latents`` / ``sde_logp`` stack along the batch axis.
+        per-sample ``latents`` / ``sde_logp`` stack along the batch axis. The
+        framework manages the row→sample mapping at concat time (matching the
+        ``LatentSegment`` field set used by every other diffusion stage).
         """
         if len(segments) == 1:
             return segments[0]
@@ -259,6 +423,205 @@ class BagelPipeline(Pipeline):
             indices=segments[0].indices,
             sde_logp=sde_logp,
             sde_indices=segments[0].sde_indices,
+        )
+
+    # ------------------------------------------------------------------
+    # Text-out (t2t / i2t / it2t)
+    # ------------------------------------------------------------------
+
+    def _generate_text(self, req: RolloutReq, task: str) -> RolloutResp:
+        """Run BAGEL text-out per-sample and pack one ``"ar"`` track.
+
+        Builds per-sample RAW prompt splits (see :class:`BagelARConditions`)
+        mirroring the vendored understanding flow (inferencer.py:242-260,
+        ``understanding_output=True``): image ingested ViT-only, then the
+        prompt text; ``BagelARStage`` owns prefill + decode + replay.
+        """
+        ar_params = get_ar_params(req.sampling_params)
+        if ar_params is None:
+            raise TypeError(
+                f"BagelPipeline.generate ({task}): sampling_params must carry ARSamplingParams, "
+                f"got {type(req.sampling_params).__name__}"
+            )
+
+        texts = req.primitives.get("text")
+        prompts: Optional[List[str]] = list(texts.texts) if isinstance(texts, Texts) else None
+        if task in ("t2t", "it2t") and prompts is None:
+            raise TypeError(
+                f"BagelPipeline.generate ({task}): req.primitives['text'] must be Texts, "
+                f"got {type(texts).__name__ if texts is not None else 'None'}"
+            )
+
+        pil_images: Optional[List[Any]] = None
+        if task in ("i2t", "it2t"):
+            pil_images = self._extract_input_images(req, task, n_prompts=len(prompts) if prompts is not None else None)
+
+        n = len(prompts) if prompts is not None else len(pil_images)
+        sample_ids = list(req.sample_ids) if req.sample_ids else [f"s{i}" for i in range(n)]
+        ntk = self.bundle.new_token_ids
+        tokenizer = self.bundle.tokenizer
+
+        splits_per_sample: List[List[Dict[str, Any]]] = []
+        for i in range(n):
+            splits: List[Dict[str, Any]] = []
+            if pil_images is not None:
+                # Understanding preproc chain (inferencer.py:249-250, vae=False):
+                # rgb → vae resize → vit_transform; store the FINAL pixels so
+                # rollout and replay consume byte-identical inputs.
+                img = self._resize_input_image(pil_images[i])
+                splits.append({"kind": "vit", "image": self.bundle.vit_transform(img)})
+            if prompts is not None:
+                # bos/eos (<|im_start|>/<|im_end|>) wrap, as prepare_prompts does
+                # (vendor bagel.py:246) — stored wrapped so replay is tokenizer-free.
+                ids = [ntk["bos_token_id"]] + tokenizer.encode(prompts[i]) + [ntk["eos_token_id"]]
+                splits.append({"kind": "text", "ids": torch.tensor(ids, dtype=torch.long)})
+            splits_per_sample.append(splits)
+
+        conditions = BagelARConditions(prompt_splits=splits_per_sample)
+        segment = self.ar.autoregress(conditions, sampling_params=ar_params)
+        decoded = self._detokenize(segment)
+
+        return RolloutResp(
+            tracks={
+                "ar": RolloutTrack(
+                    sample_ids=sample_ids,
+                    parent_ids=list(req.group_ids) if req.group_ids else None,
+                    conditions=conditions.to_dict(),
+                    segment=segment,
+                    decoded=decoded,
+                ),
+            }
+        )
+
+    def _detokenize(self, segment: TextSegment) -> Texts:
+        """Decode packed response tokens to strings, stripped at ``<|im_end|>``.
+
+        The segment holds SAMPLED tokens only (no leading bos — unlike the
+        vendored ``gen_text``, which also strips a leading ``<|im_start|>``).
+        """
+        cu = [int(c) for c in segment.cu_seqlens.tolist()]
+        out: List[str] = []
+        for i in range(len(cu) - 1):
+            toks = segment.tokens[cu[i] : cu[i + 1]].tolist()
+            out.append(self.bundle.tokenizer.decode(toks).split("<|im_end|>")[0])
+        return Texts(texts=out)
+
+    # ------------------------------------------------------------------
+    # Composed think-then-generate (t2ti)
+    # ------------------------------------------------------------------
+
+    def _build_think_contexts(self, system_prompt: str, prompt: str, think_text: str) -> Tuple[Any, Any, Any]:
+        """Build (gen, cfg_text, cfg_img) KV contexts for native think-gen (t2ti).
+
+        Mirrors ``interleave_inference(think=True, understanding_output=False)``
+        (vendor/inferencer.py:234-272)::
+
+            gen      = init + system + prompt + think_text
+            cfg_text = init + system                  (drop prompt + think)
+            cfg_img  = init + system + prompt         (drop think only — so
+                       cfg_img_scale weights the planning text's influence)
+
+        ``think_text`` is the AR-decoded planning string (stripped at
+        ``<|im_end|>``), re-encoded into the gen context exactly as the vendor's
+        ``update_context_text(gen_text, ...)`` step. The ``[system, prompt]``
+        prefix is byte-identical to the AR stage's prefill (both wrap as
+        ``[bos] + encode(text) + [eos]``), so the planning text the image
+        conditions on is the one the AR actually generated.
+        """
+        inf = self.bundle.inferencer
+        gen = inf.init_gen_context()
+        cfg_img = deepcopy(gen)
+        with torch.no_grad(), self._autocast_ctx():
+            gen = inf.update_context_text(system_prompt, gen)
+            cfg_img = inf.update_context_text(system_prompt, cfg_img)
+            cfg_text = deepcopy(gen)  # init + system → drop-prompt-and-think branch
+            gen = inf.update_context_text(prompt, gen)
+            cfg_img = inf.update_context_text(prompt, cfg_img)
+            gen = inf.update_context_text(think_text, gen)
+        return gen, cfg_text, cfg_img
+
+    def _generate_t2ti(self, req: RolloutReq) -> RolloutResp:
+        """BAGEL native think-then-generate (t2ti).
+
+        The AR und path plans a ``<think>`` caption from ``[system + prompt]``,
+        then diffusion generates the image conditioned on ``[system + prompt +
+        think]`` — one bundle, two stages. Emits two linked tracks: ``"ar"`` (the
+        planning text, grouped by prompt) and ``"image"`` (``parent_track="ar"``
+        → grouped by the rewrite, mirroring the PE composition's lineage). The
+        request carries :class:`ComposedSamplingParams` (``ar`` + ``diffusion``).
+        """
+        if req.sigmas is None:
+            raise ValueError(
+                "BagelPipeline.generate (t2ti): req.sigmas is None — the hosting engine must call "
+                "ensure_req_sigmas(req, pipeline.build_schedule_policy()) before generate."
+            )
+        ar_params = get_ar_params(req.sampling_params)
+        diff_params = get_diffusion_params(req.sampling_params)
+        if ar_params is None or not isinstance(diff_params, BagelDiffusionParams):
+            raise TypeError(
+                "BagelPipeline.generate (t2ti): sampling_params must be ComposedSamplingParams carrying "
+                f"ar=ARSamplingParams + diffusion=BagelDiffusionParams; got {type(req.sampling_params).__name__}."
+            )
+        texts = req.primitives.get("text")
+        if not isinstance(texts, Texts):
+            raise TypeError(
+                f"BagelPipeline.generate (t2ti): req.primitives['text'] must be Texts, "
+                f"got {type(texts).__name__ if texts is not None else 'None'}"
+            )
+
+        # Lazy: the vendor module hard-imports flash_attn; the bundle is loaded by now.
+        from .vendor.inferencer import GEN_THINK_SYSTEM_PROMPT
+
+        prompts = list(texts.texts)
+        n = len(prompts)
+        sample_ids = list(req.sample_ids) if req.sample_ids else [f"s{i}" for i in range(n)]
+        ar_sample_ids = [f"{sid}#think" for sid in sample_ids]
+        image_shape = (int(diff_params.height), int(diff_params.width))
+        ntk = self.bundle.new_token_ids
+        tokenizer = self.bundle.tokenizer
+
+        # Stage 1 — AR plans the think text from [system, prompt] (bos/eos-wrapped
+        # text splits, as the vendor's two update_context_text calls do).
+        ar_splits: List[List[Dict[str, Any]]] = []
+        for prompt in prompts:
+            sys_ids = [ntk["bos_token_id"]] + tokenizer.encode(GEN_THINK_SYSTEM_PROMPT) + [ntk["eos_token_id"]]
+            pr_ids = [ntk["bos_token_id"]] + tokenizer.encode(prompt) + [ntk["eos_token_id"]]
+            ar_splits.append(
+                [
+                    {"kind": "text", "ids": torch.tensor(sys_ids, dtype=torch.long)},
+                    {"kind": "text", "ids": torch.tensor(pr_ids, dtype=torch.long)},
+                ]
+            )
+        ar_conditions = BagelARConditions(prompt_splits=ar_splits)
+        ar_segment = self.ar.autoregress(ar_conditions, sampling_params=ar_params)
+        think_texts = self._detokenize(ar_segment)
+
+        # Stage 2 — diffusion conditioned on [system + prompt + think].
+        contexts = [
+            self._build_think_contexts(GEN_THINK_SYSTEM_PROMPT, prompts[i], think_texts.texts[i]) for i in range(n)
+        ]
+        segment, conditions, images = self._diffuse_and_decode(
+            contexts, params=diff_params, req=req, image_shape=image_shape
+        )
+
+        return RolloutResp(
+            tracks={
+                "ar": RolloutTrack(
+                    sample_ids=ar_sample_ids,
+                    parent_ids=list(req.group_ids) if req.group_ids else None,
+                    conditions=ar_conditions.to_dict(),
+                    segment=ar_segment,
+                    decoded=think_texts,
+                ),
+                "image": RolloutTrack(
+                    sample_ids=sample_ids,
+                    parent_track="ar",
+                    parent_ids=ar_sample_ids,
+                    conditions=conditions.to_dict(),
+                    segment=segment,
+                    decoded=images,
+                ),
+            }
         )
 
 

--- a/unirl/models/bagel/rl_ops.py
+++ b/unirl/models/bagel/rl_ops.py
@@ -11,6 +11,31 @@ two facts to UniRL's shared diffusion runtime — and nothing more:
                                  through ``functools.wraps``' ``__wrapped__``).
 - :func:`disable_inference_cache` turns off TaylorSeer (per-step determinism for replay).
 
+AR (text-out) adapters — same philosophy, for ``BagelARStage``:
+
+- :func:`init_und_context` / :func:`prefill_text_split` / :func:`prefill_vit_split`
+  build a fresh KV context from RAW prompt material (pre-tokenized ids / a
+  vit-transformed image tensor) via the pristine ``forward_cache_update_text`` /
+  ``forward_cache_update_vit`` reached through ``__wrapped__`` — grad-capable
+  under ``enable_grad`` (AR replay trains the und path, so the prompt prefill
+  must carry gradients), grad-free under rollout's ``no_grad``. One code path
+  for rollout and replay ⇒ prefix K/V parity by construction.
+- :func:`decode_text`            bs=1 per-token decode mirroring the vendored
+                                 ``generate_text`` (bagel.py:929-1001) index
+                                 bookkeeping, but emitting per-token FULL-softmax
+                                 log-probs via the caller's sampling kernel
+                                 (upstream returns token ids only).
+- :func:`score_response`         one-shot teacher-forced replay scoring: query
+                                 ``[bos] + response[:-1]`` attends causally to the
+                                 prefilled context + itself (the same
+                                 ``forward_inference(mode="und", is_causal=True)``
+                                 call shape as the vendored text prefill), row j
+                                 predicting ``response[j]`` — exactly the per-token
+                                 rollout semantics, in one grad-capable pass.
+- :func:`require_inference_dispatch` guards the eval()+grads replay regime (the
+  navit decoder layers dispatch ``forward_train``/``forward_inference`` on
+  ``self.training``; ``.train()`` mode would mis-route the packed kwargs).
+
 Everything else the RL loop needs is UniRL's, NOT a flow_grpo port:
 
 - the SDE transition + log-prob  → :class:`unirl.sde.kernels.FlowSDEStrategy`
@@ -37,11 +62,21 @@ function serves rollout, the ratio test, and training.
 
 from __future__ import annotations
 
-from typing import Any
+import sys
+from typing import Any, Callable, Dict, List, Tuple
+
+import torch
+from torch.utils.checkpoint import checkpoint
 
 __all__ = [
-    "forward_flow",
+    "decode_text",
     "disable_inference_cache",
+    "forward_flow",
+    "init_und_context",
+    "prefill_text_split",
+    "prefill_vit_split",
+    "require_inference_dispatch",
+    "score_response",
 ]
 
 
@@ -60,10 +95,19 @@ def disable_inference_cache(model: Any) -> None:
         pass
 
 
+def _raw(fn: Callable) -> Callable:
+    """Undecorated form of a vendored ``@torch.no_grad`` method (via ``__wrapped__``).
+
+    Bare ``@torch.no_grad`` applies ``functools.wraps`` so ``__wrapped__`` holds
+    the original function (verified on torch 2.11/2.12); the fallback returns the
+    function unchanged (e.g. undecorated fakes in unit tests).
+    """
+    return getattr(fn, "__wrapped__", fn)
+
+
 def _raw_forward_flow(model: Any):
     """The undecorated ``Bagel._forward_flow`` (bypasses upstream ``@torch.no_grad``)."""
-    fn = type(model)._forward_flow
-    return getattr(fn, "__wrapped__", fn)
+    return _raw(type(model)._forward_flow)
 
 
 def forward_flow(model: Any, **kwargs: Any) -> Any:
@@ -79,3 +123,250 @@ def forward_flow(model: Any, **kwargs: Any) -> Any:
     the returned velocity is the CFG-combined ``v_t`` the SDE kernel consumes.
     """
     return _raw_forward_flow(model)(model, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# AR (text-out) adapters
+# ---------------------------------------------------------------------------
+
+
+def require_inference_dispatch(model: Any) -> None:
+    """Raise unless the MoT is in eval() mode (the navit forward-dispatch contract).
+
+    Every navit module routes ``forward_train`` vs ``forward_inference`` on
+    ``self.training`` and ``Qwen2Model.forward_inference`` invokes decoder layers
+    via ``__call__`` — so ``.train()`` mode mis-routes the packed inference kwargs
+    into ``forward_train``. Replay runs in eval() with grads enabled, the same
+    regime as ``BagelDiffusionStage.replay``.
+    """
+    lm = getattr(model, "language_model", None)
+    if lm is not None and getattr(lm, "training", False):
+        raise RuntimeError(
+            "bagel.rl_ops: the MoT is in train() mode; the navit forward dispatches on "
+            "self.training, so AR rollout/replay must run in eval() (with grads enabled "
+            "for replay — same regime as BagelDiffusionStage.replay)."
+        )
+
+
+def init_und_context(model: Any) -> Dict[str, Any]:
+    """Fresh empty KV context ``{kv_lens, ropes, past_key_values}`` (navit bs=1).
+
+    Mirrors ``InterleaveInferencer.init_gen_context``. ``NaiveCache`` is resolved
+    from the model's own modeling module (hi3 ``sys.modules`` trick) so this
+    module never imports the vendored modeling (flash-attn) itself; fake models
+    must export a ``NaiveCache`` from their module (see bagel_ar_cpu_check.py).
+    """
+    lm_model = model.language_model.model
+    num_layers = int(model.config.llm_config.num_hidden_layers)
+    cache_cls = getattr(sys.modules[type(lm_model).__module__], "NaiveCache", None)
+    if cache_cls is None:
+        raise RuntimeError(
+            f"bagel.rl_ops.init_und_context: module {type(lm_model).__module__!r} exports no "
+            "NaiveCache; fake models must define one (per-layer key_cache/value_cache dicts)."
+        )
+    return {"kv_lens": [0], "ropes": [0], "past_key_values": cache_cls(num_layers)}
+
+
+def _pack_text_ids(text_ids: torch.Tensor, *, kv_len: int, rope_start: int) -> Dict[str, torch.Tensor]:
+    """``prepare_prompts``' packed-input bookkeeping for ONE pre-tokenized split.
+
+    Byte-equivalent to the vendored ``Bagel.prepare_prompts`` (bagel.py:232-264)
+    at bs=1, minus the tokenize+wrap step — ``text_ids`` are the final ids
+    INCLUDING the ``bos/eos`` (``<|im_start|>``/``<|im_end|>``) wrap, so replay is
+    tokenizer-independent and byte-aligned with rollout.
+    """
+    n = int(text_ids.numel())
+    return {
+        "text_token_lens": torch.tensor([n], dtype=torch.int),
+        "packed_text_ids": text_ids.to(dtype=torch.long),
+        "packed_text_position_ids": torch.arange(rope_start, rope_start + n, dtype=torch.long),
+        "packed_text_indexes": torch.arange(kv_len, kv_len + n, dtype=torch.long),
+        "packed_key_value_indexes": torch.arange(kv_len, dtype=torch.long),
+        "key_values_lens": torch.tensor([kv_len], dtype=torch.int),
+    }
+
+
+def _to_device(d: Dict[str, Any], device: torch.device) -> Dict[str, Any]:
+    """Move every tensor value onto ``device`` (non-tensors pass through)."""
+    return {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in d.items()}
+
+
+def prefill_text_split(
+    model: Any, ctx: Dict[str, Any], *, text_ids: torch.Tensor, device: torch.device
+) -> Dict[str, Any]:
+    """Prefill one text split into the context; returns the advanced context.
+
+    Runs the pristine ``forward_cache_update_text`` via ``__wrapped__`` so the
+    same call is grad-capable under ``enable_grad`` (replay) and grad-free under
+    ``no_grad`` (rollout).
+    """
+    kv_len, rope = int(ctx["kv_lens"][0]), int(ctx["ropes"][0])
+    gi = _to_device(_pack_text_ids(text_ids, kv_len=kv_len, rope_start=rope), device)
+    past = _raw(type(model).forward_cache_update_text)(model, ctx["past_key_values"], **gi)
+    n = int(text_ids.numel())
+    return {"kv_lens": [kv_len + n], "ropes": [rope + n], "past_key_values": past}
+
+
+def prefill_vit_split(
+    model: Any,
+    ctx: Dict[str, Any],
+    *,
+    image_tensor: torch.Tensor,
+    new_token_ids: Dict[str, int],
+    device: torch.device,
+) -> Dict[str, Any]:
+    """Prefill one ViT image split into the context; returns the advanced context.
+
+    ``image_tensor`` is the ALREADY ``vit_transform``-ed ``[3, H, W]`` tensor (the
+    conditions store the final transform output so rollout and replay consume
+    byte-identical pixels); the pristine ``prepare_vit_images`` packer is reused
+    verbatim with an identity transform. The cache update runs ``is_causal=False``
+    inside — the non-causal image block within the causal stream, exactly as at
+    rollout.
+    """
+    gi, newlens, new_rope = model.prepare_vit_images(
+        curr_kvlens=ctx["kv_lens"],
+        curr_rope=ctx["ropes"],
+        images=[image_tensor],
+        transforms=lambda x: x,
+        new_token_ids=new_token_ids,
+    )
+    gi = _to_device(gi, device)
+    past = _raw(type(model).forward_cache_update_vit)(model, ctx["past_key_values"], **gi)
+    return {"kv_lens": newlens, "ropes": new_rope, "past_key_values": past}
+
+
+def decode_text(
+    model: Any,
+    ctx: Dict[str, Any],
+    *,
+    start_token_id: int,
+    sample_fn: Callable[[torch.Tensor], Tuple[torch.Tensor, torch.Tensor]],
+    max_new_tokens: int,
+    stop_ids: List[int],
+    device: torch.device,
+) -> Tuple[List[int], List[float]]:
+    """bs=1 per-token decode over a prefilled context, emitting token+logp pairs.
+
+    Reimplements the vendored ``generate_text`` loop (bagel.py:929-1001) — which
+    returns token ids only — with the per-step ``sample_fn(logits [1, vocab]) →
+    (token_id, full-softmax log-prob)`` kernel. Index bookkeeping is the bs=1
+    collapse of the vendored multi-sample form: contiguous kv indexes
+    ``arange(kv_len)``, query index ``[kv_len]``, position/kv_len advance by one
+    per token. The returned token list INCLUDES the stop token (TextSegment
+    convention); ``start_token_id`` (``new_token_ids['bos_token_id']``, as in the
+    vendored ``prepare_start_tokens``) is the loop *input*, never recorded.
+
+    Mutates ``ctx['past_key_values']`` in place (``update_past_key_values=True``)
+    — callers prefill a fresh context per sample. Caller owns no_grad + autocast.
+    """
+    require_inference_dispatch(model)
+    disable_inference_cache(model)
+    lm = model.language_model
+    kv_len, pos = int(ctx["kv_lens"][0]), int(ctx["ropes"][0])
+    past = ctx["past_key_values"]
+    stop_set = set(int(t) for t in stop_ids)
+
+    # Hoisted index pools — per-step values are views (kv indexes grow by one
+    # contiguous slot per token, so arange slices cover every step).
+    max_new = int(max_new_tokens)
+    all_indexes = torch.arange(kv_len + max_new, dtype=torch.long, device=device)
+    all_positions = torch.arange(pos, pos + max_new, dtype=torch.long, device=device)
+    all_kv_lens = torch.arange(kv_len, kv_len + max_new, dtype=torch.int, device=device)
+
+    curr = torch.tensor([int(start_token_id)], dtype=torch.long, device=device)
+    tokens: List[int] = []
+    logps: List[float] = []
+    for j in range(max_new):
+        emb = lm.model.embed_tokens(curr)
+        out = lm.forward_inference(
+            packed_query_sequence=emb,
+            query_lens=torch.ones_like(curr),
+            packed_query_position_ids=all_positions[j : j + 1],
+            packed_query_indexes=all_indexes[kv_len + j : kv_len + j + 1],
+            past_key_values=past,
+            key_values_lens=all_kv_lens[j : j + 1],
+            packed_key_value_indexes=all_indexes[: kv_len + j],
+            update_past_key_values=True,
+            is_causal=True,
+            mode="und",
+        )
+        past = out.past_key_values
+        logits = lm.lm_head(out.packed_query_sequence)  # [1, vocab]
+        token_id, log_prob = sample_fn(logits)
+        tid = int(token_id.item())
+        tokens.append(tid)
+        logps.append(float(log_prob.item()))
+        if tid in stop_set:
+            break
+        curr = token_id.to(device=device, dtype=torch.long).reshape(1)
+    return tokens, logps
+
+
+def score_response(
+    model: Any,
+    ctx: Dict[str, Any],
+    *,
+    response_ids: torch.Tensor,
+    start_token_id: int,
+    temperature: float = 1.0,
+    logprob_chunk: int = 1024,
+    device: torch.device,
+) -> torch.Tensor:
+    """One-shot teacher-forced per-token log-probs of ``response_ids`` — grad-capable.
+
+    Query ``[start] + response[:-1]`` (length n) attends causally to the prefilled
+    context + itself (``is_causal=True``, ``update_past_key_values=False`` — the
+    same ``forward_inference(mode="und")`` call shape as the vendored text
+    prefill); flash-attn's bottom-right causal alignment makes row ``j`` attend to
+    ``prefix + query[0..j]``, so row ``j`` predicts ``response[j]`` — exactly the
+    per-token rollout semantics.
+
+    Log-probs are the FULL softmax of ``lm_head(h).float() / T`` (gather −
+    logsumexp), matching the rollout kernel's pre-truncation convention; the
+    lm_head runs chunked (never materializing ``[n, vocab]`` whole) with per-chunk
+    gradient checkpointing when grads are enabled. Returns fp32 ``[n]``. Caller
+    owns the grad scope (eval() + ``enable_grad`` for replay) and autocast.
+    """
+    require_inference_dispatch(model)
+    disable_inference_cache(model)
+    lm = model.language_model
+    kv_len, pos = int(ctx["kv_lens"][0]), int(ctx["ropes"][0])
+    n = int(response_ids.numel())
+    if n == 0:
+        return torch.zeros(0, dtype=torch.float32, device=device)
+
+    response_ids = response_ids.to(device=device, dtype=torch.long)
+    start = torch.tensor([int(start_token_id)], dtype=torch.long, device=device)
+    query_ids = torch.cat([start, response_ids[:-1]], dim=0)  # [n]
+
+    emb = lm.model.embed_tokens(query_ids)
+    out = lm.forward_inference(
+        packed_query_sequence=emb,
+        query_lens=torch.tensor([n], dtype=torch.int, device=device),
+        packed_query_position_ids=torch.arange(pos, pos + n, dtype=torch.long, device=device),
+        packed_query_indexes=torch.arange(kv_len, kv_len + n, dtype=torch.long, device=device),
+        past_key_values=ctx["past_key_values"],
+        key_values_lens=torch.tensor([kv_len], dtype=torch.int, device=device),
+        packed_key_value_indexes=torch.arange(kv_len, dtype=torch.long, device=device),
+        update_past_key_values=False,
+        is_causal=True,
+        mode="und",
+    )
+    hidden = out.packed_query_sequence  # [n, H]
+
+    temp = float(temperature) if float(temperature) > 0.0 else 1.0
+
+    def _chunk_logp(h: torch.Tensor, tgt: torch.Tensor) -> torch.Tensor:
+        logits = lm.lm_head(h).float() / temp
+        return logits.gather(-1, tgt.unsqueeze(-1)).squeeze(-1) - torch.logsumexp(logits, dim=-1)
+
+    use_ckpt = torch.is_grad_enabled() and hidden.requires_grad
+    parts: List[torch.Tensor] = []
+    for s in range(0, n, int(logprob_chunk)):
+        h, tgt = hidden[s : s + int(logprob_chunk)], response_ids[s : s + int(logprob_chunk)]
+        if use_ckpt:
+            parts.append(checkpoint(_chunk_logp, h, tgt, use_reentrant=False))
+        else:
+            parts.append(_chunk_logp(h, tgt))
+    return torch.cat(parts, dim=0)


### PR DESCRIPTION
## Summary

Extends the BAGEL-7B-MoT bundle from **T2I-only** to all generation modes at the **rollout + replay** level — **it2i** (image editing), **t2t / i2t / it2t** (text-out via the und path), and **t2ti** (native think-then-generate). GRPO / rewards / trainer / recipes are out of scope; this adds the per-mode rollout + replay primitives the algorithms consume.

- **it2i** (editing): opt-in und ViT (`enable_vit`); input image prefilled through VAE+ViT; the vendor's 3-context editing CFG recipe. Diffusion stage unchanged.
- **t2t / i2t / it2t**: a new `BagelARStage` on the und path — per-token decode with KV cache (rollout) + one-shot teacher-forced `score_response` (replay), full-softmax logprob, `BagelARConditions` storing raw prompt splits, `BAGEL_UND_LORA_TARGETS`.
- **t2ti**: native think-then-generate — the AR und path plans a `<think>` caption, then diffusion renders conditioned on `[system + prompt + think]`; two linked tracks (`ar` + `image`, `image.parent_track="ar"`), routed via `ComposedSamplingParams`.

Design discipline: `vendor/` stays pristine; all RL glue lives in `rl_ops` via the `__wrapped__` no_grad bypass; `import unirl.models.bagel` stays flash-attn-free; navit bs=1 per-sample loops. Also fixes the `bagel_trainside_lora` recipe `old_logp_source` (`native` → `rollout`; `native` was never a valid FlowGRPO value).

## Related Issue

N/A

## Test Plan

Validated on real `ByteDance-Seed/BAGEL-7B-MoT` weights (8×H20) with an out-of-tree harness (the smoke/CPU scripts are dev-only and intentionally not shipped in this PR):

- **Modality smoke (GPU, all 6 modes) — 7/7 checks PASS**: t2t/i2t/it2t text + a greedy cross-check that `rl_ops.decode_text` emits byte-identical ids to the vendored `generate_text`; t2i/it2i image (diffusion replay ratio 0.00, it2i bit-equal determinism); t2ti (think + image, AR replay median ~2e-5, diffusion ratio 0.00, lineage `parent_track="ar"`). Visual QC of the saved images confirms on-prompt content (red panda for t2i/t2ti; it2i preserves structure and applies the requested edit at an adequate step count).
- **AR CPU checks (no GPU, no flash-attn)**: AR rollout==replay logprob parity (sampled + greedy), replay gradients reach the und stack, `BagelARConditions` round-trip, and `_resolve_task` routing.
- **Diffusion-only GRPO e2e** (`bagel_trainside_lora`, PickScore, 8×H20): reward climbs 0.73 → ~0.85 plateau, confirming the `old_logp_source` recipe fix.

## Compatibility / Risk

Additive — no change to the existing T2I path or other models. Adds an optional `enable_vit` config flag (default off, needed only for image-input modes). The `old_logp_source` change touches only `examples/diffusion/bagel/bagel_trainside_lora.yaml`. No checkpoint/data-format changes.

## Reviewer Notes

AI-assisted; every changed line was reviewed and validated end-to-end (the 7/7 modality smoke on real weights, the CPU AR checks, and the diffusion e2e above). Duplicate-work check: no overlapping open bagel PRs on this repo. `vendor/` is left byte-pristine; all RL glue is confined to `rl_ops` + the bagel stage/conditions/pipeline classes.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
