### PR TITLE
docs(readme): add CPPO to News, align release dates to 2026-06

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@
 
 ## News 🚀
 
-- **[2026-05]** **DRPO** released — *"Rethinking the Divergence Regularization in LLM RL"* ([arXiv](https://arxiv.org/abs/2606.09821)).
+- **[2026-06]** **DRPO** released — *"Rethinking the Divergence Regularization in LLM RL"* ([arXiv](https://arxiv.org/abs/2606.09821)).
 - **[2026-06]** **Flow-DPPO** released — *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models"* ([arXiv](https://arxiv.org/abs/2606.11025)).
+- **[2026-06]** **CPPO** released — *"Beyond Uniform Token-Level Trust Region in LLM Reinforcement Learning"* ([arXiv](https://arxiv.org/abs/2606.10968)).
 
 ## About 💡
 


### PR DESCRIPTION
## Summary

Follow-up to #58 (CPPO). That PR added CPPO to the **Team-Proposed Algorithms** table but not to the **News** list, so the entry README's News section was missing it. This PR:

- Adds the matching News entry: `[2026-06] CPPO released — "Beyond Uniform Token-Level Trust Region in LLM Reinforcement Learning"` ([arXiv](https://arxiv.org/abs/2606.10968)).
- Bumps the DRPO News date from `[2026-05]` to `[2026-06]` so every News entry matches its `2606.*` (June 2026) arXiv month and the other entries.

Docs-only; no code, config, or recipe changes.

## Related Issue

N/A (follow-up to #58).

## Test Plan

Docs-only README change. Verified by inspection that the News list now matches the Team-Proposed Algorithms table (Flow-DPPO / DRPO / CPPO) and that all three News dates read `2026-06`. No build/test/lint behavior is affected (`.md` only).

## Compatibility / Risk

N/A — README News section only.

## Reviewer Notes

Splits the README News update out of the already-merged #58. Prepared with AI assistance; the diff was reviewed before submission. Duplicate-work check: no other open PR touches the README News section.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
