### PR TITLE
fix(sglang weight-sync): apply param_names_mapping rename + drop entries

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -133,6 +133,7 @@ def _apply_fused_param_mapping(module, named_tensors):
     model_params = dict(module.named_parameters())
     leftover: list = []
     fused = renamed = dropped = 0
+    unmatched: list = []
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
@@ -165,6 +166,13 @@ def _apply_fused_param_mapping(module, named_tensors):
                     break
                 # rename produced a non-param name; keep trying other patterns.
         if not handled:
+            # Reached only by tensors that are NOT a model param (exact matches
+            # were taken above) and matched no fused/rename rule. The exact-match
+            # loader will silently drop these — which is exactly the stale-weights
+            # failure mode this function exists to prevent. Track them and warn
+            # loudly below so a future model's incomplete mapping surfaces in the
+            # log instead of as a mysteriously flat reward curve.
+            unmatched.append(name)
             leftover.append((name, tensor))
     if fused or renamed or dropped:
         _log.info(
@@ -172,6 +180,14 @@ def _apply_fused_param_mapping(module, named_tensors):
             fused,
             renamed,
             dropped,
+        )
+    if unmatched:
+        _log.warning(
+            "weight-sync: %d tensor(s) matched no param_names_mapping rule and are not model "
+            "params — they will NOT be loaded into the rollout engine (stale-weight risk). "
+            "First few: %s",
+            len(unmatched),
+            unmatched[:5],
         )
     return leftover
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -103,9 +103,28 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
 
 
 def _apply_fused_param_mapping(module, named_tensors):
-    """Consume separate-projection tensors into their fused params via the model's
-    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    """Apply the model's ``param_names_mapping`` to the incoming named tensors.
+
+    A model's ``param_names_mapping`` (the same dict its checkpoint loader applies)
+    has two entry kinds; a model may use either or both:
+
+    * **fused projections** — ``{regex: (replacement, shard_id, num_shards)}`` —
+      write the trainer's separate-projection tensor into a dim-0 slice of the
+      model's fused param (Z-Image ``to_q/k/v -> to_qkv``, ``w1/w3 -> w13``).
+    * **plain renames** — ``{regex: replacement_str}`` — the model simply renamed
+      a param vs the checkpoint. WAN's mapping is entirely of this kind
+      (``patch_embedding.* -> patch_embedding.proj.*``,
+      ``blocks.N.attn1.to_q.* -> blocks.N.to_q.*``,
+      ``ffn.net.0.proj -> ffn.fc_in``, …). An EMPTY replacement means the model
+      dropped that param (e.g. WAN ``attn2.norm_added_q``) — the tensor is discarded.
+
+    Returns the leftover ``(name, tensor)`` list (renamed where applicable) for the
     exact-match loader. No-op when the module declares no mapping.
+
+    Before this handled the rename kind, simple-rename models (WAN) matched NOTHING
+    in the in-memory update path → 112/113 transformer tensors silently skipped →
+    the rollout engine ran stale base weights → flat reward curve (cross-engine
+    divergence), exactly the fused-model bug one step removed.
     """
     mapping = _resolve_param_names_mapping(module)
     if not mapping:
@@ -113,31 +132,47 @@ def _apply_fused_param_mapping(module, named_tensors):
 
     model_params = dict(module.named_parameters())
     leftover: list = []
-    fused = 0
+    fused = renamed = dropped = 0
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
             continue
         handled = False
         for pat, val in mapping.items():
-            if not isinstance(val, (tuple, list)) or len(val) != 3:
-                continue
             m = re.match(pat, name)
             if m is None:
                 continue
-            replacement, shard_id, num_shards = val
-            target = m.expand(replacement)
-            param = model_params.get(target)
-            if param is None:
-                continue
-            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
-            fused += 1
-            handled = True
-            break
+            if isinstance(val, (tuple, list)) and len(val) == 3:
+                replacement, shard_id, num_shards = val
+                param = model_params.get(m.expand(replacement))
+                if param is None:
+                    continue
+                _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+                fused += 1
+                handled = True
+                break
+            if isinstance(val, str):
+                if val == "":
+                    # model dropped this param — nothing to load.
+                    dropped += 1
+                    handled = True
+                    break
+                target = re.sub(pat, val, name)
+                if target in model_params:
+                    leftover.append((target, tensor))
+                    renamed += 1
+                    handled = True
+                    break
+                # rename produced a non-param name; keep trying other patterns.
         if not handled:
             leftover.append((name, tensor))
-    if fused:
-        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    if fused or renamed or dropped:
+        _log.info(
+            "weight-sync: param_names_mapping applied — %d fused, %d renamed, %d dropped",
+            fused,
+            renamed,
+            dropped,
+        )
     return leftover
 
 


### PR DESCRIPTION
## Summary

The in-memory sglang weight updater (`_apply_fused_param_mapping`) only applied **fused** (qkv-style 3-tuple) `param_names_mapping` entries and **silently skipped** plain string-rename (`{regex: replacement}`) entries and empty-string drops. For models whose `param_names_mapping` is rename-based — e.g. WAN (`blocks.N.attn1.to_q → blocks.N.to_q`, `ffn.net.0.proj → ffn.fc_in`, `attn2.norm_added_q → ""` dropped) — those tensors never reached the rollout engine, so it generated with **stale base weights** regardless of training (flat / divergent reward curve). This applies renames via `re.sub`, honors empty-string drops, and logs `fused/renamed/dropped` counts. Single-file change; the fused path is unchanged.

## Related Issue

N/A

## Test Plan

Verified on WAN 2.1 T2V full-FT sglang rollout (8×H-class GPU, colocate `TensorWeightSync`): the sync log went from `matched=1 SKIPPED=112` to `param_names_mapping applied — 0 fused, 112 renamed, 0 dropped`, after which the sglang rollout reward curve tracked the trainside reference (previously flat). Fused-path models (Z-Image qkv/w13) are unaffected — same code path, selected by entry kind.

## Compatibility / Risk

Low. Behavior changes only for models whose `param_names_mapping` contains string-rename / drop entries (previously a silent no-op, now applied). Fused 3-tuple entries take the identical pre-existing path. No config, checkpoint, or API change.

## Reviewer Notes

Prerequisite for the WAN 2.1 T2V full-FT sglang rollout (submitted separately). Developed with AI assistance.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
