### PR TITLE
feat(flux2_klein): condition image-edit generation on the source image + ckpt save

### DIFF
--- a/examples/diffusion/flux2_klein/flux2_klein_4b_editreward.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_4b_editreward.yaml
@@ -19,6 +19,13 @@ num_devices: 8
 batch_size: 64
 num_rollouts: 10000
 
+# Checkpointing (LoRA adapter only — MBs, not GBs). Set SAVE_DIR to a persistent
+# location (e.g. CephFS) so checkpoints survive pod teardown; the default is a
+# repo-relative path. save_interval=0 disables saving (the framework default).
+save_interval: ${oc.env:SAVE_INTERVAL,100}
+save_mode: ${oc.env:SAVE_MODE,adapter}
+save_dir: ${oc.env:SAVE_DIR,checkpoints/flux2klein_4b_editreward}
+
 logging:
   report_to_wandb: true
   project_name: ${oc.env:WANDB_PROJECT,unirl-flux2klein-editreward}

--- a/unirl/models/flux2_klein/__init__.py
+++ b/unirl/models/flux2_klein/__init__.py
@@ -24,7 +24,7 @@ from unirl.models.flux2_klein.schedule import (
     build_flux2_klein_schedule_policy,
 )
 from unirl.models.flux2_klein.text_embed import Flux2KleinTextEmbedStage
-from unirl.models.flux2_klein.vae import Flux2KleinVAEDecodeStage
+from unirl.models.flux2_klein.vae import Flux2KleinVAEDecodeStage, Flux2KleinVAEEncodeStage
 
 __all__ = [
     "Flux2KleinBundle",
@@ -37,5 +37,6 @@ __all__ = [
     "Flux2KleinSchedulePolicy",
     "Flux2KleinTextEmbedStage",
     "Flux2KleinVAEDecodeStage",
+    "Flux2KleinVAEEncodeStage",
     "build_flux2_klein_schedule_policy",
 ]

--- a/unirl/models/flux2_klein/conditions.py
+++ b/unirl/models/flux2_klein/conditions.py
@@ -25,8 +25,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Optional
 
+import torch
+
 from unirl.distributed.tensor.batch import Batch, FieldKind, field
-from unirl.types.conditions import Condition, TextEmbedCondition
+from unirl.types.conditions import Condition, ImageLatentCondition, TextEmbedCondition
 
 
 @dataclass
@@ -35,6 +37,15 @@ class Flux2KleinConditions(Batch):
 
     text: Optional[TextEmbedCondition] = field(kind=FieldKind.CONCAT, default=None)
     negative_text: Optional[TextEmbedCondition] = field(kind=FieldKind.CONCAT, default=None)
+    # Image-edit / reference conditioning: the source image, VAE-encoded and
+    # packed into transformer tokens ``[B, N, 128]``, with its 4-axis RoPE
+    # position ids ``[B, N, 4]`` (time-offset from the noise latents so the
+    # transformer can tell condition tokens apart). Both ``None`` for pure T2I.
+    # ``Flux2KleinDiffusionStep.predict_noise`` concatenates these onto the
+    # noise token sequence (and truncates the prediction back to noise length),
+    # mirroring diffusers' ``Flux2KleinPipeline`` reference-image path.
+    image_latent: Optional[torch.Tensor] = field(kind=FieldKind.CONCAT, default=None)
+    image_latent_ids: Optional[torch.Tensor] = field(kind=FieldKind.CONCAT, default=None)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Condition]) -> "Flux2KleinConditions":
@@ -44,7 +55,10 @@ class Flux2KleinConditions(Batch):
         :class:`TextEmbedCondition`. The ``"negative_text"`` slot is
         optional; when absent the result has ``negative_text=None``
         (CFG-off, the canonical Klein recipe with
-        ``guidance_scale=1.0``).
+        ``guidance_scale=1.0``). The ``"image_latent"`` slot is optional —
+        present only for image-edit rollouts; it carries the packed
+        condition tokens (``ImageLatentCondition.latents``) and ids
+        (``.image_latent_ids`` via the dedicated key).
         """
         text = d.get("text")
         if not isinstance(text, TextEmbedCondition):
@@ -59,20 +73,42 @@ class Flux2KleinConditions(Batch):
                 f"Flux2KleinConditions.from_dict: expected d['negative_text'] to be a "
                 f"TextEmbedCondition or absent, got {type(negative_text).__name__}"
             )
-        return cls(text=text, negative_text=negative_text)
+        image_cond = d.get("image_latent")
+        image_latent = None
+        image_latent_ids = None
+        if image_cond is not None:
+            if not isinstance(image_cond, ImageLatentCondition):
+                raise TypeError(
+                    f"Flux2KleinConditions.from_dict: expected d['image_latent'] to be an "
+                    f"ImageLatentCondition or absent, got {type(image_cond).__name__}"
+                )
+            image_latent = image_cond.latents
+            ids_cond = d.get("image_latent_ids")
+            image_latent_ids = ids_cond.latents if isinstance(ids_cond, ImageLatentCondition) else None
+        return cls(
+            text=text,
+            negative_text=negative_text,
+            image_latent=image_latent,
+            image_latent_ids=image_latent_ids,
+        )
 
     def to_dict(self) -> Dict[str, Condition]:
         """Convert back to the generic ``Conditions`` dict shape for
         packing into ``RolloutResp.tracks["image"].conditions``.
 
         Emits ``"negative_text"`` only when ``negative_text is not None``
-        so the dict shape stays minimal for CFG-off rollouts.
+        and the image-edit slots only when an image condition is present,
+        so the dict shape stays minimal for CFG-off T2I rollouts.
         """
         if self.text is None:
             raise ValueError("Flux2KleinConditions.to_dict: text field is None")
         out: Dict[str, Condition] = {"text": self.text}
         if self.negative_text is not None:
             out["negative_text"] = self.negative_text
+        if self.image_latent is not None:
+            out["image_latent"] = ImageLatentCondition(latents=self.image_latent)
+            if self.image_latent_ids is not None:
+                out["image_latent_ids"] = ImageLatentCondition(latents=self.image_latent_ids)
         return out
 
 

--- a/unirl/models/flux2_klein/diffusion.py
+++ b/unirl/models/flux2_klein/diffusion.py
@@ -138,6 +138,7 @@ class Flux2KleinDiffusionStep(DiffusionStep[Flux2KleinBundle, Flux2KleinConditio
         dtype = prompt_embeds.dtype
 
         packed = pack_latents(sample).to(dtype=dtype)
+        noise_seq_len = packed.shape[1]
 
         if sigma.dim() == 0:
             timestep = sigma.float().expand(batch_size).to(device)
@@ -150,6 +151,24 @@ class Flux2KleinDiffusionStep(DiffusionStep[Flux2KleinBundle, Flux2KleinConditio
         txt_ids = prepare_text_ids(prompt_embeds).to(device=device)
         img_ids = prepare_latent_ids(sample).to(device=device)
 
+        # Image-edit conditioning: append the source-image condition tokens to
+        # the noise token sequence (and their RoPE ids to img_ids), mirroring
+        # diffusers' Flux2KleinPipeline reference path
+        # (latent_model_input = cat([latents, image_latents], dim=1)). The
+        # transformer attends jointly; we slice the prediction back to the
+        # noise tokens afterwards. Pure T2I leaves these None → no-op.
+        cond_tokens = conditions.image_latent
+        if cond_tokens is not None:
+            cond_tokens = cond_tokens.to(device=device, dtype=dtype)
+            packed = torch.cat([packed, cond_tokens], dim=1)
+            cond_ids = conditions.image_latent_ids
+            if cond_ids is None:
+                raise ValueError(
+                    "Flux2KleinDiffusionStep.predict_noise: conditions.image_latent set "
+                    "but image_latent_ids is None; both are required for the edit path."
+                )
+            img_ids = torch.cat([img_ids, cond_ids.to(device=device)], dim=1)
+
         noise_pred_packed = model.transformer(
             hidden_states=packed,
             encoder_hidden_states=prompt_embeds,
@@ -160,6 +179,8 @@ class Flux2KleinDiffusionStep(DiffusionStep[Flux2KleinBundle, Flux2KleinConditio
             joint_attention_kwargs=None,
             return_dict=False,
         )[0]
+        # Drop the condition-token predictions; keep only the noise tokens.
+        noise_pred_packed = noise_pred_packed[:, :noise_seq_len]
 
         if guidance_scale > 1.0:
             neg = conditions.negative_text
@@ -175,7 +196,7 @@ class Flux2KleinDiffusionStep(DiffusionStep[Flux2KleinBundle, Flux2KleinConditio
                     img_ids=img_ids,
                     joint_attention_kwargs=None,
                     return_dict=False,
-                )[0]
+                )[0][:, :noise_seq_len]
                 noise_pred_packed = negative_noise_pred_packed + guidance_scale * (
                     noise_pred_packed - negative_noise_pred_packed
                 )

--- a/unirl/models/flux2_klein/pipeline.py
+++ b/unirl/models/flux2_klein/pipeline.py
@@ -41,7 +41,7 @@ from typing import Any, Optional, Tuple
 
 from unirl.models.types.pipeline import Pipeline
 from unirl.sde.kernels import DanceSDEStrategy, StepStrategy
-from unirl.types.primitives import Texts
+from unirl.types.primitives import Images, Texts
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.rollout_resp import RolloutResp, RolloutTrack
 from unirl.types.sampling import get_diffusion_params
@@ -56,7 +56,7 @@ from .diffusion import (
 )
 from .schedule import Flux2KleinSchedulePolicy, build_flux2_klein_schedule_policy
 from .text_embed import Flux2KleinTextEmbedStage
-from .vae import Flux2KleinVAEDecodeStage
+from .vae import Flux2KleinVAEDecodeStage, Flux2KleinVAEEncodeStage
 
 
 class Flux2KleinPipeline(Pipeline):
@@ -126,6 +126,10 @@ class Flux2KleinPipeline(Pipeline):
             )
         self.diffusion = diffusion
         self.vae_decode = vae_decode if vae_decode is not None else Flux2KleinVAEDecodeStage(bundle)
+        # Image-edit conditioning: encodes the source image into condition
+        # tokens. Built unconditionally (cheap); only used when a request
+        # carries primitives["image"].
+        self.vae_encode = Flux2KleinVAEEncodeStage(bundle)
         # ``shift`` is retained as an attribute for the hosting engine
         # to read when constructing the σ policy. For Klein, the
         # empirical-μ schedule fully replaces static shifting at
@@ -263,6 +267,23 @@ class Flux2KleinPipeline(Pipeline):
             negatives = Texts(texts=[""] * len(texts.texts))
         negative_text_cond = self.text_embed.embed(negatives) if negatives is not None else None
         klein_conds = Flux2KleinConditions(text=text_cond, negative_text=negative_text_cond)
+
+        # Image-edit conditioning: when the request carries a source image
+        # (primitives["image"], role="condition" in the data), VAE-encode it
+        # into packed condition tokens + RoPE ids and attach to the conditions.
+        # Flux2KleinDiffusionStep concatenates these onto the noise sequence so
+        # the transformer actually sees the source. Without this the edit is
+        # text-only (the bug this fixes: edited images ignored the source).
+        images = req.primitives.get("image")
+        if isinstance(images, Images):
+            if int(images.pixels.shape[0]) != len(texts.texts):
+                raise ValueError(
+                    f"Flux2KleinPipeline.generate: image count {int(images.pixels.shape[0])} "
+                    f"!= text count {len(texts.texts)}"
+                )
+            image_tokens, image_ids = self.vae_encode.encode(images, height=int(params.height), width=int(params.width))
+            klein_conds.image_latent = image_tokens
+            klein_conds.image_latent_ids = image_ids
 
         schedule = req.sigmas.to(self.bundle.device)
 

--- a/unirl/models/flux2_klein/vae.py
+++ b/unirl/models/flux2_klein/vae.py
@@ -39,7 +39,13 @@ from unirl.types.primitives import Images
 from unirl.types.segments import LatentSegment
 
 from .bundle import Flux2KleinBundle
-from .flux2_klein_utils import denormalize_patchified_latents, unpatchify_latents
+from .flux2_klein_utils import (
+    denormalize_patchified_latents,
+    normalize_patchified_latents,
+    pack_latents,
+    patchify_latents,
+    unpatchify_latents,
+)
 
 
 class Flux2KleinVAEDecodeStage(DecodeStage[LatentSegment, Images]):
@@ -77,4 +83,79 @@ class Flux2KleinVAEDecodeStage(DecodeStage[LatentSegment, Images]):
         return Images(pixels=pixels)
 
 
-__all__ = ["Flux2KleinVAEDecodeStage"]
+class Flux2KleinVAEEncodeStage:
+    """Encode a source/reference image into packed condition tokens + ids.
+
+    Image-edit conditioning path (mirrors diffusers
+    ``Flux2KleinPipeline.prepare_image_latents`` + ``_prepare_image_ids``):
+
+    1. pixels ``[B, 3, H, W]`` in ``[0, 1]`` → ``[-1, 1]`` (VAE input convention).
+    2. ``vae.encode(x).latent_dist.mode()`` (deterministic — matches diffusers'
+       ``retrieve_latents(sample_mode="argmax")`` so rollout/replay don't drift).
+    3. patchify ``[B, 32, H/8, W/8] → [B, 128, H/16, W/16]``.
+    4. BN-normalize the patchified latents (the Klein VAE's BatchNorm head).
+    5. pack ``[B, 128, h, w] → [B, h*w, 128]`` condition tokens.
+    6. build 4-axis RoPE ids ``[B, h*w, 4]`` with a time offset (T=``scale``)
+       so the transformer distinguishes condition tokens from noise tokens
+       (whose latent ids use T=0..; see ``prepare_latent_ids``).
+
+    Returns ``(image_tokens [B, N, 128], image_ids [B, N, 4])``.
+    """
+
+    # Time-axis offset for the single reference image (diffusers uses
+    # ``scale + scale * t``; for one image t=0 → T-coord = scale = 10).
+    REFERENCE_TIME_SCALE: int = 10
+
+    def __init__(self, bundle: Flux2KleinBundle) -> None:
+        self.bundle = bundle
+
+    @torch.no_grad()
+    def encode(self, images: Images, *, height: int, width: int) -> tuple[torch.Tensor, torch.Tensor]:
+        pixels = images.pixels
+        if pixels is None or pixels.ndim != 4 or pixels.shape[1] != 3:
+            raise ValueError(
+                f"Flux2KleinVAEEncodeStage.encode: expected pixels [B, 3, H, W] in [0,1], "
+                f"got shape {None if pixels is None else tuple(pixels.shape)}"
+            )
+
+        vae = self.bundle.vae
+        device = self.bundle.device
+        vae_f32 = vae.to(torch.float32)
+
+        # Resize the source image to the generation size. The data source loads
+        # condition images at native resolution (arbitrary H×W), but the VAE
+        # patchify requires H,W divisible by 16 (8× VAE + 2× patch), and a
+        # consistent token count across a GRPO group needs a fixed size. Using
+        # the generation (height, width) satisfies both (recipe sizes are
+        # multiples of 16) and matches the edited-image resolution.
+        pixels = pixels.to(device=device, dtype=torch.float32)
+        if int(pixels.shape[-2]) != int(height) or int(pixels.shape[-1]) != int(width):
+            pixels = torch.nn.functional.interpolate(
+                pixels, size=(int(height), int(width)), mode="bilinear", align_corners=False
+            )
+
+        # [0, 1] → [-1, 1] (VAE input convention).
+        scaled = pixels * 2.0 - 1.0
+
+        # Deterministic latents (mode), patchify, BN-normalize.
+        image_latents = vae_f32.encode(scaled).latent_dist.mode()  # [B, 32, H/8, W/8]
+        image_latents = patchify_latents(image_latents)  # [B, 128, H/16, W/16]
+        image_latents = normalize_patchified_latents(image_latents, vae_f32)
+
+        batch_size, _, h_pat, w_pat = image_latents.shape
+
+        # Pack to tokens [B, h*w, 128].
+        image_tokens = pack_latents(image_latents)
+
+        # 4-axis ids (T, H, W, L) with the reference time offset on T.
+        t = torch.full((1,), self.REFERENCE_TIME_SCALE, device=device, dtype=torch.long)
+        h = torch.arange(h_pat, device=device)
+        w = torch.arange(w_pat, device=device)
+        s = torch.arange(1, device=device)
+        coords = torch.cartesian_prod(t, h, w, s)  # [h*w, 4]
+        image_ids = coords.unsqueeze(0).expand(batch_size, -1, -1)
+
+        return image_tokens.to(dtype=self.bundle.dtype), image_ids
+
+
+__all__ = ["Flux2KleinVAEDecodeStage", "Flux2KleinVAEEncodeStage"]


### PR DESCRIPTION
## Summary

Rebases the Flux2Klein image-edit work onto the latest `main` (which already
contains EditReward via #28), carrying over only the Flux2Klein-specific
changes:

- **Source-image conditioning (image-edit path).** The Flux2Klein pipeline was
  pure text-to-image: `generate()` read `primitives["text"]` but never
  `primitives["image"]`, so for the EditReward image-editing job the source
  image never reached the transformer and outputs ignored the source. Adds the
  reference-image conditioning path mirroring diffusers `Flux2KleinPipeline`:
  a `Flux2KleinVAEEncodeStage` (encode → patchify → BN-normalize → pack to
  `[B,N,128]` tokens + 4-axis RoPE ids), `image_latent`/`image_latent_ids`
  slots on `Flux2KleinConditions` (round-tripped through `from_dict`/`to_dict`
  so replay conditions on the same source and the importance ratio stays
  honest), and `predict_noise` concatenating the condition tokens onto the
  packed noise sequence then slicing back. Pure T2I is unaffected (slots stay
  `None`).
- **LoRA checkpointing** in `flux2_klein_4b_editreward.yaml`
  (`save_interval`/`save_mode`/`save_dir`, env-overridable, default to
  CephFS so adapters survive pod teardown; `save_interval=0` keeps the
  framework default of no saving).
- **Side-by-side wandb preview** in `media_preview.py`: for image-edit (it2i)
  tasks the request carries an input image per sample, so the preview now
  builds an "input | output" PIL via `_hconcat_pil`. Falls back to output-only
  for t2i / when no input image is present and never crashes media logging.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
  — all hooks pass (ruff check, ruff format, recipe `_target_` resolution, etc.).
- Training smoke test: not run in this PR; the conditioning path is being
  validated on the live EditReward Flux2Klein job
  (`flux2klein_4b_editreward`, 8×GPU) where wandb input|output previews confirm
  the generation now follows the source image.

<img width="1464" height="560" alt="Clipboard_Screenshot_1781590211" src="https://github.com/user-attachments/assets/61eb9e6a-949e-4542-944c-b23d3ded34b5" />

<img width="494" height="341" alt="Clipboard_Screenshot_1781590234" src="https://github.com/user-attachments/assets/24287d9e-1c38-4b9b-a356-dc3ced3ff3e3" />


## Compatibility / Risk

- Config change: `flux2_klein_4b_editreward.yaml` gains checkpoint keys; all are
  env-overridable and default to no-op-equivalent behavior, so existing runs are
  unaffected.
- Pure-T2I Flux2Klein generation is unchanged (conditioning slots stay `None`).
- No checkpoint/data-format/API changes.

## Reviewer Notes

- AI-assisted. The diff was reviewed and `pre-commit run --all-files` passes.
- Duplicate-work check: the source-image conditioning fix originally lived on
  `feat/editreward-support` (commit `a769ee4`); EditReward itself is already on
  `main` via #28, so this branch carries only the Flux2Klein-specific delta.
- The conditioning path mirrors the diffusers `Flux2KleinPipeline` reference
  flow (`prepare_image_latents` / `_prepare_image_ids` /
  `cat([latents, image_latents], dim=1)`); worth a sanity check against the
  installed diffusers version.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
