### PR TITLE
feat(trainer): semi-independent reward on a dedicated GPU slab

### DIFF
--- a/examples/diffusion/sd3/sd3_dancegrpo_reward_slab.yaml
+++ b/examples/diffusion/sd3/sd3_dancegrpo_reward_slab.yaml
@@ -1,0 +1,162 @@
+# @package _global_
+# DanceGRPO SD3.5 trainside (FSDP) with a SEMI-INDEPENDENT reward slab.
+#
+# Same as sd3_dancegrpo.yaml, except reward runs on its OWN dedicated GPU slab
+# instead of time-multiplexing the policy's cards:
+#
+#   reward_fraction: 0.25        # reward gets its own disjoint slab (the tail)
+#
+# Topology on this 8-GPU example: the policy (trainside FSDP + colocate rollout)
+# owns GPU 0-5; reward (PickScore) owns the tail GPU 6,7. The reward model never
+# shares — nor offload-thrashes — the policy's cards ("reward doesn't steal
+# cards"). The reward slab takes the tail of the pool, mirroring how
+# layout="separate" gives the rollout engine the tail. Cross-slab
+# reward.score_and_attach is DP_SCATTER-dispatched and pytree-merged back on the
+# driver, so the trainer is unchanged. To reproduce the 16-GPU scenario, set
+# num_devices: 16 and reward_fraction: 0.125 (= 2 of 16 GPUs).
+#
+# NOTE: PickScore is tiny — dedicating whole cards to it is wasteful and this
+# recipe is mainly a MECHANISM demo; small rewards are better left colocated
+# (reward_fraction: 0). The separate slab pays off for a heavy reward (e.g.
+# Qwen3-VL-8B) — swap the reward.backend for that.
+#
+# Trade-off: with the synchronous reward call today, the reward cards sit idle
+# while the policy trains (and vice-versa) — lower utilization in exchange for
+# one-command, no-contention startup; true rollout/reward/train overlap is future
+# work (the dedicated slab is the prerequisite for it).
+
+num_devices: 8                # single 8-GPU node
+reward_fraction: 0.25         # reward on 2 of 8 GPUs (tail = GPU 6,7); policy on 0-5
+batch_size: 48                # prompts_per_rollout
+adv_use_global_std: true     # advantage: divide by ONE batch-wide std (v1 parity), not per-group
+num_rollouts: 10000
+
+bundle:
+  _target_: unirl.models.sd3.bundle.SD3Bundle.from_config
+  config:
+    _target_: unirl.models.sd3.config.SD3PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,stabilityai/stable-diffusion-3.5-medium}
+    model_precision: bf16
+    shift: 3.0
+
+pipeline:
+  _target_: unirl.models.sd3.pipeline.SD3Pipeline
+  shift: 3.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  # DanceGRPO: Dance SDE kernel (the one algorithmic difference from FlowGRPO).
+  strategy:
+    _target_: unirl.sde.kernels.DanceSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["JointTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: false  # SD3.5-medium is small (~5 GB bf16 full); keep params gathered, skip bwd re-gather
+    activation_checkpointing: false  # v1 base flowgrpo_fast_sd3_trainside = bf16_full_noac
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn.add_k_proj
+      - attn.add_q_proj
+      - attn.add_v_proj
+      - attn.to_add_out
+      - attn.to_k
+      - attn.to_out.0
+      - attn.to_q
+      - attn.to_v
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 8            # v1 flowgrpo_fast_sd3_trainside
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.pickscore.PickScoreRewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.pickscore.PickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.sd3.conditions.SD3Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 8
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2      # PPO mini-batches per rollout (π_old frozen once); v1 parity
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]   # SDE steps drawn from the first half (v1)
+    num_sde_steps: 3
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-dancegrpo}
+  run_name: ${oc.env:WANDB_RUN_NAME,sd3_dancegrpo_reward_slab}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["sd3.5", "dancegrpo", "grpo", "trainside", "v2", "reward-slab"]
+  log_media: true
+  media_max_items: 8
+  media_log_interval: 1

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -37,6 +37,7 @@ def main(cfg: DictConfig) -> None:
         logging_cfg=cfg.get("logging"),
         layout=cfg.get("layout", "colocate"),
         train_fraction=cfg.get("train_fraction", 0.5),
+        reward_fraction=cfg.get("reward_fraction", 0.0),
         enable_fsdp_offload=cfg.get("enable_fsdp_offload", False),
         adv_use_global_std=cfg.get("adv_use_global_std", False),
         eval_interval=cfg.get("eval_interval", 0),

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -47,6 +47,7 @@ class DiffusionTrainer(BaseTrainer):
         logging_cfg: Optional[DictConfig] = None,
         layout: str = "colocate",
         train_fraction: float = 0.5,
+        reward_fraction: float = 0.0,
         enable_fsdp_offload: bool = False,
         adv_use_global_std: bool = False,
         eval_interval: int = 0,
@@ -127,13 +128,37 @@ class DiffusionTrainer(BaseTrainer):
         # Set below from the `sync` block; None trainside (shares the module).
         self.weight_sync = None
 
+        # Reward placement, orthogonal to the rollout ``layout`` below.
+        # ``reward_fraction > 0`` carves reward its OWN disjoint slab of that
+        # fraction of the pool, opened LAST so train/rollout keep their cards —
+        # mirroring how ``layout="separate"`` gives the secondary role (rollout)
+        # the tail of the pool. The reward model then lives on dedicated GPUs and
+        # never shares — nor offload-thrashes — the policy's cards ("reward doesn't
+        # steal cards"). ``reward_fraction == 0`` (default) leaves reward as a
+        # train-side sibling = the unchanged behavior; ``train_fraction`` keeps its
+        # whole-pool meaning either way. Cross-slab ``reward.score_and_attach``
+        # needs no change: it is DP_SCATTER-dispatched over the reward role's own
+        # workgroup and its tensor args cross slabs via the standard TensorRef NCCL
+        # path, exactly as the existing ``layout="separate"`` rollout slab does.
+        reward_fraction = float(reward_fraction)
+        if not 0.0 <= reward_fraction < 1.0:
+            raise ValueError(f"reward_fraction must be in [0, 1), got {reward_fraction}")
+        if self._layout == "separate" and train_fraction + reward_fraction >= 1.0:
+            raise ValueError(
+                f"layout='separate' leaves no rollout GPUs: train_fraction ({train_fraction}) "
+                f"+ reward_fraction ({reward_fraction}) must be < 1.0"
+            )
+        reward_separate = reward_fraction > 0.0
+
         # Construction (_build_train_side / _build_rollout) is shared; only the
         # placement topology and the train→rollout sync wiring differ per layout.
+        # ``reward_cfg=None`` when reward owns its own slab (built last, below) so
+        # ``_build_train_side`` skips it; otherwise reward is a train-side sibling.
         train_cfgs = dict(
             bundle_cfg=bundle_cfg,
             pipeline_cfg=pipeline_cfg,
             backend_cfg=backend_cfg,
-            reward_cfg=reward_cfg,
+            reward_cfg=(None if reward_separate else reward_cfg),
             algorithm_cfg=algorithm_cfg,
             stack_cfg=stack_cfg,
         )
@@ -146,20 +171,28 @@ class DiffusionTrainer(BaseTrainer):
                 if sync_cfg is not None:
                     # NCCL handler: rollout is cross-slab, wired via the handshake below.
                     self.weight_sync = remote_hydra(sync_cfg, backend=self.backend)
-            # Rollout slab = the rest. Top-level ``fraction`` is relative to the
-            # WHOLE pool (placement.py), so the remainder is ``1 - train_fraction``.
-            with placement(self.pool, fraction=1.0 - train_fraction, shared_workers=True):
+            # Rollout slab = the pool minus train minus the (optional) reward slab.
+            # Top-level ``fraction`` is relative to the WHOLE pool (placement.py).
+            with placement(self.pool, fraction=1.0 - train_fraction - reward_fraction, shared_workers=True):
                 self.rollout = self._build_rollout(rollout_cfg, allow_pipeline=False)
             if self.weight_sync is not None:
                 self._connect_separate(sync_cfg)
         else:
-            # Single slab: train + rollout are siblings on one Worker.
-            with placement(self.pool, fraction=1.0, shared_workers=True):
+            # Single slab: train + rollout are siblings on one Worker; reward (if
+            # separate) takes the tail below, so this slab is the pool minus reward.
+            with placement(self.pool, fraction=1.0 - reward_fraction, shared_workers=True):
                 self._build_train_side(**train_cfgs)
                 self.rollout = self._build_rollout(rollout_cfg, allow_pipeline=True)
                 if sync_cfg is not None:
                     # Colocated handlers (tensor/ipc) take the engine as a local sibling.
                     self.weight_sync = remote_hydra(sync_cfg, backend=self.backend, rollout=self.rollout)
+
+        # Reward's own disjoint slab = the tail of the pool, opened LAST so
+        # train/rollout keep their cards. Skipped when colocated (built above as a
+        # train-side sibling); cross-slab scoring uses the same dispatch/NCCL path.
+        if reward_separate:
+            with placement(self.pool, fraction=reward_fraction, shared_workers=True):
+                self.reward = remote_hydra(reward_cfg)
 
     def _build_train_side(
         self,
@@ -175,11 +208,16 @@ class DiffusionTrainer(BaseTrainer):
 
         Scope-agnostic: ``remote_hydra`` lands each remote in whatever
         ``placement(...)`` block is open, so both layouts reuse this.
+
+        ``reward_cfg`` is ``None`` when reward already owns a separate slab (see
+        ``reward_fraction`` in ``__init__``); reward is then built there and skipped
+        here so it is not also colocated on the train slab.
         """
         self.bundle = remote_hydra(bundle_cfg)
         self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
         self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
-        self.reward = remote_hydra(reward_cfg)
+        if reward_cfg is not None:
+            self.reward = remote_hydra(reward_cfg)
         # DiffusionNFT resolves its frozen reference adapter off ``backend.ema`` (the
         # FSDPBackend owns the dual-adapter EMA), so it needs the backend sibling
         # injected alongside ``pipeline``. GRPO takes neither and would reject the


### PR DESCRIPTION
## Summary

Adds a **semi-independent reward** placement to `DiffusionTrainer` via a single opt-in
knob `reward_fraction`. When `> 0`, the reward role (`RewardService`) is built on its
**own disjoint GPU slab** (the tail of the pool) instead of time-multiplexing the
policy's cards — so a heavier reward runs on dedicated GPUs within the **same job, one
command** ("reward doesn't steal the policy's cards"). Middle ground between reward
**colocated** (offload-thrashes / contends policy GPUs) and reward **fully remote** (an
external HTTP server to operate).

Design (consistent with existing placement idioms):
- `reward_fraction: float = 0.0` (default `0` = colocated, **byte-for-byte current behavior**),
  mirroring the existing `train_fraction` (a whole-pool fraction).
- `train_fraction` keeps its whole-pool meaning; the reward slab is carved **last**, so
  train/rollout keep their cards — the same "secondary role gets the tail" pattern
  `layout="separate"` already uses for the rollout engine.
- Cross-slab `reward.score_and_attach` is **unchanged**: `DP_SCATTER`-dispatched over the
  reward role's own workgroup, tensor args cross slabs via the standard `TensorRef` NCCL
  path — exactly what `layout="separate"` rollout already uses. No change to
  `RewardService`, `Handle`/dispatch, or weight-sync.

Files: `unirl/trainer/diffusion.py`, `unirl/train_diffusion.py`, and example recipe
`examples/diffusion/sd3/sd3_dancegrpo_reward_slab.yaml`.

## Related Issue

N/A (relates to the reward roadmap under #25; this is the placement mechanism, not a new reward model).

## Test Plan

CPU (jumpbox):
- `python -m py_compile unirl/trainer/diffusion.py unirl/train_diffusion.py` — passes.
- Device-allocation simulation against the real `placement()`: `reward_fraction=0.25` on
  8 GPUs → policy slab `[0-5]`, reward slab tail `[6,7]`; 16 GPUs `0.125` → reward `[14,15]`;
  `reward_fraction=0` → byte-identical slabs to `origin/main` for both layouts.

GPU (8-GPU H20 box):
- Ray placement-group isolation: policy actors on `CUDA_VISIBLE_DEVICES {0..5}`, reward
  actors on `{6,7}`, each actor sees exactly 1 GPU, reward CVD disjoint from policy →
  reward physically cannot touch the policy's cards. PASS.
- **End-to-end SD3.5-medium DanceGRPO with `reward_fraction=0.25`** (PickScore reward,
  `examples/diffusion/sd3/sd3_dancegrpo_reward_slab.yaml`, 2 rollouts, local weights):
  `SMOKE-EXIT=0`. `Handle layout: role=SD3Bundle_0 world=6 dp_size=6` (policy confined to
  6 GPUs); nvidia-smi during load showed GPU 0-5 holding SD3.5 (~7 GB) and GPU 6,7 reserved
  for the reward slab. Cross-slab `score_and_attach` returned sane PickScore rewards
  (`0.8088`, `0.8100`), `ratio=1.0` (on-policy first step), advantage + optimizer step ran
  without policy-GPU contention. Validates placement + cross-slab plumbing; it is a smoke
  (12 prompts, 2 steps), not a convergence run.

## Compatibility / Risk

Backward compatible: `reward_fraction=0` (default) reproduces the existing slabs exactly for
both `layout` values; `train_fraction` semantics unchanged. This is a **local** reward on a
trainer-managed slab, distinct from the `cuda:<index>` pinning rejected in #125 — it does NOT
pin ordinals; each reward worker gets its own card via the placement-group
`CUDA_VISIBLE_DEVICES` isolation (verified), sidestepping the DP-pile-up / ordinal-mismap that
#125 guards against. Scope: `DiffusionTrainer` only.

## Reviewer Notes

- AI-assisted (Claude Code); duplicate-work check done. Relationship to #120 (ReFL/DRaFT):
  #120 also carves a reward slab (`policy_device_fraction`, reward on the tail) for the
  **differentiable** path; this PR is the **policy-gradient** counterpart. Principled follow-up:
  a shared `BaseTrainer` reward-slab helper so GRPO and ReFL share one convention — left out
  here to keep the PR minimal.
- Worth a maintainer view: this reintroduces "local reward on dedicated GPUs", which #125's
  docstring currently routes to the remote backend. Happy to align the wording.
- Follow-up (separate PR): a Qwen3-VL-8B local reward backend to run on this slab.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
