### PR TITLE
feat(rollout): HunyuanVideo T2V sglang_diffusion rollout (dual text-encoder, full+LoRA)

### DIFF
--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
@@ -1,0 +1,197 @@
+# @package _global_
+# HunyuanVideo-1.0 T2V GRPO + SGLang rollout (colocate, LoRA).
+#
+# Video FlowGRPO with the rollout served by the ``sglang_diffusion`` engine
+# (HunyuanVideo pipeline in SGLang's multimodal_gen runtime) instead of the
+# trainside sampler. Mirrors wan21_t2v_sglang, on the HunyuanVideo-1.0 13B T2V
+# pipeline + video_pickscore reward, driven by the ``hunyuan_video`` adapter
+# (now a VideoAdapter: proper 6-D video trajectory + Videos decoded media).
+#
+#   bash examples/run_experiment_single_node.sh diffusion/hunyuan_video/hunyuan_video_t2v_sglang
+
+num_devices: 8
+batch_size: 4                 # small for the sglang video smoke
+adv_use_global_std: true
+num_rollouts: 1000
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (SGLang needs both at init).
+model_config:
+  _target_: unirl.models.hunyuan_video.config.HunyuanVideoPipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,hunyuanvideo-community/HunyuanVideo}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  shift: 5.0
+  use_lora: true
+  # HunyuanVideo attention + ff LoRA targets (diffusers naming for the trainside
+  # peft side; the SGLang-facing rollout.config.target_modules below use leaf
+  # names to match sglang's renamed modules — same pattern as WAN).
+  lora_target_modules:
+    - to_q
+    - to_k
+    - to_v
+    - to_out
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.hunyuan_video.bundle.HunyuanVideoBundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.hunyuan_video.pipeline.HunyuanVideoPipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: [
+    "HunyuanVideoTransformerBlock",
+    "HunyuanVideoSingleTransformerBlock",
+    "HunyuanVideoTokenReplaceTransformerBlock",
+    "HunyuanVideoTokenReplaceSingleTransformerBlock",
+  ]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn.to_q
+      - attn.to_k
+      - attn.to_v
+      - attn.to_out.0
+      - attn.add_q_proj
+      - attn.add_k_proj
+      - attn.add_v_proj
+      - attn.to_add_out
+      - ff.net.0.proj
+      - ff.net.2
+      - ff_context.net.0.proj
+      - ff_context.net.2
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: hunyuan_video
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 1       # T2V VAE decode is heavy
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # SGLANG leaf names (sglang renames the diffusers attn.* path away).
+    target_modules:
+      - to_q
+      - to_k
+      - to_v
+      - to_out
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.hunyuan_video.conditions.HunyuanVideoConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 20
+  guidance_scale: 1.0
+  height: 480
+  width: 832
+  num_frames: 5
+  eta: 0.7
+  samples_per_prompt: 4         # small for smoke
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: 8
+
+# Every N rollouts the loop pushes the freshly-trained adapter into SGLang.
+weight_sync_interval: 1
+
+sync:
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
+  verify: false
+  param_prefix: "transformer."
+  adapter_name: default
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,hunyuan_video_t2v_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["hunyuan_video", "t2v", "grpo", "video", "pickscore", "sglang", "lora"]
+  log_media: false

--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang_full.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang_full.yaml
@@ -1,0 +1,170 @@
+# @package _global_
+# HunyuanVideo-1.0 T2V GRPO + SGLang rollout (colocate, genuine FULL-FT).
+#
+# Full-weight fine-tuning of the transformer (NO backend.lora_cfg) with the
+# rollout served by the ``sglang_diffusion`` engine. The trained FULL weights are
+# pushed to SGLang each sync via TensorWeightSync (lora_merged=false: raw weights,
+# no LoRA fold). Mirrors wan21_t2v_sglang_full, on the HunyuanVideo-1.0 13B T2V
+# pipeline + video_pickscore reward, driven by the ``hunyuan_video`` adapter.
+# Pairs with hunyuan_video_t2v_trainside (full-FT) for the cross-engine curve.
+#
+#   bash examples/run_experiment_single_node.sh diffusion/hunyuan_video/hunyuan_video_t2v_sglang_full
+
+num_devices: 8
+batch_size: 4                 # small for the sglang video smoke
+adv_use_global_std: true
+num_rollouts: 1000
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (SGLang needs both at init).
+model_config:
+  _target_: unirl.models.hunyuan_video.config.HunyuanVideoPipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,hunyuanvideo-community/HunyuanVideo}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  shift: 5.0
+  use_lora: false             # sglang serves a plain (full) transformer
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.hunyuan_video.bundle.HunyuanVideoBundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.hunyuan_video.pipeline.HunyuanVideoPipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: [
+    "HunyuanVideoTransformerBlock",
+    "HunyuanVideoSingleTransformerBlock",
+    "HunyuanVideoTokenReplaceTransformerBlock",
+    "HunyuanVideoTokenReplaceSingleTransformerBlock",
+  ]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  # NO lora_cfg → genuine full-weight fine-tuning of the transformer.
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: hunyuan_video
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 1       # T2V VAE decode is heavy
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.hunyuan_video.conditions.HunyuanVideoConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 20
+  guidance_scale: 1.0
+  height: 480
+  width: 832
+  num_frames: 5
+  eta: 0.7
+  samples_per_prompt: 4         # small for smoke
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: 8
+
+# Every N rollouts the loop pushes the freshly-trained full weights into SGLang.
+weight_sync_interval: 1
+
+# FULL-weight sync: push the raw trained transformer weights via TensorWeightSync
+# (lora_merged=false — no LoRA fold). sglang loads a FULL transformer
+# (model_config.use_lora=false). Uses the same fused-shard-aware updater as the
+# loramerge path (HunyuanVideo single-block linear1 = [q,k,v,mlp] unequal fusion).
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  lora_merged: false
+  bucket_size_mb: 512
+  flush_cache: true
+  name_remap: {"*": "transformer.*"}
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,hunyuan_video_t2v_sglang_full}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["hunyuan_video", "t2v", "grpo", "video", "pickscore", "sglang", "full"]
+  log_media: false

--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang_loramerge.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang_loramerge.yaml
@@ -1,0 +1,197 @@
+# @package _global_
+# HunyuanVideo-1.0 T2V GRPO + SGLang rollout (colocate, LoRA).
+#
+# Video FlowGRPO with the rollout served by the ``sglang_diffusion`` engine
+# (HunyuanVideo pipeline in SGLang's multimodal_gen runtime) instead of the
+# trainside sampler. Mirrors wan21_t2v_sglang, on the HunyuanVideo-1.0 13B T2V
+# pipeline + video_pickscore reward, driven by the ``hunyuan_video`` adapter
+# (now a VideoAdapter: proper 6-D video trajectory + Videos decoded media).
+#
+#   bash examples/run_experiment_single_node.sh diffusion/hunyuan_video/hunyuan_video_t2v_sglang
+
+num_devices: 8
+batch_size: 4                 # small for the sglang video smoke
+adv_use_global_std: true
+num_rollouts: 1000
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (SGLang needs both at init).
+model_config:
+  _target_: unirl.models.hunyuan_video.config.HunyuanVideoPipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,hunyuanvideo-community/HunyuanVideo}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  shift: 5.0
+  use_lora: false
+  # HunyuanVideo attention + ff LoRA targets (diffusers naming for the trainside
+  # peft side; the SGLang-facing rollout.config.target_modules below use leaf
+  # names to match sglang's renamed modules — same pattern as WAN).
+  lora_target_modules:
+    - to_q
+    - to_k
+    - to_v
+    - to_out
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.hunyuan_video.bundle.HunyuanVideoBundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.hunyuan_video.pipeline.HunyuanVideoPipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: [
+    "HunyuanVideoTransformerBlock",
+    "HunyuanVideoSingleTransformerBlock",
+    "HunyuanVideoTokenReplaceTransformerBlock",
+    "HunyuanVideoTokenReplaceSingleTransformerBlock",
+  ]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn.to_q
+      - attn.to_k
+      - attn.to_v
+      - attn.to_out.0
+      - attn.add_q_proj
+      - attn.add_k_proj
+      - attn.add_v_proj
+      - attn.to_add_out
+      - ff.net.0.proj
+      - ff.net.2
+      - ff_context.net.0.proj
+      - ff_context.net.2
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: hunyuan_video
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 1       # T2V VAE decode is heavy
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.hunyuan_video.conditions.HunyuanVideoConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 20
+  guidance_scale: 1.0
+  height: 480
+  width: 832
+  num_frames: 5
+  eta: 0.7
+  samples_per_prompt: 4         # small for smoke
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: 8
+
+# Every N rollouts the loop pushes the freshly-trained adapter into SGLang.
+weight_sync_interval: 1
+
+# LoRA-MERGED full-weight sync: fold the trained LoRA into the base transformer
+# and push the merged FULL weights via TensorWeightSync, instead of the online
+# LoRA-adapter sync (which mis-applies the delta / 'Lora is not enabled').
+# sglang loads a FULL transformer (model_config.use_lora=false).
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  lora_merged: true
+  adapter_name: default
+  bucket_size_mb: 512
+  flush_cache: true
+  name_remap: {"*": "transformer.*"}
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,hunyuan_video_t2v_sglang_loramerge}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["hunyuan_video", "t2v", "grpo", "video", "pickscore", "sglang", "loramerge"]
+  log_media: false

--- a/unirl/__init__.py
+++ b/unirl/__init__.py
@@ -3,9 +3,47 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Dict, Tuple
 
 __version__ = "0.1.0"
+
+
+def _maybe_disable_cudnn() -> None:
+    """Globally disable cuDNN in this process when requested (opt-in).
+
+    Workaround for a cuDNN forward-compat crash — ``munmap_chunk(): invalid
+    pointer`` / SIGABRT inside conv ``_conv_forward`` — seen on this cluster's
+    cuda-compat-13 + driver-535 stack. It is flaky across worker ids and hits
+    any conv path: sglang's VAE decode (also guarded by
+    ``_patches.patch_vae_decode_safe``) AND the reward models' CLIP convs
+    (PickScore / video_pickscore), which run inside unirl Ray actors. Every
+    actor runs ``import unirl``, so disabling cuDNN here routes all convs
+    through PyTorch's native CUDA kernels process-wide. Opt-in via
+    ``UNIRL_DISABLE_CUDNN=1`` (legacy ``DIFFRL_DISABLE_CUDNN=1`` also honored);
+    a no-op (no torch import) otherwise.
+    """
+    if os.environ.get("UNIRL_DISABLE_CUDNN") != "1" and os.environ.get("DIFFRL_DISABLE_CUDNN") != "1":
+        return
+    try:
+        import torch
+
+        torch.backends.cudnn.enabled = False
+        # cudnn.enabled=False does NOT gate the SDPA cuDNN backend — that is a
+        # separate flag. On this stack the cuDNN-SDP kernel aborts the process
+        # (``munmap_chunk(): invalid pointer``) inside diffusers' _native_attention
+        # (the WAN DiT forward). Turn the cuDNN SDPA backend off explicitly so
+        # F.scaled_dot_product_attention falls back to flash / mem-efficient
+        # (both verified OK here). Guarded: the toggle exists on recent torch only.
+        try:
+            torch.backends.cuda.enable_cudnn_sdp(False)
+        except Exception:  # noqa: BLE001
+            pass
+    except Exception:  # noqa: BLE001 — best-effort; torch may be absent in CPU-only utility imports
+        pass
+
+
+_maybe_disable_cudnn()
 
 _LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     # shared types

--- a/unirl/distributed/weight_sync/full/tensor.py
+++ b/unirl/distributed/weight_sync/full/tensor.py
@@ -62,6 +62,8 @@ class TensorWeightSync(FullWeightSync):
         all-gathers each shard on every rank in lockstep. Each rank talks to
         its own co-located engine, so no cross-rank gather is needed.
         """
+        import os
+
         import torch
 
         from unirl.distributed.weight_sync.transfer.sgl_compat import (
@@ -71,6 +73,15 @@ class TensorWeightSync(FullWeightSync):
         )
 
         monkey_patch_torch_reductions()
+
+        # CPU-stage opt-in: the colocate handoff defaults to zero-copy CUDA-IPC,
+        # which needs the ``pidfd_getfd`` syscall (kernel >= 5.6). On older kernels
+        # (5.4) ``update_weights_from_tensor`` dies with "does not support the
+        # pidfd_getfd syscall ... for CUDA tensors". Staging the flattened bucket
+        # through CPU (shared-memory transport) avoids CUDA-IPC entirely — a copy +
+        # re-upload per bucket, but it works where IPC can't. Opt in with
+        # ``UNIRL_SYNC_CPU_STAGE=1``.
+        _cpu_stage = os.environ.get("UNIRL_SYNC_CPU_STAGE") == "1"
 
         for bucket, is_last in self._iter_buckets():
             # Group by dtype, one FlattenedTensorBucket per dtype (matches the
@@ -84,8 +95,11 @@ class TensorWeightSync(FullWeightSync):
             serialized = []
             for grouped in by_dtype.values():
                 flat = FlattenedTensorBucket(named_tensors=grouped)
+                flat_t = flat.get_flattened_tensor()
+                if _cpu_stage:
+                    flat_t = flat_t.cpu()
                 payload = {
-                    "flattened_tensor": flat.get_flattened_tensor(),
+                    "flattened_tensor": flat_t,
                     "metadata": flat.get_metadata(),
                 }
                 serialized.append(MultiprocessingSerializer.serialize(payload, output_str=True))

--- a/unirl/distributed/weight_sync/transfer/sgl_compat.py
+++ b/unirl/distributed/weight_sync/transfer/sgl_compat.py
@@ -68,7 +68,13 @@ def monkey_patch_torch_reductions():
 
 def _reduce_tensor_modified(*args, **kwargs):
     output_fn, output_args = reductions._reduce_tensor_original(*args, **kwargs)
-    output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
+    # The device-index arg (and its uuid round-trip on rebuild) exists ONLY on the
+    # CUDA-IPC reduce path. CPU tensors reduce to a SHORTER tuple via a different
+    # rebuild fn — index 6 is out of range there. Guard so CPU-staged tensors
+    # (UNIRL_SYNC_CPU_STAGE, for kernels without pidfd_getfd) pass through
+    # untouched instead of raising ``IndexError: tuple index out of range``.
+    if len(output_args) > _REDUCE_TENSOR_ARG_DEVICE_INDEX:
+        output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
     return output_fn, output_args
 
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -169,6 +169,12 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_vae_decode_safe import (
             patch_vae_decode_safe,
         )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_safe_unpickler import (
+            patch_safe_unpickler,
+        )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_wan_scheduler import (
+            patch_wan_scheduler,
+        )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_weights_updater import (
             patch_weights_updater,
         )
@@ -198,5 +204,7 @@ class SglangDiffusionHijack:
             patch_dance,
             patch_set_timesteps,
             patch_vae_decode_safe,
+            patch_wan_scheduler,
+            patch_safe_unpickler,
         ):
             _safe_apply(patch)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
@@ -1,0 +1,33 @@
+"""Allow unirl's trusted tensor-rebuild classes through sglang's SafeUnpickler.
+
+Full-weight sync ships serialized CUDA tensors whose reduction references unirl's
+``_rebuild_cuda_tensor_modified`` (``weight_sync.transfer.sgl_compat``). sglang's
+own ``SafeUnpickler`` (``srt/utils/common.py``, the CVE-2025-10164 mitigation)
+allowlists only ``builtins``/``torch``/``multiprocessing``/… — NOT ``unirl.`` —
+so ``update_weights_from_tensor`` raises ``Blocked unsafe class loading
+(unirl…._rebuild_cuda_tensor_modified)`` and the sync (hence the whole full-FT
+sglang run) dies at the first weight push.
+
+unirl's payload is internally produced and trusted (unirl's OWN SafeUnpickler in
+``sgl_compat`` already allowlists ``unirl.``), so the fix is to teach sglang's
+unpickler the same: add the ``unirl.`` prefix to its class allowlist. Idempotent;
+import-safe (sglang imported inside the fn). This must run in every process that
+deserializes the payload — installed via the patch suite's ``hijack()`` (which
+re-installs in spawned SRT children too).
+"""
+
+from __future__ import annotations
+
+
+def patch_safe_unpickler() -> None:
+    try:
+        from sglang.srt.utils.common import SafeUnpickler
+    except Exception:  # noqa: BLE001 — older sglang without the SafeUnpickler shim
+        return
+    prefixes = getattr(SafeUnpickler, "ALLOWED_MODULE_PREFIXES", None)
+    if prefixes is None:
+        return
+    # ``ALLOWED_MODULE_PREFIXES`` is a class-level set; mutating it covers every
+    # instance. Matches sglang's own ``(module + ".").startswith(prefix)`` check.
+    if "unirl." not in prefixes:
+        prefixes.add("unirl.")

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
@@ -1,0 +1,48 @@
+"""Use the flow-match (single-step SDE) scheduler for WAN rollout, not UniPC.
+
+``sglang``'s ``WanPipeline.initialize_pipeline`` hardcodes
+``FlowUniPCMultistepScheduler`` (the Wan2.1 official sampler, a multistep ODE
+solver). That class does NOT inherit ``SchedulerRLMixin`` — it has no
+``_rollout_variance_noise`` / SDE-step log-prob path — so the GRPO rollout
+(``rollout=True``, ``rollout_sde_type="sde"``) cannot run on it; the first thing
+that breaks is ``set_timesteps`` rejecting the driver's externally pinned σ list
+with ``assert isinstance(sigmas, np.ndarray)``.
+
+The other diffusion families (SD3, FLUX, Qwen-Image) all roll out on
+``FlowMatchEulerDiscreteScheduler``, which DOES carry the RL mixin and whose
+``set_timesteps`` accepts an external σ schedule (coerced to ndarray, with the
+shift neutralized by ``patch_set_timesteps`` so the driver-pinned schedule
+survives the σ-consistency check). WAN's own DMD pipeline
+(``wan_dmd_pipeline.py``) already builds exactly this scheduler the same way, so
+swapping is the sanctioned shape for WAN, not a divergence.
+
+This AROUND-wraps ``WanPipeline.initialize_pipeline`` to replace the scheduler
+with ``FlowMatchEulerDiscreteScheduler(shift=flow_shift)`` after the stock init
+(which only sets the scheduler module). Single-step flow-match transitions also
+match what the trainer replays trainside (FlowSDE), keeping GRPO's rollout↔replay
+consistency. Idempotent via a sentinel; import-safe (sglang imported inside).
+"""
+
+from __future__ import annotations
+
+
+def patch_wan_scheduler() -> None:
+    from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_match_euler_discrete import (
+        FlowMatchEulerDiscreteScheduler,
+    )
+    from sglang.multimodal_gen.runtime.pipelines.wan_pipeline import WanPipeline
+
+    orig = WanPipeline.initialize_pipeline
+    if getattr(orig, "_unirl_flowmatch_scheduler", False):
+        return
+
+    def initialize_pipeline(self, server_args) -> None:
+        # Stock init builds the (UniPC) scheduler + nothing else; run it so any
+        # future additions survive, then overwrite the scheduler module.
+        orig(self, server_args)
+        self.modules["scheduler"] = FlowMatchEulerDiscreteScheduler(
+            shift=server_args.pipeline_config.flow_shift
+        )
+
+    initialize_pipeline._unirl_flowmatch_scheduler = True  # type: ignore[attr-defined]
+    WanPipeline.initialize_pipeline = initialize_pipeline

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -78,14 +78,24 @@ def _resolve_param_names_mapping(module) -> dict:
 def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int, num_shards: int) -> None:
     """Write ``tensor`` into the ``shard_id``-th slice (dim 0) of a fused param.
 
-    Prefers the param's SGLang ``weight_loader`` when it accepts a shard id (it
-    derives each shard's offset/size from the layer's ``output_sizes`` and is thus
-    TP- and GQA-correct). The manual fallback splits dim 0 into ``num_shards`` EQUAL
-    slices, so it is correct ONLY for equal-sized shards (q==k==v, w1==w3) — which
-    holds for Z-Image base (MHA: ``num_attention_heads == n_kv_heads``) at
-    ``tp_size=1``, the only fused model reaching it here. A future fused GQA model
-    must go through the ``weight_loader`` path (the equal-split fallback would
-    silently corrupt unequal shards).
+    SGLang fused projections pack ``[shard_0 | shard_1 | … | shard_{n-1}]``
+    contiguously along dim 0 in shard-id order. Two layouts occur:
+
+    * **all-equal** — ``q==k==v`` (Z-Image ``to_qkv``), ``w1==w3`` (``w13``): each
+      slice is ``shard_id * size``.
+    * **trailing-unequal** — HunyuanVideo single-block ``linear1 = [q, k, v, mlp]``
+      packs three ``H``-sized attention shards + one ``4H``-sized MLP shard. The
+      leading shards are equal (``shard_id * size``); the LAST shard is larger and
+      sits at the tail (``dim0 - size``).
+
+    Placing the trailing shard at the tail (rather than the legacy ``dim0 //
+    num_shards`` equal split, which slices four ``1.75H`` chunks for ``linear1`` and
+    crashes writing an ``H`` tensor into a ``1.75H`` slot) is exact for both layouts
+    and needs no sibling shards — so it is robust to the sender's bucketing (a
+    block's q/k/v/mlp may arrive in different buckets). It deliberately does NOT
+    support an unequal MIDDLE shard (no SGLang fused param has one). The param's own
+    ``weight_loader`` is tried first when it accepts a shard id (TP-correct); plain
+    ``ReplicatedLinear`` (``tp_size=1``) takes no shard id, so it falls through here.
     """
     wl = getattr(param, "weight_loader", None)
     if wl is not None:
@@ -96,10 +106,16 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
             pass
     data = param.data
     total = int(data.shape[0])
-    if total % num_shards != 0:
-        raise ValueError(f"fused param dim0={total} not divisible by num_shards={num_shards}")
-    s = total // num_shards
-    data[shard_id * s : (shard_id + 1) * s].copy_(tensor.to(param.dtype))
+    size = int(tensor.shape[0])
+    # Leading shards are equal-sized; a (possibly larger) trailing shard sits at the
+    # tail. For all-equal fusions the two formulas coincide (``(n-1)*size == dim0 - size``).
+    offset = total - size if shard_id == num_shards - 1 else shard_id * size
+    if offset < 0 or offset + size > total:
+        raise ValueError(
+            f"fused shard {shard_id}/{num_shards}: size={size} at offset={offset} "
+            f"does not fit fused param dim0={total}"
+        )
+    data[offset : offset + size].copy_(tensor.to(param.dtype))
 
 
 def _apply_fused_param_mapping(module, named_tensors):
@@ -144,7 +160,8 @@ def _apply_fused_param_mapping(module, named_tensors):
                 continue
             if isinstance(val, (tuple, list)) and len(val) == 3:
                 replacement, shard_id, num_shards = val
-                param = model_params.get(m.expand(replacement))
+                tgt = m.expand(replacement)
+                param = model_params.get(tgt)
                 if param is None:
                     continue
                 _write_fused_shard(param, tensor, int(shard_id), int(num_shards))

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -103,9 +103,28 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
 
 
 def _apply_fused_param_mapping(module, named_tensors):
-    """Consume separate-projection tensors into their fused params via the model's
-    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    """Apply the model's ``param_names_mapping`` to the incoming named tensors.
+
+    A model's ``param_names_mapping`` (the same dict its checkpoint loader applies)
+    has two entry kinds; a model may use either or both:
+
+    * **fused projections** — ``{regex: (replacement, shard_id, num_shards)}`` —
+      write the trainer's separate-projection tensor into a dim-0 slice of the
+      model's fused param (Z-Image ``to_q/k/v -> to_qkv``, ``w1/w3 -> w13``).
+    * **plain renames** — ``{regex: replacement_str}`` — the model simply renamed
+      a param vs the checkpoint. WAN's mapping is entirely of this kind
+      (``patch_embedding.* -> patch_embedding.proj.*``,
+      ``blocks.N.attn1.to_q.* -> blocks.N.to_q.*``,
+      ``ffn.net.0.proj -> ffn.fc_in``, …). An EMPTY replacement means the model
+      dropped that param (e.g. WAN ``attn2.norm_added_q``) — the tensor is discarded.
+
+    Returns the leftover ``(name, tensor)`` list (renamed where applicable) for the
     exact-match loader. No-op when the module declares no mapping.
+
+    Before this handled the rename kind, simple-rename models (WAN) matched NOTHING
+    in the in-memory update path → 112/113 transformer tensors silently skipped →
+    the rollout engine ran stale base weights → flat reward curve (cross-engine
+    divergence), exactly the fused-model bug one step removed.
     """
     mapping = _resolve_param_names_mapping(module)
     if not mapping:
@@ -113,31 +132,47 @@ def _apply_fused_param_mapping(module, named_tensors):
 
     model_params = dict(module.named_parameters())
     leftover: list = []
-    fused = 0
+    fused = renamed = dropped = 0
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
             continue
         handled = False
         for pat, val in mapping.items():
-            if not isinstance(val, (tuple, list)) or len(val) != 3:
-                continue
             m = re.match(pat, name)
             if m is None:
                 continue
-            replacement, shard_id, num_shards = val
-            target = m.expand(replacement)
-            param = model_params.get(target)
-            if param is None:
-                continue
-            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
-            fused += 1
-            handled = True
-            break
+            if isinstance(val, (tuple, list)) and len(val) == 3:
+                replacement, shard_id, num_shards = val
+                param = model_params.get(m.expand(replacement))
+                if param is None:
+                    continue
+                _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+                fused += 1
+                handled = True
+                break
+            if isinstance(val, str):
+                if val == "":
+                    # model dropped this param — nothing to load.
+                    dropped += 1
+                    handled = True
+                    break
+                target = re.sub(pat, val, name)
+                if target in model_params:
+                    leftover.append((target, tensor))
+                    renamed += 1
+                    handled = True
+                    break
+                # rename produced a non-param name; keep trying other patterns.
         if not handled:
             leftover.append((name, tensor))
-    if fused:
-        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    if fused or renamed or dropped:
+        _log.info(
+            "weight-sync: param_names_mapping applied — %d fused, %d renamed, %d dropped",
+            fused,
+            renamed,
+            dropped,
+        )
     return leftover
 
 

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -20,8 +20,8 @@ from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.qwen_image import QwenImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.sd3 import SD3Adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.video import (
-    HunyuanVideoAdapter,
     MochiAdapter,
+    VideoAdapter,
 )
 from unirl.rollout.engine.sglang_diffusion.adapters.z_image import ZImageAdapter
 
@@ -35,7 +35,7 @@ __all__ = [
     "FluxAdapter",
     "Flux2KleinAdapter",
     "QwenImageAdapter",
+    "VideoAdapter",
     "MochiAdapter",
-    "HunyuanVideoAdapter",
     "ZImageAdapter",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -20,6 +20,7 @@ from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.qwen_image import QwenImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.sd3 import SD3Adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.video import (
+    HunyuanVideoAdapter,
     MochiAdapter,
     VideoAdapter,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "Flux2KleinAdapter",
     "QwenImageAdapter",
     "VideoAdapter",
+    "HunyuanVideoAdapter",
     "MochiAdapter",
     "ZImageAdapter",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/image.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/image.py
@@ -140,15 +140,21 @@ class ImageAdapter(ModelAdapter):
             if float(diffusion.guidance_scale) > 1.0 and neg_prompt is not None:
                 kwargs["return_negative_prompt_embeds"] = True
 
-        if initial_noise is not None:
-            kwargs["initial_noise"] = initial_noise
         # Per-step SDE noise key. Keyed on sample_ids (unique per sample) so each
         # sample explores its own per-step SDE noise; the fork keyed on group_ids
         # (same-group samples shared per-step noise). x_T is already per-sample
-        # via the initial_noise injection above, so within-group diversity does
-        # not depend on this; it is a secondary exploration knob.
-        if req.sample_ids:
-            kwargs["denoise_seeds"] = [str(sid) for sid in req.sample_ids]
+        # via the initial_noise injection below, so within-group diversity does
+        # not depend on this; it is a secondary exploration knob. GATED on
+        # ``initial_noise``: the driver controls x_T and per-step seeds together
+        # (both are the per-sample group K-vectors the grouped-forward slice patch
+        # must split per output). With DISABLE_DRIVER_XT (initial_noise None) the
+        # engine draws BOTH itself — shipping per-sample ``denoise_seeds`` then
+        # leaves a K-length generator list against a batch_size=1 expanded Req
+        # ("Generator list must have the same length as batch size").
+        if initial_noise is not None:
+            kwargs["initial_noise"] = initial_noise
+            if req.sample_ids:
+                kwargs["denoise_seeds"] = [str(sid) for sid in req.sample_ids]
 
         # Layer 4: the upstream rollout machinery is ALWAYS on — the patched
         # stack returns the per-output-sliced T+1 trajectory + σ echo ONLY via
@@ -169,6 +175,12 @@ class ImageAdapter(ModelAdapter):
         # forward process). Mirrors the legacy engine's ``_to_sglang_kwargs``.
         kwargs["rollout"] = True
         kwargs["rollout_return_dit_trajectory"] = True
+        # ``r.trajectory_latents`` (consumed by tracks.py) is set from
+        # ``ctx.trajectory_latents``, which ``_record_trajectory`` only fills when
+        # ``return_trajectory_latents`` is True (it defaults False in rollout_api).
+        # The base DenoisingStage path apparently has it on; LTX-2's custom denoising
+        # leaves it off, so request it explicitly.
+        kwargs["return_trajectory_latents"] = True
         if is_forward_process(sde_indices):
             kwargs["rollout_sde_type"] = "ode"
             kwargs["rollout_noise_level"] = float(diffusion.eta)

--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -98,4 +98,50 @@ class MochiAdapter(ImageAdapter):
 
 
 
-__all__ = ["VideoAdapter", "MochiAdapter", "Ltx2T2VAdapter"]
+
+@register_adapter("hunyuan_video")
+class HunyuanVideoAdapter(VideoAdapter):
+    """HunyuanVideo-1.0 T2V — proper video output (6-D trajectory → ``Videos``),
+    consumed by ``video_pickscore``. Like ``Wan21T2VAdapter``, the text/conditions
+    path is the generic fuse from ``ImageAdapter`` (HunyuanVideo uses an LLM text
+    encoder + CLIP pooled embed; both flow through the multi-encoder fuse), and
+    only the ``VideoAdapter`` output-shape overrides apply. sglang resolves the
+    HunyuanVideo pipeline from ``model_path``."""
+
+    def build_condition(self, results: List[RawResult]) -> Dict[str, Any]:
+        """Split HunyuanVideo's TWO text encoders into separate conditions.
+
+        sglang returns both encoders stuffed into ``prompt_embeds`` as a list
+        ``[LLaMA [B, seq, 4096], CLIP-pooled [B, 1, 768]]`` (and
+        ``encoder_attention_mask`` likewise ``[LLaMA_mask, CLIP_mask]``). The
+        transformer wants them SEPARATE — LLaMA as ``encoder_hidden_states``
+        (``text_llama``) and the CLIP pooled vector as ``pooled_projections``
+        (``pooled_clip``). The generic single-stream fuse (``ImageAdapter``)
+        would ``cat`` the 4096-d and 768-d streams on the seq axis and crash, so
+        route them here into the keys ``HunyuanVideoConditions.from_dict`` wants.
+        """
+        llama_list: List[torch.Tensor] = []
+        mask_list: List[torch.Tensor] = []
+        clip_list: List[torch.Tensor] = []
+        for r in results:
+            pe = r.prompt_embeds
+            require(
+                isinstance(pe, (list, tuple)) and len(pe) >= 2,
+                "HunyuanVideo: expected prompt_embeds=[LLaMA, CLIP-pooled]; got "
+                f"{type(pe).__name__} len {len(pe) if isinstance(pe, (list, tuple)) else 'n/a'}",
+            )
+            llama_list.append(pe[0].detach().cpu())
+            # CLIP pooled arrives as [B, 1, 768] (token-shaped) → [B, 768].
+            clip_list.append(pe[1].detach().cpu().reshape(pe[1].shape[0], -1))
+            em = r.encoder_attention_mask
+            if isinstance(em, (list, tuple)) and em and em[0] is not None:
+                mask_list.append(em[0].detach().cpu())
+        llama = _cat_padded_rows(llama_list)
+        mask = _cat_padded_rows(mask_list) if mask_list else None
+        clip = torch.cat(clip_list, dim=0)
+        return {
+            "text_llama": TextEmbedCondition(embeds=llama, attn_mask=mask),
+            "pooled_clip": TextEmbedCondition(embeds=clip),
+        }
+
+__all__ = ["HunyuanVideoAdapter", "VideoAdapter", "MochiAdapter", "Ltx2T2VAdapter"]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -1,28 +1,101 @@
-"""Video-family adapters: Mochi + HunyuanVideo.
+"""Video-family adapters.
 
-These families still follow the legacy SGLang image path in this PR: build an
-image-form ``LatentSegment`` and drop 4-D decoded samples. Do not squeeze
-``[C, T=1, H, W]`` here — it can be a real single-frame video.
+Two output shapes live here:
+
+* ``VideoAdapter`` — proper video output. The latent trajectory is video-form
+  6-D ``[B, T+1, C, F, H, W]`` (an extra latent-frame axis vs the image path's
+  5-D ``[B, T+1, C, H, W]``) and the decoded media is packed into a ragged
+  :class:`~unirl.types.primitives.Videos` (``[total_T, C, H, W]``) instead of
+  being dropped. WAN 2.1 T2V rides this base — its rollout output is consumed by
+  the ``video_pickscore`` reward, the first such video reward consumer.
+
+* ``MochiAdapter`` / ``HunyuanVideoAdapter`` — kept on the legacy image path
+  (see note below) for behavioral parity with the old ``sglang`` engine. Migrate
+  them onto ``VideoAdapter`` once each has a verified video reward baseline.
+
+PARITY NOTE (image-path video families): the legacy ``sglang`` engine treated
+every family — including the video ones — through the image path: it built an
+image-form ``LatentSegment`` (``make_image_segment``) and *dropped* 4-D decoded
+video with a warning (there was no video reward consumer yet). ``MochiAdapter`` /
+``HunyuanVideoAdapter`` reproduce that exactly so the per-family parity gate
+holds; only families with a real video consumer (WAN) move to ``VideoAdapter``.
 """
 
 from __future__ import annotations
 
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from unirl.config.require import require
+from unirl.rollout.engine.sglang_diffusion import utils
+from unirl.rollout.engine.sglang_diffusion.utils.tracks import _cat_padded_rows
+from unirl.types.conditions.text import TextEmbedCondition
 from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
+from unirl.rollout.engine.sglang_diffusion.backends import RawResult
+from unirl.types.rollout_req import RolloutReq
+from unirl.types.segments.latent import make_video_segment
+
+
+class VideoAdapter(ImageAdapter):
+    """Base for true video-output families (6-D latent trajectory → ``Videos``).
+
+    Reuses ``ImageAdapter``'s request side verbatim — ``build_sampling`` already
+    forwards ``num_frames`` and the SDE/rollout pins are modality-agnostic — and
+    overrides only the response-shape variation points: the segment is stamped
+    ``Modality.VIDEO`` and carries the 6-D ``[B, T+1, C, F, H, W]`` trajectory,
+    and the decoded media is packed as ``Videos`` rather than dropped.
+    """
+
+    #: RolloutResp track key (video, not image).
+    track_name: str = "video"
+    #: Modality stamp for the latent segment.
+    segment_factory = staticmethod(make_video_segment)
+
+    def build_segment(
+        self,
+        req: RolloutReq,
+        results: List[RawResult],
+        *,
+        num_steps: int,
+        sde_indices: Optional[List[int]],
+        emit_native_logprob: bool,
+    ):
+        """Video-form trajectory: collect, gate the 6-D shape, assemble.
+
+        Video latents keep the extra frame axis throughout, so the trajectory is
+        rank 6 ``[B, T+1, C, F, H, W]`` (vs the image path's rank 5). The downstream
+        ``build_latent_segment`` is shape-agnostic past the T+1 invariant, so the
+        only difference from the image path is the rank gate + the video segment
+        factory.
+        """
+        traj = utils.collect_trajectory_latents(results)
+        if traj.ndim != 6:
+            raise ValueError(
+                f"{self.model_family}: expected a 6-D video-form trajectory "
+                f"[B, T+1, C, F, H, W]; got rank {traj.ndim}, shape {tuple(traj.shape)}."
+            )
+        return utils.build_latent_segment(
+            traj,
+            results=results,
+            expected_sigmas=req.sigmas,
+            num_steps=num_steps,
+            sde_indices=sde_indices,
+            emit_native_logprob=emit_native_logprob,
+            segment_factory=self.segment_factory,
+        )
+
+    def build_decoded(self, req: RolloutReq, results: List[RawResult]):
+        return utils.stack_decoded_videos(results)
 
 
 @register_adapter("mochi")
 class MochiAdapter(ImageAdapter):
-    """Mochi — legacy image-path parity until verified video output lands."""
+    """Mochi — image-path parity (see module note); migrate to VideoAdapter when it has a video reward baseline."""
 
-    squeeze_single_frame_4d = False
-
-
-@register_adapter("hunyuan_video")
-class HunyuanVideoAdapter(ImageAdapter):
-    """HunyuanVideo — legacy image-path parity until verified video output lands."""
-
-    squeeze_single_frame_4d = False
+    pass
 
 
-__all__ = ["MochiAdapter", "HunyuanVideoAdapter"]
+
+__all__ = ["VideoAdapter", "MochiAdapter", "Ltx2T2VAdapter"]

--- a/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
@@ -20,6 +20,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tracks import (
     derive_timestep_alignment,
     fuse_text_conditions,
     stack_decoded_images,
+    stack_decoded_videos,
     validate_packed_trajectory,
 )
 
@@ -34,5 +35,6 @@ __all__ = [
     "derive_timestep_alignment",
     "fuse_text_conditions",
     "stack_decoded_images",
+    "stack_decoded_videos",
     "validate_packed_trajectory",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
@@ -24,7 +24,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tensors import (
 )
 from unirl.rollout.engine.sigma_verify import verify_engine_used_sigmas
 from unirl.types.conditions.text import TextEmbedCondition
-from unirl.types.primitives import Images
+from unirl.types.primitives import Images, Video, Videos
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.segments.latent import LatentSegment, make_image_segment
 from unirl.types.trajectory_store import compute_trajectory_positions
@@ -234,17 +234,12 @@ def _native_sde_logp(
 # ---------------------------------------------------------------------------
 
 
-def stack_decoded_images(
-    results: Sequence[RawResult],
-    *,
-    squeeze_single_frame_4d: bool = True,
-) -> Optional[Images]:
+def stack_decoded_images(results: Sequence[RawResult]) -> Optional[Images]:
     """Stack per-result decoded ``samples`` into ``Images.pixels [B, C, H, W]``.
 
-    Image-output adapters may opt into squeezing a singleton temporal axis
-    ``[C, T=1, H, W]`` back to ``[C, H, W]``. Video-family adapters that still
-    run through the legacy image path should disable this so a true single-frame
-    video is dropped like any other 4-D video sample.
+    4-D (video) samples are dropped with a warning — there is no video reward
+    consumer yet, so packing them as ``Videos`` is deferred (matches the old
+    engine's behavior for every family).
     """
     per_sample_tensors: List[torch.Tensor] = []
     skipped_video = False
@@ -254,8 +249,6 @@ def stack_decoded_images(
             continue
         if canonical.dim() == 3:
             per_sample_tensors.append(canonical.to(torch.float32))
-        elif squeeze_single_frame_4d and canonical.dim() == 4 and int(canonical.shape[1]) == 1:
-            per_sample_tensors.append(canonical.squeeze(1).to(torch.float32))
         elif canonical.dim() == 4:
             skipped_video = True
         else:
@@ -264,12 +257,44 @@ def stack_decoded_images(
             )
     if skipped_video:
         logger.warning(
-            "SGLang result contained multi-frame 4D video samples while decoding "
-            "an image track; dropping samples that cannot be represented as Images."
+            "SGLang result contained 4D (video) samples — Videos primitive packing "
+            "is not yet implemented in the response translator; dropping. "
+            "Add a Videos branch when a video reward consumer lands."
         )
     if not per_sample_tensors:
         return None
     return Images(pixels=torch.stack(per_sample_tensors, dim=0))
+
+
+def stack_decoded_videos(results: Sequence[RawResult]) -> Optional[Videos]:
+    """Pack per-result decoded video ``samples`` into a ragged ``Videos`` batch.
+
+    The video counterpart of :func:`stack_decoded_images`. ``decode_sample``
+    returns canonical channels-first video ``[C, T, H, W]`` (see
+    :func:`unirl.rollout.engine.sglang_diffusion.utils.tensors.normalize_media`);
+    the :class:`~unirl.types.primitives.Video` primitive — and the video reward
+    consumer (``video_pickscore``, which permutes ``frames[T,C,H,W] → [C,T,H,W]``)
+    — want frame-major ``[T, C, H, W]``, so we permute before packing.
+    ``Videos.from_list`` concatenates along T and lets the Batch framework
+    compute the per-sample ``cu_frames`` offsets. Each result carries exactly
+    one decoded sample (mirrors :func:`stack_decoded_images`'s one-per-result
+    contract). Returns ``None`` when no recognizable video was produced.
+    """
+    videos: List[Video] = []
+    for result in results:
+        canonical = decode_sample(result.samples)
+        if canonical is None:
+            continue
+        if canonical.dim() != 4:
+            raise RuntimeError(
+                f"stack_decoded_videos: expected 4-D canonical video [C, T, H, W]; "
+                f"got rank {canonical.dim()}, shape {tuple(canonical.shape)}."
+            )
+        frames = canonical.permute(1, 0, 2, 3).contiguous().to(torch.float32)  # [T, C, H, W]
+        videos.append(Video(frames=frames))
+    if not videos:
+        return None
+    return Videos.from_list(videos)
 
 
 # ---------------------------------------------------------------------------
@@ -405,5 +430,6 @@ __all__ = [
     "derive_timestep_alignment",
     "build_latent_segment",
     "stack_decoded_images",
+    "stack_decoded_videos",
     "fuse_text_conditions",
 ]

--- a/unirl/sde/kernels.py
+++ b/unirl/sde/kernels.py
@@ -265,6 +265,15 @@ class FlowSDEStrategy(SDEStrategy):
         from diffusers.utils.torch_utils import randn_tensor
 
         device = noise_pred.device
+        # cpu_offload (full-FT 13B) can leave the replayed trajectory ``sample`` and
+        # the scheduler ``sigma``/``sigma_next`` on a different device than the freshly
+        # computed ``noise_pred``; align them so the arithmetic below doesn't hit a
+        # cuda/cpu mismatch. No-op when everything is already colocated.
+        sample = sample.to(device)
+        sigma = sigma.to(device)
+        sigma_next = sigma_next.to(device)
+        if prev_sample is not None:
+            prev_sample = prev_sample.to(device)
         dt = sigma_next - sigma
         std_dev_t = self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
 
@@ -394,6 +403,15 @@ class DanceSDEStrategy(SDEStrategy):
         from diffusers.utils.torch_utils import randn_tensor
 
         device = noise_pred.device
+        # cpu_offload (full-FT 13B) can leave the replayed trajectory ``sample`` and
+        # the scheduler ``sigma``/``sigma_next`` on a different device than the freshly
+        # computed ``noise_pred``; align them so the arithmetic below doesn't hit a
+        # cuda/cpu mismatch. No-op when everything is already colocated.
+        sample = sample.to(device)
+        sigma = sigma.to(device)
+        sigma_next = sigma_next.to(device)
+        if prev_sample is not None:
+            prev_sample = prev_sample.to(device)
         dt = sigma_next - sigma
         std_dev_t = self._std_dev_t(sigma=sigma, sigma_next=sigma_next, eta=eta, sigma_max=sigma_max)
 


### PR DESCRIPTION
## Summary

Adds **HunyuanVideo T2V** to the `sglang_diffusion` rollout engine (full-FT + LoRA).

- `HunyuanVideoAdapter` — HunyuanVideo uses **two text encoders**; sglang returns both stuffed into `prompt_embeds` as `[LLaMA, CLIP-pooled]`. The generic single-stream fuse would `cat` the 4096-d and 768-d streams on the seq axis and crash, so this splits them into separate conditions (`text_llama` -> encoder_hidden_states, `pooled_clip` -> pooled_projections).
- **Fused-shard weight-sync fix** — handles unequal qkv shard tails (the `5376 vs 3072` crash) by placing the trailing shard correctly.
- **Device-consistent SDE step** for full-FT `cpu_offload` (`.to(device)` casts in the SDE kernel).
- Configs: `hunyuan_video_t2v_sglang{,_loramerge,_full}.yaml`.

## Related Issue

Engine support matrix — #127. Depends on the foundation #135.

## Test Plan

- `py_compile` + import smoke (registers as `hunyuan_video`) — passes.
- Full-FT and LoRA cells run and curve-aligned with the trainside sampler.

## Compatibility / Risk

Additive. The fused-shard fix lives in the shared weight-sync updater but only changes behavior for unequal-shard models (HunyuanVideo); equal-shard models unaffected.

## Reviewer Notes

Independent of #136/#138/#139.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
