### PR TITLE
feat(z-image): SGLang Diffusion v2 rollout-engine support

### DIFF
--- a/examples/diffusion/z_image_sglang_full_tensor.yaml
+++ b/examples/diffusion/z_image_sglang_full_tensor.yaml
@@ -1,0 +1,212 @@
+# @package _global_
+# Z-Image (base) + SGLang Diffusion v2 dedicated rollout — COLOCATE, LoRA training
+# + MERGED full-weight sync (tensor-payload), FlowGRPO, REPLAY log-probs.
+#
+# SGLang twin of the trainside recipe: identical train side, the rollout runs in
+# the sglang_diffusion engine (its own DiffGenerator worker runs the FULL Z-Image
+# pipeline — Qwen3 text-encode + S3-DiT denoise + VAE decode). REPLAY mode: the
+# trainer recomputes the pi_old anchor via ZImageDiffusionStage.replay, so the GRPO
+# ratio is ~1.0 at iter 0 (rollout/replay share the same sigma schedule + conditions).
+#
+# Why full-weight MERGED sync (not LoRA-adapter sync): SGLang's Z-Image attention
+# uses a FUSED qkv projection (one MergedColumnParallelLinear ``attention.to_qkv``)
+# and fused FFN ``feed_forward.w13``, while the trainer-side diffusers
+# ZImageTransformer2DModel uses SEPARATE to_q/to_k/to_v + w1/w3. We still TRAIN LoRA
+# (backend.lora_cfg), but each sync folds the LoRA delta into the base weights
+# (sync.lora_merged: true) and pushes the MERGED full model. The engine's weight
+# updater applies the model's ``param_names_mapping`` so the separate q/k/v + w1/w3
+# tensors land in the fused to_qkv / w13 shards (see
+# sglang_diffusion/_patches/patch_weights_updater.py:_apply_fused_param_mapping).
+#
+# CFG OFF (guidance_scale=0): SGLang gates CFG on guidance_scale>1, so 0 keeps it
+# off; trainer-side replay also runs CFG-free (no negative_text emitted).
+#
+# Scale via launcher (num_devices = cluster GPU count). batch_size=64 divides
+# 2/8/32. Quick smoke: batch_size=2 sampling.samples_per_prompt=4 num_rollouts=2
+
+num_devices: 8
+batch_size: 64                # prompts_per_rollout (divisible by 2/8/32)
+adv_use_global_std: true      # advantage: divide by ONE batch-wide std (v1 parity), not per-group
+num_rollouts: 10000
+
+# Every N rollouts the loop pushes the freshly-trained full weights into the engine
+# just before that rollout's generate. 1 = on-policy.
+weight_sync_interval: 1
+
+logging:
+  # Env-driven so multi-node runs enable W&B with REPORT_TO_WANDB=true (the launcher
+  # exports it). rank-0/driver only; no-op when false.
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,false}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-zimage}
+  run_name: ${oc.env:WANDB_RUN_NAME,z_image_base_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: null
+
+bundle:
+  _target_: unirl.models.z_image.bundle.ZImageBundle.from_config
+  config:
+    _target_: unirl.models.z_image.config.ZImagePipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:Z_IMAGE_PATH,Tongyi-MAI/Z-Image}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: bf16
+    logprob_precision: fp32
+    max_sequence_length: 512
+    # Static FlowMatch shift; base Z-Image's scheduler_config.json declares
+    # use_dynamic_shifting=false + shift=6.0. The engine reads this to build its
+    # sigma schedule via the generic static-shift FlowMatchSchedulePolicy (Z-Image
+    # is static-shift, like SD3 — unlike Qwen-Image / Flux.2 dynamic shift).
+    shift: 6.0
+
+pipeline:
+  _target_: unirl.models.z_image.pipeline.ZImagePipeline
+  shift: 6.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["ZImageTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    # 6B S3-DiT + Qwen3 text encoder under full-graph replay: keep AC on.
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  # LoRA training — synced as a MERGED full model (sync.lora_merged: true), so the
+  # rollout engine runs the merged weights without a separate adapter.
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    # Z-Image single-stream attention (diffusers Attention inside
+    # ZImageTransformerBlock): q/k/v projections + output proj.
+    target_modules:
+      - to_k
+      - to_out.0
+      - to_q
+      - to_v
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  # model_config carries the sigma-schedule `shift` + checkpoint path; share the
+  # bundle's config (the worker materializes the nested _target_).
+  model_config: ${bundle.config}
+  # SDE strategy -> engine resolves the SGLang kernel label (sde_label). Colocate
+  # doesn't inject `strategy` via setup(), so pass the pipeline's strategy explicitly.
+  strategy: ${pipeline.strategy}
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    # Explicit family selects the ZImageAdapter (registry key) + trainer-side typed
+    # condition reconstruction.
+    model_family: z_image
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    populate_conditions: true   # pack SGLang prompt_embeds into resp.conditions['text'] for replay
+    init_same_noise: ${sampling.init_same_noise}
+    # Chunk generate into sub-batches so sglang bounds its DiT-forward / VAE-decode
+    # peak memory (6B DiT + Qwen3 encoder are heavy); mirrors z_image_trainside.
+    forward_batch_size: 8
+    engine_kwargs:
+      model_type: z_image
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.pickscore.PickScoreRewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.pickscore.PickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  # REPLAY mode: trainer recomputes the pi_old anchor via stage.replay at update
+  # time (engine emits trajectories; its native log-probs, if any, are ignored).
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.z_image.conditions.ZImageConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 8
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2      # PPO mini-batches per rollout (π_old frozen once); v1 parity
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 12       # base Z-Image multi-step (matches trainside)
+  guidance_scale: 0.0           # CFG OFF (SGLang gates CFG on >1; 0 disables it)
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 3
+    # SDE-step window: confine SDE noise to the early high-σ steps.
+    timestep_fraction: [0, 0.5]
+
+# LoRA -> MERGED full-weight sync -> SGLang rollout (colocate tensor-payload).
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  # Fold the trained LoRA delta into the base weights and push the merged full model
+  # (we LoRA-train but serve a merged model — no separate adapter); the engine's
+  # weight updater maps the separate q/k/v + w1/w3 into the fused to_qkv / w13 shards.
+  lora_merged: true
+  bucket_size_mb: 512
+  flush_cache: true
+  # Ordered first-match-wins name rewrite (see FullWeightSync._apply_name_remap):
+  # backend.model is the bare ZImageTransformer2DModel (merged_state_dict yields
+  # layers.* / noise_refiner.* / all_x_embedder.* etc.), so the "*" catch-all nests
+  # every key under the receiver's transformer.* namespace.
+  name_remap: {"*": "transformer.*"}

--- a/examples/diffusion/z_image_trainside.yaml
+++ b/examples/diffusion/z_image_trainside.yaml
@@ -5,12 +5,17 @@
 # (no separate rollout actor, no weight sync). Strongest colocate form.
 #
 # This recipe targets the BASE checkpoint Tongyi-MAI/Z-Image (not the distilled
-# Turbo): multi-step sampling WITH classifier-free guidance (guidance_scale>0,
-# empty-string negatives auto-added by the pipeline) and static shift=6.0. The
-# S3-DiT single-stream transformer + Qwen3 text encoder are loaded by the
-# bundle; the VAE is the flux-style 16-channel AutoencoderKL. (To run Turbo
-# instead: set Z_IMAGE_PATH=.../Z-Image-Turbo and override shift=3.0,
-# sampling.guidance_scale=0.0, sampling.num_inference_steps=8.)
+# Turbo): multi-step sampling and static shift=6.0. The S3-DiT single-stream
+# transformer + Qwen3 text encoder are loaded by the bundle; the VAE is the
+# flux-style 16-channel AutoencoderKL.
+#
+# CFG is intentionally OFF here (guidance_scale=0 -> single forward, no negative
+# prompt). Empirically CFG slows the reward curve: it sharpens the per-prompt
+# distribution (less in-group diversity -> weaker GRPO advantage) AND doubles
+# the per-step forward cost. Off = more exploration + ~2x faster rollouts.
+# (To re-enable CFG: set sampling.guidance_scale>0; the pipeline then auto-adds
+# empty-string negatives. To run Turbo: set Z_IMAGE_PATH=.../Z-Image-Turbo and
+# override shift=3.0, sampling.num_inference_steps=8.)
 #
 # Scale is set by the launcher (num_devices = cluster GPU count); this same
 # recipe runs on 2 (H20 smoke), 8 (1-node) and 32 (4x8) GPUs. batch_size=64
@@ -124,8 +129,10 @@ algorithm:
   stage_attr: diffusion
   clip_range: 1.0e-4
   clip_schedule: constant
-  # forward_batch_size (8) != micro_batch_size (1); recompute pi_old at the
-  # train micro-geometry so the on-policy ratio is exactly 1 (see SD3 recipe).
+  # Recompute pi_old at the exact train micro-geometry so the on-policy ratio is
+  # exactly 1 (bf16 forwards are batch-shape sensitive). Correct & safe to keep
+  # even now that micro_batch_size happens to equal forward_batch_size, and
+  # required again the moment they diverge (see SD3 recipe).
   old_logp_source: replay
   conditions_cls:
     _target_: hydra.utils.get_class
@@ -134,7 +141,15 @@ algorithm:
 
 stack:
   _target_: unirl.train.stack.TrainStack
-  micro_batch_size: 1
+  # Train-side micro-batch (pure speed/memory knob — it only sets grad-accum
+  # granularity, NOT the effective batch, so it never changes the optimization
+  # math). Observed: mbs 1->4 barely moved HBM (~42 -> ~40 GB) because resident
+  # frozen weights (transformer + Qwen3 encoder + VAE) dominate and activations
+  # don't persist under AC. So push it hard. On the 4x8 run the per-GPU
+  # mini-batch is 16 (batch_size*spp/num_devices/num_updates_per_batch =
+  # 64*16/32/2), so mbs=16 means zero accumulation (max SM feed); 8 = 2 accum
+  # steps. Start at 8, bump to 16 via `stack.micro_batch_size=16` if HBM allows.
+  micro_batch_size: 8
   max_grad_norm: 1.0
   num_updates_per_batch: 2      # PPO mini-batches per rollout (π_old frozen once); v1 parity
 
@@ -150,10 +165,12 @@ data_source:
 
 sampling:
   _target_: unirl.types.sampling.DiffusionSamplingParams
-  num_inference_steps: 16       # base Z-Image: multi-step (RL-reduced from ~30-50)
-  guidance_scale: 4.0           # base needs CFG; empty-string negatives auto-added.
-                                # diffusers default is 5.0 — lower => more in-group
-                                # diversity for GRPO. Set 0.0 only for Turbo.
+  num_inference_steps: 12       # base Z-Image: multi-step (RL-reduced from ~30-50;
+                                # 12 ≈ Qwen-Image recipe — trims rollout cost, which
+                                # CFG already doubles per step). Set 8 only for Turbo.
+  guidance_scale: 0.0           # CFG OFF (single forward, no negative). Faster
+                                # reward curve: more in-group diversity for GRPO +
+                                # ~2x cheaper rollouts. Set >0 to re-enable CFG.
   height: 512
   width: 512
   eta: 0.7

--- a/tests/rollout/test_sglang_diffusion_z_image.py
+++ b/tests/rollout/test_sglang_diffusion_z_image.py
@@ -1,0 +1,230 @@
+"""CPU-only guards for the ``sglang_diffusion`` Z-Image wiring.
+
+Covers the pure-logic pieces of the Z-Image v2 rollout-engine port — no SGLang
+import, no GPU:
+
+* ``patch_weights_updater._apply_fused_param_mapping`` — separate diffusers
+  ``to_q/to_k/to_v`` + ``w1/w3`` tensors must land in Z-Image's FUSED
+  ``to_qkv`` / ``w13`` shards (the flat-reward bug otherwise).
+* ``patch_conditions._ensure_batched_embed_list`` — un-batched ``[seq, hidden]``
+  captions (single-prompt encode) get a batch dim; batched / pooled / masks are
+  left as-is.
+* ``adapters.z_image`` — the 6-D -> 5-D frame squeeze and the caption-mask
+  backfill (so cross-padded zero rows are never denoised as real tokens).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from unirl.rollout.engine.sglang_diffusion._patches.patch_conditions import (
+    _ensure_batched_embed_list,
+)
+from unirl.rollout.engine.sglang_diffusion._patches.patch_weights_updater import (
+    _apply_fused_param_mapping,
+    _resolve_param_names_mapping,
+)
+from unirl.rollout.engine.sglang_diffusion.adapters import registered_adapters
+from unirl.rollout.engine.sglang_diffusion.adapters.z_image import (
+    ZImageAdapter,
+    _backfill_caption_mask,
+    _to_image_form_trajectory,
+)
+from unirl.types.conditions.text import TextEmbedCondition
+
+# The Z-Image fused-projection subset of ZImageArchConfig.param_names_mapping
+# (weight-only entries; the lora_*/weight_scale_inv variants share the same shape).
+_ZIMAGE_MAPPING = {
+    r"(.*)\.attention\.to_q\.weight$": (r"\1.attention.to_qkv.weight", 0, 3),
+    r"(.*)\.attention\.to_k\.weight$": (r"\1.attention.to_qkv.weight", 1, 3),
+    r"(.*)\.attention\.to_v\.weight$": (r"\1.attention.to_qkv.weight", 2, 3),
+    r"(.*)\.feed_forward\.w1\.weight$": (r"\1.feed_forward.w13.weight", 0, 2),
+    r"(.*)\.feed_forward\.w3\.weight$": (r"\1.feed_forward.w13.weight", 1, 2),
+}
+
+
+class _FakeFusedModule:
+    """Minimal stand-in for the fused Z-Image transformer module.
+
+    ``_apply_fused_param_mapping`` reads ``type(module).param_names_mapping`` and
+    ``dict(module.named_parameters())`` only; plain tensors (no ``weight_loader``)
+    exercise the equal-split fallback in ``_write_fused_shard`` — the exact path
+    Z-Image base (MHA, equal q/k/v) takes at tp_size=1.
+    """
+
+    param_names_mapping = _ZIMAGE_MAPPING
+
+    def __init__(self, params):
+        self._params = params
+
+    def named_parameters(self):
+        return list(self._params.items())
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+
+
+def test_z_image_adapter_registered():
+    assert "z_image" in registered_adapters()
+
+
+# --------------------------------------------------------------------------- #
+# Fused weight mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_fused_param_mapping_routes_qkv_and_w13_shards():
+    d, h = 4, 6
+    qkv = torch.zeros(3 * d, d)
+    w13 = torch.zeros(2 * h, d)
+    module = _FakeFusedModule(
+        {
+            "layers.0.attention.to_qkv.weight": qkv,
+            "layers.0.feed_forward.w13.weight": w13,
+        }
+    )
+    named = [
+        ("layers.0.attention.to_q.weight", torch.full((d, d), 1.0)),
+        ("layers.0.attention.to_k.weight", torch.full((d, d), 2.0)),
+        ("layers.0.attention.to_v.weight", torch.full((d, d), 3.0)),
+        ("layers.0.feed_forward.w1.weight", torch.full((h, d), 7.0)),
+        ("layers.0.feed_forward.w3.weight", torch.full((h, d), 8.0)),
+    ]
+
+    leftover = _apply_fused_param_mapping(module, named)
+
+    assert leftover == []  # every separate tensor was consumed into a fused shard
+    assert torch.equal(qkv[0:d], torch.full((d, d), 1.0))  # q -> shard 0
+    assert torch.equal(qkv[d : 2 * d], torch.full((d, d), 2.0))  # k -> shard 1
+    assert torch.equal(qkv[2 * d : 3 * d], torch.full((d, d), 3.0))  # v -> shard 2
+    assert torch.equal(w13[0:h], torch.full((h, d), 7.0))  # w1 -> shard 0
+    assert torch.equal(w13[h : 2 * h], torch.full((h, d), 8.0))  # w3 -> shard 1
+
+
+def test_fused_param_mapping_passes_through_exact_matches():
+    # A name already present as a real param must NOT be fused — it falls through
+    # to the exact-match loader untouched.
+    p = torch.zeros(4, 4)
+    module = _FakeFusedModule({"layers.0.attention.to_qkv.weight": p, "norm.weight": torch.zeros(4)})
+    payload = [("norm.weight", torch.ones(4))]
+    assert _apply_fused_param_mapping(module, payload) == payload
+
+
+def test_resolve_param_names_mapping_absent_is_empty():
+    class _Plain:
+        pass
+
+    assert _resolve_param_names_mapping(_Plain()) == {}
+    # No mapping -> _apply_fused_param_mapping is a pure pass-through.
+    payload = [("transformer_blocks.0.attn.to_q.weight", torch.ones(2, 2))]
+    assert _apply_fused_param_mapping(_Plain(), payload) == payload
+
+
+# --------------------------------------------------------------------------- #
+# Un-batched embed normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_batched_adds_dim_for_unbatched_caption():
+    out = _ensure_batched_embed_list([torch.randn(37, 2560)])
+    assert tuple(out[0].shape) == (1, 37, 2560)
+
+
+def test_ensure_batched_noop_for_batched_and_none():
+    batched = torch.randn(4, 37, 2560)
+    out = _ensure_batched_embed_list([batched, None])
+    assert out[0] is batched  # already [B, seq, h] -> untouched (same object)
+    assert out[1] is None
+    assert _ensure_batched_embed_list(None) is None  # non-list passthrough
+
+
+# --------------------------------------------------------------------------- #
+# Trajectory frame squeeze
+# --------------------------------------------------------------------------- #
+
+
+def test_trajectory_frame_axis_squeezed():
+    t6 = torch.randn(2, 13, 16, 1, 8, 8)  # [B, T+1, C, F=1, H, W]
+    assert tuple(_to_image_form_trajectory(t6).shape) == (2, 13, 16, 8, 8)
+
+
+def test_trajectory_5d_passthrough():
+    t5 = torch.randn(2, 13, 16, 8, 8)
+    assert _to_image_form_trajectory(t5) is t5
+
+
+def test_trajectory_nonsingleton_frame_raises():
+    with pytest.raises(ValueError):
+        _to_image_form_trajectory(torch.randn(2, 13, 16, 2, 8, 8))
+
+
+# --------------------------------------------------------------------------- #
+# Caption mask backfill
+# --------------------------------------------------------------------------- #
+
+
+def test_backfill_mask_from_zero_rows():
+    emb = torch.zeros(2, 5, 4)
+    emb[0, :3] = 1.0  # sample 0: 3 real tokens, 2 zero-pad
+    emb[1, :5] = 1.0  # sample 1: 5 real tokens
+    out = _backfill_caption_mask(TextEmbedCondition(embeds=emb, pooled=None, attn_mask=None))
+    assert out.attn_mask.tolist() == [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]]
+
+
+def test_backfill_leaves_real_mask_untouched():
+    emb = torch.zeros(2, 5, 4)
+    emb[0, :3] = 1.0
+    real = torch.ones(2, 5, dtype=torch.long)
+    tc = TextEmbedCondition(embeds=emb, pooled=None, attn_mask=real)
+    assert _backfill_caption_mask(tc) is tc  # already has a mask -> returned as-is
+
+
+def test_backfill_none_passthrough():
+    assert _backfill_caption_mask(None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Adapter integration (CPU, fake RawResults)
+# --------------------------------------------------------------------------- #
+
+
+def _make_adapter():
+    cfg = SimpleNamespace(populate_conditions=True, target_modules=None)
+    mc = SimpleNamespace(
+        pretrained_model_ckpt_path="Tongyi-MAI/Z-Image",
+        shift=6.0,
+        weight_sync_param_name_prefix="transformer.",
+    )
+    return ZImageAdapter(cfg, mc, strategy=None)
+
+
+def _res(**kw):
+    fields = {
+        f: None
+        for f in (
+            "prompt_embeds",
+            "pooled_prompt_embeds",
+            "encoder_attention_mask",
+            "negative_prompt_embeds",
+            "neg_pooled_prompt_embeds",
+            "negative_attention_mask",
+        )
+    }
+    fields.update(kw)
+    return SimpleNamespace(**fields)
+
+
+def test_build_condition_backfills_mask_for_cross_padded_captions():
+    # Two single-prompt encodes (pre-trimmed, no mask) of different lengths: the
+    # generic fuse zero-pads to the max with no mask -> build_condition must recover
+    # the validity mask so replay's _caption_list trims the pad.
+    adapter = _make_adapter()
+    r0 = _res(prompt_embeds=[torch.ones(1, 3, 4)])
+    r1 = _res(prompt_embeds=[torch.ones(1, 5, 4)])
+    out = adapter.build_condition([r0, r1])
+    text = out["text"]
+    assert tuple(text.embeds.shape) == (2, 5, 4)
+    assert text.attn_mask.tolist() == [[1, 1, 1, 0, 0], [1, 1, 1, 1, 1]]

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
@@ -113,6 +113,14 @@ _NEG_MAP = {
     "negative_attention_mask": "negative_prompt_embeds_mask",
 }
 
+# Dest fields whose per-encoder tensor may arrive un-batched ``[seq, hidden]``.
+# Single-encoder token-level models (Z-Image / Qwen3) emit a bare ``[seq, hidden]``
+# caption when a chunk encodes a single prompt (``zimage_postprocess_text`` returns
+# ``hidden_states[0][mask]`` for batch-size 1). Only these dests get a batch dim
+# added at ingestion; pooled (``[B, hidden]``) and masks (``[B, seq]``) are already
+# batched and must be sliced/merged as-is.
+_TOKEN_EMBED_DESTS = frozenset({"prompt_embeds", "negative_prompt_embeds"})
+
 # Sentinels.
 _OUTPUT_BATCH_FIELDS_SENTINEL = "_unirl_conditions_output_batch_fields"
 _GEN_RESULT_FIELDS_SENTINEL = "_unirl_conditions_gen_result_fields"
@@ -278,11 +286,38 @@ def _copy_conditions(src, output_batch) -> None:
     ``return_negative_prompt_embeds`` (delegated to ``sampling_params``).
     """
     if getattr(src, "return_prompt_embeds", False):
-        for dst, srcattr in _POS_MAP.items():
-            setattr(output_batch, dst, _to_cpu_embed_list(getattr(src, srcattr, None)))
+        _copy_mapped_conditions(src, output_batch, _POS_MAP)
     if getattr(src, "return_negative_prompt_embeds", False):
-        for dst, srcattr in _NEG_MAP.items():
-            setattr(output_batch, dst, _to_cpu_embed_list(getattr(src, srcattr, None)))
+        _copy_mapped_conditions(src, output_batch, _NEG_MAP)
+
+
+def _copy_mapped_conditions(src, output_batch, mapping) -> None:
+    """Copy each ``dst <- srcattr`` field, normalizing un-batched token embeds so
+    every per-encoder field reaches the slice/merge transforms as ``[B, ...]``.
+
+    Single-encoder token-level models (Z-Image) emit a bare ``[seq, hidden]``
+    caption for a single-prompt encode; per-output ``_slice_embed_list`` would then
+    slice the SEQ axis and corrupt it. Adding the missing batch dim here (gated to
+    ``_TOKEN_EMBED_DESTS``) keeps every downstream transform batch-first; a no-op
+    for already-batched multi-encoder embeds (SD3/Qwen) and for pooled/masks.
+    """
+    for dst, srcattr in mapping.items():
+        val = _to_cpu_embed_list(getattr(src, srcattr, None))
+        if dst in _TOKEN_EMBED_DESTS:
+            val = _ensure_batched_embed_list(val)
+        setattr(output_batch, dst, val)
+
+
+def _ensure_batched_embed_list(value):
+    """Add a leading batch dim to any un-batched ``[seq, hidden]`` per-encoder tensor.
+
+    No-op for already-batched ``[B, seq, hidden]`` (``dim() >= 3``, multi-encoder
+    models) and for ``None`` holes; preserves the container type.
+    """
+    if not isinstance(value, (list, tuple)):
+        return value
+    out = [t if (t is None or t.dim() >= 3) else t.unsqueeze(0) for t in value]
+    return out if isinstance(value, list) else type(value)(out)
 
 
 def _wrap_decoding_stage(DecodingStage) -> None:

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_latent_prep.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_latent_prep.py
@@ -29,9 +29,13 @@ rollout-with-initial_noise on both the single and grouped paths.
 
 from __future__ import annotations
 
+import logging
+import math
 import os
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 _DEBUG = os.environ.get("UNIRL_DEBUG_LATENT_SHAPE") == "1"
 
@@ -82,12 +86,39 @@ def patch_latent_prep() -> None:
         device = get_local_torch_device()
         batch_size = int(batch.batch_size)
         nopp = int(getattr(batch, "num_outputs_per_prompt", 1) or 1)
+        pcfg = server_args.pipeline_config
 
         # 1) Expand driver-shipped noise to batch_size (fork's rule).
         latents = _expand_initial_noise(latents, batch_size, nopp).to(device=device)
 
+        # 1b) Insert the singleton frame axis for image-form 5-D DiTs (Z-Image).
+        # The driver ships frame-less image-form noise [B, C, H, W] (from the model's
+        # latent_shape), but Z-Image's S3-DiT denoises in 5-D [B, C, 1, H, W]:
+        # ``ZImageTransformer2DModel._as_image_list`` treats a 4-D tensor as a SINGLE
+        # [C, F, H, W] image, folding the 16 channels into the token count so the
+        # x_embedder matmul fails. The randn branch already gets 5-D via
+        # ``prepare_latent_shape``; mirror that for provided latents. Gated TIGHTLY to
+        # the Z-Image signature (4-D driver -> 5-D expected with channels preserved at
+        # dim 1 and a size-1 frame at dim 2) so it is a strict no-op for every other
+        # family: SD3/Flux/ernie (4-D expected), Qwen-Image ([B, 1, C, H, W] — dim 1 is
+        # the frame, not channels, so expected[1] != C), and video (frame > 1).
+        try:
+            num_frames = int(getattr(batch, "num_frames", 1) or 1)
+            expected = tuple(int(d) for d in pcfg.prepare_latent_shape(batch, batch_size, num_frames))
+            if (
+                latents.ndim == 4
+                and len(expected) == 5
+                and expected[1] == int(latents.shape[1])
+                and expected[2] == 1
+                and latents.numel() == math.prod(expected)
+            ):
+                latents = latents.reshape(expected)
+        except Exception as exc:  # pragma: no cover - defensive; preserve prior behavior on any failure
+            # Surface at normal log level (not _DEBUG-gated): a swallowed reconcile
+            # leaves un-reshaped latents that fail later inside the DiT, far from here.
+            logger.warning("latent_prep frame-axis reconcile skipped: %s: %s", type(exc).__name__, exc)
+
         # 2) Compute latent_ids on the UNPACKED shape (mirror randn branch order).
-        pcfg = server_args.pipeline_config
         latent_ids = pcfg.maybe_prepare_latent_ids(latents)
         if latent_ids is not None:
             batch.latent_ids = latent_ids.to(device=device)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -44,6 +44,8 @@ Idempotent via sentinel guards. Import-safe (sglang imported inside the fn).
 from __future__ import annotations
 
 import gc
+import logging
+import re
 from collections import defaultdict
 from collections.abc import Iterable
 
@@ -51,6 +53,92 @@ import torch
 
 _METHODS_SENTINEL = "_unirl_named_tensor_methods"
 _LWIM_SENTINEL = "_unirl_lora_name_remap"
+
+_log = logging.getLogger(__name__)
+
+
+def _resolve_param_names_mapping(module) -> dict:
+    """Return the model's ``param_names_mapping`` dict, or ``{}``.
+
+    SGLang models that FUSE projections (Z-Image's ``ZImageTransformer2DModel``
+    maps ``to_q/to_k/to_v`` -> ``to_qkv`` and ``feed_forward.w1/w3`` -> ``w13``)
+    carry a class-level ``param_names_mapping`` of
+    ``{regex: (replacement, shard_id, num_shards)}`` (the same dict the checkpoint
+    loader applies). The in-memory named-tensor update path does NOT apply it, so
+    without this the trainer's separate-projection tensors match no fused param and
+    are silently dropped — the bug behind a flat reward curve on fused-attention
+    models like Z-Image.
+    """
+    mapping = getattr(type(module), "param_names_mapping", None)
+    if not isinstance(mapping, dict):
+        mapping = getattr(module, "param_names_mapping", None)
+    return mapping if isinstance(mapping, dict) else {}
+
+
+def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int, num_shards: int) -> None:
+    """Write ``tensor`` into the ``shard_id``-th slice (dim 0) of a fused param.
+
+    Prefers the param's SGLang ``weight_loader`` when it accepts a shard id (it
+    derives each shard's offset/size from the layer's ``output_sizes`` and is thus
+    TP- and GQA-correct). The manual fallback splits dim 0 into ``num_shards`` EQUAL
+    slices, so it is correct ONLY for equal-sized shards (q==k==v, w1==w3) — which
+    holds for Z-Image base (MHA: ``num_attention_heads == n_kv_heads``) at
+    ``tp_size=1``, the only fused model reaching it here. A future fused GQA model
+    must go through the ``weight_loader`` path (the equal-split fallback would
+    silently corrupt unequal shards).
+    """
+    wl = getattr(param, "weight_loader", None)
+    if wl is not None:
+        try:
+            wl(param, tensor.to(param.dtype), shard_id)
+            return
+        except Exception:  # pragma: no cover - signature varies; manual fallback below
+            pass
+    data = param.data
+    total = int(data.shape[0])
+    if total % num_shards != 0:
+        raise ValueError(f"fused param dim0={total} not divisible by num_shards={num_shards}")
+    s = total // num_shards
+    data[shard_id * s : (shard_id + 1) * s].copy_(tensor.to(param.dtype))
+
+
+def _apply_fused_param_mapping(module, named_tensors):
+    """Consume separate-projection tensors into their fused params via the model's
+    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    exact-match loader. No-op when the module declares no mapping.
+    """
+    mapping = _resolve_param_names_mapping(module)
+    if not mapping:
+        return list(named_tensors)
+
+    model_params = dict(module.named_parameters())
+    leftover: list = []
+    fused = 0
+    for name, tensor in named_tensors:
+        if name in model_params:
+            leftover.append((name, tensor))
+            continue
+        handled = False
+        for pat, val in mapping.items():
+            if not isinstance(val, (tuple, list)) or len(val) != 3:
+                continue
+            m = re.match(pat, name)
+            if m is None:
+                continue
+            replacement, shard_id, num_shards = val
+            target = m.expand(replacement)
+            param = model_params.get(target)
+            if param is None:
+                continue
+            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+            fused += 1
+            handled = True
+            break
+        if not handled:
+            leftover.append((name, tensor))
+    if fused:
+        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    return leftover
 
 
 def patch_weights_updater() -> None:
@@ -100,11 +188,15 @@ def patch_weights_updater() -> None:
             """Copy weights from weights_iter into model_params in-place."""
             lora_remap = _build_lora_name_remap(model_params)
 
+            _matched = 0
+            _skipped: list[str] = []
             for name, loaded_weight in weights_iter:
                 if name not in model_params:
                     name = lora_remap.get(name, name)
                 if name not in model_params:
+                    _skipped.append(name)
                     continue
+                _matched += 1
                 param = model_params[name]
                 if param.shape != loaded_weight.shape:
                     raise ValueError(f"Shape mismatch for {name}: model={param.shape}, loaded={loaded_weight.shape}")
@@ -117,6 +209,23 @@ def patch_weights_updater() -> None:
                     param._local_tensor.copy_(distributed_weight._local_tensor)
                 else:
                     param.data.copy_(loaded_weight.to(param.dtype))
+
+            # Silent weight-drop is dangerous: a name matching no model param is
+            # skipped above (``continue``), so a sender/receiver naming or fusion
+            # mismatch (diffusers separate ``to_q/to_k/to_v`` vs SGLang's fused
+            # ``to_qkv``) leaves those weights at their loaded base value with NO
+            # error — the rollout silently never sees the trained update. Fused
+            # projections are consumed upstream by ``_apply_fused_param_mapping``;
+            # anything still unmatched here is a real mismatch, surfaced loudly.
+            if _skipped:
+                logger.warning(
+                    "load_weights_into_model: matched=%d SKIPPED=%d unmatched name(s) "
+                    "(not in target module params — naming/fusion mismatch; those "
+                    "weights were NOT updated). Sample: %s",
+                    _matched,
+                    len(_skipped),
+                    _skipped[:10],
+                )
 
         load_weights_into_model._unirl_lora_name_remap = True  # type: ignore[attr-defined]
         wu._build_lora_name_remap = _build_lora_name_remap
@@ -317,6 +426,12 @@ def patch_weights_updater() -> None:
             if not module_tensors:
                 continue
             try:
+                # Fused-projection models (Z-Image: to_q/k/v -> to_qkv,
+                # feed_forward.w1/w3 -> w13) need the model's param_names_mapping
+                # applied so the trainer's separate-projection tensors land in the
+                # right fused shard. Consume those here; the rest fall through to
+                # the exact-match loader below.
+                module_tensors = _apply_fused_param_mapping(module, module_tensors)
                 _load_weights_into_module(module, module_tensors)
                 updated_modules.append(module_name)
             except Exception as e:

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -23,6 +23,7 @@ from unirl.rollout.engine.sglang_diffusion.adapters.video import (
     HunyuanVideoAdapter,
     MochiAdapter,
 )
+from unirl.rollout.engine.sglang_diffusion.adapters.z_image import ZImageAdapter
 
 __all__ = [
     "ModelAdapter",
@@ -36,4 +37,5 @@ __all__ = [
     "QwenImageAdapter",
     "MochiAdapter",
     "HunyuanVideoAdapter",
+    "ZImageAdapter",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/z_image.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/z_image.py
@@ -1,0 +1,113 @@
+"""Z-Image (S3-DiT single-stream) image adapter — frame-axis squeeze + caption mask.
+
+Two Z-Image-specific overrides on top of the default ``ImageAdapter`` path; the
+generic schedule policy (static ``model_config.shift`` — Z-Image is static-shift,
+unlike Qwen-Image / Flux.2), the ``transformer.`` LoRA prefix, the SDE label, the
+``Images`` decode, and the ``text`` / ``negative_text`` condition fusion are all
+inherited.
+
+* ``build_segment``: Z-Image's S3-DiT runs its denoise loop in 5-D image form
+  ``[B, C, F=1, H, W]`` (``ZImageTransformer2DModel._as_image_list`` requires the
+  frame axis), so the captured rollout trajectory arrives 6-D
+  ``[B, T+1, C, 1, H, W]`` (``rollout_denoising_mixin`` stacks per-step 5-D latents
+  along dim 1). The trainer-side segment and ``ZImageDiffusionStage.replay`` use
+  image-form ``[B, T+1, C, H, W]``, so the singleton frame axis is squeezed here.
+  A trajectory already in 5-D image form passes through unchanged.
+
+* ``build_condition``: the stock Z-Image text stage (``zimage_postprocess_text``)
+  trims a single-prompt encode to its real tokens and returns a bare
+  ``[seq, hidden]`` with NO ``prompt_embeds_mask``; the engine then zero-pads
+  mixed-length captions across forward chunks (``utils.tracks._cat_padded_rows``)
+  with no mask to mark the pad. Replay's ``_caption_list`` forwards EVERY token
+  when ``attn_mask is None``, so those zero-pad rows would be denoised as real
+  caption tokens and dilute the GRPO policy gradient. Recover the validity mask
+  from the embeds' non-zero rows whenever the engine emitted none; a real
+  embeds-aligned mask (the multi-prompt encode path, which DOES emit
+  ``prompt_embeds_mask``) is left untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import torch
+
+from unirl.rollout.engine.sglang_diffusion import utils
+from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
+from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
+from unirl.rollout.engine.sglang_diffusion.backends import RawResult
+from unirl.types.conditions.text import TextEmbedCondition
+from unirl.types.rollout_req import RolloutReq
+
+
+def _to_image_form_trajectory(traj: torch.Tensor) -> torch.Tensor:
+    """Squeeze Z-Image's singleton frame axis: 6-D ``[B,T,C,1,H,W]`` -> 5-D ``[B,T,C,H,W]``.
+
+    A trajectory already in 5-D image form passes through unchanged. Raises on a
+    non-singleton frame axis (a t2i rollout must have ``F==1``) rather than
+    silently collapsing real frames.
+    """
+    if traj.ndim == 6:
+        if int(traj.shape[3]) != 1:
+            raise ValueError(
+                f"z_image: trajectory has a non-singleton frame axis "
+                f"(shape={tuple(traj.shape)}); expected [B, T, C, 1, H, W] for t2i."
+            )
+        return traj.squeeze(3)
+    return traj
+
+
+def _backfill_caption_mask(text: Optional[TextEmbedCondition]) -> Optional[TextEmbedCondition]:
+    """Recover a per-token validity mask from embed non-zero rows when none was emitted.
+
+    Only fires for token-level ``[B, T, D]`` embeds with no ``attn_mask`` (the
+    single-prompt encode path). The cross-chunk pad is literally zeros
+    (``_cat_padded_rows`` right-pads with ``new_zeros``) and real Qwen3 hidden
+    states are non-zero, so ``(embeds != 0).any(-1)`` recovers exactly the valid
+    rows; an unpadded single caption yields all-ones, which is also correct. A real
+    emitted mask (multi-prompt encode) is returned untouched.
+    """
+    if text is None or text.attn_mask is not None or text.embeds is None or text.embeds.dim() != 3:
+        return text
+    mask = (text.embeds != 0).any(dim=-1).to(torch.long)
+    return TextEmbedCondition(embeds=text.embeds, pooled=text.pooled, attn_mask=mask)
+
+
+@register_adapter("z_image")
+class ZImageAdapter(ImageAdapter):
+    """Z-Image S3-DiT image adapter (image-form trajectory + caption mask backfill)."""
+
+    def build_segment(
+        self,
+        req: RolloutReq,
+        results: List[RawResult],
+        *,
+        num_steps: int,
+        sde_indices: Optional[List[int]],
+        emit_native_logprob: bool,
+    ):
+        traj = _to_image_form_trajectory(utils.collect_trajectory_latents(results))
+        if traj.ndim != 5:
+            raise ValueError(
+                f"z_image: expected a 5-D image-form trajectory [B, T, C, H, W] after the "
+                f"frame squeeze; got rank {traj.ndim}, shape {tuple(traj.shape)}."
+            )
+        return utils.build_latent_segment(
+            traj,
+            results=results,
+            expected_sigmas=req.sigmas,
+            num_steps=num_steps,
+            sde_indices=sde_indices,
+            emit_native_logprob=emit_native_logprob,
+            segment_factory=self.segment_factory,
+        )
+
+    def build_condition(self, results: List[RawResult]) -> Dict[str, object]:
+        out = super().build_condition(results)
+        for key in ("text", "negative_text"):
+            if key in out:
+                out[key] = _backfill_caption_mask(out[key])
+        return out
+
+
+__all__ = ["ZImageAdapter"]


### PR DESCRIPTION
## Summary

Adds **Z-Image** support to the **v2 `sglang_diffusion`** dedicated rollout
engine. This is a re-port of #51 (by @xshrz) onto v2: #35 retired the v1
`sglang` engine that #51 was built on, so every code file #51 touched was
deleted or relocated. None of #51's wiring survived as-is — this re-expresses
the work on v2's adapter architecture, on stock `sglang[diffusion]==0.5.12.post1`.

What's in it:

- **`adapters/z_image.py`** — `ZImageAdapter(ImageAdapter)`, registered as
  `model_family="z_image"`. Two overrides: `build_segment` squeezes Z-Image's
  6-D `[B,T,C,1,H,W]` trajectory to 5-D image form; `build_condition` recovers
  the caption validity mask when a single-prompt encode emitted none, so
  cross-padded zero rows are not denoised as real caption tokens.
- **`_patches/patch_weights_updater.py`** — apply the model's
  `param_names_mapping` so the trainer's separate diffusers `to_q/k/v` + `w1/w3`
  land in Z-Image's **fused** `to_qkv` / `w13` shards (otherwise silently
  dropped → flat reward). Adds a loud warning on any still-unmatched name.
- **`_patches/patch_latent_prep.py`** — insert the singleton frame axis for
  Z-Image's 5-D S3-DiT, gated tightly to the Z-Image shape signature so it is a
  **strict no-op** for SD3 / Qwen-Image / Flux / video.
- **`_patches/patch_conditions.py`** — add a batch dim to un-batched
  single-prompt captions before per-output slicing (no-op for batched
  multi-encoder embeds and for pooled / masks).
- **Recipe** `examples/diffusion/z_image_sglang_full_tensor.yaml` (LoRA-train,
  merged full-weight tensor sync, CFG off, replay log-probs) + trainside tuning
  in `z_image_trainside.yaml` (CFG off, 12 steps, mbs 8).

Key decisions where v2's substrate forced a divergence from #51 (the fork
behaved differently): #51's "recover mask from embed zero-rows" relied on the
fork zero-padding captions; stock sglang repeat-pads (B>1, with a real mask) or
pre-trims (B==1), so that hack is dropped from the shared path in favor of v2's
`prompt_embeds_mask` path plus a Z-Image-local backfill for the residual B==1
case. The latent reshape is gated to Z-Image's `[B,C,1,H,W]` signature so it
cannot perturb Qwen-Image (whose `prepare_latent_shape` is also 5-D but
`[B,1,C,H,W]`).

## Related Issue

N/A — supersedes PR #51 (rebased onto the v2 engine).

## Test Plan

CPU-only dev box, so the end-to-end GPU rollout is **not** run here.

- `ruff check` + `ruff format --check` on the changed Python — clean.
- `python -m py_compile` on all changed/new modules — OK.
- `python scripts/check_recipe_targets.py` — all recipe `_target_` paths resolve
  (1121).
- `python -m pytest tests/rollout/test_sglang_diffusion_z_image.py -q` —
  **13 passed** (fused weight mapping, embed batching, frame squeeze, caption
  mask backfill, adapter registration).
- Adapter registration + config validation:
  `SGLangDiffusionEngineConfig(model_family="z_image")` validates;
  `z_image` is in `registered_adapters()`; the adapter import is sglang-free.
- **GPU smoke — Not run; reason: CPU-only dev box.** Planned (2-card H20):
  `bash examples/run_experiment_multinode_taiji.sh diffusion/z_image_sglang_full_tensor`
  watching `verify_engine_used_sigmas`, the FlowGRPO ratio (~1 at iter 0), and
  the new weight-sync `param_names_mapping` / silent-drop logs.

## Compatibility / Risk

Additive: new `z_image` adapter + recipe. The three shared `_patches` edits are
gated to be **strict no-ops** for every existing family (verified by the CPU
tests): the weight-updater mapping fires only when a module declares
`param_names_mapping`; the latent reshape only for the Z-Image `[B,C,1,H,W]`
signature; the embed batch-dim only for un-batched token embeds. No change to
SD3 / Qwen-Image / Flux behavior.

## Reviewer Notes

- **AI-assisted.** Duplicate-work check: this intentionally supersedes #51 (same
  author thread); it does not duplicate any other open PR.
- Builds on @xshrz's Z-Image work in #51 — please credit accordingly (squash/
  co-author as you see fit).
- The end-to-end path (trajectory shapes, grouped `nopp>1` conditions slicing,
  and whether the trainer's diffusers param names match the fusion regex) needs
  the GPU smoke to confirm; the new silent-drop warning in `patch_weights_updater`
  is the safety net that surfaces a naming mismatch loudly.
- #51's posted reward curve was on the v1/fork path and must be re-run on v2.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
