### PR TITLE
feat(bagel): it2i editreward RL — recipe + VAE decode fix + diffusion eval

### DIFF
--- a/examples/diffusion/bagel/bagel_editreward.yaml
+++ b/examples/diffusion/bagel/bagel_editreward.yaml
@@ -1,0 +1,200 @@
+# @package _global_
+# BAGEL-7B-MoT image-EDIT (it2i) GRPO — trainside + remote EditReward.
+#
+# Text + source image -> edited image: condition generation on (source image +
+# instruction), then score the edit remotely with EditReward. This is the T2I recipe
+# (bagel_trainside_lora.yaml) plus the it2i enablement from the BAGEL multi-mode bundle:
+#   - bundle.config.enable_vit: true  -> loads the SigLIP ViT/und path so the SOURCE
+#       image is ingested into the gen/cfg KV contexts (VAE latents + ViT semantics).
+#   - the pipeline auto-takes the it2i branch when the request carries an input image.
+#   - reward -> RemoteRewardBackend (HTTP to an EditReward service on its own GPU; it
+#       builds the [source, edited] pair from the request's input image — no BAGEL code).
+#   - sampling -> the defaults below reproduce the validated single-node run
+#       (cfg_text=1 single-forward; eta=1.0 SDE exploration; group=8; WindowScheduler).
+#       cfg_text>1 enables CFG (amplifies the instruction) at +1 forward/step (more memory).
+#
+# Deploy (keep EditReward OFF the training GPUs):
+#   reward node:  cd unirl-reward-service && ray start --head --num-gpus=1 \
+#                 && python -m reward_service --config configs/editreward_service.yaml
+#   train node:   export REWARD_SERVICE_URL=http://<reward_node_ip>:8080
+#                 # optional local overrides: BAGEL_PATH / EDIT_DATA_PATH / EDIT_EVAL_DATA_PATH
+#                 bash examples/run_experiment_single_node.sh diffusion/bagel/bagel_editreward
+#
+# Compose check (CPU):  python -m unirl.train_diffusion \
+#   --config-name diffusion/bagel/bagel_editreward --cfg job --resolve
+# These defaults reproduce the validated single-node run (8xH20). Smoke first: override
+#   batch_size=2 num_rollouts=2 eval_interval=2 to exercise the path cheaply.
+
+num_devices: 8
+batch_size: 8                  # prompts/rollout (x samples_per_prompt = images/rollout). Single-node
+                               # 7B it2i is memory-tight; raise only with reward off the train GPUs.
+adv_use_global_std: false      # per-group GRPO normalization
+num_rollouts: 10000            # intentionally large; stop manually
+
+# Periodic eval on the eval set (deterministic generation: eval_eta=0), logged under eval/*.
+# eval_interval=0 disables it. Eval prompts are chunked (eval_chunk_prompts) to stay within
+# the it2i driver-memory budget. These match the validated run.
+eval_interval: 25
+eval_num_prompts: 16
+eval_samples_per_prompt: 4
+eval_chunk_prompts: 8
+eval_cfg_text_scale: 1
+eval_eta: 0.0
+
+transport_kind: colocate_store
+workers_per_device: 1
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,bagel-editreward}
+  run_name: bagel_editreward_it2i_lora
+  # entity: set via the WANDB_ENTITY env var (wandb picks it up automatically)
+  tags: [bagel, it2i, edit, editreward, lora, trainside, fp32master]
+  log_media: true              # logs the source|edited side-by-side preview for it2i edits
+  media_max_items: 8
+  media_log_interval: 5
+
+bundle:
+  _target_: unirl.models.bagel.bundle.BagelBundle.from_config
+  config:
+    _target_: unirl.models.bagel.config.BagelPipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:BAGEL_PATH,ByteDance-Seed/BAGEL-7B-MoT}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp32   # keep diffuse<->replay bit-exact (ratio=1); do NOT lower
+    logprob_precision: fp32
+    shift: 3.0
+    use_lora: true
+    enable_vit: true             # EDIT: load the SigLIP ViT/und path for source-image conditioning
+
+pipeline:
+  _target_: unirl.models.bagel.pipeline.BagelPipeline
+  autocast_precision: bf16
+  trajectory_precision: fp32
+  logprob_precision: fp32
+  shift: 3.0
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Qwen2MoTDecoderLayer"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16                  # COMPUTE dtype (FSDP all-gather + forward/backward)
+    master_dtype: fp32                 # load-bearing: fp32 LoRA master + Adam (reward-collapse fix)
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true     # 7B + multi-step replay + dual-CFG forwards: required
+    use_torch_compile: false
+    root_wrap: false                   # vendored BAGEL calls embed_tokens/lm_head outside a root forward
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 1.0e-4
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 100000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:                    # = BAGEL_MOE_GEN_LORA_TARGETS (gen experts only; und/ViT frozen)
+      - self_attn.q_proj_moe_gen
+      - self_attn.k_proj_moe_gen
+      - self_attn.v_proj_moe_gen
+      - self_attn.o_proj_moe_gen
+      - mlp_moe_gen.gate_proj
+      - mlp_moe_gen.up_proj
+      - mlp_moe_gen.down_proj
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 1                # navit bs=1; one sample per generate call
+
+# Remote EditReward (own GPU/node). RemoteRewardBackend builds the [source, edited] pair
+# from the request's input image -> model-agnostic, no BAGEL code on the reward side.
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.remote.RemoteRewardBackend
+    base_device: cpu
+    config:
+      _target_: unirl.reward.remote.RemoteRewardSpec
+      base_url: ${oc.env:REWARD_SERVICE_URL,http://localhost:8080}
+      required_rewards: [editreward]
+      reward_weights:
+        editreward: 1.0
+      batch_size: 8
+      timeout: 300.0
+      sub_metric_reduce: mean
+      aggregation_method: weighted_sum
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  old_logp_source: replay              # recompute pi_old via replay -> ratio!=1 on update 2 = real gradient signal
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.bagel.conditions.BagelDiffusionConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2             # 2 optimizer updates/rollout (disjoint mini-batches)
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      # Editing instruction + SOURCE image (role: condition -> the request's input image).
+      data_path: ${oc.env:EDIT_DATA_PATH,datasets/image_edit/train.jsonl}
+      eval_data_path: ${oc.env:EDIT_EVAL_DATA_PATH,datasets/image_edit/test.jsonl}
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+# BAGEL edit sampling (BagelDiffusionParams). Dual-CFG: cfg_text amplifies the INSTRUCTION,
+# cfg_img amplifies the SOURCE (cfg_img active only when cfg_text_scale>1; cfg_img>1 = 3rd forward).
+sampling:
+  _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
+  num_inference_steps: 14
+  guidance_scale: 1.0
+  cfg_text_scale: 1                    # 1 = No-CFG single forward (validated config). >1 enables CFG
+                                       # (amplifies the instruction) = +1 forward/step -> more memory.
+  cfg_img_scale: 1.0                   # source<->diversity knob; only active when cfg_text_scale>1
+  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when cfg_text_scale>1
+  cfg_renorm_min: 0.0
+  cfg_renorm_type: text_channel        # CFG renorm; only active when cfg_text_scale>1
+  eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)
+  samples_per_prompt: 8                # GRPO group size
+  height: 512
+  width: 512
+  seed: 42
+  init_same_noise: true                # siblings share x_T; in-group diversity comes from the SDE noise (eta>0)
+  autocast_precision: bf16
+  trajectory_precision: fp32
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.WindowScheduler
+    num_timesteps: 7                   # SDE window drawn from the first half of the 14 inference steps
+    config:
+      _target_: unirl.utils.scheduler_utils.WindowConfig
+      strategy: random
+      window_size: 3                   # a random contiguous 3-step SDE window per rollout

--- a/examples/diffusion/bagel/bagel_editreward.yaml
+++ b/examples/diffusion/bagel/bagel_editreward.yaml
@@ -44,6 +44,13 @@ eval_eta: 0.0
 transport_kind: colocate_store
 workers_per_device: 1
 
+# Pin the it2i edit task. This recipe is image-EDIT only: every sample MUST carry a
+# source image (dataset `media` entry with role: condition). Pinning the task makes a
+# dataset that is missing source images FAIL LOUDLY (BagelPipeline._extract_input_images
+# raises) instead of silently falling back to t2i and scoring a single-image edit.
+stage_config:
+  task: it2i
+
 logging:
   report_to_wandb: true
   project_name: ${oc.env:WANDB_PROJECT,bagel-editreward}

--- a/unirl/models/bagel/vae.py
+++ b/unirl/models/bagel/vae.py
@@ -126,7 +126,14 @@ class BagelVAEDecodeStage(DecodeStage[LatentSegment, Images]):
 
         spatial = unpatchify_latent(clean.float(), h=h, w=w, patch_size=p, latent_channels=z)
         with torch.no_grad():
-            decoded = self.bundle.vae.to(torch.float32).decode(spatial)
+            vae = self.bundle.vae
+            orig_dtype = next(vae.parameters()).dtype
+            decoded = vae.to(torch.float32).decode(spatial)
+            # Restore the VAE's loaded dtype: the image-edit path also ENCODES the
+            # source with this shared VAE on the next rollout, and a left-over fp32
+            # cast would make encode emit fp32 latents that mismatch the bf16 vae2llm.
+            if orig_dtype != torch.float32:
+                vae.to(orig_dtype)
         pixels = (decoded * 0.5 + 0.5).clamp(0.0, 1.0)
         return Images(pixels=pixels)
 

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -45,6 +45,7 @@ def main(cfg: DictConfig) -> None:
         eval_chunk_prompts=cfg.get("eval_chunk_prompts", 16),
         eval_cfg_text_scale=cfg.get("eval_cfg_text_scale", 4.0),
         eval_eta=cfg.get("eval_eta", 0.0),
+        stage_config=cfg.get("stage_config"),
     )
     trainer.train(
         num_rollouts=cfg.get("num_rollouts", 100),

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -39,6 +39,12 @@ def main(cfg: DictConfig) -> None:
         train_fraction=cfg.get("train_fraction", 0.5),
         enable_fsdp_offload=cfg.get("enable_fsdp_offload", False),
         adv_use_global_std=cfg.get("adv_use_global_std", False),
+        eval_interval=cfg.get("eval_interval", 0),
+        eval_num_prompts=cfg.get("eval_num_prompts", 64),
+        eval_samples_per_prompt=cfg.get("eval_samples_per_prompt", 4),
+        eval_chunk_prompts=cfg.get("eval_chunk_prompts", 16),
+        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale", 4.0),
+        eval_eta=cfg.get("eval_eta", 0.0),
     )
     trainer.train(
         num_rollouts=cfg.get("num_rollouts", 100),

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -49,6 +49,12 @@ class DiffusionTrainer(BaseTrainer):
         train_fraction: float = 0.5,
         enable_fsdp_offload: bool = False,
         adv_use_global_std: bool = False,
+        eval_interval: int = 0,
+        eval_num_prompts: int = 64,
+        eval_samples_per_prompt: int = 4,
+        eval_chunk_prompts: int = 16,
+        eval_cfg_text_scale: float = 4.0,
+        eval_eta: float = 0.0,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -64,6 +70,18 @@ class DiffusionTrainer(BaseTrainer):
         # ``use_global_std=True`` scale) instead of each prompt's own std. Off by
         # default → unchanged per-group GRPO normalization for every other recipe.
         self._adv_use_global_std = bool(adv_use_global_std)
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
+        # eval_interval=0 disables it (zero-impact for runs that don't set it).
+        # Diffusion eval generates at the deterministic best-quality setting
+        # (cfg_text=eval_cfg_text_scale, eta=eval_eta) and CHUNKS the eval prompts
+        # (eval_chunk_prompts): one generate over the whole eval set would hold N x
+        # the KV/decoded on the driver (the it2i memory bottleneck).
+        self.eval_interval = int(eval_interval)
+        self.eval_num_prompts = int(eval_num_prompts)
+        self.eval_samples_per_prompt = int(eval_samples_per_prompt)
+        self.eval_chunk_prompts = int(eval_chunk_prompts)
+        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
+        self.eval_eta = float(eval_eta)
         # Set in _build_rollout: True when the rollout is the trainside
         # direct-sampling engine (it reuses the train model → must NOT offload).
         self._rollout_is_trainside = False
@@ -244,7 +262,9 @@ class DiffusionTrainer(BaseTrainer):
             return None
         return [int(x) for x in shape]
 
-    def _build_req(self, inputs: RolloutInputs, rollout_id: int) -> RolloutReq:
+    def _build_req(
+        self, inputs: RolloutInputs, rollout_id: int, *, base_sampling: Optional[Dict[str, BaseSamplingParams]] = None
+    ) -> RolloutReq:
         """Turn a data source batch into a typed :class:`RolloutReq`.
 
         Expands ``inputs`` by ``total_samples_per_prompt(sampling_params)`` so
@@ -255,12 +275,16 @@ class DiffusionTrainer(BaseTrainer):
         resolved indices are stamped onto a per-request copy of the diffusion
         sampling params, and the schedule config itself is nulled so only the
         resolved ``sde_indices`` ride to the engine.
+
+        ``base_sampling`` overrides the modality-keyed sampling dict (``evaluate``
+        passes its own deterministic params); ``None`` uses ``self.sampling_params``.
         """
-        inputs = inputs.expand(total_samples_per_prompt(self.sampling_params))
-        diffusion = self.sampling_params.get("diffusion")
+        base = base_sampling if base_sampling is not None else self.sampling_params
+        inputs = inputs.expand(total_samples_per_prompt(base))
+        diffusion = base.get("diffusion")
         sde_indices = diffusion.resolve_sde_indices(rollout_id)
         diffusion = dataclasses.replace(diffusion, sde_indices=sde_indices, scheduler=None)
-        sampling_params = {**self.sampling_params, "diffusion": diffusion}
+        sampling_params = {**base, "diffusion": diffusion}
         # Driver-authoritative x_T, shipped as a deterministic RECIPE. The driver
         # is the single source of initial noise: it authors per-sample noise group
         # ids keyed on (rollout_id, STABLE sample/group id); base_seed rides on
@@ -284,7 +308,7 @@ class DiffusionTrainer(BaseTrainer):
         init_noise_group_ids: list = []
         init_noise_latent_shape = self._noise_latent_shape
         if init_noise_latent_shape is not None:
-            if bool(getattr(self.sampling_params.get("diffusion"), "init_same_noise", False)):
+            if bool(getattr(base.get("diffusion"), "init_same_noise", False)):
                 init_noise_group_ids = [f"r{rollout_id}:{g}" for g in inputs.group_ids]
             else:
                 init_noise_group_ids = [f"r{rollout_id}:{s}" for s in inputs.sample_ids]
@@ -382,6 +406,60 @@ class DiffusionTrainer(BaseTrainer):
         self.wandb_logger.log_rollout_step(rollout_id, result, resp, step_time_s=time.perf_counter() - t0)
         return result, mean_reward
 
+    def evaluate(self, step: int) -> float:
+        """Periodic eval on the eval set (no training); returns the mean reward.
+
+        Mirrors :meth:`train_step`'s rollout+reward path but skips advantage/backward.
+        Generates at the deterministic best-quality setting (``cfg_text_scale=
+        eval_cfg_text_scale``, ``eta=eval_eta``; ``eval_samples_per_prompt`` x_T per
+        prompt) over ``eval_num_prompts`` eval prompts (``run.eval_data_path``),
+        scores, logs the mean reward under ``eval/*``, and returns it. The eval
+        prompts are CHUNKED (``eval_chunk_prompts``) so one generate never holds N x
+        the KV/decoded on the driver.
+        """
+        # Override only the "diffusion" entry of the modality-keyed sampling dict
+        # (mirrors the AR trainer's evaluate()).
+        eval_diffusion = dataclasses.replace(
+            self.sampling_params.get("diffusion"),
+            samples_per_prompt=self.eval_samples_per_prompt,
+            cfg_text_scale=self.eval_cfg_text_scale,
+            eta=self.eval_eta,
+        )
+        eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
+        all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
+        n_prompts = len(all_inputs.sample_ids)
+        chunk = max(1, self.eval_chunk_prompts)
+        reward_sum, reward_n = 0.0, 0
+        self.rollout.wake_up()
+        if self.weight_sync is not None:
+            self.weight_sync.sync()
+        for start in range(0, n_prompts, chunk):
+            sub = all_inputs.slice(start, min(start + chunk, n_prompts))
+            req = self._build_req(sub, step, base_sampling=eval_sp)
+            resp = self.rollout.generate(req)
+            for name, track in list(resp.tracks.items()):
+                if track.segment is not None:
+                    resp.tracks[name] = self.reward.score_and_attach(req=req, track=track)
+            for track in resp.tracks.values():
+                if track.rewards is not None:
+                    rewards = hydrate(track.rewards).to(torch.float32)
+                    reward_sum += float(rewards.sum().item())
+                    reward_n += int(rewards.numel())
+                    break  # single-track for now; revisit if multi-track lands
+        self.rollout.sleep()
+        mean_reward = reward_sum / max(1, reward_n)
+        logger.info(
+            "EVAL step %d  eval_reward(%d prompts x %d samples, cfg=%.1f eta=%.1f)=%.4f",
+            step,
+            self.eval_num_prompts,
+            self.eval_samples_per_prompt,
+            self.eval_cfg_text_scale,
+            self.eval_eta,
+            mean_reward,
+        )
+        self.wandb_logger.log_eval(step, {"reward": mean_reward})
+        return mean_reward
+
     def train(
         self,
         *,
@@ -415,6 +493,8 @@ class DiffusionTrainer(BaseTrainer):
             self.data_source.get_samples(self.batch_size)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
+            if self.eval_interval > 0:
+                self.evaluate(start_rollout)  # baseline eval before any training
             for rollout_id in range(start_rollout, num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 inputs = self.data_source.get_samples(self.batch_size)
@@ -432,6 +512,8 @@ class DiffusionTrainer(BaseTrainer):
                     rollout_id=rollout_id,
                 )
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, result, mean_reward, logger=logger)
+                if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
+                    self.evaluate(rollout_id + 1)
                 self.maybe_save_checkpoint(
                     rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir, save_mode=save_mode
                 )

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import os
 import time
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from hydra.utils import get_class, instantiate
@@ -55,6 +55,7 @@ class DiffusionTrainer(BaseTrainer):
         eval_chunk_prompts: int = 16,
         eval_cfg_text_scale: float = 4.0,
         eval_eta: float = 0.0,
+        stage_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -82,6 +83,12 @@ class DiffusionTrainer(BaseTrainer):
         self.eval_chunk_prompts = int(eval_chunk_prompts)
         self.eval_cfg_text_scale = float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
+        # Per-request routing metadata pinned by the recipe (e.g. {"task": "it2i"}),
+        # forwarded onto every RolloutReq. Pinning the task makes a dataset that is
+        # MISSING source images fail loudly in the pipeline (it2i requires an input
+        # image) instead of silently degrading to t2i. Empty ⇒ the pipeline infers
+        # the task as before (unchanged for every other recipe).
+        self._stage_config: Dict[str, Any] = dict(stage_config) if stage_config else {}
         # Set in _build_rollout: True when the rollout is the trainside
         # direct-sampling engine (it reuses the train model → must NOT offload).
         self._rollout_is_trainside = False
@@ -317,6 +324,7 @@ class DiffusionTrainer(BaseTrainer):
             group_ids=list(inputs.group_ids),
             primitives=dict(inputs.primitives),
             request_conditions={},
+            stage_config=dict(self._stage_config),
             sampling_params=sampling_params,
             metadata=list(inputs.metadata) if inputs.metadata else [],
             init_noise_group_ids=init_noise_group_ids,


### PR DESCRIPTION
## Summary

Enables BAGEL-7B-MoT **image-edit (it2i) editreward** RL end to end, on top of #62. Three pieces:

1. **Recipe** `examples/diffusion/bagel/bagel_editreward.yaml` — text + source image → edited image, scored by a remote EditReward service. Extends the T2I `bagel_trainside_lora.yaml` with the it2i enablement (`enable_vit`, edit pipeline) from #62.
2. **`fix(bagel)` VAE decode dtype** — `BagelVAEDecodeStage.decode` cast the shared VAE to fp32 in place. The it2i path reuses the same VAE to **encode** the source on the next rollout, so a leftover fp32 cast would poison that encode. Snapshot + restore the loaded dtype around decode.
3. **Diffusion-trainer periodic eval** — mirrors the AR trainer's `evaluate()`: on a cadence, generate on the eval set at a deterministic setting, score, and log `eval/reward` (eval prompts are chunked to bound driver memory). Off by default (`eval_interval=0`).

## Related Issue

N/A — but **depends on #62** (it provides the it2i model side this recipe needs). See Reviewer Notes.

## Test Plan

Live it2i editreward run on top of #62 — the recipe **as shipped** (BAGEL-7B-MoT, 8×H20, single node; remote MiMo EditReward; `cfg_text=1` single-forward, `eta=1.0`, group=8):

- **No OOM** through generate + replay + backward across 225+ rollouts; periodic eval + LoRA checkpointing both working.
- **Train reward** climbs −1.04 → ≈−0.35 (EMA); **eval reward** climbs −0.93 → **−0.40 **:

<img width="1040" height="650" alt="reward_curves" src="https://github.com/user-attachments/assets/d78aaa35-dbf2-4541-81f0-a304f43d51ab" />

- A few sampled rollout edits (source | output) — object addition / background change:

<img width="2048" height="1024" alt="edit_add_object" src="https://github.com/user-attachments/assets/72c5f6ed-be6c-45a6-8d70-16a7f7a79b11" />
<img width="2048" height="1024" alt="edit_background" src="https://github.com/user-attachments/assets/dba8bc98-55ab-4476-8934-e96b69d906fd" />

- Hydra compose check:
  `python -m unirl.train_diffusion --config-name diffusion/bagel/bagel_editreward --cfg job --resolve`
- `eval_interval=0` (default) path unchanged.

## Compatibility / Risk

- **Additive.** Periodic eval is off by default (`eval_interval=0`) → existing diffusion runs are byte-for-byte unchanged. `_build_req` gains an optional `base_sampling` (default `None` = the training path, unchanged).
- The VAE fix is a **no-op for T2I** (T2I only decodes); it only affects the it2i encode-after-decode path.
- The new recipe references `enable_vit` from #62 → **depends on #62**. No file overlap with #62 (this touches only `vae.py`, the diffusion trainer, and the new recipe), so it rebases onto `main` cleanly once #62 lands.
- No checkpoint / data-format / public-API changes. Checkpointing reuses the existing `maybe_save_checkpoint`.

## Reviewer Notes

- **Merge after #62.**
- The recipe ships the **validated single-node config**: `cfg_text=1` (No-CFG, single forward — single-node 7B is memory-tight), `eta=1.0` SDE exploration, group=8. `cfg_text>1` enables CFG (+1 forward/step, more memory) and was not exercised in this run.
- MiMo EditReward is a Bradley-Terry-style head → a **raw, often-negative logit**; only group-relative differences matter for GRPO.
- The periodic-eval addition mirrors the AR trainer's `evaluate()`; happy to split it into its own PR if you'd prefer to review it separately.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
