### PR TITLE
docs(readme): list Z-Image in the Model Support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ dimension; all listed models are supported (✅).
 | Stable Diffusion 3 / 3.5 | Image diffusion | Text → Image | ✅ |
 | Qwen-Image | Image diffusion | Text → Image | ✅ |
 | FLUX.2-Klein | Image diffusion | Text → Image | ✅ |
+| Z-Image | Image diffusion | Text → Image | ✅ |
 | WAN 2.1 | Video diffusion | Text / Image → Video | ✅ |
 | WAN 2.2 | Video diffusion | Text / Image → Video | ✅ |
 | HunyuanVideo 1.0 / 1.5 | Video diffusion | Text → Video | ✅ |


### PR DESCRIPTION
## Summary

Z-Image landed in the `sglang_diffusion` v2 rollout engine via #73 but was never
added to the README's **Model Support** table. This adds the missing row so the
documented model list matches what the framework actually supports.

Z-Image is an image-diffusion model (Text → Image), so the row is grouped with
the other supported Text → Image diffusion models (SD3, Qwen-Image,
FLUX.2-Klein).

## Related Issue

N/A — documentation follow-up to #73.

## Test Plan

Docs-only change (one table row). No code touched.
- Verified the rendered Markdown table stays well-formed (column count matches
  the existing header/rows).

## Compatibility / Risk

N/A — README only; no config, checkpoint, API, or behavior change.

## Reviewer Notes

AI-assisted. Duplicate-work check: no other open PR edits the README Model
Support table; #73 (the Z-Image engine support) is already merged.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
