### PR TITLE
docs(flowdppo): list official HF checkpoints, clarify curve is SD3.5-medium

### DIFF
--- a/FlowDPPO/README.md
+++ b/FlowDPPO/README.md
@@ -9,7 +9,9 @@ pushes too aggressively in the reward-improving direction.
 - **Loss:** [`unirl/algorithms/flowdppo.py`](../unirl/algorithms/flowdppo.py) (`_gaussian_kl_div`, `_flowdppo_kl_adv_loss`, `FlowDPPO`)
 - **SDE / replay path:** [`unirl/models/sd3/diffusion.py`](../unirl/models/sd3/diffusion.py), [`unirl/sde/kernels.py`](../unirl/sde/kernels.py)
 - **Recipe:** [`examples/diffusion/sd3/sd3_flowdppo.yaml`](../examples/diffusion/sd3/sd3_flowdppo.yaml) · **Config extract:** [`config.yaml`](config.yaml)
-- **Checkpoints:** [🤗 FlowDPPO](https://huggingface.co/Eculid/sd3.5-flowdppo)
+- **Checkpoints:**
+  - [🤗 Eculid/sd3.5-flowdppo](https://huggingface.co/Eculid/sd3.5-flowdppo) — SD3.5-medium, full weights (community run)
+  - [🤗 Tencent-Hunyuan-Multimodal-RL](https://huggingface.co/Tencent-Hunyuan-Multimodal-RL) — official GenEval2 LoRA adapters (single- & multi-reward) on SD3.5-medium and FLUX.2-klein-base-9B
 - **Paper:** *"FlowDPPO: Divergence Proximal Policy Optimization for Flow Matching Models."*
 
 FlowDPPO builds on the same GRPO-style SDE rollout, trained-step gating, and
@@ -154,8 +156,8 @@ python -m unirl.train_diffusion --config-name=diffusion/sd3/sd3_flowdppo num_dev
 
 ![FlowDPPO training curve: rollout/reward_mean for SD3.5-medium rises from ~0.75 to ~0.89 over ~270 rollout steps.](../assets/flowdppo_wandb.png)
 
-A healthy run climbs `rollout/reward_mean` quickly and then keeps inching up — here
-SD3.5-medium goes from ~0.75 to ~0.89 over ~270 steps.
+A healthy run climbs `rollout/reward_mean` quickly and then keeps inching up — the
+curve above is the **SD3.5-medium** run, going from ~0.75 to ~0.89 over ~270 steps.
 
 ## Related tutorial
 


### PR DESCRIPTION
## Summary

Follow-up to #27 (the Hugging Face release request). The official Flow-DPPO
checkpoints now live under the `Tencent-Hunyuan-Multimodal-RL` org and are linked
to the paper page, but the `FlowDPPO/README.md` only pointed at the community
`Eculid/sd3.5-flowdppo` run. This adds the official checkpoints and makes the
base-model split explicit so the reward curve is not misread.

Changes (docs only, `FlowDPPO/README.md`):

- Expand the **Checkpoints** bullet to list, alongside the community SD3.5-medium
  run, the official `Tencent-Hunyuan-Multimodal-RL` GenEval2 LoRA adapters
  (single- & multi-reward) on **two bases**: SD3.5-medium and FLUX.2-klein-base-9B.
- Clarify the training-curve caption/prose: the `rollout/reward_mean` curve is the
  **SD3.5-medium** run specifically; the FLUX.2-klein adapters are separate runs and
  are not reflected in that curve.

## Related Issue

Related to #27.

## Test Plan

Not run; reason: documentation-only change (no code, config, or recipe touched).
HF links and model bases verified against the live Hub API — all four
`Tencent-Hunyuan-Multimodal-RL` models carry the `flow-dppo` + `arxiv:2606.11025`
tags (SD3.5-medium and FLUX.2-klein-base-9B bases), and `Eculid/sd3.5-flowdppo` is
linked to the paper.

## Compatibility / Risk

N/A — Markdown documentation only.

## Reviewer Notes

AI-assisted. Duplicate-work check: no other open PR touches `FlowDPPO/README.md`.
The curve image (`assets/flowdppo_wandb.png`) is unchanged; only the surrounding
text was adjusted to avoid conflating it with the FLUX.2 adapters.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
