### PR TITLE
refactor(examples): prune unread bundle precision from qwen3_dppo recipe

### DIFF
--- a/examples/ar/qwen3_dppo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_dppo_4b_base_dapo_sglang.yaml
@@ -62,8 +62,6 @@ bundle:
     # steps land exactly in fp32 instead of rounding away below the bf16 ULP
     # (lr 1e-6 vs ULP ~7.8e-5 at |w|~0.02 → most updates silently vanished).
     model_precision: fp32
-    autocast_precision: bf16
-    logprob_precision: fp32
     use_gradient_checkpointing: true
 
 pipeline:


### PR DESCRIPTION
## Summary

Follow-up to #84. That PR grouped the diffusion recipes into per-model folders and pruned the dead stage-precision fields (`autocast_precision` / `trajectory_precision` / `logprob_precision`) from every recipe's `bundle:` / `model_config:` / `sampling:` blocks, keeping only the live `pipeline:` copies. The AR DPPO recipe (`examples/ar/qwen3_dppo_4b_base_dapo_sglang.yaml`, added later in #85) predated that prune and was the one recipe #84 missed: its `bundle.config` still carried `autocast_precision` / `logprob_precision`.

This removes those two dead fields. They are read only by `Qwen3Pipeline.from_config`, which no recipe targets — the trainer builds the pipeline via `remote_hydra(pipeline_cfg, bundle=...)` → `Qwen3Pipeline.from_bundle`, which takes precision from the **`pipeline:` block**. That block is left untouched (its fp32 `logprob_precision` + Binary-TV rationale comment stay), and `model_precision: fp32` (the live weight-load dtype) is kept.

After this, a repo-wide audit reports **0 remaining unread precision fields** — the invariant #84 intended.

## Related Issue

N/A

## Test Plan

- Re-parsed the edited recipe with PyYAML: OK.
- Repo-wide structural audit (classify every precision field in `examples/**/*.yaml`): **0** leftover `bundle`/`model_config`/`sampling` copies; all 186 remaining fields are live `pipeline:` (or hi3 bundle / SGLang `sampling.autocast`) copies.
- Hydra compose-check not run (no GPU/engine deps in this env). Recommended: `python -m unirl.train_ar --config-name=ar/qwen3_dppo_4b_base_dapo_sglang --cfg job --resolve`

## Compatibility / Risk

Config-only and behavior-preserving — the removed fields had no runtime reader (dead duplicates of the live `pipeline:` copies). No checkpoint / API / data-format impact.

## Reviewer Notes

AI-assisted. Duplicate-work check: scanned open PRs — none touch this recipe or precision config. Load-bearing claim: `Qwen3Pipeline.from_config` is never the construction path (the recipe's `pipeline._target_` is `Qwen3Pipeline.from_bundle`) — worth a quick sanity-check.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
