### PR TITLE
build(deps): unblock the sglang install by overriding diffusers>=0.38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,14 +115,9 @@ index-strategy = "unsafe-best-match"
 override-dependencies = [
   "kernels>=0.12,<0.13",
   "tokenizers>=0.22,<0.23",
-  # sglang[diffusion] hard-pins diffusers==0.37.0 (unchanged across every
-  # released sglang through 0.5.13.post1 AND main — upstream curates it as a
-  # tight manual pin, last bumped 0.36->0.37 in sgl PR #20318). It collides
-  # with the base diffusers>=0.38.0 floor LTX-2 needs (#91), making the
-  # ".[sglang,...]" install unsatisfiable. Force the floor graph-wide — same
-  # tactic as the kernels/tokenizers overrides above. This fixes resolution;
-  # sglang's own diffusion runtime then runs against 0.38 (verify rollout
-  # parity on-pod, since upstream only validated 0.37).
+  # sglang[diffusion] hard-pins diffusers==0.37.0 (still pinned on sglang main),
+  # colliding with the base diffusers>=0.38.0 floor (#91); override to the floor
+  # so ".[sglang,...]" stays solvable (same tactic as kernels/tokenizers above).
   "diffusers>=0.38.0",
 ]
 environments = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,15 @@ index-strategy = "unsafe-best-match"
 override-dependencies = [
   "kernels>=0.12,<0.13",
   "tokenizers>=0.22,<0.23",
+  # sglang[diffusion] hard-pins diffusers==0.37.0 (unchanged across every
+  # released sglang through 0.5.13.post1 AND main — upstream curates it as a
+  # tight manual pin, last bumped 0.36->0.37 in sgl PR #20318). It collides
+  # with the base diffusers>=0.38.0 floor LTX-2 needs (#91), making the
+  # ".[sglang,...]" install unsatisfiable. Force the floor graph-wide — same
+  # tactic as the kernels/tokenizers overrides above. This fixes resolution;
+  # sglang's own diffusion runtime then runs against 0.38 (verify rollout
+  # parity on-pod, since upstream only validated 0.37).
+  "diffusers>=0.38.0",
 ]
 environments = [
   "sys_platform == 'linux' and platform_machine == 'x86_64'",


### PR DESCRIPTION
## Summary

The documented sglang install (`uv pip install -e ".[sglang,train,infer]" --prerelease=allow`, see INSTALL.md) is currently **unsatisfiable**. `sglang[diffusion]==0.5.12.post1` hard-pins `diffusers==0.37.0`, which collides with the base `diffusers>=0.38.0` floor that #91 raised for LTX-2 — `uv` reports `No solution found`.

This adds a `[tool.uv] override-dependencies` entry forcing `diffusers>=0.38` graph-wide — the **same mechanism already used for the `kernels`/`tokenizers` pins** — so sglang's transitive `0.37.0` pin is superseded while sglang itself stays at the verified `0.5.12.post1`. Bumping sglang is not an option: the `diffusers==0.37.0` pin is unchanged across every released sglang (through `0.5.13.post1`) **and** upstream `main`.

## Related Issue

N/A (regression introduced by #91 raising the diffusers floor to `>=0.38`).

## Test Plan

- **Resolution** (previously failed with `No solution found`): `uv pip compile pyproject.toml --extra sglang --extra train --extra infer --prerelease=allow` resolves cleanly — `diffusers==0.38.0` (attributed by uv to `--override` + base), `sglang==0.5.12.post1`, and the existing overrides intact (`transformers==5.6.0`, `tokenizers==0.22.2`, `kernels==0.12.3`) plus the `+cu130` torch stack.
- **Static API-compat**: all 60 distinct `diffusers` symbols sglang's `multimodal_gen` diffusion backend imports resolve in diffusers `0.38.0` (no removed/renamed/moved symbols).
- **On-pod runtime** (1×H20, `.[sglang,train,infer]` built fresh): full install `rc=0`; `diffusers 0.38.0` / `sglang 0.5.12.post1` / `torch 2.11.0+cu130`; `sglang.multimodal_gen` + the `sglang_diffusion` engine import cleanly against diffusers 0.38; and **one SD3.5 FlowGRPO sglang rollout end-to-end — generate → PickScore `reward=0.7794` → 1 PPO update, `rc=0`**.

## Compatibility / Risk

- Resolution-only change; no code/API/config/checkpoint changes. The INSTALL.md command is unchanged and now resolves.
- Forces sglang's `[diffusion]` extra onto diffusers `0.38` (upstream only validated `0.37`); confirmed safe both at symbol level and at runtime via the on-pod SD3 rollout above.
- The override is global, so it also applies to the `vllm` venv — but there it is a no-op, since the base already requires `diffusers>=0.38`.

## Reviewer Notes

- Mirrors the existing `kernels`/`tokenizers` override pattern; rationale is documented inline in the `[tool.uv].override-dependencies` block.
- AI-assisted change. Duplicate-work check: no overlapping open PR (searched upstream for `diffusers`/`sglang`).

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not (dependency-resolution override only).