### PR TITLE
fix(rollout): make sglang_diffusion engine.sleep() idempotent

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/engine.py
+++ b/unirl/rollout/engine/sglang_diffusion/engine.py
@@ -189,6 +189,10 @@ class SGLangDiffusionRolloutEngine(BaseRolloutEngine):
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def sleep(self) -> None:
+        # Idempotent, symmetric with ``wake_up``: a second ``sleep()`` while already
+        # offloaded would issue ``release_memory_occupation`` to the scheduler twice.
+        if self._is_offloaded:
+            return
         self._backend.release_memory(tags=_OFFLOAD_TAGS, cpu_backup_tags=_CPU_BACKUP_TAGS)
         self._is_offloaded = True
         # The released tags include the transformer weights → the loaded LoRA pool


### PR DESCRIPTION
## Summary

Follow-up to #35. `SGLangDiffusionRolloutEngine.wake_up()` guards on `_is_offloaded`, but `sleep()` did not: a second `sleep()` while the engine is already offloaded issues `release_memory_occupation` to the SGLang scheduler twice (and re-fires `mark_weights_released`). The shipped trainer loops pair `sleep`/`wake_up`, so this never triggers today, but the asymmetry is a footgun for retry paths and future callers — the sibling `sglang_llm` engine already guards its `sleep()`. This adds the symmetric early-return guard.

## Related Issue

N/A — small robustness follow-up to #35.

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files unirl/rollout/engine/sglang_diffusion/engine.py` → all hooks pass (ruff check, ruff format, python-ast, `recipe _target_ paths resolve`).
- `python -m py_compile unirl/rollout/engine/sglang_diffusion/engine.py` → OK.
- GPU/runtime e2e not run; reason: no GPU + SGLang runtime on this box. The change is a pure idempotency guard mirroring `wake_up()` and cannot alter the normal single-`sleep()` path.

## Compatibility / Risk

No config, checkpoint, data-format, or API changes. Behavior is unchanged for the normal paired `sleep`/`wake_up` sequence; the guard only suppresses a redundant double-release when `sleep()` is called while already offloaded.

## Reviewer Notes

While reviewing #35 I also looked at two adjacent items and deliberately left them out of this PR because they are design decisions, not mechanical fixes:

- **`lora_dirty` is currently unwired.** `sleep()` → `WeightSync.mark_weights_released()` sets `_lora_loaded=False`, which feeds only `lora_dirty`, which only `engine.lora_dirty` reads, which nothing reads (LoRA freshness appears to be enforced by the scheduler patch + the unconditional per-rollout re-sync). It's a documented hook, so the right call — wire it into the sync cadence vs. retire the mechanism — is the author's.
- **`model_family` validation accepts every registered adapter** (incl. `flux` / `mochi` / `hunyuan_video`). Those are intentionally registered for image-path parity (see the PARITY NOTE in `adapters/video.py`), so tightening validation would contradict that intent. Left as-is.

AI-assisted; single-file change reviewed in full.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not (no test added: trivial guard; this engine currently ships without a unit-test harness).
