### PR TITLE
fix(qwen3): disable cuDNN SDPA in AR replay to avoid NaN grads

### DIFF
--- a/unirl/models/qwen3/ar.py
+++ b/unirl/models/qwen3/ar.py
@@ -108,6 +108,15 @@ def _replay_aware_forward(
                 return f(self, **kw)
         raise RuntimeError("_replay_aware_forward: no class-level forward found in the MRO")
 
+    # cuDNN's fused SDPA backward (ScaledDotProductCudnnAttentionBackward0) returns
+    # NaN grads on some bf16 sequences while the forward stays finite (confirmed via
+    # torch.autograd.detect_anomaly): it floods every parameter grad and forces the
+    # optimizer to skip the whole step (~half of them, observed on Qwen3-4B-Base AR
+    # RL). Disable the cuDNN SDPA backend so PyTorch uses the stable flash /
+    # mem-efficient attention kernels for the replay forward.
+    if torch.cuda.is_available():
+        torch.backends.cuda.enable_cudnn_sdp(False)
+
     # Body in autocast (matmul bf16, norms fp32); the caller passes None off-CUDA.
     autocast_ctx = (
         torch.autocast("cuda", autocast_dtype) if autocast_dtype in (torch.float16, torch.bfloat16) else nullcontext()

--- a/unirl/train/backend/base_backend.py
+++ b/unirl/train/backend/base_backend.py
@@ -262,11 +262,28 @@ class BaseFSDP2Backend(Remote):
         grad_norm = float(clipped.item()) if isinstance(clipped, torch.Tensor) else float(clipped or 0.0)
 
         if not math.isfinite(grad_norm):
+            # On a skipped step (already discarded), pinpoint which params carry the
+            # non-finite grad (sharded DTensor -> check the local shard) so the
+            # offending module is identifiable from the log. Runs only on this skip
+            # path, so it adds nothing to healthy steps.
+            bad_params = []
+            total_with_grad = 0
+            for _name, _p in self.model.named_parameters():
+                if _p.grad is None:
+                    continue
+                total_with_grad += 1
+                _gl = _p.grad.to_local() if hasattr(_p.grad, "to_local") else _p.grad
+                if _gl.numel() and not bool(torch.isfinite(_gl).all()):
+                    bad_params.append(_name)
             logger.warning(
-                "%s.optimizer_step: non-finite grad norm (%s) at step %d; skipping step.",
+                "%s.optimizer_step: non-finite grad norm (%s) at step %d; skipping step. "
+                "%d/%d grad-params non-finite; first: %s",
                 type(self).__name__,
                 grad_norm,
                 self._optimizer_step_count,
+                len(bad_params),
+                total_with_grad,
+                bad_params[:12],
             )
             self.optimizer.zero_grad(set_to_none=True)
             return grad_norm


### PR DESCRIPTION
## Summary

Two robustness fixes for the Qwen3 autoregressive (text) RL replay path, found while
bringing up DPPO on Qwen3-4B-Base / DAPO-Math (SGLang colocate, FSDP2). They are
independent of any single algorithm — they affect GRPO/DRPO/CPPO/DPPO alike, since all
replay through `Qwen3ARStage`.

- **Disable the cuDNN SDPA backend in the AR replay forward** (`unirl/models/qwen3/ar.py`).
  cuDNN's fused SDPA backward (`ScaledDotProductCudnnAttentionBackward0`) returns NaN
  gradients on some bf16 sequences while the forward stays finite. Since the loss /
  LM-head / log-prob math is all fp32 and finite, it surfaces as "finite loss, NaN grad":
  the NaN floods every parameter grad and the optimizer-step guard skips the whole step
  (~half the steps on Qwen3-4B-Base AR RL). Pinpointed with `torch.autograd.detect_anomaly`.
  Disabling cuDNN SDPA falls back to the stable flash / mem-efficient kernels — same
  attention math, no NaN.
- **Name the offending params on a skipped step** (`unirl/train/backend/base_backend.py`).
  When `optimizer_step` skips on a non-finite clipped grad norm, also log which parameters
  carry the non-finite grad (sharded DTensor → local shard). Runs only on the
  already-skipped path, so healthy steps are unaffected; this is how the cuDNN NaN was localized.

## Related Issue

N/A

## Test Plan

- `pre-commit run --all-files` — passed (ruff check/format, python-ast, recipe `_target_` resolve).
- 1×8 validation — Qwen3-4B-Base · DAPO-Math · SGLang colocate · H20 · `num_rollouts=20`:
  - Before (cuDNN SDPA enabled): **10/20** optimizer steps skipped (`non-finite grad norm`).
  - After (this PR): **0/20** skipped, all `grad_norm` finite (~0.009–0.015); `reward_mean`
    0.11 → ~0.31; AIME avg@16 (AIME24+25) 0.022 → 0.064 (baseline → rollout 20); `ratio_mean` ≈ 1.0.
- Root cause confirmed via `torch.autograd.detect_anomaly()`:
  `RuntimeError: Function 'ScaledDotProductCudnnAttentionBackward0' returned nan values in its 0th output.`

## Compatibility / Risk

- `enable_cudnn_sdp(False)` is a process-global torch flag set inside the Qwen3 replay
  forward; it changes only the attention *kernel* (cuDNN → flash/mem-efficient), not the
  math. No config / checkpoint / data-format / API changes. Other model families are
  unaffected (they don't go through this forward). Speed is neutral-to-better.
- The diagnostic logging runs only on an already-skipped step → no training-throughput impact.

## Reviewer Notes

- AI-assisted; human-reviewed. Checked open PRs — none touch the Qwen3 AR replay attention
  or this NaN.
- The port-overflow and chat-template return-type issues hit during the same bring-up are
  already handled on `main` (`SGLangPorts`, `sglang/adapters/text.py`), so they are
  intentionally excluded here.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not (kernel-selection fix + diagnostic; no test/doc change needed).