### PR TITLE
feat(rollout): LTX-2 T2V sglang_diffusion rollout (audio co-denoise aux, full+LoRA)

### DIFF
--- a/examples/diffusion/ltx2/ltx2_t2v_sglang_full.yaml
+++ b/examples/diffusion/ltx2/ltx2_t2v_sglang_full.yaml
@@ -1,0 +1,187 @@
+# @package _global_
+# LTX-2 T2V GRPO + SGLang rollout (colocate, FULL fine-tune).
+#
+# Full-FT sibling of ``ltx2_t2v_sglang_loramerge``: the trainside fine-tunes the
+# WHOLE LTX-2 DiT (no backend.lora_cfg) and pushes the full transformer weights
+# each step via TensorWeightSync (lora_merged=false) through the fused-shard-aware
+# updater. sglang serves the same plain (full) transformer (model_config.use_lora=
+# false). Mirrors hunyuan_video_t2v_sglang_full on the LTX-2 ~2.4B T2V DiT +
+# video_pickscore. The rollout/replay alignment (sigma schedule + co-denoised audio
+# trajectory carried into segment.aux_latents) is identical to the lora config —
+# only the train mode + weight-sync payload differ.
+#
+#   bash examples/run_experiment_single_node.sh diffusion/ltx2/ltx2_t2v_sglang_full
+
+num_devices: 8
+batch_size: 4
+adv_use_global_std: true
+num_rollouts: 1000
+
+model_config:
+  _target_: unirl.models.ltx2.config.LTX2PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Lightricks/LTX-2}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 1.0
+  max_sequence_length: 512
+  enable_audio: false
+  default_height: 512
+  default_width: 768
+  default_num_frames: 33
+  default_frame_rate: 24.0
+  use_lora: false             # sglang serves a plain (full) transformer
+  # Park the frozen aux components (VAE, Gemma3, connectors) on CPU on the
+  # trainside: with sglang doing all generation/encode/decode, the trainside only
+  # replays the DiT, so these non-FSDP modules are dead weight that would otherwise
+  # stay GPU-resident during sglang generation and OOM the colocate DiT-resume.
+  aux_components_on_cpu: true
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.ltx2.pipeline.LTX2Pipeline.from_bundle
+  config: ${bundle.config}
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["LTX2VideoTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    # 1-node (8-GPU) colocate: full-FT trains the WHOLE 2.4B DiT, so after the first
+    # optimizer.step the fp32 Adam states (~2.4GB/rank) become GPU-resident. With
+    # cpu_offload=false they push the colocate over 95GB and the NEXT rollout's sglang
+    # resume_memory_occupation OOMs ("_move_modules move failed"). cpu_offload=true keeps
+    # params+grads on CPU during generation so sglang has room (memory-safe; the trade is
+    # a slow CPU-Adam step). For MULTI-NODE (e.g. 32-GPU) FSDP shards the optimizer 32-way
+    # → set cpu_offload=false for a much faster step (mirrors hunyuan_video_t2v_sglang_full).
+    cpu_offload: true
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: ltx2
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 1
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # LTX-2 colocate memory: the trainside process (~38GB: DiT + Gemma3 + 3D-VAE +
+    # connectors) plus the sglang server's generation footprint overflow a single
+    # 95GB GPU during the denoise/decode step. Offload the sglang 3D-VAE decode (the
+    # generation-time memory spike) to CPU — the DiT already rides the default
+    # dit_cpu_offload. NOTE: dit_layerwise_offload also fits but streams every DiT
+    # layer per step → generation so slow the sglang scheduler times out; VAE-only
+    # offload keeps it fast enough.
+    engine_kwargs:
+      # Offload sglang's heavy frozen aux (3D-VAE decode spike + Gemma3 text encoder) to
+      # CPU so the colocate has room for the trainside full-FT optimizer states on resume.
+      vae_cpu_offload: true
+      text_encoder_cpu_offload: true
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 4
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.ltx2.conditions.LTX2Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 768
+  num_frames: 33
+  eta: 0.7
+  samples_per_prompt: 4
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 5
+    timestep_fraction: [0.0, 0.5]
+
+weight_sync_interval: 1
+
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  lora_merged: false
+  adapter_name: default
+  bucket_size_mb: 512
+  flush_cache: true
+  name_remap: {"*": "transformer.*"}
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-ltx2-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,ltx2_t2v_sglang_full}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["ltx2", "t2v", "grpo", "video", "pickscore", "sglang", "full"]
+  log_media: false

--- a/examples/diffusion/ltx2/ltx2_t2v_sglang_loramerge.yaml
+++ b/examples/diffusion/ltx2/ltx2_t2v_sglang_loramerge.yaml
@@ -1,0 +1,200 @@
+# @package _global_
+# LTX-2 T2V GRPO + SGLang rollout (colocate, LoRA-train + merged full-weight push).
+#
+# Video FlowGRPO with the rollout served by the ``sglang_diffusion`` engine
+# (LTX-2 pipeline in SGLang's multimodal_gen runtime) instead of the trainside
+# sampler. The trainside trains a LoRA adapter (backend.lora_cfg); the sync folds
+# it into the base and pushes the merged FULL weights via TensorWeightSync
+# (lora_merged=true) through the fused-shard-aware updater. sglang serves a plain
+# (full) transformer (model_config.use_lora=false). Mirrors
+# hunyuan_video_t2v_sglang_loramerge on the LTX-2 ~2.4B T2V DiT + video_pickscore.
+#
+#   bash examples/run_experiment_single_node.sh diffusion/ltx2/ltx2_t2v_sglang_loramerge
+#
+# VALIDATION TODO (first LTX-2 sglang config): confirm the sglang LTX-2 server
+# boots + returns text embeds in the format Ltx2T2VAdapter expects (Gemma3 →
+# connector ``video_embeds`` vs raw Gemma — see the adapter docstring) with a
+# 1-rollout EMBED dump, and confirm the LTX-2 DiT param_names_mapping fuses
+# correctly through the weight-sync, before trusting the curve.
+
+num_devices: 8
+batch_size: 4
+adv_use_global_std: true
+num_rollouts: 1000
+
+model_config:
+  _target_: unirl.models.ltx2.config.LTX2PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Lightricks/LTX-2}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 1.0
+  max_sequence_length: 512
+  enable_audio: false
+  default_height: 512
+  default_width: 768
+  default_num_frames: 33
+  default_frame_rate: 24.0
+  use_lora: false             # sglang serves a plain (merged full) transformer
+  # Park the frozen aux components (VAE, Gemma3, connectors) on CPU on the
+  # trainside: with sglang doing all generation/encode/decode, the trainside only
+  # replays the DiT, so these non-FSDP modules are dead weight that would otherwise
+  # stay GPU-resident during sglang generation and OOM the colocate DiT-resume.
+  aux_components_on_cpu: true
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.ltx2.pipeline.LTX2Pipeline.from_bundle
+  config: ${bundle.config}
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["LTX2VideoTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+      - ff.net.0.proj
+      - ff.net.2
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: ltx2
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 1
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # LTX-2 colocate memory: the trainside process (~38GB: DiT + Gemma3 + 3D-VAE +
+    # connectors) plus the sglang server's generation footprint overflow a single
+    # 95GB GPU during the denoise/decode step. Offload the sglang 3D-VAE decode (the
+    # generation-time memory spike) to CPU — the DiT already rides the default
+    # dit_cpu_offload. NOTE: dit_layerwise_offload also fits but streams every DiT
+    # layer per step → generation so slow the sglang scheduler times out; VAE-only
+    # offload keeps it fast enough.
+    engine_kwargs:
+      vae_cpu_offload: true
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 4
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: rollout
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.ltx2.conditions.LTX2Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 768
+  num_frames: 33
+  eta: 0.7
+  samples_per_prompt: 4
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 5
+    timestep_fraction: [0.0, 0.5]
+
+weight_sync_interval: 1
+
+sync:
+  _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync
+  lora_merged: true
+  adapter_name: default
+  bucket_size_mb: 512
+  flush_cache: true
+  name_remap: {"*": "transformer.*"}
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-ltx2-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,ltx2_t2v_sglang_loramerge}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["ltx2", "t2v", "grpo", "video", "pickscore", "sglang", "loramerge"]
+  log_media: false

--- a/unirl/__init__.py
+++ b/unirl/__init__.py
@@ -3,9 +3,47 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Dict, Tuple
 
 __version__ = "0.1.0"
+
+
+def _maybe_disable_cudnn() -> None:
+    """Globally disable cuDNN in this process when requested (opt-in).
+
+    Workaround for a cuDNN forward-compat crash — ``munmap_chunk(): invalid
+    pointer`` / SIGABRT inside conv ``_conv_forward`` — seen on this cluster's
+    cuda-compat-13 + driver-535 stack. It is flaky across worker ids and hits
+    any conv path: sglang's VAE decode (also guarded by
+    ``_patches.patch_vae_decode_safe``) AND the reward models' CLIP convs
+    (PickScore / video_pickscore), which run inside unirl Ray actors. Every
+    actor runs ``import unirl``, so disabling cuDNN here routes all convs
+    through PyTorch's native CUDA kernels process-wide. Opt-in via
+    ``UNIRL_DISABLE_CUDNN=1`` (legacy ``DIFFRL_DISABLE_CUDNN=1`` also honored);
+    a no-op (no torch import) otherwise.
+    """
+    if os.environ.get("UNIRL_DISABLE_CUDNN") != "1" and os.environ.get("DIFFRL_DISABLE_CUDNN") != "1":
+        return
+    try:
+        import torch
+
+        torch.backends.cudnn.enabled = False
+        # cudnn.enabled=False does NOT gate the SDPA cuDNN backend — that is a
+        # separate flag. On this stack the cuDNN-SDP kernel aborts the process
+        # (``munmap_chunk(): invalid pointer``) inside diffusers' _native_attention
+        # (the WAN DiT forward). Turn the cuDNN SDPA backend off explicitly so
+        # F.scaled_dot_product_attention falls back to flash / mem-efficient
+        # (both verified OK here). Guarded: the toggle exists on recent torch only.
+        try:
+            torch.backends.cuda.enable_cudnn_sdp(False)
+        except Exception:  # noqa: BLE001
+            pass
+    except Exception:  # noqa: BLE001 — best-effort; torch may be absent in CPU-only utility imports
+        pass
+
+
+_maybe_disable_cudnn()
 
 _LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     # shared types

--- a/unirl/distributed/weight_sync/full/tensor.py
+++ b/unirl/distributed/weight_sync/full/tensor.py
@@ -62,6 +62,8 @@ class TensorWeightSync(FullWeightSync):
         all-gathers each shard on every rank in lockstep. Each rank talks to
         its own co-located engine, so no cross-rank gather is needed.
         """
+        import os
+
         import torch
 
         from unirl.distributed.weight_sync.transfer.sgl_compat import (
@@ -71,6 +73,15 @@ class TensorWeightSync(FullWeightSync):
         )
 
         monkey_patch_torch_reductions()
+
+        # CPU-stage opt-in: the colocate handoff defaults to zero-copy CUDA-IPC,
+        # which needs the ``pidfd_getfd`` syscall (kernel >= 5.6). On older kernels
+        # (5.4) ``update_weights_from_tensor`` dies with "does not support the
+        # pidfd_getfd syscall ... for CUDA tensors". Staging the flattened bucket
+        # through CPU (shared-memory transport) avoids CUDA-IPC entirely — a copy +
+        # re-upload per bucket, but it works where IPC can't. Opt in with
+        # ``UNIRL_SYNC_CPU_STAGE=1``.
+        _cpu_stage = os.environ.get("UNIRL_SYNC_CPU_STAGE") == "1"
 
         for bucket, is_last in self._iter_buckets():
             # Group by dtype, one FlattenedTensorBucket per dtype (matches the
@@ -84,8 +95,11 @@ class TensorWeightSync(FullWeightSync):
             serialized = []
             for grouped in by_dtype.values():
                 flat = FlattenedTensorBucket(named_tensors=grouped)
+                flat_t = flat.get_flattened_tensor()
+                if _cpu_stage:
+                    flat_t = flat_t.cpu()
                 payload = {
-                    "flattened_tensor": flat.get_flattened_tensor(),
+                    "flattened_tensor": flat_t,
                     "metadata": flat.get_metadata(),
                 }
                 serialized.append(MultiprocessingSerializer.serialize(payload, output_str=True))

--- a/unirl/distributed/weight_sync/transfer/sgl_compat.py
+++ b/unirl/distributed/weight_sync/transfer/sgl_compat.py
@@ -68,7 +68,13 @@ def monkey_patch_torch_reductions():
 
 def _reduce_tensor_modified(*args, **kwargs):
     output_fn, output_args = reductions._reduce_tensor_original(*args, **kwargs)
-    output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
+    # The device-index arg (and its uuid round-trip on rebuild) exists ONLY on the
+    # CUDA-IPC reduce path. CPU tensors reduce to a SHORTER tuple via a different
+    # rebuild fn — index 6 is out of range there. Guard so CPU-staged tensors
+    # (UNIRL_SYNC_CPU_STAGE, for kernels without pidfd_getfd) pass through
+    # untouched instead of raising ``IndexError: tuple index out of range``.
+    if len(output_args) > _REDUCE_TENSOR_ARG_DEVICE_INDEX:
+        output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
     return output_fn, output_args
 
 

--- a/unirl/models/ltx2/bundle.py
+++ b/unirl/models/ltx2/bundle.py
@@ -74,6 +74,11 @@ class LTX2Bundle(Bundle):
         device = config.device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
         if isinstance(device, str):
             device = torch.device(device)
+        # Frozen non-trainable components (VAE / Gemma3 / connectors) optionally stay
+        # on CPU — for sglang-rollout configs the trainside never invokes them, and
+        # parking them off-GPU frees the headroom the sglang DiT-resume needs in
+        # colocate. The trainable transformer always loads to ``device``.
+        aux_device = torch.device("cpu") if getattr(config, "aux_components_on_cpu", False) else device
 
         dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
         vae_raw = config.vae_dtype if config.vae_dtype is not None else config.model_precision
@@ -86,7 +91,7 @@ class LTX2Bundle(Bundle):
         transformer = transformer.to(device, dtype=dtype)
 
         # Video VAE (frozen)
-        vae = AutoencoderKLLTX2Video.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(device).eval()
+        vae = AutoencoderKLLTX2Video.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(aux_device).eval()
         vae.requires_grad_(False)
 
         # Text encoder — Gemma3 (frozen). LTX-2 uses Gemma-3-12B whose config is
@@ -96,7 +101,7 @@ class LTX2Bundle(Bundle):
         # which uses Gemma3ForConditionalGeneration.
         text_encoder = (
             Gemma3ForConditionalGeneration.from_pretrained(te_path, subfolder="text_encoder", torch_dtype=te_dtype)
-            .to(device)
+            .to(aux_device)
             .eval()
         )
         text_encoder.requires_grad_(False)
@@ -111,7 +116,7 @@ class LTX2Bundle(Bundle):
         from diffusers.pipelines.ltx2.connectors import LTX2TextConnectors
 
         connectors = (
-            LTX2TextConnectors.from_pretrained(path, subfolder="connectors", torch_dtype=dtype).to(device).eval()
+            LTX2TextConnectors.from_pretrained(path, subfolder="connectors", torch_dtype=dtype).to(aux_device).eval()
         )
         connectors.requires_grad_(False)
 

--- a/unirl/models/ltx2/config.py
+++ b/unirl/models/ltx2/config.py
@@ -80,6 +80,16 @@ class LTX2PipelineConfig:
     use_lora: bool = False
     lora_target_modules: Optional[list] = None
 
+    # Keep the frozen NON-trainable components (VAE, Gemma3 text encoder,
+    # connectors) on CPU instead of the train device. For sglang-rollout configs
+    # the trainside only replays the DiT for the policy gradient — encoding,
+    # decoding and generation all happen in the sglang server — so these
+    # components are dead weight on the train GPU and, being non-FSDP, stay
+    # resident during sglang generation, starving its DiT-resume of headroom in
+    # colocate. CPU-parking them frees that headroom. MUST stay False for the
+    # trainside-rollout recipe (which needs them on-device).
+    aux_components_on_cpu: bool = False
+
     def __post_init__(self) -> None:
         validate_precision_type(self.model_precision, field="LTX2PipelineConfig.model_precision")
 

--- a/unirl/models/ltx2/text_embed.py
+++ b/unirl/models/ltx2/text_embed.py
@@ -107,11 +107,24 @@ class LTX2TextEmbedStage:
         padding_side="left")`` returns a 3-tuple
         ``(video_text_embedding, audio_text_embedding, binary_attn_mask)``.
         """
-        padding_side = getattr(self.tokenizer, "padding_side", "left")
+        # diffusers-version robustness: newer ``LTX2TextConnectors.forward`` takes a
+        # ``padding_side`` kwarg, but the installed diffusers (0.37.0) signature is
+        # ``(hidden_states, attention_mask, additive_mask=False)`` and rejects it.
+        # The tokenizer is already pinned to left-padding (see ``__init__``), so the
+        # packed hidden states are correctly oriented; only pass ``padding_side``
+        # when the bound connector actually accepts it.
+        import inspect
+
+        conn_kwargs = {}
+        try:
+            if "padding_side" in inspect.signature(self.connectors.forward).parameters:
+                conn_kwargs["padding_side"] = getattr(self.tokenizer, "padding_side", "left")
+        except (TypeError, ValueError):  # pragma: no cover - exotic forward; fall back to no kwarg
+            pass
         video_embeds, audio_embeds, conn_mask = self.connectors(
             packed_hidden,
             attention_mask,
-            padding_side=padding_side,
+            **conn_kwargs,
         )
         return video_embeds, audio_embeds, conn_mask
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -169,6 +169,12 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_vae_decode_safe import (
             patch_vae_decode_safe,
         )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_safe_unpickler import (
+            patch_safe_unpickler,
+        )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_wan_scheduler import (
+            patch_wan_scheduler,
+        )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_weights_updater import (
             patch_weights_updater,
         )
@@ -198,5 +204,7 @@ class SglangDiffusionHijack:
             patch_dance,
             patch_set_timesteps,
             patch_vae_decode_safe,
+            patch_wan_scheduler,
+            patch_safe_unpickler,
         ):
             _safe_apply(patch)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -175,6 +175,15 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_wan_scheduler import (
             patch_wan_scheduler,
         )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_ltx2_scheduler import (
+            patch_ltx2_scheduler,
+        )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_force_math_sdp import (
+            patch_force_math_sdp,
+        )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_ltx2_rollout_sde import (
+            patch_ltx2_rollout_sde,
+        )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_weights_updater import (
             patch_weights_updater,
         )
@@ -205,6 +214,9 @@ class SglangDiffusionHijack:
             patch_set_timesteps,
             patch_vae_decode_safe,
             patch_wan_scheduler,
+            patch_ltx2_scheduler,
+            patch_force_math_sdp,
+            patch_ltx2_rollout_sde,
             patch_safe_unpickler,
         ):
             _safe_apply(patch)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_force_math_sdp.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_force_math_sdp.py
@@ -1,0 +1,63 @@
+"""Force the math SDP backend in the sglang worker (LTX-2 attention crash probe).
+
+The LTX-2 DiT attention runs through torch SDPA
+(``runtime/layers/attention/layer.py``'s ``F.scaled_dot_product_attention``). On
+this cu130 / torch-2.11 build it heap-corrupts (``munmap_chunk(): invalid
+pointer`` → ``Fatal Python error: Aborted``) — localized via
+``PYTHONFAULTHANDLER`` to ``layer.py:323`` inside ``ltx_2.py:720 forward``.
+
+Setting ``torch.backends.cuda.enable_flash_sdp(False)`` etc. is a *global* flag
+that other code can flip back, so to GUARANTEE the math kernel we monkeypatch
+``torch.nn.functional.scaled_dot_product_attention`` itself to run inside an
+explicit ``sdpa_kernel(SDPBackend.MATH)`` context on every call. Math is the
+reference kernel — slower but numerically exact and crash-free. Logs once on
+install so we can confirm it actually took effect in the spawn worker.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_SENTINEL = "_unirl_force_math_sdp"
+
+
+def patch_force_math_sdp() -> None:
+    import torch
+    import torch.nn.functional as F
+
+    orig = F.scaled_dot_product_attention
+    if getattr(orig, _SENTINEL, False):
+        return
+
+    try:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+    except Exception:  # pragma: no cover - very old torch
+        # Fall back to the global flags if the context API is unavailable.
+        for setter in ("enable_flash_sdp", "enable_mem_efficient_sdp", "enable_cudnn_sdp"):
+            fn = getattr(getattr(torch.backends, "cuda", None), setter, None)
+            if fn is not None:
+                try:
+                    fn(False)
+                except Exception:
+                    pass
+        return
+
+    def _math_sdpa(*args, **kwargs):
+        with sdpa_kernel(SDPBackend.MATH):
+            return orig(*args, **kwargs)
+
+    _math_sdpa._unirl_force_math_sdp = True  # type: ignore[attr-defined]
+    F.scaled_dot_product_attention = _math_sdpa
+    # Also flip the globals (belt-and-suspenders for code paths that call the
+    # C-level op directly rather than the python F.* wrapper).
+    for setter, val in (("enable_flash_sdp", False), ("enable_mem_efficient_sdp", False),
+                        ("enable_cudnn_sdp", False), ("enable_math_sdp", True)):
+        fn = getattr(getattr(torch.backends, "cuda", None), setter, None)
+        if fn is not None:
+            try:
+                fn(val)
+            except Exception:
+                pass
+    logger.warning("UNIRL: forced MATH SDP backend (LTX-2 attention crash workaround) installed")

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_ltx2_rollout_sde.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_ltx2_rollout_sde.py
@@ -1,0 +1,186 @@
+"""Make LTX-2's custom AV denoising/decoding stages RL-rollout-complete.
+
+LTX-2 overrides the shared sglang stages (``LTX2SigmaPreparationStage``,
+``LTX2DenoisingStage``, ``LTX2AVDecodingStage``) for its audiovisual pipeline, and
+each override drops a piece of the rollout contract the base stages provide. This
+patch restores the four missing pieces so the LTX-2 rollout matches what the
+trainside replays (and the GRPO ratio stays ~1):
+
+  (1) σ-schedule alignment — ``LTX2SigmaPreparationStage`` recomputes ``batch.sigmas``
+      from its own schedule, clobbering the driver-pinned ``req.sigmas``; keep the
+      pinned schedule in rollout (``_patch_sigma_alignment``).
+  (2) AV-decode output carry — ``LTX2AVDecodingStage`` builds its ``OutputBatch``
+      without the ``rollout_trajectory_data`` / text-embed conditions / co-denoised
+      audio trajectory the base ``DecodingStage`` + ``patch_conditions`` provide;
+      pass all three through (``_patch_av_decode_carry``).
+  (3)+(4) SDE log-prob bridge — ``LTX2DenoisingStage._run_denoising_step`` advances
+      the video latents without passing ``batch``/``generator``, so the RL flow-match
+      scheduler silently takes the plain ODE branch (no log-prob capture, "Generator
+      must be provided"); stash them on the scheduler and inject them into
+      ``step()`` (``_patch_sde_logprob_bridge``).
+
+All wraps are idempotent (sentinel-guarded) and import-safe (sglang imported
+locally). Applied via the hijack ``_safe_apply`` list, after ``patch_ltx2_scheduler``
+installs the RL-mixin video scheduler.
+"""
+
+from __future__ import annotations
+
+_SENTINEL = "_unirl_ltx2_rollout_sde"
+
+
+def patch_ltx2_rollout_sde() -> None:
+    _patch_sigma_alignment()
+    _patch_av_decode_carry()
+    _patch_sde_logprob_bridge()
+
+
+def _patch_sigma_alignment() -> None:
+    """Keep the driver-pinned σ schedule in rollout.
+
+    ``LTX2SigmaPreparationStage`` OVERWRITES ``batch.sigmas`` with its own
+    ``build_official_ltx2_sigmas`` (a linear-then-shifted schedule), clobbering the
+    driver-pinned ``req.sigmas`` the trainside uses. So sglang rolled out on
+    [1.0, 0.9, 0.8, …] while the driver pinned [1.0, 0.958, 0.910, …] →
+    ``verify_engine_used_sigmas`` fails and the curves diverge. In ROLLOUT, honor the
+    already-set sigmas (mirrors the base ``TimestepPreparationStage``).
+    """
+    from sglang.multimodal_gen.runtime.pipelines.ltx_2_pipeline import (
+        LTX2SigmaPreparationStage,
+    )
+
+    orig = LTX2SigmaPreparationStage.forward
+    if getattr(orig, _SENTINEL, False):
+        return
+
+    def forward(self, batch, server_args):
+        pinned = getattr(batch, "sigmas", None)
+        if getattr(batch, "rollout", False) and pinned is not None and len(pinned) > 0:
+            return batch  # keep the driver-pinned σ schedule; do not recompute.
+        return orig(self, batch, server_args)
+
+    forward._unirl_ltx2_rollout_sde = True  # type: ignore[attr-defined]
+    LTX2SigmaPreparationStage.forward = forward
+
+
+def _patch_av_decode_carry() -> None:
+    """Carry the rollout trajectory, audio trajectory, and text conditions onto
+    ``LTX2AVDecodingStage``'s OutputBatch (the base ``DecodingStage`` includes them).
+
+    Three fields the unirl adapter reads off the result never reach it for LTX-2,
+    because ``LTX2AVDecodingStage`` overrides ``forward`` and builds a bare OutputBatch:
+
+    * ``rollout_trajectory_data`` — base ``DecodingStage`` sets it from ``batch``;
+      ``RawResult.trajectory_latents`` reads ``…dit_trajectory.latents`` off it
+      ("SGLang result missing trajectory_latents" without this).
+    * text-embed conditions — ``patch_conditions`` wraps only the BASE
+      ``DecodingStage.forward``; mirror that copy here ("missing prompt_embeds").
+    * co-denoised AUDIO trajectory — LTX-2's video DiT cross-attends to an audio
+      latent, and the trainside replay (``LTX2DiffusionStage.replay``) needs the SAME
+      per-step audio (``segment.aux_latents``) or it raises "aux_latents (audio
+      trajectory) missing" and the curve diverges. The denoising stage stacks it onto
+      ``batch.trajectory_audio_latents`` ([B_out, T+1, …]); ride it inside
+      ``dit_trajectory`` (set post-hoc — not a declared field) so the existing
+      per-output concat/slice + RawResult plumbing carry it alongside the video.
+    """
+    from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding_av import (
+        LTX2AVDecodingStage,
+    )
+    from unirl.rollout.engine.sglang_diffusion._patches.patch_conditions import (
+        _copy_conditions,
+    )
+
+    orig = LTX2AVDecodingStage.forward
+    if getattr(orig, _SENTINEL, False):
+        return
+
+    def forward(self, batch, server_args):
+        out = orig(self, batch, server_args)
+        rtd = getattr(out, "rollout_trajectory_data", None)
+        if rtd is None:
+            rtd = getattr(batch, "rollout_trajectory_data", None)
+            if rtd is not None:
+                out.rollout_trajectory_data = rtd
+        audio_traj = getattr(batch, "trajectory_audio_latents", None)
+        dit_traj = getattr(rtd, "dit_trajectory", None)
+        if dit_traj is not None and audio_traj is not None and getattr(dit_traj, "audio_latents", None) is None:
+            dit_traj.audio_latents = audio_traj.detach().cpu()
+        _copy_conditions(batch, out)
+        return out
+
+    forward._unirl_ltx2_rollout_sde = True  # type: ignore[attr-defined]
+    LTX2AVDecodingStage.forward = forward
+
+
+def _patch_sde_logprob_bridge() -> None:
+    """Feed ``batch`` + per-step SDE generators into the RL flow-match ``step()``.
+
+    ``LTX2DenoisingStage._run_denoising_step`` advances the video latents with
+    ``scheduler.step(..., return_dict=False)`` — WITHOUT ``batch``. The RL scheduler
+    runs ``flow_sde_sampling`` (the per-step log-prob capture) only ``if batch is not
+    None and batch.rollout``, so LTX-2's batch-less call silently takes the plain ODE
+    branch → nothing is appended → ``collect_rollout_log_probs`` stacks an empty list.
+    The base ``DenoisingStage`` passes ``batch``, so SD3 / WAN / HunyuanVideo capture
+    fine; only LTX-2's override misses it. Bridge it without re-vendoring the large
+    ``_run_denoising_step``: stash the rollout ``batch`` + SDE generators on the
+    scheduler around the step, then inject them into ``step()`` when absent. Only the
+    VIDEO scheduler is bridged — for T2V the audio scheduler keeps the plain step.
+    ``patch_denoising`` builds the per-sample generators for the base path; LTX-2
+    bypasses it, so reuse the same derivation (else ``generator=None``).
+    """
+    from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_match_euler_discrete import (
+        FlowMatchEulerDiscreteScheduler,
+    )
+    from sglang.multimodal_gen.runtime.pipelines_core.stages.ltx_2_denoising import (
+        LTX2DenoisingStage,
+    )
+    from unirl.rollout.engine.sglang_diffusion._patches.patch_denoising import (
+        _make_step_generators,
+        _resolve_base_seed,
+    )
+
+    orig_stage_step = LTX2DenoisingStage._run_denoising_step
+    if not getattr(orig_stage_step, _SENTINEL, False):
+
+        def _run_denoising_step(self, ctx, step, batch, server_args):
+            sched = getattr(ctx, "scheduler", None)
+            gen = None
+            denoise_seeds = getattr(batch, "denoise_seeds", None)
+            if getattr(batch, "rollout", False) and denoise_seeds is not None:
+                base_seed = _resolve_base_seed(batch)
+                if base_seed is not None:
+                    gen = _make_step_generators(
+                        base_seed, int(step.step_index), ctx.latents.device, list(denoise_seeds)
+                    )
+            if sched is not None:
+                sched._unirl_rollout_batch = batch
+                sched._unirl_rollout_generator = gen
+            # Trajectory capture is handled by the BASE DenoisingStage.forward loop
+            # (LTX2AVDenoisingStage.forward delegates to super().forward()), gated on
+            # return_trajectory_latents. Do NOT append it here too — double-recording
+            # corrupts the stacked tensor.
+            try:
+                return orig_stage_step(self, ctx, step, batch, server_args)
+            finally:
+                if sched is not None:
+                    sched._unirl_rollout_batch = None
+                    sched._unirl_rollout_generator = None
+
+        _run_denoising_step._unirl_ltx2_rollout_sde = True  # type: ignore[attr-defined]
+        LTX2DenoisingStage._run_denoising_step = _run_denoising_step
+
+    orig_step = FlowMatchEulerDiscreteScheduler.step
+    if not getattr(orig_step, _SENTINEL, False):
+
+        def step(self, *args, **kwargs):
+            if kwargs.get("batch") is None:
+                stashed = getattr(self, "_unirl_rollout_batch", None)
+                if stashed is not None:
+                    kwargs["batch"] = stashed
+                    gen = getattr(self, "_unirl_rollout_generator", None)
+                    if gen is not None and kwargs.get("generator") is None:
+                        kwargs["generator"] = gen
+            return orig_step(self, *args, **kwargs)
+
+        step._unirl_ltx2_rollout_sde = True  # type: ignore[attr-defined]
+        FlowMatchEulerDiscreteScheduler.step = step

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_ltx2_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_ltx2_scheduler.py
@@ -1,0 +1,49 @@
+"""Use the RL-capable flow-match scheduler for LTX-2 rollout.
+
+sglang's LTX-2 pipeline (``_BaseLTX2Pipeline.initialize_pipeline``) builds
+``LTX2FlowMatchScheduler``, which subclasses the **diffusers** stock
+``FlowMatchEulerDiscreteScheduler`` (``from diffusers import ...`` at the top of
+``ltx_2_pipeline.py``). That class does NOT inherit ``SchedulerRLMixin``, so the
+GRPO rollout (``rollout=True``, ``rollout_sde_type="sde"``) raises
+``Scheduler <LTX2FlowMatchScheduler> does not support rollout`` the moment the
+denoising mixin checks ``isinstance(self.scheduler, SchedulerRLMixin)``.
+
+Swap it for sglang's OWN ``FlowMatchEulerDiscreteScheduler``
+(``runtime.models.schedulers.scheduling_flow_match_euler_discrete``), which DOES
+carry the RL mixin (the SDE-step log-prob / variance-noise path) and whose
+``set_timesteps`` accepts the driver's externally pinned σ schedule (shift
+neutralized by ``patch_set_timesteps``). This is the exact shape WAN uses
+(``patch_wan_scheduler``); single-step flow-match transitions also match what the
+trainer replays trainside (``FlowSDEStrategy``), keeping GRPO rollout↔replay
+consistency.
+
+AROUND-wraps ``_BaseLTX2Pipeline.initialize_pipeline`` (T2V ``LTX2Pipeline``
+inherits it; the two-stage HQ pipeline overrides it and is out of scope here),
+rebuilding the swapped scheduler ``from_config`` so the LTX-2 shift/config
+survive. Idempotent via a sentinel; import-safe (sglang imported inside, guarded
+by ``_safe_apply`` in ``hijack``).
+"""
+
+from __future__ import annotations
+
+
+def patch_ltx2_scheduler() -> None:
+    from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_match_euler_discrete import (
+        FlowMatchEulerDiscreteScheduler,
+    )
+    from sglang.multimodal_gen.runtime.pipelines.ltx_2_pipeline import _BaseLTX2Pipeline
+
+    orig = _BaseLTX2Pipeline.initialize_pipeline
+    if getattr(orig, "_unirl_flowmatch_scheduler", False):
+        return
+
+    def initialize_pipeline(self, server_args) -> None:
+        # Stock init builds the (diffusers-based) LTX2FlowMatchScheduler; run it so
+        # any future additions survive, then overwrite the scheduler module with the
+        # RL-mixin-carrying sglang scheduler, preserving the LTX-2 config (shift, …).
+        orig(self, server_args)
+        sched = self.get_module("scheduler")
+        self.modules["scheduler"] = FlowMatchEulerDiscreteScheduler.from_config(sched.config)
+
+    initialize_pipeline._unirl_flowmatch_scheduler = True  # type: ignore[attr-defined]
+    _BaseLTX2Pipeline.initialize_pipeline = initialize_pipeline

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_rollout_trajectory.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_rollout_trajectory.py
@@ -94,6 +94,18 @@ def _concat_rollout_trajectory_data(output_batches: list):
             latents=_cat0([r.dit_trajectory.latents for r in rtds if r.dit_trajectory is not None]),
             timesteps=first.dit_trajectory.timesteps,
         )
+        # LTX-2 carries a parallel AUDIO trajectory (``audio_latents``) the video
+        # forward cross-attends to; it is attached onto each per-output
+        # ``dit_trajectory`` by ``patch_ltx2_rollout_sde``. Concat it dim-0 like the
+        # video latents so the grouped (nopp>1) merge preserves per-output audio.
+        # ``RolloutDitTrajectory.__init__`` has no such field, so set it post-hoc.
+        _auds = [
+            getattr(r.dit_trajectory, "audio_latents", None)
+            for r in rtds
+            if r.dit_trajectory is not None
+        ]
+        if _auds and all(a is not None for a in _auds):
+            new_dit.audio_latents = _cat0(_auds)
 
     new_debug = None
     if first.rollout_debug_tensors is not None:
@@ -141,6 +153,11 @@ def _slice_rollout_trajectory_keepdim(rtd, idx: int):
             latents=_slice_row_keepdim(rtd.dit_trajectory.latents, idx),
             timesteps=rtd.dit_trajectory.timesteps,
         )
+        # Carry the LTX-2 audio trajectory through the per-output slice (keep-dim),
+        # mirroring the video latents (see ``_concat_rollout_trajectory_data``).
+        _aud = getattr(rtd.dit_trajectory, "audio_latents", None)
+        if _aud is not None:
+            new_dit.audio_latents = _slice_row_keepdim(_aud, idx)
 
     new_debug = None
     if rtd.rollout_debug_tensors is not None:

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
@@ -1,0 +1,33 @@
+"""Allow unirl's trusted tensor-rebuild classes through sglang's SafeUnpickler.
+
+Full-weight sync ships serialized CUDA tensors whose reduction references unirl's
+``_rebuild_cuda_tensor_modified`` (``weight_sync.transfer.sgl_compat``). sglang's
+own ``SafeUnpickler`` (``srt/utils/common.py``, the CVE-2025-10164 mitigation)
+allowlists only ``builtins``/``torch``/``multiprocessing``/… — NOT ``unirl.`` —
+so ``update_weights_from_tensor`` raises ``Blocked unsafe class loading
+(unirl…._rebuild_cuda_tensor_modified)`` and the sync (hence the whole full-FT
+sglang run) dies at the first weight push.
+
+unirl's payload is internally produced and trusted (unirl's OWN SafeUnpickler in
+``sgl_compat`` already allowlists ``unirl.``), so the fix is to teach sglang's
+unpickler the same: add the ``unirl.`` prefix to its class allowlist. Idempotent;
+import-safe (sglang imported inside the fn). This must run in every process that
+deserializes the payload — installed via the patch suite's ``hijack()`` (which
+re-installs in spawned SRT children too).
+"""
+
+from __future__ import annotations
+
+
+def patch_safe_unpickler() -> None:
+    try:
+        from sglang.srt.utils.common import SafeUnpickler
+    except Exception:  # noqa: BLE001 — older sglang without the SafeUnpickler shim
+        return
+    prefixes = getattr(SafeUnpickler, "ALLOWED_MODULE_PREFIXES", None)
+    if prefixes is None:
+        return
+    # ``ALLOWED_MODULE_PREFIXES`` is a class-level set; mutating it covers every
+    # instance. Matches sglang's own ``(module + ".").startswith(prefix)`` check.
+    if "unirl." not in prefixes:
+        prefixes.add("unirl.")

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
@@ -1,0 +1,48 @@
+"""Use the flow-match (single-step SDE) scheduler for WAN rollout, not UniPC.
+
+``sglang``'s ``WanPipeline.initialize_pipeline`` hardcodes
+``FlowUniPCMultistepScheduler`` (the Wan2.1 official sampler, a multistep ODE
+solver). That class does NOT inherit ``SchedulerRLMixin`` — it has no
+``_rollout_variance_noise`` / SDE-step log-prob path — so the GRPO rollout
+(``rollout=True``, ``rollout_sde_type="sde"``) cannot run on it; the first thing
+that breaks is ``set_timesteps`` rejecting the driver's externally pinned σ list
+with ``assert isinstance(sigmas, np.ndarray)``.
+
+The other diffusion families (SD3, FLUX, Qwen-Image) all roll out on
+``FlowMatchEulerDiscreteScheduler``, which DOES carry the RL mixin and whose
+``set_timesteps`` accepts an external σ schedule (coerced to ndarray, with the
+shift neutralized by ``patch_set_timesteps`` so the driver-pinned schedule
+survives the σ-consistency check). WAN's own DMD pipeline
+(``wan_dmd_pipeline.py``) already builds exactly this scheduler the same way, so
+swapping is the sanctioned shape for WAN, not a divergence.
+
+This AROUND-wraps ``WanPipeline.initialize_pipeline`` to replace the scheduler
+with ``FlowMatchEulerDiscreteScheduler(shift=flow_shift)`` after the stock init
+(which only sets the scheduler module). Single-step flow-match transitions also
+match what the trainer replays trainside (FlowSDE), keeping GRPO's rollout↔replay
+consistency. Idempotent via a sentinel; import-safe (sglang imported inside).
+"""
+
+from __future__ import annotations
+
+
+def patch_wan_scheduler() -> None:
+    from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_match_euler_discrete import (
+        FlowMatchEulerDiscreteScheduler,
+    )
+    from sglang.multimodal_gen.runtime.pipelines.wan_pipeline import WanPipeline
+
+    orig = WanPipeline.initialize_pipeline
+    if getattr(orig, "_unirl_flowmatch_scheduler", False):
+        return
+
+    def initialize_pipeline(self, server_args) -> None:
+        # Stock init builds the (UniPC) scheduler + nothing else; run it so any
+        # future additions survive, then overwrite the scheduler module.
+        orig(self, server_args)
+        self.modules["scheduler"] = FlowMatchEulerDiscreteScheduler(
+            shift=server_args.pipeline_config.flow_shift
+        )
+
+    initialize_pipeline._unirl_flowmatch_scheduler = True  # type: ignore[attr-defined]
+    WanPipeline.initialize_pipeline = initialize_pipeline

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -103,9 +103,28 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
 
 
 def _apply_fused_param_mapping(module, named_tensors):
-    """Consume separate-projection tensors into their fused params via the model's
-    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    """Apply the model's ``param_names_mapping`` to the incoming named tensors.
+
+    A model's ``param_names_mapping`` (the same dict its checkpoint loader applies)
+    has two entry kinds; a model may use either or both:
+
+    * **fused projections** — ``{regex: (replacement, shard_id, num_shards)}`` —
+      write the trainer's separate-projection tensor into a dim-0 slice of the
+      model's fused param (Z-Image ``to_q/k/v -> to_qkv``, ``w1/w3 -> w13``).
+    * **plain renames** — ``{regex: replacement_str}`` — the model simply renamed
+      a param vs the checkpoint. WAN's mapping is entirely of this kind
+      (``patch_embedding.* -> patch_embedding.proj.*``,
+      ``blocks.N.attn1.to_q.* -> blocks.N.to_q.*``,
+      ``ffn.net.0.proj -> ffn.fc_in``, …). An EMPTY replacement means the model
+      dropped that param (e.g. WAN ``attn2.norm_added_q``) — the tensor is discarded.
+
+    Returns the leftover ``(name, tensor)`` list (renamed where applicable) for the
     exact-match loader. No-op when the module declares no mapping.
+
+    Before this handled the rename kind, simple-rename models (WAN) matched NOTHING
+    in the in-memory update path → 112/113 transformer tensors silently skipped →
+    the rollout engine ran stale base weights → flat reward curve (cross-engine
+    divergence), exactly the fused-model bug one step removed.
     """
     mapping = _resolve_param_names_mapping(module)
     if not mapping:
@@ -113,31 +132,47 @@ def _apply_fused_param_mapping(module, named_tensors):
 
     model_params = dict(module.named_parameters())
     leftover: list = []
-    fused = 0
+    fused = renamed = dropped = 0
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
             continue
         handled = False
         for pat, val in mapping.items():
-            if not isinstance(val, (tuple, list)) or len(val) != 3:
-                continue
             m = re.match(pat, name)
             if m is None:
                 continue
-            replacement, shard_id, num_shards = val
-            target = m.expand(replacement)
-            param = model_params.get(target)
-            if param is None:
-                continue
-            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
-            fused += 1
-            handled = True
-            break
+            if isinstance(val, (tuple, list)) and len(val) == 3:
+                replacement, shard_id, num_shards = val
+                param = model_params.get(m.expand(replacement))
+                if param is None:
+                    continue
+                _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+                fused += 1
+                handled = True
+                break
+            if isinstance(val, str):
+                if val == "":
+                    # model dropped this param — nothing to load.
+                    dropped += 1
+                    handled = True
+                    break
+                target = re.sub(pat, val, name)
+                if target in model_params:
+                    leftover.append((target, tensor))
+                    renamed += 1
+                    handled = True
+                    break
+                # rename produced a non-param name; keep trying other patterns.
         if not handled:
             leftover.append((name, tensor))
-    if fused:
-        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    if fused or renamed or dropped:
+        _log.info(
+            "weight-sync: param_names_mapping applied — %d fused, %d renamed, %d dropped",
+            fused,
+            renamed,
+            dropped,
+        )
     return leftover
 
 

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -20,8 +20,8 @@ from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.qwen_image import QwenImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.sd3 import SD3Adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.video import (
-    HunyuanVideoAdapter,
     MochiAdapter,
+    VideoAdapter,
 )
 from unirl.rollout.engine.sglang_diffusion.adapters.z_image import ZImageAdapter
 
@@ -35,7 +35,7 @@ __all__ = [
     "FluxAdapter",
     "Flux2KleinAdapter",
     "QwenImageAdapter",
+    "VideoAdapter",
     "MochiAdapter",
-    "HunyuanVideoAdapter",
     "ZImageAdapter",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -20,6 +20,7 @@ from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.qwen_image import QwenImageAdapter
 from unirl.rollout.engine.sglang_diffusion.adapters.sd3 import SD3Adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.video import (
+    Ltx2T2VAdapter,
     MochiAdapter,
     VideoAdapter,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "Flux2KleinAdapter",
     "QwenImageAdapter",
     "VideoAdapter",
+    "Ltx2T2VAdapter",
     "MochiAdapter",
     "ZImageAdapter",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/image.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/image.py
@@ -140,15 +140,21 @@ class ImageAdapter(ModelAdapter):
             if float(diffusion.guidance_scale) > 1.0 and neg_prompt is not None:
                 kwargs["return_negative_prompt_embeds"] = True
 
-        if initial_noise is not None:
-            kwargs["initial_noise"] = initial_noise
         # Per-step SDE noise key. Keyed on sample_ids (unique per sample) so each
         # sample explores its own per-step SDE noise; the fork keyed on group_ids
         # (same-group samples shared per-step noise). x_T is already per-sample
-        # via the initial_noise injection above, so within-group diversity does
-        # not depend on this; it is a secondary exploration knob.
-        if req.sample_ids:
-            kwargs["denoise_seeds"] = [str(sid) for sid in req.sample_ids]
+        # via the initial_noise injection below, so within-group diversity does
+        # not depend on this; it is a secondary exploration knob. GATED on
+        # ``initial_noise``: the driver controls x_T and per-step seeds together
+        # (both are the per-sample group K-vectors the grouped-forward slice patch
+        # must split per output). With DISABLE_DRIVER_XT (initial_noise None) the
+        # engine draws BOTH itself — shipping per-sample ``denoise_seeds`` then
+        # leaves a K-length generator list against a batch_size=1 expanded Req
+        # ("Generator list must have the same length as batch size").
+        if initial_noise is not None:
+            kwargs["initial_noise"] = initial_noise
+            if req.sample_ids:
+                kwargs["denoise_seeds"] = [str(sid) for sid in req.sample_ids]
 
         # Layer 4: the upstream rollout machinery is ALWAYS on — the patched
         # stack returns the per-output-sliced T+1 trajectory + σ echo ONLY via
@@ -169,6 +175,12 @@ class ImageAdapter(ModelAdapter):
         # forward process). Mirrors the legacy engine's ``_to_sglang_kwargs``.
         kwargs["rollout"] = True
         kwargs["rollout_return_dit_trajectory"] = True
+        # ``r.trajectory_latents`` (consumed by tracks.py) is set from
+        # ``ctx.trajectory_latents``, which ``_record_trajectory`` only fills when
+        # ``return_trajectory_latents`` is True (it defaults False in rollout_api).
+        # The base DenoisingStage path apparently has it on; LTX-2's custom denoising
+        # leaves it off, so request it explicitly.
+        kwargs["return_trajectory_latents"] = True
         if is_forward_process(sde_indices):
             kwargs["rollout_sde_type"] = "ode"
             kwargs["rollout_noise_level"] = float(diffusion.eta)

--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -98,4 +98,62 @@ class MochiAdapter(ImageAdapter):
 
 
 
-__all__ = ["VideoAdapter", "MochiAdapter", "Ltx2T2VAdapter"]
+
+@register_adapter("ltx2")
+class Ltx2T2VAdapter(VideoAdapter):
+    """LTX-2 / LTX-2.3 T2V — ~2.4B video DiT, Gemma3 text encoding, proper video
+    output (6-D trajectory → ``Videos``) consumed by ``video_pickscore``.
+
+    First-cut on the generic single-text fuse (like ``Wan21T2VAdapter``): LTX2's
+    primary condition is a single ``text`` stream (``LTX2Conditions.text``), unlike
+    HunyuanVideo's dual encoder. CAVEAT — needs smoke validation: LTX2's trainside
+    text path is Gemma3 → text CONNECTORS → ``video_embeds`` (the DiT consumes
+    connector outputs, not raw Gemma). If sglang's LTX2 server returns the connector
+    ``video_embeds`` as ``prompt_embeds`` the generic fuse suffices; if it returns
+    raw Gemma hidden states, this adapter must apply the connectors here (override
+    ``build_condition``) and route the result onto the ``text`` key. Confirm the
+    sglang output shape/format with a 1-rollout EMBED dump before alignment.
+    """
+
+    def build_segment(
+        self,
+        req: RolloutReq,
+        results: List[RawResult],
+        *,
+        num_steps: int,
+        sde_indices: Optional[List[int]],
+        emit_native_logprob: bool,
+    ):
+        """LTX-2 latents are PACKED token sequences, not a spatial video grid.
+
+        WAN/HunyuanVideo carry a 6-D ``[B, T+1, C, F, H, W]`` trajectory, but LTX-2's
+        DiT operates on a patchified token sequence, so the rollout trajectory is
+        rank-4 ``[B, T+1, seq, dim]`` (e.g. ``[B, 11, 192, 128]``). ``VideoAdapter``'s
+        strict 6-D gate rejects it; ``build_latent_segment`` itself only needs the
+        ``T+1`` axis at dim 1 and is otherwise shape-agnostic, so accept the packed
+        trajectory directly (the trainside replays the identical packed latents, so
+        rollout↔replay stays aligned).
+        """
+        traj = utils.collect_trajectory_latents(results)
+        if traj.ndim < 3:
+            raise ValueError(
+                f"ltx2: expected a packed trajectory [B, T+1, ...]; got rank {traj.ndim}, "
+                f"shape {tuple(traj.shape)}."
+            )
+        # LTX-2 co-denoises an AUDIO latent the video DiT cross-attends to; collect
+        # the parallel audio trajectory and stamp it as ``segment.aux_latents`` so the
+        # trainside ``LTX2DiffusionStage.replay`` replays the same per-step audio
+        # (else it raises "aux_latents (audio trajectory) missing").
+        aux_traj = utils.collect_aux_trajectory_latents(results)
+        return utils.build_latent_segment(
+            traj,
+            results=results,
+            expected_sigmas=req.sigmas,
+            num_steps=num_steps,
+            sde_indices=sde_indices,
+            emit_native_logprob=emit_native_logprob,
+            segment_factory=self.segment_factory,
+            aux_trajectory=aux_traj,
+        )
+
+__all__ = ["Ltx2T2VAdapter", "VideoAdapter", "MochiAdapter", "Ltx2T2VAdapter"]

--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -1,28 +1,101 @@
-"""Video-family adapters: Mochi + HunyuanVideo.
+"""Video-family adapters.
 
-These families still follow the legacy SGLang image path in this PR: build an
-image-form ``LatentSegment`` and drop 4-D decoded samples. Do not squeeze
-``[C, T=1, H, W]`` here — it can be a real single-frame video.
+Two output shapes live here:
+
+* ``VideoAdapter`` — proper video output. The latent trajectory is video-form
+  6-D ``[B, T+1, C, F, H, W]`` (an extra latent-frame axis vs the image path's
+  5-D ``[B, T+1, C, H, W]``) and the decoded media is packed into a ragged
+  :class:`~unirl.types.primitives.Videos` (``[total_T, C, H, W]``) instead of
+  being dropped. WAN 2.1 T2V rides this base — its rollout output is consumed by
+  the ``video_pickscore`` reward, the first such video reward consumer.
+
+* ``MochiAdapter`` / ``HunyuanVideoAdapter`` — kept on the legacy image path
+  (see note below) for behavioral parity with the old ``sglang`` engine. Migrate
+  them onto ``VideoAdapter`` once each has a verified video reward baseline.
+
+PARITY NOTE (image-path video families): the legacy ``sglang`` engine treated
+every family — including the video ones — through the image path: it built an
+image-form ``LatentSegment`` (``make_image_segment``) and *dropped* 4-D decoded
+video with a warning (there was no video reward consumer yet). ``MochiAdapter`` /
+``HunyuanVideoAdapter`` reproduce that exactly so the per-family parity gate
+holds; only families with a real video consumer (WAN) move to ``VideoAdapter``.
 """
 
 from __future__ import annotations
 
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from unirl.config.require import require
+from unirl.rollout.engine.sglang_diffusion import utils
+from unirl.rollout.engine.sglang_diffusion.utils.tracks import _cat_padded_rows
+from unirl.types.conditions.text import TextEmbedCondition
 from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
+from unirl.rollout.engine.sglang_diffusion.backends import RawResult
+from unirl.types.rollout_req import RolloutReq
+from unirl.types.segments.latent import make_video_segment
+
+
+class VideoAdapter(ImageAdapter):
+    """Base for true video-output families (6-D latent trajectory → ``Videos``).
+
+    Reuses ``ImageAdapter``'s request side verbatim — ``build_sampling`` already
+    forwards ``num_frames`` and the SDE/rollout pins are modality-agnostic — and
+    overrides only the response-shape variation points: the segment is stamped
+    ``Modality.VIDEO`` and carries the 6-D ``[B, T+1, C, F, H, W]`` trajectory,
+    and the decoded media is packed as ``Videos`` rather than dropped.
+    """
+
+    #: RolloutResp track key (video, not image).
+    track_name: str = "video"
+    #: Modality stamp for the latent segment.
+    segment_factory = staticmethod(make_video_segment)
+
+    def build_segment(
+        self,
+        req: RolloutReq,
+        results: List[RawResult],
+        *,
+        num_steps: int,
+        sde_indices: Optional[List[int]],
+        emit_native_logprob: bool,
+    ):
+        """Video-form trajectory: collect, gate the 6-D shape, assemble.
+
+        Video latents keep the extra frame axis throughout, so the trajectory is
+        rank 6 ``[B, T+1, C, F, H, W]`` (vs the image path's rank 5). The downstream
+        ``build_latent_segment`` is shape-agnostic past the T+1 invariant, so the
+        only difference from the image path is the rank gate + the video segment
+        factory.
+        """
+        traj = utils.collect_trajectory_latents(results)
+        if traj.ndim != 6:
+            raise ValueError(
+                f"{self.model_family}: expected a 6-D video-form trajectory "
+                f"[B, T+1, C, F, H, W]; got rank {traj.ndim}, shape {tuple(traj.shape)}."
+            )
+        return utils.build_latent_segment(
+            traj,
+            results=results,
+            expected_sigmas=req.sigmas,
+            num_steps=num_steps,
+            sde_indices=sde_indices,
+            emit_native_logprob=emit_native_logprob,
+            segment_factory=self.segment_factory,
+        )
+
+    def build_decoded(self, req: RolloutReq, results: List[RawResult]):
+        return utils.stack_decoded_videos(results)
 
 
 @register_adapter("mochi")
 class MochiAdapter(ImageAdapter):
-    """Mochi — legacy image-path parity until verified video output lands."""
+    """Mochi — image-path parity (see module note); migrate to VideoAdapter when it has a video reward baseline."""
 
-    squeeze_single_frame_4d = False
-
-
-@register_adapter("hunyuan_video")
-class HunyuanVideoAdapter(ImageAdapter):
-    """HunyuanVideo — legacy image-path parity until verified video output lands."""
-
-    squeeze_single_frame_4d = False
+    pass
 
 
-__all__ = ["MochiAdapter", "HunyuanVideoAdapter"]
+
+__all__ = ["VideoAdapter", "MochiAdapter", "Ltx2T2VAdapter"]

--- a/unirl/rollout/engine/sglang_diffusion/backends/native.py
+++ b/unirl/rollout/engine/sglang_diffusion/backends/native.py
@@ -103,6 +103,14 @@ class _RawResultView:
         return getattr(getattr(rtd, "dit_trajectory", None), "timesteps", None)
 
     @property
+    def aux_trajectory_latents(self) -> Any:
+        """LTX-2's co-denoised AUDIO trajectory ([B, T+1, ...]), attached onto
+        ``dit_trajectory.audio_latents`` by ``patch_ltx2_rollout_sde`` and carried
+        through the per-output concat/slice. ``None`` for models without it."""
+        rtd = getattr(self._result, "rollout_trajectory_data", None)
+        return getattr(getattr(rtd, "dit_trajectory", None), "audio_latents", None)
+
+    @property
     def trajectory_log_probs(self) -> Any:
         rtd = getattr(self._result, "rollout_trajectory_data", None)
         return getattr(rtd, "rollout_log_probs", None)

--- a/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
@@ -20,6 +20,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tracks import (
     derive_timestep_alignment,
     fuse_text_conditions,
     stack_decoded_images,
+    stack_decoded_videos,
     validate_packed_trajectory,
 )
 
@@ -34,5 +35,6 @@ __all__ = [
     "derive_timestep_alignment",
     "fuse_text_conditions",
     "stack_decoded_images",
+    "stack_decoded_videos",
     "validate_packed_trajectory",
 ]

--- a/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/__init__.py
@@ -17,6 +17,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tensors import (
 from unirl.rollout.engine.sglang_diffusion.utils.tracks import (
     build_latent_segment,
     collect_trajectory_latents,
+    collect_aux_trajectory_latents,
     derive_timestep_alignment,
     fuse_text_conditions,
     stack_decoded_images,
@@ -32,6 +33,7 @@ __all__ = [
     "tensorize",
     "build_latent_segment",
     "collect_trajectory_latents",
+    "collect_aux_trajectory_latents",
     "derive_timestep_alignment",
     "fuse_text_conditions",
     "stack_decoded_images",

--- a/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
@@ -46,6 +46,21 @@ def collect_trajectory_latents(results: Sequence[RawResult]) -> torch.Tensor:
     return torch.cat(latents, dim=0)
 
 
+def collect_aux_trajectory_latents(results: Sequence[RawResult]) -> Optional[torch.Tensor]:
+    """Concat per-result AUXILIARY trajectory latents (LTX-2 audio) on the batch dim.
+
+    Returns ``None`` when no result carries one (non-LTX-2 families); requires all
+    results to agree (present or absent) so a partial set never silently mis-aligns
+    the per-sample audio the trainside replay cross-attends to.
+    """
+    auxes = [getattr(r, "aux_trajectory_latents", None) for r in results]
+    present = [a is not None for a in auxes]
+    if not any(present):
+        return None
+    require(all(present), "SGLang results inconsistent: some carry aux_trajectory_latents, some do not")
+    return torch.cat([a.detach().cpu() for a in auxes], dim=0)
+
+
 def validate_packed_trajectory(
     traj: torch.Tensor,
     req: RolloutReq,
@@ -139,6 +154,7 @@ def build_latent_segment(
     sde_indices: Optional[List[int]],
     emit_native_logprob: bool,
     segment_factory: Callable[..., LatentSegment] = make_image_segment,
+    aux_trajectory: Optional[torch.Tensor] = None,
 ) -> LatentSegment:
     """Pack an (already-unpacked) trajectory tensor into one batched ``LatentSegment``.
 
@@ -146,6 +162,10 @@ def build_latent_segment(
     passes ``make_video_segment``. The caller owns the model-specific unpack of
     ``trajectories_tensor`` (e.g. Klein); this function is shape-agnostic past
     the T+1 invariant.
+
+    ``aux_trajectory`` (LTX-2 audio, ``[B, T+1, ...]``) — when present it is stored
+    as ``segment.aux_latents`` and column-trimmed in lockstep with the video latents
+    so ``aux_latents_at(step)`` and ``latents_at(step)`` index the same sparse steps.
     """
     sigmas, step_indices = derive_timestep_alignment(
         trajectories_tensor=trajectories_tensor,
@@ -167,6 +187,10 @@ def build_latent_segment(
         if keep_cols and len(keep_cols) < traj_len:
             trajectories_tensor = trajectories_tensor[:, keep_cols]
             indices_t = torch.tensor(keep_cols, dtype=torch.long)
+            # Trim the audio trajectory to the SAME kept columns so it stays indexed
+            # by the same sparse positions as the video latents.
+            if aux_trajectory is not None and aux_trajectory.shape[1] == traj_len:
+                aux_trajectory = aux_trajectory[:, keep_cols]
 
     # sde_indices: always populated (trainer needs to know which steps to replay).
     # sde_logp: best-effort native emission; whether it is used or recomputed is
@@ -186,6 +210,7 @@ def build_latent_segment(
         indices=indices_t,
         sde_logp=sde_logp,
         sde_indices=sde_indices_t,
+        aux_latents=aux_trajectory,
     )
 
 
@@ -234,12 +259,17 @@ def _native_sde_logp(
 # ---------------------------------------------------------------------------
 
 
-def stack_decoded_images(results: Sequence[RawResult]) -> Optional[Images]:
+def stack_decoded_images(
+    results: Sequence[RawResult],
+    *,
+    squeeze_single_frame_4d: bool = True,
+) -> Optional[Images]:
     """Stack per-result decoded ``samples`` into ``Images.pixels [B, C, H, W]``.
 
-    4-D (video) samples are dropped with a warning — there is no video reward
-    consumer yet, so packing them as ``Videos`` is deferred (matches the old
-    engine's behavior for every family).
+    Image-output adapters may opt into squeezing a singleton temporal axis
+    ``[C, T=1, H, W]`` back to ``[C, H, W]``. Video-family adapters that still
+    run through the legacy image path should disable this so a true single-frame
+    video is dropped like any other 4-D video sample.
     """
     per_sample_tensors: List[torch.Tensor] = []
     skipped_video = False
@@ -249,6 +279,8 @@ def stack_decoded_images(results: Sequence[RawResult]) -> Optional[Images]:
             continue
         if canonical.dim() == 3:
             per_sample_tensors.append(canonical.to(torch.float32))
+        elif squeeze_single_frame_4d and canonical.dim() == 4 and int(canonical.shape[1]) == 1:
+            per_sample_tensors.append(canonical.squeeze(1).to(torch.float32))
         elif canonical.dim() == 4:
             skipped_video = True
         else:
@@ -257,9 +289,8 @@ def stack_decoded_images(results: Sequence[RawResult]) -> Optional[Images]:
             )
     if skipped_video:
         logger.warning(
-            "SGLang result contained 4D (video) samples — Videos primitive packing "
-            "is not yet implemented in the response translator; dropping. "
-            "Add a Videos branch when a video reward consumer lands."
+            "SGLang result contained multi-frame 4D video samples while decoding "
+            "an image track; dropping samples that cannot be represented as Images."
         )
     if not per_sample_tensors:
         return None

--- a/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
+++ b/unirl/rollout/engine/sglang_diffusion/utils/tracks.py
@@ -24,7 +24,7 @@ from unirl.rollout.engine.sglang_diffusion.utils.tensors import (
 )
 from unirl.rollout.engine.sigma_verify import verify_engine_used_sigmas
 from unirl.types.conditions.text import TextEmbedCondition
-from unirl.types.primitives import Images
+from unirl.types.primitives import Images, Video, Videos
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.segments.latent import LatentSegment, make_image_segment
 from unirl.types.trajectory_store import compute_trajectory_positions
@@ -234,17 +234,12 @@ def _native_sde_logp(
 # ---------------------------------------------------------------------------
 
 
-def stack_decoded_images(
-    results: Sequence[RawResult],
-    *,
-    squeeze_single_frame_4d: bool = True,
-) -> Optional[Images]:
+def stack_decoded_images(results: Sequence[RawResult]) -> Optional[Images]:
     """Stack per-result decoded ``samples`` into ``Images.pixels [B, C, H, W]``.
 
-    Image-output adapters may opt into squeezing a singleton temporal axis
-    ``[C, T=1, H, W]`` back to ``[C, H, W]``. Video-family adapters that still
-    run through the legacy image path should disable this so a true single-frame
-    video is dropped like any other 4-D video sample.
+    4-D (video) samples are dropped with a warning — there is no video reward
+    consumer yet, so packing them as ``Videos`` is deferred (matches the old
+    engine's behavior for every family).
     """
     per_sample_tensors: List[torch.Tensor] = []
     skipped_video = False
@@ -254,8 +249,6 @@ def stack_decoded_images(
             continue
         if canonical.dim() == 3:
             per_sample_tensors.append(canonical.to(torch.float32))
-        elif squeeze_single_frame_4d and canonical.dim() == 4 and int(canonical.shape[1]) == 1:
-            per_sample_tensors.append(canonical.squeeze(1).to(torch.float32))
         elif canonical.dim() == 4:
             skipped_video = True
         else:
@@ -264,12 +257,44 @@ def stack_decoded_images(
             )
     if skipped_video:
         logger.warning(
-            "SGLang result contained multi-frame 4D video samples while decoding "
-            "an image track; dropping samples that cannot be represented as Images."
+            "SGLang result contained 4D (video) samples — Videos primitive packing "
+            "is not yet implemented in the response translator; dropping. "
+            "Add a Videos branch when a video reward consumer lands."
         )
     if not per_sample_tensors:
         return None
     return Images(pixels=torch.stack(per_sample_tensors, dim=0))
+
+
+def stack_decoded_videos(results: Sequence[RawResult]) -> Optional[Videos]:
+    """Pack per-result decoded video ``samples`` into a ragged ``Videos`` batch.
+
+    The video counterpart of :func:`stack_decoded_images`. ``decode_sample``
+    returns canonical channels-first video ``[C, T, H, W]`` (see
+    :func:`unirl.rollout.engine.sglang_diffusion.utils.tensors.normalize_media`);
+    the :class:`~unirl.types.primitives.Video` primitive — and the video reward
+    consumer (``video_pickscore``, which permutes ``frames[T,C,H,W] → [C,T,H,W]``)
+    — want frame-major ``[T, C, H, W]``, so we permute before packing.
+    ``Videos.from_list`` concatenates along T and lets the Batch framework
+    compute the per-sample ``cu_frames`` offsets. Each result carries exactly
+    one decoded sample (mirrors :func:`stack_decoded_images`'s one-per-result
+    contract). Returns ``None`` when no recognizable video was produced.
+    """
+    videos: List[Video] = []
+    for result in results:
+        canonical = decode_sample(result.samples)
+        if canonical is None:
+            continue
+        if canonical.dim() != 4:
+            raise RuntimeError(
+                f"stack_decoded_videos: expected 4-D canonical video [C, T, H, W]; "
+                f"got rank {canonical.dim()}, shape {tuple(canonical.shape)}."
+            )
+        frames = canonical.permute(1, 0, 2, 3).contiguous().to(torch.float32)  # [T, C, H, W]
+        videos.append(Video(frames=frames))
+    if not videos:
+        return None
+    return Videos.from_list(videos)
 
 
 # ---------------------------------------------------------------------------
@@ -405,5 +430,6 @@ __all__ = [
     "derive_timestep_alignment",
     "build_latent_segment",
     "stack_decoded_images",
+    "stack_decoded_videos",
     "fuse_text_conditions",
 ]


### PR DESCRIPTION
## Summary

Adds **LTX-2 T2V** to the `sglang_diffusion` rollout engine (full-FT + LoRA), with the audiovisual co-denoising handled for rollout<->replay alignment.

LTX-2 is a unified AV transformer: the video DiT cross-attends to a co-denoised **audio latent** each step, so the trainside replay must consume the SAME per-step audio the rollout used.
- `Ltx2T2VAdapter` — LTX-2 latents are packed token sequences (rank-4 `[B, T+1, seq, dim]`), not a spatial grid; relaxes the strict 6-D gate.
- **Audio-trajectory carry** — captures sglang's co-denoised audio trajectory and routes it to `segment.aux_latents` so `LTX2DiffusionStage.replay` reproduces the exact audio (else "aux_latents missing" + curve divergence).
- `patch_ltx2_rollout_sde` (sigma-schedule pin / AV-decode output carry / SDE log-prob bridge for LTX-2's overridden stages); RL-mixin scheduler swap; forced-MATH-SDP attention workaround; aux-components-on-CPU for the colocate budget.
- Configs: `ltx2_t2v_sglang_{loramerge,full}.yaml`.

## Related Issue

Engine support matrix — #127. Depends on the foundation #135.

## Test Plan

- `py_compile` + import smoke (registers as `ltx2`) — passes.
- GRPO smoke, rollout<->replay ratio: **LoRA 0.9985 -> 0.9988 -> 0.9992** (3 rollouts), **full-FT 0.9968** — the sglang dual-AV rollout matches trainside replay.

## Compatibility / Risk

Additive; LTX-2-specific patches are gated on the LTX-2 stages. The aux-trajectory plumbing (`collect_aux_trajectory_latents`, `RawResult.aux_trajectory_latents`, segment `aux_latents`) is additive and `None` for non-LTX-2 families.

## Reviewer Notes

Independent of #136/#137/#139. Full-FT multi-rollout on a single node uses the documented colocate-offload settings in the config.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
