### PR TITLE
docs: note LTX-Video-2.3 T2AV support in model table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ dimension; all listed models are supported (✅).
 | WAN 2.2 | Video diffusion | Text / Image → Video | ✅ |
 | HunyuanVideo 1.0 / 1.5 | Video diffusion | Text → Video | ✅ |
 | LTX-Video-2 | Video diffusion | Text → Video | ✅ |
+| LTX-Video-2.3 | Video diffusion | Text → Audio + Video | ✅ |
 | Qwen-VL | Vision-language AR | Text + Image → Text | ✅ |
 | Qwen3 | LLM AR | Text → Text | ✅ |
 | Prompt-Enhancer | LLM + diffusion | Text → Text → Image | ✅ |


### PR DESCRIPTION
## Summary

The model-support table in the README listed only LTX-Video-2 (text → video).
LTX-Video-2.3 extends it with joint audio-video generation (text → audio + video)
and is now supported via T2AV training recipes and the joint audio+video SDE
policy. Add a new row for LTX-Video-2.3 in the table. Documentation only — no
code changes.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files README.md` — runs the
  whitespace / end-of-file / merge-conflict / private-key checks on the edited
  file.
- Visual check: the table still renders as a valid 4-column Markdown table.

## Compatibility / Risk

N/A — single-line documentation change; no code, config, API, or data impact.

## Reviewer Notes

- AI-assisted. One-line README edit; full diff reviewed.
- Branched from latest `origin/main` (`cc1caed`); only the model-support table
  gains a new row for LTX-Video-2.3.
- The T2AV (text → audio + video) capability itself is being added in a separate
  PR (`feat/ltx2-t2av-audio-reward`); this PR only documents model support.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
