### PR TITLE
feat(ltx2.3): add LTX-2.3 T2AV support with joint audio+video SDE policy

### DIFF
--- a/examples/diffusion/ltx2/ltx2_3_t2av_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_trainside.yaml
@@ -1,0 +1,179 @@
+# @package _global_
+# LTX-Video-2.3 T2AV GRPO — trainside (in-process FSDP).
+#
+# LTX-2.3 extends LTX-2 with joint audio-video generation. The transformer
+# handles both video and audio in a unified attention space. With
+# ``audio_joint_sde: true`` (the config default), video AND audio form a single
+# joint SDE policy: audio is SDE-stepped with the same eta as video, emits its
+# own per-step log-prob, and the two are merged into the joint policy log-prob
+# (see unirl/models/ltx2/diffusion.py). Set ``audio_joint_sde: false`` on the
+# bundle config to fall back to the legacy ODE-audio behavior (video-only RL).
+#
+# NOTE (test scope): the pipeline currently decodes/rewards VIDEO only — audio
+# participates in the joint SDE rollout/replay but is not yet decoded to a
+# waveform or scored. The reward below is VideoPickScore (video-only). This
+# recipe validates that the T2AV model loads and the joint audio+video SDE
+# train loop runs; end-to-end audio (decode + audio reward) is follow-up work.
+#
+# Architecture:
+#   - 48 LTX2VideoTransformerBlock layers (unified video+audio attention)
+#   - 3D Video VAE: 32x spatial, 8x temporal, 128 latent channels
+#   - Audio VAE + Vocoder for waveform generation (loaded, not yet used in reward)
+#   - Gemma3 text encoder + connector projections (video + audio streams)
+#   - FlowMatch Euler Discrete scheduler
+#
+# Launch (1 node × 8 GPUs):
+#   bash examples/run_experiment_multinode_taiji.sh diffusion/ltx2/ltx2_3_t2av_trainside
+
+num_devices: 8
+batch_size: 8
+num_rollouts: 10000
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,unirl-ltx2.3-t2av}
+  run_name: null
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [ltx2.3, t2av, grpo, trainside, dancegrpo, audio]
+  log_media: true
+  media_max_items: 4
+  # How often (in ROLLOUTS) to log generated media to wandb. One rollout =
+  # one sampling batch (batch_size prompts x samples_per_prompt), NOT one
+  # optimizer step. Set high to keep media logging sparse / cheap.
+  media_log_interval: 1000
+
+bundle:
+  _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config
+  config:
+    _target_: unirl.models.ltx2.config.LTX2PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,dg845/LTX-2.3-Diffusers}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp16
+    logprob_precision: fp32
+    shift: 1.0
+    max_sequence_length: 512
+    enable_audio: true
+    # Joint audio+video SDE policy (default True). False => legacy ODE audio.
+    audio_joint_sde: true
+    default_height: 512
+    default_width: 768
+    default_num_frames: 33
+    default_frame_rate: 24.0
+
+pipeline:
+  _target_: unirl.models.ltx2.pipeline.LTX2Pipeline.from_bundle
+  config: ${bundle.config}
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["LTX2VideoTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      # Video self-attention
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      # Video cross-attention (text)
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+      # Video FFN
+      - ff.net.0.proj
+      - ff.net.2
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 2
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 4
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.ltx2.conditions.LTX2Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 1
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 768
+  num_frames: 33
+  eta: 0.7
+  samples_per_prompt: 4
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 5
+    timestep_fraction: [0, 0.5]

--- a/unirl/models/ltx2/bundle.py
+++ b/unirl/models/ltx2/bundle.py
@@ -126,14 +126,29 @@ class LTX2Bundle(Bundle):
                 from diffusers import AutoencoderKLLTX2Audio
                 from diffusers.pipelines.ltx2.vocoder import LTX2Vocoder
 
+                # low_cpu_mem_usage=False: the vocoder holds non-persistent
+                # anti-alias filter buffers (``*.upsample.filter`` /
+                # ``*.downsample.filter``) that are computed at init, NOT stored
+                # in the checkpoint. With the default meta-device load path those
+                # buffers stay on ``meta`` (HF warns "newly initialized"), and the
+                # subsequent ``.to(device)`` raises "Cannot copy out of meta
+                # tensor". Forcing a real (CPU) instantiation materializes the
+                # filters so ``.to(device)`` works. Mirrors load_pipeline's
+                # low_cpu_mem_usage=False used elsewhere for FSDP compatibility.
                 audio_vae = (
-                    AutoencoderKLLTX2Audio.from_pretrained(path, subfolder="audio_vae", torch_dtype=vae_dtype)
+                    AutoencoderKLLTX2Audio.from_pretrained(
+                        path, subfolder="audio_vae", torch_dtype=vae_dtype, low_cpu_mem_usage=False
+                    )
                     .to(device)
                     .eval()
                 )
                 audio_vae.requires_grad_(False)
 
-                vocoder = LTX2Vocoder.from_pretrained(path, subfolder="vocoder", torch_dtype=dtype).to(device).eval()
+                vocoder = (
+                    LTX2Vocoder.from_pretrained(path, subfolder="vocoder", torch_dtype=dtype, low_cpu_mem_usage=False)
+                    .to(device)
+                    .eval()
+                )
                 vocoder.requires_grad_(False)
             except (ImportError, OSError) as e:
                 raise RuntimeError(

--- a/unirl/models/ltx2/config.py
+++ b/unirl/models/ltx2/config.py
@@ -55,6 +55,18 @@ class LTX2PipelineConfig:
     # Audio support (LTX-2.3). Set True to load audio VAE + vocoder.
     enable_audio: bool = False
 
+    # When True (and the bundle has audio), video+audio form a SINGLE joint SDE
+    # policy: audio is SDE-stepped with the same ``eta`` as video, emits its own
+    # per-step log-prob, and the two are merged by an element-weighted mean (the
+    # mean a single SDE over the concatenated ``[video|audio]`` latent would
+    # produce). This keeps the RL importance ratio consistent with the
+    # audio<->video cross-attention coupling. When False, audio is denoised with
+    # ODE (``eta=0``, no log-prob, no RL gradient) and only video carries the
+    # policy signal — the legacy behavior. No effect for ``enable_audio=False``
+    # (T2V): the audio stream is then a synthetic placeholder that is never
+    # decoded or rewarded, so it stays out of the policy regardless of this flag.
+    audio_joint_sde: bool = True
+
     # Video generation defaults.
     default_height: int = 512
     default_width: int = 768

--- a/unirl/models/ltx2/diffusion.py
+++ b/unirl/models/ltx2/diffusion.py
@@ -77,6 +77,24 @@ def _audio_packed_feature_dim() -> int:
     return _LTX2_AUDIO_LATENT_CHANNELS * (_LTX2_AUDIO_MEL_BINS // _LTX2_AUDIO_MEL_COMPRESSION)
 
 
+def _combine_modality_logp(
+    video_logp: torch.Tensor,
+    audio_logp: torch.Tensor,
+    n_video: int,
+    n_audio: int,
+) -> torch.Tensor:
+    """Element-weighted mean of the per-step video/audio log-probs.
+
+    Video and audio are stepped by the SAME stateless strategy, each returning a
+    per-sample log-prob already meaned over its own latent dims. Weighting by the
+    element counts reproduces the mean a single SDE over the concatenated
+    ``[video|audio]`` latent would produce, so the joint log-prob keeps the same
+    scale as the video-only path. Mirrors Flow-Factory ``combine_modality_log_prob``.
+    """
+    total = n_video + n_audio
+    return (video_logp * n_video + audio_logp * n_audio) / total
+
+
 class LTX2DiffusionStep(DiffusionStep[LTX2Bundle, LTX2Conditions]):
     """Per-step LTX2 denoising kernel — stateless.
 
@@ -203,6 +221,7 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
         autocast_precision: str = "bf16",
         trajectory_precision: str = "fp16",
         logprob_precision: str = "fp32",
+        audio_joint_sde: bool = True,
     ) -> None:
         self.bundle = bundle
         self.step_kernel = LTX2DiffusionStep()
@@ -210,6 +229,13 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
         self.autocast_dtype = parse_torch_dtype(autocast_precision, field_name="autocast_precision")
         self.trajectory_dtype = parse_torch_dtype(trajectory_precision, field_name="trajectory_precision")
         self.logprob_dtype = parse_torch_dtype(logprob_precision, field_name="logprob_precision")
+        # Joint audio+video SDE policy. Only meaningful when the bundle actually
+        # has audio (LTX-2.3 T2AV); for T2V the audio stream is a synthetic
+        # placeholder that is never decoded/rewarded, so it must stay out of the
+        # policy regardless of the flag. ``_audio_in_policy`` is the resolved
+        # gate used throughout generate()/replay().
+        self.audio_joint_sde = bool(audio_joint_sde)
+        self._audio_in_policy = self.audio_joint_sde and bool(getattr(bundle, "has_audio", False))
 
     def trainable_module(self) -> torch.nn.Module:
         """The trainable transformer (for FSDP wrapping)."""
@@ -326,14 +352,19 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
                 )
                 x = x_next.to(dtype=self.trajectory_dtype)
 
-                # Audio: ODE step (eta=0) — no RL gradient, just track the state
-                # the video branch conditions on. eta=0 → euler velocity step.
-                a_next, _, _ = self.strategy.denoise(
+                # Audio step. Joint mode (LTX-2.3 + audio_joint_sde): share the
+                # video ``eta`` so audio is a stochastic SDE twin, capture its
+                # log-prob, and merge into a single joint-policy log-prob. Legacy
+                # mode: ODE (eta=0), no RL gradient — audio is only the state the
+                # video branch cross-attends to. The strategy is stateless
+                # (step_index passed in), so the same instance serves both steps.
+                audio_eta = step_eta if self._audio_in_policy else 0.0
+                a_next, audio_log_prob, _ = self.strategy.denoise(
                     noise_pred=audio_pred,
                     sample=a,
                     sigma=sigma,
                     sigma_next=sigma_next,
-                    eta=0.0,
+                    eta=audio_eta,
                     sigma_max=sigma_max,
                     step_index=step_idx,
                 )
@@ -343,6 +374,13 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
                     stored_pairs.append((step_idx + 1, x.detach().clone()))
                     stored_audio.append(a.detach().clone())
                 if log_prob is not None:
+                    if self._audio_in_policy and audio_log_prob is not None:
+                        log_prob = _combine_modality_logp(
+                            log_prob,
+                            audio_log_prob,
+                            n_video=x[0].numel(),
+                            n_audio=a[0].numel(),
+                        )
                     sde_logp_list.append(log_prob.to(dtype=self.logprob_dtype))
 
         positions = [p for p, _ in stored_pairs]
@@ -426,11 +464,12 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
                 prev_sample = segment.latents_at(step_idx + 1).to(device=device, dtype=self.trajectory_dtype)
                 # Reuse the audio state stored at this step from the rollout, so
                 # the video prediction matches what generate() produced (the
-                # video forward cross-attends to audio). Only the video pred is
-                # used for the log-prob; we discard the audio pred.
+                # video forward cross-attends to audio). In joint mode the audio
+                # pred is also stepped for its own log-prob; in legacy mode it is
+                # discarded.
                 audio_sample = segment.aux_latents_at(step_idx).to(device=device, dtype=self.trajectory_dtype)
 
-                video_pred, _ = self.step_kernel.predict_noise(
+                video_pred, audio_pred = self.step_kernel.predict_noise(
                     self.bundle,
                     sample,
                     sigma.expand(sample.shape[0]),
@@ -458,6 +497,42 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
                         f"LTX2DiffusionStage.replay: strategy returned None log-prob at step_index={step_idx} "
                         f"(deterministic mode); replay requires a stochastic SDE strategy."
                     )
+
+                # Joint mode: replay the audio transition too (same eta) and merge
+                # its log-prob/mean into the joint policy, mirroring generate(). The
+                # combined log-prob keeps the ratio consistent with rollout; the
+                # concatenated means feed FlowDPPO's Gaussian KL (video-only models
+                # leave _audio_in_policy False → unchanged).
+                if self._audio_in_policy:
+                    audio_prev = segment.aux_latents_at(step_idx + 1).to(device=device, dtype=self.trajectory_dtype)
+                    _, audio_log_prob, audio_prev_mean = self.strategy.denoise(
+                        noise_pred=audio_pred,
+                        sample=audio_sample,
+                        sigma=sigma,
+                        sigma_next=sigma_next,
+                        eta=eta,
+                        prev_sample=audio_prev,
+                        sigma_max=sigma_max,
+                        step_index=step_idx,
+                    )
+                    if audio_log_prob is None:
+                        raise RuntimeError(
+                            f"LTX2DiffusionStage.replay: audio strategy returned None log-prob at "
+                            f"step_index={step_idx}; joint audio SDE requires a stochastic strategy."
+                        )
+                    log_prob = _combine_modality_logp(
+                        log_prob,
+                        audio_log_prob,
+                        n_video=sample[0].numel(),
+                        n_audio=audio_sample[0].numel(),
+                    )
+                    if prev_mean is not None and audio_prev_mean is not None:
+                        # Concat on the sequence dim (both packed latents are
+                        # C=128). KL reduces over all non-batch dims and sigma_t
+                        # broadcasts, so the joint mean is the well-defined mean of
+                        # the concatenated [video|audio] SDE Gaussian.
+                        prev_mean = torch.cat([prev_mean, audio_prev_mean], dim=1)
+
                 log_probs.append(log_prob)
                 if prev_mean is not None:
                     prev_sample_means.append(prev_mean)

--- a/unirl/models/ltx2/pipeline.py
+++ b/unirl/models/ltx2/pipeline.py
@@ -101,6 +101,7 @@ class LTX2Pipeline(Pipeline):
             autocast_precision=config.autocast_precision,
             trajectory_precision=config.trajectory_precision,
             logprob_precision=config.logprob_precision,
+            audio_joint_sde=config.audio_joint_sde,
         )
         vae_decode = LTX2VAEDecodeStage(bundle)
         vae_encode = LTX2VAEEncodeStage(bundle)


### PR DESCRIPTION
## Summary

Adds LTX-2.3 text-to-audio-video (T2AV) RL training support to the LTX-2 model
bundle. LTX-2 is a unified audiovisual DiT whose video forward cross-attends to
the audio stream at every layer, so the RL policy should cover both modalities.

Three changes:

1. **Joint audio+video SDE policy (config-gated).** Previously the diffusion
   stage stepped video with SDE (log-prob, RL gradient) but audio with ODE
   (`eta=0`, no log-prob) — the importance ratio reflected only half of the
   coupled state. New `audio_joint_sde` flag (default `True`) on
   `LTX2PipelineConfig`: when set and the bundle has audio (LTX-2.3), video and
   audio form a single joint SDE policy. Audio is SDE-stepped with the same
   `eta` as video, emits its own per-step log-prob, and the two are merged by an
   element-weighted mean (the mean a single SDE over the concatenated
   `[video|audio]` latent would produce). `replay` mirrors this and concatenates
   the per-step `prev_sample_means` on the sequence dim so FlowDPPO's Gaussian KL
   stays consistent. Mirrors the Flow-Factory `ltx2_t2av`/`ltx2_i2av` reference.
   UniRL's `FlowSDEStrategy` is stateless, so no separate "twin" audio scheduler
   is needed — the same instance steps both modalities.

2. **T2AV trainside recipe** `examples/diffusion/ltx2/ltx2_3_t2av_trainside.yaml`
   — `enable_audio: true` + `audio_joint_sde: true`, defaults to the
   `dg845/LTX-2.3-Diffusers` checkpoint (diffusers format with `audio_vae` +
   `vocoder`).

3. **Audio component load fix.** `LTX2Vocoder` holds anti-alias sinc filter
   buffers computed at `__init__` (not stored in the checkpoint). Under the
   default meta-device load path they stay on `meta` and the subsequent
   `.to(device)` raises `Cannot copy out of meta tensor`. Load `audio_vae` /
   `vocoder` with `low_cpu_mem_usage=False` so the filters materialize on CPU.

## Related Issue

N/A

## Test Plan

- `python3 -m py_compile unirl/models/ltx2/{bundle,config,diffusion,pipeline}.py` — passes.
- YAML lint of the new recipe — passes.
- **Live smoke run on Taiji (1 node × 8 H20):** submitted
  `diffusion/ltx2/ltx2_3_t2av_trainside` with `PRETRAINED_MODEL=dg845/LTX-2.3-Diffusers`.
  - First attempt surfaced the `LTX2Vocoder` meta-tensor crash → fixed by change #3.
  - After the fix the LTX-2.3 bundle (transformer + video VAE + `audio_vae` +
    `vocoder` + Gemma3 + connectors) loads and joint audio+video SDE
    rollout/replay + video-reward GRPO training runs.
- Recommended reviewer check (no GPU on this checkout):
  `python -m unirl.train_diffusion --config-name=diffusion/ltx2/ltx2_3_t2av_trainside --cfg job --resolve`

<img width="480" height="350" alt="Clipboard_Screenshot_1782229562" src="https://github.com/user-attachments/assets/5628bd23-3bdf-4527-8236-e20ba8a8091a" />

<img width="1428" height="654" alt="Clipboard_Screenshot_1782229590" src="https://github.com/user-attachments/assets/675c8148-e264-49cd-b65a-5b1a4d649e81" />

<img width="1452" height="575" alt="Clipboard_Screenshot_1782229605" src="https://github.com/user-attachments/assets/cd5b6c83-6524-4bf7-9bb8-1dd644c4a125" />

## Compatibility / Risk

- Behavioral change applies ONLY to `enable_audio: true` (LTX-2.3 T2AV) with the
  new default `audio_joint_sde: true`. Set `audio_joint_sde: false` to restore
  the legacy ODE-audio behavior (A/B).
- **T2V (`enable_audio: false`) is unaffected**: the resolved gate
  `_audio_in_policy = audio_joint_sde and bundle.has_audio` is False, so the
  audio step stays ODE exactly as before. Existing T2V recipes are unchanged.
- `low_cpu_mem_usage=False` only touches the audio-component load path
  (enable_audio=True); the video transformer/VAE load path is unchanged.
- `sde_means` trailing shape grows (video → video+audio on the seq dim) for joint
  T2AV replay; only FlowDPPO reads it and its KL reduction is shape-agnostic. No
  checkpoint/data migration: replay recomputes means.

## Reviewer Notes

- AI-assisted. Full diff reviewed; 3 focused commits (joint-SDE / recipe /
  load-fix), +295/-9 across 5 files. No model-architecture changes — the audio
  pathway and transformer audio params already existed; this wires them into the
  RL policy.
- **Known limitation (follow-up):** the pipeline currently decodes/rewards VIDEO
  only (`VideoPickScore`). Audio participates in the joint SDE rollout/replay but
  is not yet decoded to a waveform or scored. End-to-end audio (decode + audio
  reward) is future work; this PR establishes the joint-policy training loop.
- Duplicate-work check: no open PR touches `unirl/models/ltx2/`; builds on the
  LTX-2 bundle merged in #91.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
