### PR TITLE
fix(diffusion): make evaluate() work across trainside/sglang/vllm_omni backends

### DIFF
--- a/unirl/data/data_source.py
+++ b/unirl/data/data_source.py
@@ -330,11 +330,15 @@ class MultimodalRLDataSource:
 
         return batch
 
-    def get_eval_samples(self, batch_size: int) -> Dict[str, Any]:
+    def get_eval_samples(self, batch_size: int) -> RolloutInputs:
         """Get a stable eval batch from the dedicated evaluation prompt source."""
         batch_size = max(0, int(batch_size))
         if batch_size == 0:
-            return {"prompts": []}
+            return RolloutInputs(
+                primitives={"text": Texts(texts=[])},
+                sample_ids=[],
+                group_ids=[],
+            )
 
         self._ensure_eval_dataset()
         if self.eval_dataset is None:
@@ -407,7 +411,12 @@ class DefaultDataSource:
             group_ids=[f"prompt:{i}" for i in range(len(prompts))],
         )
 
-    def get_eval_samples(self, batch_size: int) -> Dict[str, List[str]]:
+    def get_eval_samples(self, batch_size: int) -> RolloutInputs:
         """Get a stable eval batch."""
         batch_size = max(0, int(batch_size))
-        return {"prompts": self.prompts[:batch_size]}
+        prompts = self.prompts[:batch_size]
+        return RolloutInputs(
+            primitives={"text": Texts(texts=prompts)},
+            sample_ids=[f"prompt:{i}:sample:0" for i in range(len(prompts))],
+            group_ids=[f"prompt:{i}" for i in range(len(prompts))],
+        )

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -432,13 +432,25 @@ class DiffusionTrainer(BaseTrainer):
         the KV/decoded on the driver.
         """
         # Override only the "diffusion" entry of the modality-keyed sampling dict
-        # (mirrors the AR trainer's evaluate()).
-        eval_diffusion = dataclasses.replace(
-            self.sampling_params.get("diffusion"),
+        # (mirrors the AR trainer's evaluate()). ``cfg_text_scale`` only exists
+        # on Bagel's sampling params; for the standard DiffusionSamplingParams
+        # (Qwen-Image, SD3, ...) the CFG strength lives in ``guidance_scale``,
+        # so fall back to that when the field is absent. ``sde_indices=[]`` forces
+        # the ODE forward branch (eval measures final-sample quality, not per-step
+        # logp) and sidesteps the shared_field chunk-slice mismatch (sde_indices
+        # is shared_field on RolloutReq — does NOT slice per chunk).
+        base_diffusion = self.sampling_params.get("diffusion")
+        replace_kwargs = dict(
             samples_per_prompt=self.eval_samples_per_prompt,
-            cfg_text_scale=self.eval_cfg_text_scale,
             eta=self.eval_eta,
+            sde_indices=[],  # eval runs forward/ODE — no SDE step subset
+            scheduler=None,  # bypass resolve_sde_indices's scheduler branch
         )
+        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
+            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
+        else:
+            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
+        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
         all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
         n_prompts = len(all_inputs.sample_ids)
@@ -447,10 +459,29 @@ class DiffusionTrainer(BaseTrainer):
         self.rollout.wake_up()
         if self.weight_sync is not None:
             self.weight_sync.sync()
+        # Same colocate-FSDP-offload gate as train_step: free the train state for
+        # the memory-heavy generate when a SEPARATE engine does the rollout.
+        _do_fsdp_offload = (
+            self._enable_fsdp_offload
+            and self._layout != "separate"
+            and not self._rollout_is_trainside
+            and not self._uses_ema  # _uses_ema == "is DiffusionNFT"
+        )
+        if _do_fsdp_offload:
+            self.backend.offload()
+        # DiffusionNFT samples under the EMA ("old") adapter. For the trainside
+        # engine (reuses THIS process's model), swap in place around each chunk's
+        # generate and restore "default" after. Separate engines already received
+        # "old" via weight_sync.sync() above. No-op for GRPO (gated on _uses_ema).
+        _inproc_ema_swap = self._uses_ema and self._rollout_is_trainside
         for start in range(0, n_prompts, chunk):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             req = self._build_req(sub, step, base_sampling=eval_sp)
+            if _inproc_ema_swap:
+                self.backend.apply_eval_ema()
             resp = self.rollout.generate(req)
+            if _inproc_ema_swap:
+                self.backend.restore_from_eval()
             for name, track in list(resp.tracks.items()):
                 if track.segment is not None:
                     resp.tracks[name] = self.reward.score_and_attach(req=req, track=track)
@@ -460,6 +491,10 @@ class DiffusionTrainer(BaseTrainer):
                     reward_sum += float(rewards.sum().item())
                     reward_n += int(rewards.numel())
                     break  # single-track for now; revisit if multi-track lands
+            # Free decoded media each chunk so it doesn't accumulate across chunks.
+            self._drop_decoded(req, resp, rollout_id=step)
+        if _do_fsdp_offload:
+            self.backend.onload()
         self.rollout.sleep()
         mean_reward = reward_sum / max(1, reward_n)
         logger.info(


### PR DESCRIPTION
## Summary

`DiffusionTrainer.evaluate()` (added in #88) mirrors `train_step`'s rollout+reward path but was missing several pieces `train_step` has, causing crashes or silent wrong behavior across the three rollout engines (trainside / sglang_diffusion / vllm_omni). Five bugs fixed:

1. **NFT trainside EMA swap missing** — `train_step` brackets `generate` with `apply_eval_ema()`/`restore_from_eval()` for NFT+trainside (`diffusion.py:389-394`); `evaluate()` didn't, so eval sampled under the trainable `default` adapter instead of the EMA `old` shadow.
2. **`get_eval_samples` return type** — `DefaultDataSource.get_eval_samples` returned `Dict` not `RolloutInputs`; `MultimodalRLDataSource.get_eval_samples` had a `batch_size==0` branch that also returned `Dict`. Both crashed `evaluate()` on `.sample_ids`/`.slice()`.
3. **FSDP offload missing** — `train_step` does `backend.offload()`/`onload()` around generate for colocate+non-NFT; `evaluate()` didn't → may OOM under colocate.
4. **`_drop_decoded` missing** — decoded media accumulated across eval chunks.
5. **FlowGRPO SDE + eval chunk mismatch** — `sde_indices` is a `shared_field` on `RolloutReq` (does NOT slice per chunk), so chunked eval passed full-batch `sde_indices` to a chunk-sized trajectory → shape mismatch. Setting `sde_indices=[]` + `scheduler=None` on the eval sampling-params copy forces the ODE forward branch (intended eval semantics: final-sample quality, not per-step logp) and sidesteps the mismatch.

Also fixes a pre-existing crash on `main`: `evaluate()` hardcoded `cfg_text_scale=self.eval_cfg_text_scale` (#88 assumed Bagel-only), which `TypeError`'d non-Bagel models (Qwen-Image, SD3, …). Now falls back to `guidance_scale` when the field is absent.

## Related Issue

N/A — no open issue filed. Discovered while enabling eval for `qwen_image_edit_plus` (PR #128).

## Test Plan

- `ruff check` + `ruff format --check` on both files — pass.
- `python -c "import unirl.trainer.diffusion; import unirl.data.data_source"` — pass.
- Hydra compose: `python -m unirl.train_diffusion --config-name=diffusion/sd3/sd3_nft --cfg job --resolve` — resolves cleanly.
- Not run; reason: no pytest suite in this repo (no `tests/` dir). Full eval smoke tests require multi-GPU + model weights; maintainers please confirm on BAGEL/Qwen-Image/SD3 recipes with `eval_interval>0`.

## Compatibility / Risk

- **Additive / off by default.** `eval_interval=0` is the default for every existing recipe → `evaluate()` is never called → behavior is byte-for-byte unchanged.
- Every fix is gated by conditions already used in `train_step` (same `_uses_ema`, `_rollout_is_trainside`, `_enable_fsdp_offload`, `_layout` checks) or by the `eval_interval>0` opt-in.
- No config/YAML changes, no new files, no new dependencies, no interface changes.
- The `cfg_text_scale` → `guidance_scale` fallback only changes behavior for non-Bagel models **with `eval_interval>0`** (previously crashed; now works). Bagel behavior unchanged.

## Reviewer Notes

- **AI-assisted** (CodeBuddy Code); duplicate-work check performed — verified `gh pr list` (15 open PRs) and `gh search prs "evaluate"`; no open PR/issue addresses eval bugs. PR #88 is the source of the eval code (and these bugs), not a fix.
- **Human submitter** reviewed the full diff and ran the import + ruff + Hydra compose checks above.
- The fix is a strict superset of the partial eval fix `0cc3a5a` on `feat/qwen-image-edit` (PR #128); when PR #128 rebases onto this, `0cc3a5a` auto-drops as redundant. Zero net conflict (designed to converge).
- `sde_indices=[]` for eval is the intended semantics: eval measures final-sample quality, not per-step logp. NFT already runs ODE forward (`num_sde_steps=0`); this just makes FlowGRPO eval consistent.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not. (No tests in repo; no config changes needed.)