### PR TITLE
fix(bagel): replace removed get_diffusion_params with modality-keyed dict access

### DIFF
--- a/unirl/rollout/engine/vllm_omni/adapters/bagel.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/bagel.py
@@ -58,7 +58,6 @@ from unirl.rollout.engine.vllm_omni.utils.sigmas import sigmas_list_from_req
 from unirl.sde.runtime import FlowMatchSchedulePolicy
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.rollout_resp import RolloutResp
-from unirl.types.sampling import get_diffusion_params
 
 
 class BagelInputAdapter(DitInputAdapter):
@@ -86,7 +85,7 @@ class BagelInputAdapter(DitInputAdapter):
         ride ``extra_args``; the driver-authoritative x_T recipe is packed in.
         """
         texts = texts_from_req(req)
-        diff_params = get_diffusion_params(req.sampling_params)
+        diff_params = req.sampling_params.get("diffusion")
 
         T = int(diff_params.num_inference_steps)
         diff_kwargs: Dict[str, Any] = dict(
@@ -168,7 +167,7 @@ class BagelOutputAdapter(DitOutputAdapter):
         """
         del per_request
         texts = texts_from_req(req)
-        diff_params = get_diffusion_params(req.sampling_params)
+        diff_params = req.sampling_params.get("diffusion")
         image_shape = (int(diff_params.height), int(diff_params.width))
         prompts = list(texts.texts)
         conditions = BagelDiffusionConditions(


### PR DESCRIPTION
## Summary

`origin/main` currently fails to import `unirl.rollout.engine.vllm_omni.adapters`, which breaks the entire vllm-omni adapter registry for every user:

```
ImportError: cannot import name 'get_diffusion_params' from 'unirl.types.sampling'
```

PR #89 (BAGEL integration, `ae2693a`) imported `get_diffusion_params` from `unirl.types.sampling`, but that helper was already removed by PR #70 (`30654a8` — *"refactor(sampling): modality-keyed sampling dict in RolloutReq, drop ComposedSamplingParams"*).

The same issue was already noted in `unirl/models/ltx2/pipeline.py:213-215`:
> `get_diffusion_params` helper only exists on the in-flight ComposedSamplingParams branch, not on main, so it broke import here.

…but PR #89 missed it.

## Fix

Replace `get_diffusion_params(req.sampling_params)` with `req.sampling_params.get("diffusion")` — the same accessor every sibling adapter uses (`qwen_image.py`, `sd3.py`, …). 3 lines changed.

## Test Plan

Verified import on clean `origin/main` + this patch:

```python
import unirl.rollout.engine.vllm_omni.adapters as a
adapters = a.registered_adapters()
print("count:", len(adapters))         # 9
print("bagel_t2i" in adapters)         # True
```

Imports cleanly; all 9 modalities registered including `bagel_t2i`.

Not run; reason: I don't have BAGEL weights handy to confirm the BAGEL recipe still runs end-to-end. Maintainers please confirm.
