### PR TITLE
feat(rollout): WAN 2.1 T2V sglang_diffusion rollout (full-FT + LoRA, curve-aligned)

### DIFF
--- a/examples/diffusion/wan21/wan21_t2v_full.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_full.yaml
@@ -1,0 +1,136 @@
+# @package _global_
+# GRPO WAN 2.1 T2V trainside, FULL fine-tuning (no LoRA). Curve-alignment twin
+# of wan21_t2v_sglang_full.yaml — IDENTICAL config except the rollout engine
+# (trainside FSDP sampler here vs SGLang there). Trains the whole transformer
+# (no lora_cfg); trainside uses the live model so there is no weight sync.
+
+num_devices: 16
+batch_size: 24
+adv_use_global_std: true
+num_rollouts: 60
+
+model_config:
+  _target_: unirl.models.wan21.config.WAN21PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.1-T2V-1.3B-Diffusers}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 5.0
+  max_sequence_length: 512
+  use_lora: false
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.wan21.bundle.WAN21Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.wan21.pipeline.WAN21Pipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 60
+  # NO lora_cfg → genuine full-weight fine-tuning of the transformer.
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 4
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 14
+  guidance_scale: 1.0
+  height: 480
+  width: 832
+  num_frames: 5
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: null
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan21_t2v_full}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan21", "t2v", "grpo", "video", "pickscore", "trainside", "full", "v2"]
+  log_media: false

--- a/examples/diffusion/wan21/wan21_t2v_sglang.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_sglang.yaml
@@ -1,0 +1,214 @@
+# @package _global_
+# GRPO WAN 2.1 T2V + SGLang rollout (colocate), v2 trainer, 1x8.
+#
+# Video FlowGRPO with the rollout served by the ``sglang_diffusion`` engine
+# (WAN pipeline runs inside SGLang's multimodal_gen runtime) instead of the
+# trainside FSDP sampler. Mirrors sd3_sglang_rollout_colocate, but on the WAN
+# 2.1 T2V 1.3B video pipeline + video_pickscore reward, driven by the new
+# ``wan21`` video adapter (proper 6-D video trajectory + Videos decoded media).
+#
+#   1x8:  bash examples/run_experiment_single_node.sh diffusion/wan21/wan21_t2v_sglang
+#
+# Resolution: 480x832 is WAN 2.1 T2V **1.3B**'s native supported resolution
+# (720p is the 14B preset); num_frames=5 → 2 latent frames after the WAN VAE's
+# 4x temporal compression ((F-1)%4==0 required). Kept small for a fast RL loop.
+#
+# old_logp_source=replay: the trainer recomputes the π_old anchor with the WAN
+# pipeline (cross-engine safe — independent of SGLang's native log-prob emission).
+# Flip to ``rollout`` once the SGLang "sde" kernel is confirmed bit-equal for WAN.
+
+num_devices: 8                # 1 node x 8 GPUs
+batch_size: 8                 # prompts_per_rollout (small for the sglang video smoke)
+adv_use_global_std: true      # advantage: divide by ONE batch-wide std (v1 parity), not per-group
+num_rollouts: 1000
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (SGLang needs both at init).
+model_config:
+  _target_: unirl.models.wan21.config.WAN21PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.1-T2V-1.3B-Diffusers}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 5.0
+  max_sequence_length: 512
+  # SGLang builds its LoRA ServerArgs from these two fields.
+  use_lora: true
+  # WAN transformer attention LoRA targets — SGLANG NAMING (leaf module names).
+  # sglang's WanAttention (runtime/models/dits/wanvideo.py) has SEPARATE leaf
+  # modules to_q/to_k/to_v/to_out (no qkv fusion) under both self- and cross-attn,
+  # and renames diffusers attn1./attn2./.0 away. sglang wraps LoRA by substring
+  # match ``target in module_name``, so diffusers paths (attn1.to_q) miss the
+  # renamed modules → only 90/240 layers applied → sglang ran ~base → flat curve.
+  # Leaf names match every self+cross projection (2 attns × 4 = 8/block = 240).
+  # The trainside (peft) keeps diffusers paths in backend.lora_cfg.target_modules.
+  lora_target_modules:
+    - to_q
+    - to_k
+    - to_v
+    - to_out
+
+# Shared SDE strategy; SGLang resolves its sde_label from it.
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.wan21.bundle.WAN21Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.wan21.pipeline.WAN21Pipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: false
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: wan21
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    # Chunk generate into sub-batches so sglang bounds its DiT-forward / VAE-decode
+    # peak memory (video latents are heavy); without shrinking the logical batch.
+    forward_batch_size: 8
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # SGLANG leaf names (see model_config.lora_target_modules above).
+    target_modules:
+      - to_q
+      - to_k
+      - to_v
+      - to_out
+  # SGLang reads ckpt/LoRA off model_config and sde_label off strategy.
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  # REPLAY mode: recompute π_old trainside (cross-engine safe). See header.
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0          # no CFG → no negative-prompt branch
+  height: 480                  # WAN 2.1 T2V 1.3B native (480x832); not the 14B 720p preset
+  width: 832
+  num_frames: 5                # (num_frames-1)%4==0 required → 2 latent frames
+  eta: 0.7
+  samples_per_prompt: 8
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]   # SDE noise confined to the early high-σ steps
+    num_sde_steps: null
+
+# LoRA weight-sync cadence (loop concern, read by DiffusionTrainer.train).
+# Every N rollouts the loop pushes the freshly-trained adapter into SGLang.
+weight_sync_interval: 1
+
+sync:
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
+  verify: false
+  # Mirrors WAN21PipelineConfig.weight_sync_param_name_prefix; must match the
+  # engine-side LoRA key naming.
+  param_prefix: "transformer."
+  adapter_name: default
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan21_t2v_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan21", "t2v", "grpo", "video", "pickscore", "sglang", "v2"]
+  log_media: false
+  media_max_items: 8
+  media_log_interval: 1

--- a/examples/diffusion/wan21/wan21_t2v_sglang_full.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_sglang_full.yaml
@@ -1,0 +1,168 @@
+# @package _global_
+# GRPO WAN 2.1 T2V + SGLang rollout, FULL fine-tuning (no LoRA), colocate.
+#
+# Full-FT twin of wan21_t2v_sglang.yaml: trains the WHOLE transformer (no
+# lora_cfg) and pushes the RAW full weights to SGLang each sync
+# (TensorWeightSync lora_merged=false). Removes the entire LoRA path
+# (alpha/scale/format/adapter) so the only train↔rollout difference is the DiT
+# implementation itself. Pair with wan21_t2v_full.yaml (trainside, identical
+# config) for the curve-alignment comparison.
+#
+# old_logp_source=rollout: π_old = the rollout engine's own emitted log-probs,
+# so the importance ratio is correctly anchored on the policy that actually
+# generated (the principled cross-engine on/off-policy correction; matches SD3's
+# sglang recipe). Full weights are synced, so sglang generates with the exact
+# trained model.
+
+num_devices: 16
+batch_size: 24
+adv_use_global_std: true
+num_rollouts: 60
+
+model_config:
+  _target_: unirl.models.wan21.config.WAN21PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.1-T2V-1.3B-Diffusers}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 5.0
+  max_sequence_length: 512
+  use_lora: false
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.wan21.bundle.WAN21Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.wan21.pipeline.WAN21Pipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true     # full-FT: reshard to bound memory
+    activation_checkpointing: true  # full-FT: AC to fit optimizer states
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-5           # full-FT lr (much lower than LoRA's 3e-4)
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 60
+  # NO lora_cfg → genuine full-weight fine-tuning of the transformer.
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  model_config: ${model_config}
+  strategy: ${strategy}
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: wan21
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 4
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # No LoRA: full-weight sync replaces the adapter path.
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 14
+  guidance_scale: 1.0
+  height: 480
+  width: 832
+  num_frames: 5
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: null
+
+# Full-weight sync → SGLang rollout (colocate tensor-payload). lora_merged=false
+# pushes the RAW trained transformer weights (no LoRA merge).
+weight_sync_interval: 1
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  lora_merged: false
+  bucket_size_mb: 512
+  flush_cache: true
+  # backend.model is the bare WAN transformer; nest every key under the
+  # receiver's transformer.* namespace.
+  name_remap: {"*": "transformer.*"}
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan21_t2v_sglang_full}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan21", "t2v", "grpo", "video", "pickscore", "sglang", "full", "v2"]
+  log_media: false

--- a/examples/diffusion/wan21/wan21_t2v_sglang_loramerge.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_sglang_loramerge.yaml
@@ -1,0 +1,220 @@
+# @package _global_
+# GRPO WAN 2.1 T2V + SGLang rollout (colocate), v2 trainer, 1x8.
+#
+# Video FlowGRPO with the rollout served by the ``sglang_diffusion`` engine
+# (WAN pipeline runs inside SGLang's multimodal_gen runtime) instead of the
+# trainside FSDP sampler. Mirrors sd3_sglang_rollout_colocate, but on the WAN
+# 2.1 T2V 1.3B video pipeline + video_pickscore reward, driven by the new
+# ``wan21`` video adapter (proper 6-D video trajectory + Videos decoded media).
+#
+#   1x8:  bash examples/run_experiment_single_node.sh diffusion/wan21/wan21_t2v_sglang
+#
+# Resolution: 480x832 is WAN 2.1 T2V **1.3B**'s native supported resolution
+# (720p is the 14B preset); num_frames=5 → 2 latent frames after the WAN VAE's
+# 4x temporal compression ((F-1)%4==0 required). Kept small for a fast RL loop.
+#
+# old_logp_source=replay: the trainer recomputes the π_old anchor with the WAN
+# pipeline (cross-engine safe — independent of SGLang's native log-prob emission).
+# Flip to ``rollout`` once the SGLang "sde" kernel is confirmed bit-equal for WAN.
+
+num_devices: 8                # 1 node x 8 GPUs
+batch_size: 8                 # prompts_per_rollout (small for the sglang video smoke)
+adv_use_global_std: true      # advantage: divide by ONE batch-wide std (v1 parity), not per-group
+num_rollouts: 1000
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (SGLang needs both at init).
+model_config:
+  _target_: unirl.models.wan21.config.WAN21PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.1-T2V-1.3B-Diffusers}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 5.0
+  max_sequence_length: 512
+  # sglang loads a FULL transformer (NOT LoRA layers): the LoRA-merged sync pushes
+  # merged base weights, so the engine must not also apply an online adapter.
+  # The trainside still trains LoRA via backend.lora_cfg (peft) — independent of
+  # this flag, which only gates the sglang engine's LoRA ServerArgs.
+  use_lora: false
+  # WAN transformer attention LoRA targets — SGLANG NAMING (leaf module names).
+  # sglang's WanAttention (runtime/models/dits/wanvideo.py) has SEPARATE leaf
+  # modules to_q/to_k/to_v/to_out (no qkv fusion) under both self- and cross-attn,
+  # and renames diffusers attn1./attn2./.0 away. sglang wraps LoRA by substring
+  # match ``target in module_name``, so diffusers paths (attn1.to_q) miss the
+  # renamed modules → only 90/240 layers applied → sglang ran ~base → flat curve.
+  # Leaf names match every self+cross projection (2 attns × 4 = 8/block = 240).
+  # The trainside (peft) keeps diffusers paths in backend.lora_cfg.target_modules.
+  lora_target_modules:
+    - to_q
+    - to_k
+    - to_v
+    - to_out
+
+# Shared SDE strategy; SGLang resolves its sde_label from it.
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.wan21.bundle.WAN21Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.wan21.pipeline.WAN21Pipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: false
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: wan21
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    # Chunk generate into sub-batches so sglang bounds its DiT-forward / VAE-decode
+    # peak memory (video latents are heavy) without shrinking the logical batch.
+    forward_batch_size: 4
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # NO target_modules: LoRA-merged path pushes the FULL transformer (use_lora
+    # =false), so the weight sync updates the whole 'transformer' module via
+    # sync.name_remap, not per-leaf LoRA targets. Leaving leaf names here made the
+    # sync request modules 'to_q'/'to_k'/'to_v'/'to_out' that don't exist as
+    # top-level pipeline modules ("not found in pipeline").
+  # SGLang reads ckpt/LoRA off model_config and sde_label off strategy.
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  # REPLAY mode: recompute π_old trainside (cross-engine safe). See header.
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0          # no CFG → no negative-prompt branch
+  height: 480                  # WAN 2.1 T2V 1.3B native (480x832); not the 14B 720p preset
+  width: 832
+  num_frames: 5                # (num_frames-1)%4==0 required → 2 latent frames
+  eta: 0.7
+  samples_per_prompt: 8
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]   # SDE noise confined to the early high-σ steps
+    num_sde_steps: null
+
+# LoRA weight-sync cadence (loop concern, read by DiffusionTrainer.train).
+# Every N rollouts the loop pushes the freshly-trained adapter into SGLang.
+weight_sync_interval: 1
+
+# LoRA-MERGED full-weight sync: fold the trained LoRA into the base transformer
+# and push the merged FULL weights via TensorWeightSync, instead of the online
+# LoRA-adapter sync (LocalLoraWeightSync). sglang loads a FULL transformer
+# (model_config.use_lora=false) and receives the merged base weights.
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  lora_merged: true
+  adapter_name: default
+  bucket_size_mb: 512
+  flush_cache: true
+  name_remap: {"*": "transformer.*"}
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan21_t2v_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan21", "t2v", "grpo", "video", "pickscore", "sglang", "v2"]
+  log_media: false
+  media_max_items: 8
+  media_log_interval: 1

--- a/unirl/models/wan21/config.py
+++ b/unirl/models/wan21/config.py
@@ -16,7 +16,7 @@ an error — there is no silent fallback.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from unirl.config.validation import validate_precision_type
 
@@ -62,6 +62,19 @@ class WAN21PipelineConfig:
     # Trainer-side policy wraps the bare DiT, while vLLM-Omni loads it under
     # the pipeline's ``transformer.*`` namespace.
     weight_sync_param_name_prefix: str = "transformer."
+
+    # ------------------------------------------------------------------
+    # Optional LoRA hints for rollout-side engines (sglang in particular).
+    #
+    # Trainer-side LoRA lives in ``cfg.training.policies`` (LoRAPolicy →
+    # PEFT injection on the FSDP-wrapped module). The SGLang rollout server
+    # still needs to know at construction time whether to boot in LoRA mode
+    # and which target modules to wrap — those flags travel through this
+    # model_config. ``None`` / ``False`` are the default (no LoRA). Mirrors
+    # ``SD3PipelineConfig`` so the ``sglang_diffusion`` engine's
+    # ``server_intent`` can read them uniformly across families.
+    use_lora: bool = False
+    lora_target_modules: Optional[List[str]] = None
 
     def __post_init__(self) -> None:
         validate_precision_type(self.model_precision, field="WAN21PipelineConfig.model_precision")

--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -153,6 +153,9 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_rollout_trajectory import (
             patch_rollout_trajectory,
         )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_safe_unpickler import (
+            patch_safe_unpickler,
+        )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_sampling_io import (
             patch_sampling_io,
         )
@@ -168,6 +171,9 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_srt import patch_srt
         from unirl.rollout.engine.sglang_diffusion._patches.patch_vae_decode_safe import (
             patch_vae_decode_safe,
+        )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_wan_scheduler import (
+            patch_wan_scheduler,
         )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_weights_updater import (
             patch_weights_updater,
@@ -198,5 +204,7 @@ class SglangDiffusionHijack:
             patch_dance,
             patch_set_timesteps,
             patch_vae_decode_safe,
+            patch_wan_scheduler,
+            patch_safe_unpickler,
         ):
             _safe_apply(patch)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
@@ -1,0 +1,33 @@
+"""Allow unirl's trusted tensor-rebuild classes through sglang's SafeUnpickler.
+
+Full-weight sync ships serialized CUDA tensors whose reduction references unirl's
+``_rebuild_cuda_tensor_modified`` (``weight_sync.transfer.sgl_compat``). sglang's
+own ``SafeUnpickler`` (``srt/utils/common.py``, the CVE-2025-10164 mitigation)
+allowlists only ``builtins``/``torch``/``multiprocessing``/… — NOT ``unirl.`` —
+so ``update_weights_from_tensor`` raises ``Blocked unsafe class loading
+(unirl…._rebuild_cuda_tensor_modified)`` and the sync (hence the whole full-FT
+sglang run) dies at the first weight push.
+
+unirl's payload is internally produced and trusted (unirl's OWN SafeUnpickler in
+``sgl_compat`` already allowlists ``unirl.``), so the fix is to teach sglang's
+unpickler the same: add the ``unirl.`` prefix to its class allowlist. Idempotent;
+import-safe (sglang imported inside the fn). This must run in every process that
+deserializes the payload — installed via the patch suite's ``hijack()`` (which
+re-installs in spawned SRT children too).
+"""
+
+from __future__ import annotations
+
+
+def patch_safe_unpickler() -> None:
+    try:
+        from sglang.srt.utils.common import SafeUnpickler
+    except Exception:  # noqa: BLE001 — older sglang without the SafeUnpickler shim
+        return
+    prefixes = getattr(SafeUnpickler, "ALLOWED_MODULE_PREFIXES", None)
+    if prefixes is None:
+        return
+    # ``ALLOWED_MODULE_PREFIXES`` is a class-level set; mutating it covers every
+    # instance. Matches sglang's own ``(module + ".").startswith(prefix)`` check.
+    if "unirl." not in prefixes:
+        prefixes.add("unirl.")

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
@@ -1,0 +1,46 @@
+"""Use the flow-match (single-step SDE) scheduler for WAN rollout, not UniPC.
+
+``sglang``'s ``WanPipeline.initialize_pipeline`` hardcodes
+``FlowUniPCMultistepScheduler`` (the Wan2.1 official sampler, a multistep ODE
+solver). That class does NOT inherit ``SchedulerRLMixin`` — it has no
+``_rollout_variance_noise`` / SDE-step log-prob path — so the GRPO rollout
+(``rollout=True``, ``rollout_sde_type="sde"``) cannot run on it; the first thing
+that breaks is ``set_timesteps`` rejecting the driver's externally pinned σ list
+with ``assert isinstance(sigmas, np.ndarray)``.
+
+The other diffusion families (SD3, FLUX, Qwen-Image) all roll out on
+``FlowMatchEulerDiscreteScheduler``, which DOES carry the RL mixin and whose
+``set_timesteps`` accepts an external σ schedule (coerced to ndarray, with the
+shift neutralized by ``patch_set_timesteps`` so the driver-pinned schedule
+survives the σ-consistency check). WAN's own DMD pipeline
+(``wan_dmd_pipeline.py``) already builds exactly this scheduler the same way, so
+swapping is the sanctioned shape for WAN, not a divergence.
+
+This AROUND-wraps ``WanPipeline.initialize_pipeline`` to replace the scheduler
+with ``FlowMatchEulerDiscreteScheduler(shift=flow_shift)`` after the stock init
+(which only sets the scheduler module). Single-step flow-match transitions also
+match what the trainer replays trainside (FlowSDE), keeping GRPO's rollout↔replay
+consistency. Idempotent via a sentinel; import-safe (sglang imported inside).
+"""
+
+from __future__ import annotations
+
+
+def patch_wan_scheduler() -> None:
+    from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_match_euler_discrete import (
+        FlowMatchEulerDiscreteScheduler,
+    )
+    from sglang.multimodal_gen.runtime.pipelines.wan_pipeline import WanPipeline
+
+    orig = WanPipeline.initialize_pipeline
+    if getattr(orig, "_unirl_flowmatch_scheduler", False):
+        return
+
+    def initialize_pipeline(self, server_args) -> None:
+        # Stock init builds the (UniPC) scheduler + nothing else; run it so any
+        # future additions survive, then overwrite the scheduler module.
+        orig(self, server_args)
+        self.modules["scheduler"] = FlowMatchEulerDiscreteScheduler(shift=server_args.pipeline_config.flow_shift)
+
+    initialize_pipeline._unirl_flowmatch_scheduler = True  # type: ignore[attr-defined]
+    WanPipeline.initialize_pipeline = initialize_pipeline

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -103,9 +103,28 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
 
 
 def _apply_fused_param_mapping(module, named_tensors):
-    """Consume separate-projection tensors into their fused params via the model's
-    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    """Apply the model's ``param_names_mapping`` to the incoming named tensors.
+
+    A model's ``param_names_mapping`` (the same dict its checkpoint loader applies)
+    has two entry kinds; a model may use either or both:
+
+    * **fused projections** — ``{regex: (replacement, shard_id, num_shards)}`` —
+      write the trainer's separate-projection tensor into a dim-0 slice of the
+      model's fused param (Z-Image ``to_q/k/v -> to_qkv``, ``w1/w3 -> w13``).
+    * **plain renames** — ``{regex: replacement_str}`` — the model simply renamed
+      a param vs the checkpoint. WAN's mapping is entirely of this kind
+      (``patch_embedding.* -> patch_embedding.proj.*``,
+      ``blocks.N.attn1.to_q.* -> blocks.N.to_q.*``,
+      ``ffn.net.0.proj -> ffn.fc_in``, …). An EMPTY replacement means the model
+      dropped that param (e.g. WAN ``attn2.norm_added_q``) — the tensor is discarded.
+
+    Returns the leftover ``(name, tensor)`` list (renamed where applicable) for the
     exact-match loader. No-op when the module declares no mapping.
+
+    Before this handled the rename kind, simple-rename models (WAN) matched NOTHING
+    in the in-memory update path → 112/113 transformer tensors silently skipped →
+    the rollout engine ran stale base weights → flat reward curve (cross-engine
+    divergence), exactly the fused-model bug one step removed.
     """
     mapping = _resolve_param_names_mapping(module)
     if not mapping:
@@ -113,31 +132,47 @@ def _apply_fused_param_mapping(module, named_tensors):
 
     model_params = dict(module.named_parameters())
     leftover: list = []
-    fused = 0
+    fused = renamed = dropped = 0
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
             continue
         handled = False
         for pat, val in mapping.items():
-            if not isinstance(val, (tuple, list)) or len(val) != 3:
-                continue
             m = re.match(pat, name)
             if m is None:
                 continue
-            replacement, shard_id, num_shards = val
-            target = m.expand(replacement)
-            param = model_params.get(target)
-            if param is None:
-                continue
-            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
-            fused += 1
-            handled = True
-            break
+            if isinstance(val, (tuple, list)) and len(val) == 3:
+                replacement, shard_id, num_shards = val
+                param = model_params.get(m.expand(replacement))
+                if param is None:
+                    continue
+                _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+                fused += 1
+                handled = True
+                break
+            if isinstance(val, str):
+                if val == "":
+                    # model dropped this param — nothing to load.
+                    dropped += 1
+                    handled = True
+                    break
+                target = re.sub(pat, val, name)
+                if target in model_params:
+                    leftover.append((target, tensor))
+                    renamed += 1
+                    handled = True
+                    break
+                # rename produced a non-param name; keep trying other patterns.
         if not handled:
             leftover.append((name, tensor))
-    if fused:
-        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    if fused or renamed or dropped:
+        _log.info(
+            "weight-sync: param_names_mapping applied — %d fused, %d renamed, %d dropped",
+            fused,
+            renamed,
+            dropped,
+        )
     return leftover
 
 

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -22,6 +22,8 @@ from unirl.rollout.engine.sglang_diffusion.adapters.sd3 import SD3Adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.video import (
     HunyuanVideoAdapter,
     MochiAdapter,
+    VideoAdapter,
+    Wan21T2VAdapter,
 )
 from unirl.rollout.engine.sglang_diffusion.adapters.z_image import ZImageAdapter
 
@@ -35,6 +37,8 @@ __all__ = [
     "FluxAdapter",
     "Flux2KleinAdapter",
     "QwenImageAdapter",
+    "VideoAdapter",
+    "Wan21T2VAdapter",
     "MochiAdapter",
     "HunyuanVideoAdapter",
     "ZImageAdapter",

--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -1,37 +1,116 @@
-"""Video-family adapters: Mochi + HunyuanVideo.
+"""Video-family adapters.
 
-PARITY NOTE: the legacy ``sglang`` engine treats every family — including the
-video ones — through the image path: it builds an image-form ``LatentSegment``
-(``make_image_segment``) and *drops* 4-D decoded video with a warning (there is no
-video reward consumer yet). These adapters reproduce that behavior exactly so the
-per-family parity gate holds.
+Two output shapes live here:
 
-Proper video output (a ``video`` track, ``make_video_segment``, and ``Videos``
-decoded via ``from_list``) is a deliberate follow-up — it would diverge from the
-current engine, needs the packed/ragged ``Videos`` wiring, and has no parity
-baseline until a video reward consumer lands. When that happens, give these a
-``VideoAdapter`` base that overrides ``segment_factory`` / ``build_decoded`` /
-``track_name``.
+* ``VideoAdapter`` — proper video output. The latent trajectory is video-form
+  6-D ``[B, T+1, C, F, H, W]`` (an extra latent-frame axis vs the image path's
+  5-D ``[B, T+1, C, H, W]``) and the decoded media is packed into a ragged
+  :class:`~unirl.types.primitives.Videos` (``[total_T, C, H, W]``) instead of
+  being dropped. WAN 2.1 T2V rides this base — its rollout output is consumed by
+  the ``video_pickscore`` reward, the first such video reward consumer.
+
+* ``MochiAdapter`` / ``HunyuanVideoAdapter`` — kept on the legacy image path
+  (see note below) for behavioral parity with the old ``sglang`` engine. Migrate
+  them onto ``VideoAdapter`` once each has a verified video reward baseline.
+
+PARITY NOTE (image-path video families): the legacy ``sglang`` engine treated
+every family — including the video ones — through the image path: it built an
+image-form ``LatentSegment`` (``make_image_segment``) and *dropped* 4-D decoded
+video with a warning (there was no video reward consumer yet). ``MochiAdapter`` /
+``HunyuanVideoAdapter`` reproduce that exactly so the per-family parity gate
+holds; only families with a real video consumer (WAN) move to ``VideoAdapter``.
 """
 
 from __future__ import annotations
 
+from typing import List, Optional
+
+from unirl.rollout.engine.sglang_diffusion import utils
 from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
+from unirl.rollout.engine.sglang_diffusion.backends import RawResult
+from unirl.types.rollout_req import RolloutReq
+from unirl.types.segments.latent import make_video_segment
+
+
+class VideoAdapter(ImageAdapter):
+    """Base for true video-output families (6-D latent trajectory → ``Videos``).
+
+    Reuses ``ImageAdapter``'s request side verbatim — ``build_sampling`` already
+    forwards ``num_frames`` and the SDE/rollout pins are modality-agnostic — and
+    overrides only the response-shape variation points: the segment is stamped
+    ``Modality.VIDEO`` and carries the 6-D ``[B, T+1, C, F, H, W]`` trajectory,
+    and the decoded media is packed as ``Videos`` rather than dropped.
+    """
+
+    #: RolloutResp track key (video, not image).
+    track_name: str = "video"
+    #: Modality stamp for the latent segment.
+    segment_factory = staticmethod(make_video_segment)
+
+    def build_segment(
+        self,
+        req: RolloutReq,
+        results: List[RawResult],
+        *,
+        num_steps: int,
+        sde_indices: Optional[List[int]],
+        emit_native_logprob: bool,
+    ):
+        """Video-form trajectory: collect, gate the 6-D shape, assemble.
+
+        Video latents keep the extra frame axis throughout, so the trajectory is
+        rank 6 ``[B, T+1, C, F, H, W]`` (vs the image path's rank 5). The downstream
+        ``build_latent_segment`` is shape-agnostic past the T+1 invariant, so the
+        only difference from the image path is the rank gate + the video segment
+        factory.
+        """
+        traj = utils.collect_trajectory_latents(results)
+        if traj.ndim != 6:
+            raise ValueError(
+                f"{self.model_family}: expected a 6-D video-form trajectory "
+                f"[B, T+1, C, F, H, W]; got rank {traj.ndim}, shape {tuple(traj.shape)}."
+            )
+        return utils.build_latent_segment(
+            traj,
+            results=results,
+            expected_sigmas=req.sigmas,
+            num_steps=num_steps,
+            sde_indices=sde_indices,
+            emit_native_logprob=emit_native_logprob,
+            segment_factory=self.segment_factory,
+        )
+
+    def build_decoded(self, results: List[RawResult]):
+        return utils.stack_decoded_videos(results)
+
+
+@register_adapter("wan21")
+class Wan21T2VAdapter(VideoAdapter):
+    """WAN 2.1 T2V — proper video output consumed by ``video_pickscore``.
+
+    The text/conditions path is the generic UMT5 fuse from ``ImageAdapter``
+    (single text encoder; no CFG negative branch when ``guidance_scale <= 1``);
+    only the video-output overrides on ``VideoAdapter`` apply. The sglang server
+    resolves the WAN pipeline from ``model_path`` (the ``Wan-AI/Wan2.1-T2V-1.3B``
+    -Diffusers checkpoint), so no extra ``boot_kwargs`` are needed.
+    """
+
+    pass
 
 
 @register_adapter("mochi")
 class MochiAdapter(ImageAdapter):
-    """Mochi — image-path parity (see module note); proper video output is a follow-up."""
+    """Mochi — image-path parity (see module note); migrate to VideoAdapter when it has a video reward baseline."""
 
     pass
 
 
 @register_adapter("hunyuan_video")
 class HunyuanVideoAdapter(ImageAdapter):
-    """HunyuanVideo — image-path parity (see module note); proper video output is a follow-up."""
+    """HunyuanVideo — image-path parity (see module note); migrate to VideoAdapter when it has a video reward baseline."""
 
     pass
 
 
-__all__ = ["MochiAdapter", "HunyuanVideoAdapter"]
+__all__ = ["VideoAdapter", "Wan21T2VAdapter", "MochiAdapter", "HunyuanVideoAdapter"]

--- a/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
@@ -20,6 +20,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tracks import (
     derive_timestep_alignment,
     fuse_text_conditions,
     stack_decoded_images,
+    stack_decoded_videos,
     validate_packed_trajectory,
 )
 
@@ -34,5 +35,6 @@ __all__ = [
     "derive_timestep_alignment",
     "fuse_text_conditions",
     "stack_decoded_images",
+    "stack_decoded_videos",
     "validate_packed_trajectory",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
@@ -24,7 +24,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tensors import (
 )
 from unirl.rollout.engine.sigma_verify import verify_engine_used_sigmas
 from unirl.types.conditions.text import TextEmbedCondition
-from unirl.types.primitives import Images
+from unirl.types.primitives import Images, Video, Videos
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.segments.latent import LatentSegment, make_image_segment
 from unirl.types.trajectory_store import compute_trajectory_positions
@@ -266,6 +266,37 @@ def stack_decoded_images(results: Sequence[RawResult]) -> Optional[Images]:
     return Images(pixels=torch.stack(per_sample_tensors, dim=0))
 
 
+def stack_decoded_videos(results: Sequence[RawResult]) -> Optional[Videos]:
+    """Pack per-result decoded video ``samples`` into a ragged ``Videos`` batch.
+
+    The video counterpart of :func:`stack_decoded_images`. ``decode_sample``
+    returns canonical channels-first video ``[C, T, H, W]`` (see
+    :func:`unirl.rollout.engine.sglang_diffusion.utils.tensors.normalize_media`);
+    the :class:`~unirl.types.primitives.Video` primitive — and the video reward
+    consumer (``video_pickscore``, which permutes ``frames[T,C,H,W] → [C,T,H,W]``)
+    — want frame-major ``[T, C, H, W]``, so we permute before packing.
+    ``Videos.from_list`` concatenates along T and lets the Batch framework
+    compute the per-sample ``cu_frames`` offsets. Each result carries exactly
+    one decoded sample (mirrors :func:`stack_decoded_images`'s one-per-result
+    contract). Returns ``None`` when no recognizable video was produced.
+    """
+    videos: List[Video] = []
+    for result in results:
+        canonical = decode_sample(result.samples)
+        if canonical is None:
+            continue
+        if canonical.dim() != 4:
+            raise RuntimeError(
+                f"stack_decoded_videos: expected 4-D canonical video [C, T, H, W]; "
+                f"got rank {canonical.dim()}, shape {tuple(canonical.shape)}."
+            )
+        frames = canonical.permute(1, 0, 2, 3).contiguous().to(torch.float32)  # [T, C, H, W]
+        videos.append(Video(frames=frames))
+    if not videos:
+        return None
+    return Videos.from_list(videos)
+
+
 # ---------------------------------------------------------------------------
 # Conditions packing
 # ---------------------------------------------------------------------------
@@ -399,5 +430,6 @@ __all__ = [
     "derive_timestep_alignment",
     "build_latent_segment",
     "stack_decoded_images",
+    "stack_decoded_videos",
     "fuse_text_conditions",
 ]


### PR DESCRIPTION
## Summary

Adds **WAN 2.1 T2V** to the `sglang_diffusion` rollout engine, plus example configs that align sglang rollout reward curves to the trainside reference for both **full fine-tuning** and **LoRA**.

- Video adapter infra: `VideoAdapter` base + `Wan21T2VAdapter` (6-D video-form trajectory `[B,T+1,C,F,H,W]`, `stack_decoded_videos` → ragged `Videos`) + `utils/tracks`.
- WAN scheduler patch: swap the hardcoded `FlowUniPCMultistepScheduler` → `FlowMatchEulerDiscreteScheduler` (the RL-mixin scheduler the other diffusion families use).
- `safe_unpickler` allowlist: let sglang's `SafeUnpickler` load unirl's tensor-rebuild in the full-weight-sync payload.
- LoRA wrap fix: sglang `lora_target_modules` use leaf names (`to_q/to_k/to_v/to_out`; sglang keeps separate q/k/v/out, no qkv fusion) so all 240 layers wrap instead of 90.
- `wan21_t2v_sglang_loramerge.yaml`: train LoRA on the train side but sync via the full-weight path (`lora_merged=true`) — the online LoRA-adapter sync mis-applies the delta.

## Related Issue

N/A. Builds on the `param_names_mapping` rename fix (separate PR), which the full-FT sglang sync needs.

## Test Plan

WAN 2.1 T2V 1.3B, `video_pickscore` (PickScore) reward, 2 nodes × 8 GPU per run, `datasets/pickscore`.
- Hydra config validation (all wan21 recipes parse + resolve):
  `python -m unirl.train_diffusion --config-name=diffusion/wan21/wan21_t2v_sglang_full --cfg job --resolve` (also `_loramerge`, `_sglang`, `_full`).
- Curve-alignment runs: full-FT and LoRA each as a sglang-rollout vs trainside-reference pair (`num_rollouts=1000`). The sglang rollout reward curve tracks the trainside curve throughout — full-FT to ~3 decimals at matched rollout index; LoRA likewise via the merged-sync path — to several hundred rollouts with 0 errors.

## Compatibility / Risk

Additive: new `wan21` adapter + example configs. Existing families are untouched — Mochi / HunyuanVideo stay on the legacy image path. Full-FT sglang sync depends on the rename-fix PR. `video_pickscore` is the first video reward consumer.

## Reviewer Notes

Depends on the `param_names_mapping` rename fix PR. The online LoRA-adapter sync (`LocalLoraWeightSync`) mis-applies the delta for WAN; this PR routes LoRA through the merged full-weight sync instead, leaving a fix to the online path as follow-up. Developed with AI assistance.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.


## EXP
FULL TRAINSIDE vs SGLANG
<img width="438" height="314" alt="截屏2026-06-22 04 58 12" src="https://github.com/user-attachments/assets/36f889e7-df6d-471b-a229-529a7adc18f6" />

LORA TRAINSIDE vs SGLANG
<img width="434" height="308" alt="截屏2026-06-22 04 58 27" src="https://github.com/user-attachments/assets/7f7048b9-ede0-44dd-9aab-a4053c26e10b" />
