### PR TITLE
docs: note Bagel supports Text + Image → Image in model table

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ dimension; all listed models are supported (✅).
 | Qwen3 | LLM AR | Text → Text | ✅ |
 | Prompt-Enhancer | LLM + diffusion | Text → Text → Image | ✅ |
 | HunyuanImage3 | Unified AR + diffusion | Text → Image | ✅ |
-| Bagel | Unified AR + diffusion | Text → Image | ✅ |
+| Bagel | Unified AR + diffusion | Text → Image / Text + Image → Image | ✅ |
 
 </div>
 


### PR DESCRIPTION
## Summary

The model-support table in the README listed Bagel as `Text → Image` only, but
Bagel also supports image editing (text + image → image). Update the Modality
column for the Bagel row to `Text → Image / Text + Image → Image`, matching the
`Text → Image / Text + Image → Image` style already used for the FLUX.2-Klein
row. Documentation only — no code changes.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files README.md` — runs the
  whitespace / end-of-file / merge-conflict / private-key checks on the edited
  file.
- Visual check: the table still renders as a valid 4-column Markdown table.

## Compatibility / Risk

N/A — single-line documentation change; no code, config, API, or data impact.

## Reviewer Notes

- AI-assisted. One-line README edit; full diff reviewed.
- Branched from latest `origin/main` (`d74d4fb`); only the Bagel Modality cell
  changes.
- The TI2I (text + image → image) capability itself is being added/validated
  separately; this PR only documents that Bagel supports it.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
