### PR TITLE
feat(train): add DCP sharded checkpoints

### DIFF
--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -181,8 +181,7 @@ class FSDPBackend(Remote):
         checkpoint_format = str(getattr(fsdp_cfg, "checkpoint_format", "torch"))
         if checkpoint_format not in ("torch", "dcp"):
             raise ValueError(
-                "FSDPBackend: fsdp_cfg.checkpoint_format must be 'torch' or 'dcp', "
-                f"got {checkpoint_format!r}"
+                f"FSDPBackend: fsdp_cfg.checkpoint_format must be 'torch' or 'dcp', got {checkpoint_format!r}"
             )
         self._checkpoint_format: str = checkpoint_format
         self._checkpoint_async: bool = bool(getattr(fsdp_cfg, "checkpoint_async", False))

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -511,6 +511,12 @@ class FSDPBackend(Remote):
         meta_path = os.path.join(path, "metadata.pt")
         meta: Dict[str, object] = torch.load(meta_path, map_location="cpu")
         mode = str(meta.get("save_mode", "full"))
+        # Symmetric with _save_dcp: a trainable param on meta would be dropped by
+        # drop_meta_entries below and then left unresolved by the non-strict load
+        # (has_meta_params relaxes strict), silently keeping its pre-load weights.
+        # Reject it here; the remaining meta is the frozen aux that legitimately
+        # relaxes strict.
+        self._reject_trainable_meta_params("load")
         has_meta_params = any(p.is_meta for p in self.model.parameters())
         strict = mode == "full" and not has_meta_params
 
@@ -551,8 +557,8 @@ class FSDPBackend(Remote):
     def _reject_trainable_meta_params(self, op: str) -> None:
         """Fail fast on *trainable* params left on meta (the sharded "dcp" path).
 
-        The DCP save drops every meta entry, which is correct for the frozen aux
-        (vae / vit) that meta-init bundles never materialize. But a param that is
+        Both DCP save and load drop every meta entry, which is correct for the
+        frozen aux (vae / vit) that meta-init bundles never materialize. But a param that is
         ``requires_grad`` AND on meta is a materialize bug, not aux — dropping it
         would silently produce a checkpoint missing trained weights. ``requires_grad``
         is what tells the two apart, so this guard rejects only the former and

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -34,6 +34,7 @@ from unirl.train.factories import build_lr_scheduler, build_optimizer
 from unirl.train.fsdp_utils import (
     _current_rank,
     clip_grad_norm,
+    drop_meta_entries,
     fsdp_offload,
     fsdp_onload,
     gather_lora_state_dict,
@@ -41,6 +42,10 @@ from unirl.train.fsdp_utils import (
     gather_state_dict,
     load_model_state_dict,
     load_optimizer_state_dict,
+    load_sharded_model_state_dict,
+    load_sharded_optimizer_state_dict,
+    sharded_model_state_dict,
+    sharded_optimizer_state_dict,
     trainable_params,
 )
 from unirl.train.inject import (
@@ -171,6 +176,16 @@ class FSDPBackend(Remote):
         self.model: nn.Module = model
         self._optimizer_step_count: int = 0
         self._eval_ema_active: bool = False
+        # Checkpoint storage backend ("torch" legacy single-file vs "dcp"
+        # sharded). save honors this; load auto-detects the on-disk format.
+        checkpoint_format = str(getattr(fsdp_cfg, "checkpoint_format", "torch"))
+        if checkpoint_format not in ("torch", "dcp"):
+            raise ValueError(
+                "FSDPBackend: fsdp_cfg.checkpoint_format must be 'torch' or 'dcp', "
+                f"got {checkpoint_format!r}"
+            )
+        self._checkpoint_format: str = checkpoint_format
+        self._checkpoint_async: bool = bool(getattr(fsdp_cfg, "checkpoint_async", False))
         # Checkpointed for export tooling: the LoRA fold needs scaling =
         # alpha / rank, and alpha is not derivable from the weights.
         active_lora = lora_cfg or ema_lora_cfg
@@ -321,7 +336,7 @@ class FSDPBackend(Remote):
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def save(self, path: str, step: Optional[int] = None, mode: str = "full") -> None:
-        """Gather state (collective on every rank); write ``path/checkpoint.pt`` on dist rank 0.
+        """Save training state; dispatch on ``checkpoint_format`` ("torch" | "dcp").
 
         ``step`` is the trainer's rollout step — :meth:`load` returns it so
         the loop resumes where it stopped. ``mode="adapter"`` gathers only the
@@ -329,10 +344,23 @@ class FSDPBackend(Remote):
         from the pretrained snapshot on resume). ``mode="auto"`` selects
         adapter mode when LoRA is present, otherwise full. The optimizer state is
         identical under all modes — it only ever covers trainable params.
+
+        "torch" gathers a full state dict to dist rank 0 and writes a single
+        ``checkpoint.pt``. "dcp" writes per-rank shards directly under
+        ``path`` via DCP's ``checkpoint_id`` (including its ``.metadata``) plus
+        a light app-level ``metadata.pt`` on rank 0 —
+        this is the path that supports 80B meta-init bundles and reshard.
         """
         mode = self._resolve_save_mode(mode)
         if mode == "adapter" and not any("lora_" in name for name, _ in self.model.named_parameters()):
             raise RuntimeError("FSDPBackend.save: mode='adapter' but the model has no LoRA params")
+        if self._checkpoint_format == "dcp":
+            self._save_dcp(path, step, mode)
+        else:
+            self._save_torch(path, step, mode)
+
+    def _save_torch(self, path: str, step: Optional[int], mode: str) -> None:
+        """Legacy single-file save: gather full state to rank 0, torch.save."""
         if mode == "adapter":
             self._reject_lora_meta_params("save")
             policy_state = gather_lora_state_dict(self.model)
@@ -357,32 +385,94 @@ class FSDPBackend(Remote):
         os.makedirs(path, exist_ok=True)
         torch.save(state, os.path.join(path, "checkpoint.pt"))
 
+    def _save_dcp(self, path: str, step: Optional[int], mode: str) -> None:
+        """Sharded save: every rank writes its own shard under ``path``.
+
+        Never gathers a full tensor on any single rank, so meta-init bundles
+        (whose frozen aux stays on meta) are supported — those keys carry no
+        data and are dropped here. Non-tensor metadata (step / save_mode /
+        lora_config / scheduler / optimizer_step_count) is light and rides in a
+        rank-0 ``metadata.pt`` beside DCP's own ``.metadata``.
+        """
+        import torch.distributed.checkpoint as dcp
+
+        os.makedirs(path, exist_ok=True)
+        model_sd = drop_meta_entries(sharded_model_state_dict(self.model))
+        if mode == "adapter":
+            model_sd = {k: v for k, v in model_sd.items() if "lora_A" in k or "lora_B" in k}
+        sharded_state: Dict[str, object] = {
+            "model": model_sd,
+            "optim": sharded_optimizer_state_dict(self.model, self.optimizer),
+        }
+        dcp.save(sharded_state, checkpoint_id=path)
+
+        if _current_rank() != 0:
+            return
+        meta: Dict[str, object] = {
+            "optimizer_step_count": self._optimizer_step_count,
+            "step": step,
+            "save_mode": mode,
+            "lora_config": self._lora_meta,
+        }
+        if self.scheduler is not None:
+            meta["scheduler_state_dict"] = self.scheduler.state_dict()
+        torch.save(meta, os.path.join(path, "metadata.pt"))
+
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def load(self, path: str) -> int:
-        """Restore the state written by :meth:`save`; return the saved rollout step (0 if absent).
+        """Restore state written by :meth:`save`; return the saved rollout step (0 if absent).
 
-        Every rank runs this (the DCP set is a collective): each reads the
-        checkpoint from shared storage to CPU, then tensors broadcast from
-        dist rank 0 and re-shard into the local model/optimizer state.
+        Auto-detects the on-disk format: DCP's root ``path/.metadata`` loads
+        via DCP (each rank reads only its own shard, reshard-aware); otherwise
+        the legacy ``path/checkpoint.pt`` loads via torch. So checkpoints
+        written before this change still resume regardless of
+        ``checkpoint_format``.
         Adapter-mode checkpoints load non-strict — only the LoRA keys are
         present; the frozen base keeps the weights the bundle loaded.
         """
+        dcp_metadata_path = os.path.join(path, ".metadata")
+        metadata_path = os.path.join(path, "metadata.pt")
         checkpoint_path = os.path.join(path, "checkpoint.pt")
         # Agree on visibility BEFORE the collectives: on multi-node, a rank
         # whose node does not mount the checkpoint path would raise alone and
-        # strand the others in the DCP broadcast until the NCCL timeout.
-        exists = os.path.exists(checkpoint_path)
+        # strand the others in the load collective until the NCCL timeout.
+        local_visible = {
+            "dcp": os.path.exists(dcp_metadata_path),
+            "metadata": os.path.exists(metadata_path),
+            "torch": os.path.exists(checkpoint_path),
+        }
         if dist.is_available() and dist.is_initialized():
-            verdicts: List[Optional[bool]] = [None] * dist.get_world_size()
-            dist.all_gather_object(verdicts, exists)
-            missing_on = [rank for rank, ok in enumerate(verdicts) if not ok]
+            verdicts: List[Optional[Dict[str, bool]]] = [None] * dist.get_world_size()
+            dist.all_gather_object(verdicts, local_visible)
         else:
-            missing_on = [] if exists else [0]
+            verdicts = [local_visible]
+
+        saw_dcp = [rank for rank, ok in enumerate(verdicts) if ok and ok["dcp"]]
+        if saw_dcp:
+            missing_dcp = [rank for rank, ok in enumerate(verdicts) if not (ok and ok["dcp"])]
+            if missing_dcp:
+                raise FileNotFoundError(
+                    f"FSDPBackend.load: DCP metadata not visible on rank(s) {missing_dcp}: {dcp_metadata_path} "
+                    "(save_dir/load_dir must live on storage mounted on every node)"
+                )
+            missing_meta = [rank for rank, ok in enumerate(verdicts) if not (ok and ok["metadata"])]
+            if missing_meta:
+                raise FileNotFoundError(
+                    f"FSDPBackend.load: app metadata not visible on rank(s) {missing_meta}: {metadata_path}"
+                )
+            return self._load_dcp(path)
+
+        missing_on = [rank for rank, ok in enumerate(verdicts) if not (ok and ok["torch"])]
         if missing_on:
             raise FileNotFoundError(
                 f"FSDPBackend.load: checkpoint not visible on rank(s) {missing_on}: {checkpoint_path} "
                 "(save_dir/load_dir must live on storage mounted on every node)"
             )
+        return self._load_torch(checkpoint_path)
+
+    def _load_torch(self, checkpoint_path: str) -> int:
+        """Legacy single-file load: read full state, broadcast from rank 0, reshard."""
+        self._reject_meta_params("load")
         checkpoint = torch.load(checkpoint_path, map_location="cpu")
 
         strict = checkpoint.get("save_mode", "full") == "full"
@@ -405,18 +495,53 @@ class FSDPBackend(Remote):
             raise ValueError(f"FSDPBackend.save: unknown mode {mode!r} (use 'auto', 'full' or 'adapter')")
         return mode
 
+    def _load_dcp(self, path: str) -> int:
+        """Sharded load: each rank reads its own shard from DCP ``path``.
+
+        Reshard-aware — the same shard dir loads under a different world size.
+        The current model/optimizer sharded state dicts seed the layout, DCP
+        fills them in place, then we set them back (the canonical DCP recipe).
+        """
+        import torch.distributed.checkpoint as dcp
+
+        meta_path = os.path.join(path, "metadata.pt")
+        meta: Dict[str, object] = torch.load(meta_path, map_location="cpu")
+        mode = str(meta.get("save_mode", "full"))
+        has_meta_params = any(p.is_meta for p in self.model.parameters())
+        strict = mode == "full" and not has_meta_params
+
+        model_sd = drop_meta_entries(sharded_model_state_dict(self.model))
+        if mode == "adapter":
+            model_sd = {k: v for k, v in model_sd.items() if "lora_A" in k or "lora_B" in k}
+        sharded_state: Dict[str, object] = {
+            "model": model_sd,
+            "optim": sharded_optimizer_state_dict(self.model, self.optimizer),
+        }
+        dcp.load(sharded_state, checkpoint_id=path)
+
+        load_sharded_model_state_dict(self.model, sharded_state["model"], strict=strict)
+        load_sharded_optimizer_state_dict(self.model, self.optimizer, sharded_state["optim"])
+        if self.scheduler is not None and "scheduler_state_dict" in meta:
+            self.scheduler.load_state_dict(meta["scheduler_state_dict"])
+        if meta.get("optimizer_step_count") is not None:
+            self._optimizer_step_count = int(meta["optimizer_step_count"])
+        return int(meta.get("step") or 0)
+
     def _reject_meta_params(self, op: str) -> None:
         """Fail fast on never-materialized params (meta-init bundles, e.g. hi3 80B).
 
         Their frozen aux (vae / vit) stays on meta and a full-state-dict gather
         would die deep inside DCP ("Cannot copy out of meta tensor"). Same
-        verdict on every rank, so raising here is collective-safe.
+        verdict on every rank, so raising here is collective-safe. Only the
+        legacy "torch" path needs this — the sharded "dcp" path drops meta keys
+        (they carry no data) instead of gathering them.
         """
         meta = [name for name, p in self.model.named_parameters() if p.is_meta]
         if meta:
             raise RuntimeError(
                 f"FSDPBackend.{op}: {len(meta)} params are on meta (e.g. {meta[:3]}); "
-                "full-state-dict checkpointing of meta-init bundles is not supported yet."
+                "full-state-dict checkpointing of meta-init bundles is not supported under "
+                "checkpoint_format='torch' (use 'dcp')."
             )
 
     def _reject_lora_meta_params(self, op: str) -> None:

--- a/unirl/train/backend/fsdp.py
+++ b/unirl/train/backend/fsdp.py
@@ -396,6 +396,11 @@ class FSDPBackend(Remote):
         """
         import torch.distributed.checkpoint as dcp
 
+        # Frozen aux (vae / vit) on meta is expected and dropped below; a
+        # *trainable* param on meta means materialize missed it, and dropping it
+        # would write a checkpoint missing weights with no error. is_meta alone
+        # can't tell the two apart, but requires_grad can — so fail fast here.
+        self._reject_trainable_meta_params("save")
         os.makedirs(path, exist_ok=True)
         model_sd = drop_meta_entries(sharded_model_state_dict(self.model))
         if mode == "adapter":
@@ -472,7 +477,6 @@ class FSDPBackend(Remote):
 
     def _load_torch(self, checkpoint_path: str) -> int:
         """Legacy single-file load: read full state, broadcast from rank 0, reshard."""
-        self._reject_meta_params("load")
         checkpoint = torch.load(checkpoint_path, map_location="cpu")
 
         strict = checkpoint.get("save_mode", "full") == "full"
@@ -542,6 +546,23 @@ class FSDPBackend(Remote):
                 f"FSDPBackend.{op}: {len(meta)} params are on meta (e.g. {meta[:3]}); "
                 "full-state-dict checkpointing of meta-init bundles is not supported under "
                 "checkpoint_format='torch' (use 'dcp')."
+            )
+
+    def _reject_trainable_meta_params(self, op: str) -> None:
+        """Fail fast on *trainable* params left on meta (the sharded "dcp" path).
+
+        The DCP save drops every meta entry, which is correct for the frozen aux
+        (vae / vit) that meta-init bundles never materialize. But a param that is
+        ``requires_grad`` AND on meta is a materialize bug, not aux — dropping it
+        would silently produce a checkpoint missing trained weights. ``requires_grad``
+        is what tells the two apart, so this guard rejects only the former and
+        leaves the frozen aux to ``drop_meta_entries``. Same verdict on every rank.
+        """
+        meta = [name for name, param in self.model.named_parameters() if param.requires_grad and param.is_meta]
+        if meta:
+            raise RuntimeError(
+                f"FSDPBackend.{op}: {len(meta)} trainable params are on meta (e.g. {meta[:3]}); "
+                "they would be silently dropped from the DCP checkpoint (materialize missed them)."
             )
 
     def _reject_lora_meta_params(self, op: str) -> None:

--- a/unirl/train/configs.py
+++ b/unirl/train/configs.py
@@ -79,6 +79,17 @@ class FSDPConfig:
     # code) or whose wrapped object carries frozen mixed-dtype sibling
     # sub-models that must not be sharded (hunyuan_image3's VAE/ViT).
     root_wrap: bool = True
+    # Checkpoint storage backend. "torch" (default) keeps the legacy path:
+    # gather a full state dict to rank 0 and torch.save a single checkpoint.pt.
+    # "dcp" uses torch.distributed.checkpoint sharded save/load — each rank
+    # reads/writes only its own shard (no rank-0 full-tensor gather), which
+    # enables meta-init bundles (80B) to checkpoint, parallelizes I/O across
+    # ranks, and resumes under a different world size. load auto-detects the
+    # on-disk format, so legacy checkpoint.pt dirs still resume regardless.
+    checkpoint_format: str = "torch"
+    # dcp only: background (async) save so the train loop is not blocked on the
+    # I/O. Ignored under checkpoint_format="torch". (Wired in a later phase.)
+    checkpoint_async: bool = False
 
 
 __all__ = [

--- a/unirl/train/fsdp_utils.py
+++ b/unirl/train/fsdp_utils.py
@@ -115,6 +115,82 @@ def load_optimizer_state_dict(model: nn.Module, optimizer: torch.optim.Optimizer
         set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict)
 
 
+def sharded_model_state_dict(model: nn.Module) -> StateDict:
+    """Per-rank sharded model state for DCP.
+
+    Unlike :func:`gather_state_dict`, this keeps each rank's local DTensor
+    shard (``full_state_dict=False``, no rank-0 gather, no cpu_offload) so
+    every rank writes only its own slice via ``dcp.save``. Never materializes
+    a full tensor on any single rank — the basis for checkpointing models too
+    large to gather (80B meta-init bundles).
+    """
+    from torch.distributed.checkpoint.state_dict import get_model_state_dict
+
+    options = _build_state_dict_options(full_state_dict=False)
+    try:
+        return dict(get_model_state_dict(model, options=options))
+    except TypeError:
+        return dict(get_model_state_dict(model))
+
+
+def sharded_optimizer_state_dict(model: nn.Module, optimizer: torch.optim.Optimizer) -> StateDict:
+    """Per-rank sharded optimizer state for DCP (symmetric with
+    :func:`sharded_model_state_dict`)."""
+    from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
+
+    options = _build_state_dict_options(full_state_dict=False)
+    try:
+        return dict(get_optimizer_state_dict(model, optimizer, options=options))
+    except TypeError:
+        return dict(get_optimizer_state_dict(model, optimizer))
+
+
+def load_sharded_model_state_dict(model: nn.Module, state_dict: StateDict, *, strict: bool = True) -> None:
+    """Load a per-rank sharded model state read by ``dcp.load`` in place.
+
+    ``strict=False`` loads adapter-only checkpoints: keys absent from
+    ``state_dict`` keep the model's current weights.
+    """
+    from torch.distributed.checkpoint.state_dict import set_model_state_dict
+
+    options = _build_state_dict_options(full_state_dict=False, strict=strict)
+    try:
+        set_model_state_dict(model, state_dict, options=options)
+    except TypeError:
+        set_model_state_dict(model, state_dict)
+
+
+def load_sharded_optimizer_state_dict(
+    model: nn.Module, optimizer: torch.optim.Optimizer, state_dict: StateDict
+) -> None:
+    """Load a per-rank sharded optimizer state read by ``dcp.load`` in place."""
+    from torch.distributed.checkpoint.state_dict import set_optimizer_state_dict
+
+    options = _build_state_dict_options(full_state_dict=False)
+    try:
+        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict, options=options)
+    except TypeError:
+        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict)
+
+
+def drop_meta_entries(state_dict: StateDict) -> StateDict:
+    """Drop never-materialized (meta) entries from a sharded state dict.
+
+    Meta-init bundles (e.g. hi3 80B) keep frozen aux (vae / vit) on meta —
+    those tensors carry no data and DCP cannot read/write them. The trained
+    decoder + heads are materialized and remain. A plain ``.is_meta`` check on
+    the (possibly DTensor) value's local view is enough: a DTensor over meta
+    shards reports ``is_meta`` on its local tensor.
+    """
+    kept: StateDict = {}
+    for key, value in state_dict.items():
+        local = getattr(value, "_local_tensor", value)
+        if isinstance(local, torch.Tensor) and local.is_meta:
+            continue
+        kept[key] = value
+    return kept
+
+
 def local_view(tensor: Tensor) -> Tensor:
     """DTensor -> local shard.  Identity for non-DTensors."""
     if hasattr(tensor, "_local_tensor"):
@@ -327,6 +403,11 @@ __all__ = [
     "gather_state_dict",
     "load_model_state_dict",
     "load_optimizer_state_dict",
+    "sharded_model_state_dict",
+    "sharded_optimizer_state_dict",
+    "load_sharded_model_state_dict",
+    "load_sharded_optimizer_state_dict",
+    "drop_meta_entries",
     "local_view",
     "is_materialized",
     "trainable_params",


### PR DESCRIPTION
## Summary

Add opt-in PyTorch Distributed Checkpoint (DCP) sharded checkpoint support to `FSDPBackend`.

This keeps the legacy `checkpoint.pt` format as the default while allowing `checkpoint_format="dcp"` to save and load per-rank model and optimizer shards directly from the checkpoint root. The DCP path avoids rank-0 full-state gathering, supports reshard-aware resume, and handles meta-init bundles by omitting never-materialized meta entries.

## Related Issue

N/A

## Test Plan

Not run; reason: the available Python environment does not have `torch` installed, and the DCP/FSDP round-trip requires torch distributed support.

Validation performed:
- `ReadLints` on changed training files: no diagnostics.
- `git diff --check upstream/main...HEAD`: passed.
- Opus review subagent checked DCP API usage, cross-rank load branching, meta-init strictness, and fresh optimizer resume semantics.

## Compatibility / Risk

Default behavior remains `checkpoint_format="torch"`, so existing `checkpoint.pt` checkpoints continue to save and load as before.

DCP checkpoints use the checkpoint directory root as PyTorch DCP `checkpoint_id`, with DCP's `.metadata` at the root and UniRL training metadata in `metadata.pt`. `export_hf.py` does not yet read DCP checkpoints.

## Reviewer Notes

AI-assisted. Checked for overlapping public PRs/issues via web search because the installed `gh` command is not GitHub CLI. No direct overlapping DCP/FSDP sharded-checkpoint PR was found; roadmap issue #25 mentions checkpoint parity directionally.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.