### PR TITLE
feat(rollout): WAN 2.2-A14B T2V sglang_diffusion rollout (dual-expert MoE, full+LoRA)

### DIFF
--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -1,0 +1,180 @@
+# @package _global_
+# LTX-Video-2.3 T2AV GRPO with AUDIO REWARD — trainside (in-process FSDP).
+#
+# Extends the T2AV recipe (ltx2_3_t2av_trainside) by scoring the jointly-
+# generated AUDIO in addition to the video. The pipeline decodes the audio
+# waveform (audio_vae + vocoder) and carries it on the track as a parallel
+# stream; the reward service injects it into the reward request so a composite
+# scorer can blend video + audio signals.
+#
+# Reward = T2AVCompositeScorer:
+#   - videopickscore (video quality / image-text alignment on first frame)
+#   - clap           (audio-text alignment, LAION CLAP; zero extra deps)
+# ImageBind (audio-video alignment) is also available as an inner scorer but is
+# NOT enabled here: it requires the facebookresearch/ImageBind package and is
+# CC-BY-NC-SA 4.0 (NonCommercial). To enable, add `imagebind: <weight>` to the
+# composite weights (and install the package).
+#
+# With audio_joint_sde=true, audio is part of the SDE policy AND now receives a
+# direct reward signal, so it is optimized toward prompt alignment (not just
+# passively coupled through cross-attention).
+#
+# Launch (1 node × 8 GPUs):
+#   bash examples/run_experiment_multinode_taiji.sh diffusion/ltx2/ltx2_3_t2av_audioreward_trainside
+
+num_devices: 8
+batch_size: 8
+num_rollouts: 10000
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,unirl-ltx2.3-t2av-audioreward}
+  run_name: null
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [ltx2.3, t2av, grpo, trainside, dancegrpo, audio, audioreward]
+  log_media: true
+  media_max_items: 4
+  # How often (in ROLLOUTS) to log generated media to wandb. One rollout =
+  # one sampling batch (batch_size prompts x samples_per_prompt), NOT one
+  # optimizer step. Set high to keep media logging sparse / cheap.
+  media_log_interval: 500
+
+bundle:
+  _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config
+  config:
+    _target_: unirl.models.ltx2.config.LTX2PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,dg845/LTX-2.3-Diffusers}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp16
+    logprob_precision: fp32
+    shift: 1.0
+    max_sequence_length: 512
+    enable_audio: true
+    # Joint audio+video SDE policy (default True). False => legacy ODE audio.
+    audio_joint_sde: true
+    default_height: 512
+    default_width: 768
+    default_num_frames: 33
+    default_frame_rate: 24.0
+
+pipeline:
+  _target_: unirl.models.ltx2.pipeline.LTX2Pipeline.from_bundle
+  config: ${bundle.config}
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["LTX2VideoTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      # Video self-attention
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      # Video cross-attention (text)
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+      # Video FFN
+      - ff.net.0.proj
+      - ff.net.2
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 2
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.t2av_composite.T2AVCompositeScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
+      batch_size: 4
+      device: auto
+      # Inner scorer name -> blend weight. videopickscore reads the video,
+      # clap reads the parallel audio side-channel. To add audio-video
+      # alignment, install ImageBind and add `imagebind: <w>` here.
+      weights:
+        videopickscore: 0.5
+        clap: 0.5
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.ltx2.conditions.LTX2Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 1
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 768
+  num_frames: 33
+  eta: 0.7
+  samples_per_prompt: 4
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 5
+    timestep_fraction: [0, 0.5]

--- a/examples/diffusion/wan22/wan22_t2v_14b_sglang.yaml
+++ b/examples/diffusion/wan22/wan22_t2v_14b_sglang.yaml
@@ -1,0 +1,218 @@
+# @package _global_
+# GRPO WAN 2.2-A14B T2V + SGLang rollout (colocate), DUAL-EXPERT.
+#
+# Video FlowGRPO with the rollout served by the ``sglang_diffusion`` engine on the
+# WAN 2.2-A14B dual-expert pipeline. WAN 2.2-A14B runs two WanTransformer3DModel
+# experts switched at a sigma boundary (high-noise for sigma >= boundary_ratio,
+# low-noise below). The DUAL-EXPERT mechanism is entirely engine-side and needs no
+# new sglang code: ``composed_pipeline_base.load_modules`` auto-loads ``transformer_2``
+# because the Wan2.2-T2V-A14B-Diffusers ``model_index.json`` carries ``boundary_ratio``
+# + both ``transformer``/``transformer_2``, and the generic ``DenoisingStage.
+# _select_and_manage_model`` routes per-step by the boundary timestep. The UniRL side
+# is the ``wan22`` adapter (a thin subclass of the wan21 adapter — same UMT5 single-text
+# fuse, same 6-D video trajectory + video_pickscore, no aux audio). The trainside
+# ``WAN22DiffusionStage`` replays with the SAME boundary routing → rollout↔replay align.
+#
+#   1x8:  bash examples/run_experiment_single_node.sh diffusion/wan22/wan22_t2v_14b_sglang
+#
+# old_logp_source=replay: the trainer recomputes the pi_old anchor with the WAN22
+# dual-expert pipeline (cross-engine safe). Flip to ``rollout`` once the sglang "sde"
+# kernel is confirmed bit-equal for WAN.
+
+num_devices: 8
+batch_size: 8
+adv_use_global_std: true
+num_rollouts: 1000
+
+model_config:
+  _target_: unirl.models.wan22.config.WAN22PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.2-T2V-A14B-Diffusers}
+  model_precision: bf16
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  shift: 5.0
+  max_sequence_length: 512
+  boundary_ratio: 0.875        # WAN 2.2 reference: sigma >= 0.875 → high_noise, else low_noise
+  num_train_timesteps: 1000
+  # SGLang builds its LoRA ServerArgs from these two fields.
+  use_lora: true
+  # WAN attention LoRA targets — SGLANG leaf names (no qkv fusion); applied to BOTH
+  # experts' self+cross attn. Trainside (peft) keeps diffusers paths in backend.lora_cfg.
+  lora_target_modules:
+    - to_q
+    - to_k
+    - to_v
+    - to_out
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.wan22.bundle.WAN22Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.wan22.pipeline.WAN22Pipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: true            # 27B dual-expert frozen base: offload during sglang gen
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    model_family: wan22
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 8
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    # Memory: A14B is TWO 14B experts (~56GB resident) + heavy video activations on a
+    # single GPU (tp=1). Offload the inactive expert (A14B uses ONE at a time via the
+    # boundary-switch) AND the frozen aux (Gemma/UMT5 text encoder + VAE decode spike)
+    # to CPU so peak HBM ≈ one 14B DiT + activations.
+    engine_kwargs:
+      # A14B = two 13.5B experts (~54GB if both resident) — too big for one GPU at
+      # tp=1 even with the inactive expert nominally on CPU (LoRA-wrapping pins both).
+      # dit_layerwise_offload streams each transformer block CPU→GPU per step and frees
+      # it after, so resident weights ≈ a few layers → either expert fits with room for
+      # video activations. Slower per step, but the only way to fit 27B at tp=1 colocate.
+      dit_layerwise_offload: true
+      dit_offload_prefetch_size: 2.0
+      text_encoder_cpu_offload: true
+      vae_cpu_offload: true
+    # SGLANG leaf names (see model_config.lora_target_modules above).
+    target_modules:
+      - to_q
+      - to_k
+      - to_v
+      - to_out
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0           # no CFG → no negative-prompt branch
+  guidance_scale_2: null        # low-noise expert CFG; null → engine reuses guidance_scale
+  height: 480
+  width: 832
+  num_frames: 5                 # (num_frames-1)%4==0 → 2 latent frames after WAN VAE 4x temporal
+  eta: 0.7
+  samples_per_prompt: 8
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: null
+
+weight_sync_interval: 1
+
+# Dual-expert LoRA sync: the trainside LoRA lives on transformer.high_noise.* and
+# transformer.low_noise.*; after the ``transformer.`` prefix strip the keys become
+# high_noise.* / low_noise.*, which the sync layer remaps to the engine's
+# transformer.* (high) / transformer_2.* (low) via WAN22Bundle.weight_sync_name_map().
+sync:
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
+  verify: false
+  param_prefix: "transformer."
+  adapter_name: default
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan22_t2v_14b_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan22", "a14b", "t2v", "grpo", "video", "pickscore", "sglang", "dual-expert"]
+  log_media: false

--- a/examples/unified_model/hi3_vllmomni_veomni_ep.yaml
+++ b/examples/unified_model/hi3_vllmomni_veomni_ep.yaml
@@ -1,0 +1,262 @@
+# @package _global_
+# HunyuanImage3 think_recaption RL — v2 unified-backbone trainer, COLOCATE.
+#
+# One shared HunyuanImage3 transformer (mode=gen_text for AR, mode=gen_image for
+# DiT) trained jointly by GRPO (AR TextSegment) + FlowGRPO (DiT
+# LatentSegment), both backward-accumulating into ONE LoRA adapter with a single
+# optimizer step (UnifiedModelTrainStack). Rollout is a two-engine vLLM-Omni setup
+# (modality=ar_recaption: AR think/recaption → modality=dit_recaption: DiT); the
+# trained LoRA is synced back into both engines every rollout.
+#
+# Pairs with unirl/train_unified_model.py (UnifiedModelTrainer). Modeled on
+# sd3_vllmomni_full_ipc.yaml (single-backbone v2 + vllm-omni + colocate sync)
+# and pe_trainside_pickscore.yaml (two-algorithm shape).
+#
+# Confirm at smoke time (GPU-specific, can't be unit-checked):
+#   - backend.block_class_names: the HF HunyuanImage3 decoder-layer class name.
+#   - sync.param_prefix: must match the engine-side LoRA key naming (see
+#     HunyuanImage3PipelineConfig.weight_sync_param_name_prefix). The fused qkv
+#     is split q/k/v engine-side by vLLM's native packed-modules mapping.
+
+num_devices: 8
+batch_size: 4                 # prompts per rollout; each expands to samples_per_prompt
+
+weight_sync_interval: 1
+
+# Intrusive debug dump (UnifiedModelTrainer._dump_rollout): per rollout, dump original
+# prompt + AR output text (the think/recaption fed into DiT) + decoded images +
+# image rewards. null = disabled (default); set to a writable path to enable.
+dump_dir: null
+
+# W&B reporting (UnifiedModelTrainer._init_wandb). Secrets stay in the env:
+# WANDB_API_KEY + WANDB_ENTITY (entity falls back to ${oc.env:WANDB_ENTITY}).
+# report_to_wandb=false → fully no-op. Override run_name per launch.
+logging:
+  report_to_wandb: true
+  project_name: hi3-grpo
+  run_name: null
+  entity: ${oc.env:WANDB_ENTITY,null}
+  logging_dir: null
+  tags: [hi3, two-engine, grpo]
+  # Generated-image previews (off by default elsewhere; HI3 wants them).
+  log_media: true
+  media_max_items: 8
+  media_log_interval: 1
+
+bundle:
+  # 80B path: meta-init (no per-rank full load) → FSDPBackend wraps the meta
+  # decoder and calls bundle.materialize(), which loads each rank's shard via
+  # DCP (~20GB/card). ``from_config`` (the .to(device) path) would try to put
+  # the full ~160GB model on one GPU → OOM (see bundle.from_config docstring).
+  _target_: unirl.models.hunyuan_image3.bundle.HunyuanImage3Bundle.from_meta_config
+  config:
+    _target_: unirl.models.hunyuan_image3.config.HunyuanImage3PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,tencent/HunyuanImage-3.0-Instruct}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp16
+    logprob_precision: fp32
+    shift: 3.0
+    guidance_scale: 1.0
+
+pipeline:
+  # Assemble from the SHARED bundle (auto-injected by the trainer) so the
+  # algorithms' replay reads the FSDP-trained weights. from_bundle builds all
+  # sub-stages (text_embed / diffusion / vae_* / ar / vit); shift + precisions
+  # come off the bundle config. (The raw __init__ would need all 6 stages
+  # passed explicitly; from_config/from_meta_config would build a SECOND,
+  # unshared bundle — wrong for colocate.)
+  _target_: unirl.models.hunyuan_image3.pipeline.HunyuanImage3Pipeline.from_bundle
+  config: ${bundle.config}
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  # VeOmni FSDP2 + expert parallelism. resolve_trainable_module prefers the
+  # bundle's trainable_module() -> the bare decoder (transformer.model), so
+  # VeOmni root-shards the single decoder (not the composite wrapper); the frozen
+  # VAE/ViT/heads stay outside the wrap. Needs meta-init (from_meta_config).
+  _target_: unirl.train.backend.veomni.backend.VeOmniBackend
+  block_class_names: ["HunyuanImage3DecoderLayer"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false       # VeOmniBackend v1 rejects cpu_offload=true
+    mixed_precision: true    # VeOmniBackend v1 requires mixed_precision=true
+    fsdp_mode: full          # VeOmniBackend v1 supports only 'full'
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+    sp_size: 1
+    # Expert-parallel degree (THE single EP switch): when >1 the backend asks the
+    # bundle to fuse its MoE experts ([E,2I,H] via veomni grouped GEMM + all_to_all)
+    # and shards them across ep_size ranks (each holds num_experts/ep_size experts;
+    # tokens routed via all_to_all). Must divide world_size and num_experts(=64).
+    # Experts are frozen (LoRA trains attention only) -> EP is a throughput/memory win.
+    ep_size: 8
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  # Single shared LoRA adapter — both AR and DiT algorithms train it.
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 8
+    alpha: 16
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - qkv_proj
+      - o_proj
+
+# Two standalone vLLM-Omni engines (the v2 two-engine design). The AR engine
+# (modality ar_recaption, single LLM stage, GPUs 0-3) emits N think/recaption
+# texts per prompt; the DiT engine (modality dit_recaption, single diffusion
+# stage, GPUs 4-7) renders M distinct-noise images per recaption. UnifiedModelTrainer
+# wires both with remote() in the shared placement; each engine clears
+# CUDA_VISIBLE_DEVICES for its multi-GPU HI3 modality and its stage YAML's
+# runtime.devices pins the physical cards (a real partition, NOT anchor+pop).
+# Both run enable_sleep_mode so the trainer can sleep/wake them around the
+# colocate train phase. The two engines share ONE backbone/LoRA via sync.
+ar_rollout:
+  _target_: unirl.rollout.engine.vllm_omni.engine.VLLMOmniRolloutEngine
+  model_config: ${bundle.config}
+  config:
+    _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
+    model_path: ${oc.env:PRETRAINED_MODEL,tencent/HunyuanImage-3.0-Instruct}
+    # AR-only think/recaption stage (is_comprehension:false), GPUs 0-3.
+    modality: hi3_ar_recaption
+    enable_sleep_mode: true
+
+dit_rollout:
+  _target_: unirl.rollout.engine.vllm_omni.engine.VLLMOmniRolloutEngine
+  model_config: ${bundle.config}
+  config:
+    _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
+    model_path: ${oc.env:PRETRAINED_MODEL,tencent/HunyuanImage-3.0-Instruct}
+    # Standalone DiT stage that eats an externally-injected recaption, GPUs 4-7.
+    modality: hi3_dit_recaption
+    enable_sleep_mode: true
+
+reward:
+  # main reward API (#169): one RewardService over a single backend (the old
+  # RewardServiceNew + executors[] / InProcessRewardExecutor wrapper was dropped).
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.pickscore.PickScoreRewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.pickscore.PickScoreSpec
+      batch_size: 4
+      device: auto
+      processor_id: ${oc.env:PICKSCORE_PROCESSOR,yuvalkirstain/PickScore_v1}
+      model_id: ${oc.env:PICKSCORE_MODEL,yuvalkirstain/PickScore_v1}
+
+# Two algorithms over the one shared pipeline. ``ar`` resolves pipeline.ar,
+# ``image`` resolves pipeline.diffusion (via stage_attr). UnifiedModelTrainer reads
+# cfg.algorithm.ar / cfg.algorithm.image.
+algorithm:
+  ar:
+    _target_: unirl.algorithms.grpo.GRPO
+    stage_attr: ar
+    clip_range: 1.0e-2            # AR/LLM trust region (matches ar/qwen_vl grpo; 0.2 never binds -> no clip)
+    clip_schedule: constant
+    conditions_cls:
+      _target_: hydra.utils.get_class
+      path: unirl.models.hunyuan_image3.conditions.HunyuanImage3ARConditions
+    sampling_temperature: ${sampling.ar.temperature}
+  image:
+    _target_: unirl.algorithms.flowgrpo.FlowGRPO
+    stage_attr: diffusion
+    clip_range: 1.0e-4            # diffusion trust region (matches sd3/qwen_image; 0.2 never binds -> no clip on SDE-logprob ratio)
+    clip_schedule: constant
+    conditions_cls:
+      _target_: hydra.utils.get_class
+      path: unirl.models.hunyuan_image3.conditions.HunyuanImage3DiffusionConditions
+    # FlowGRPO.replay needs the same guidance_scale / eta the rollout
+    # sampled with — bind to the "diffusion" entry of the sampling dict.
+    params: ${sampling.diffusion}
+
+# One stack: single backend + both algorithms → one optimizer step.
+stack:
+  _target_: unirl.train.unified_model_stack.UnifiedModelTrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+# Modality-keyed sampling dict: intended hierarchy is
+#   original prompt → ar.samples_per_prompt AR trajectories (temperature-sampled
+#   think/recaption) → each trajectory → diffusion.samples_per_prompt images.
+#   AR GRPO groups by original prompt; image GRPO groups by AR trajectory.
+#
+# NOTE (current engine reality): the two-engine ar_recaption→dit_recaption flow
+# runs ONE AR + ONE image per request (flat 1:1; num_images_per_prompt defaults
+# to 1). So today
+# ar/diffusion samples_per_prompt simply multiply to G = N*M flat (AR, image)
+# pairs per prompt, each with its own temperature-sampled think/recaption and its
+# own seed. True 2-level "M images per AR trajectory" needs engine-side
+# num_images_per_prompt fan-out + response.py lineage for n images/AR (follow-up).
+# These small values are for the dump-first observe run.
+sampling:
+  ar:
+    _target_: unirl.types.sampling.ARSamplingParams
+    samples_per_prompt: 2       # N AR trajectories per prompt (temperature-driven)
+    temperature: 0.6            # >0 so the N trajectories actually differ
+    max_new_tokens: 4096
+    top_p: 0.95
+    top_k: 1024
+  diffusion:
+    _target_: unirl.types.sampling.DiffusionSamplingParams
+    samples_per_prompt: 2       # M images per AR trajectory (see NOTE above)
+    num_inference_steps: 16
+    guidance_scale: 1.0
+    height: 1024
+    width: 1024
+    eta: 1.0
+    # Base seed; per-sample exploration needs distinct noise per sample. The dump
+    # surfaces whether images within a prompt actually differ (seed check).
+    seed: 42
+    init_same_noise: false
+    scheduler:
+      # Sparse SDE (mirrors sd3_vllmomni / sd3_dancegrpo): record SDE log-probs at
+      # only a few steps, ODE elsewhere -> lower-variance GRPO gradient. null = all-SDE.
+      _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+      num_timesteps: ${..num_inference_steps}
+      num_sde_steps: 3               # sparse subset (sd3.5 uses 3)
+      timestep_fraction: [0, 0.5]    # SDE steps drawn from the first-half high-σ steps
+
+# LoRA → vLLM-Omni rollout (cross-process Ray push). RemoteLoraWeightSync.sync()
+# extracts the adapter on the train workers and pushes it from rank 0 into both
+# engines (AR + DiT) via each engine's set_lora_from_tensors_copy (the engines are
+# anchored on separate workers — wired in UnifiedModelTrainer via set_rollout_targets).
+# copy: true is required — the AR / DiT stages are TP>1, where the zero-copy LoRA
+# handle's one-shot fd breaks the collective_rpc broadcast to ranks 2..N.
+# param_prefix mirrors HunyuanImage3PipelineConfig.weight_sync_param_name_prefix.
+# The fused qkv is shipped WHOLE and split into q/k/v engine-side by vLLM's native
+# packed-modules mapping (post-#181: no trainer-side packed_modules block).
+sync:
+  _target_: unirl.distributed.weight_sync.lora.RemoteLoraWeightSync
+  copy: true
+  param_prefix: "model."
+  adapter_name: default
+
+num_rollouts: 100

--- a/unirl/__init__.py
+++ b/unirl/__init__.py
@@ -3,47 +3,9 @@
 from __future__ import annotations
 
 import importlib
-import os
 from typing import Dict, Tuple
 
 __version__ = "0.1.0"
-
-
-def _maybe_disable_cudnn() -> None:
-    """Globally disable cuDNN in this process when requested (opt-in).
-
-    Workaround for a cuDNN forward-compat crash — ``munmap_chunk(): invalid
-    pointer`` / SIGABRT inside conv ``_conv_forward`` — seen on this cluster's
-    cuda-compat-13 + driver-535 stack. It is flaky across worker ids and hits
-    any conv path: sglang's VAE decode (also guarded by
-    ``_patches.patch_vae_decode_safe``) AND the reward models' CLIP convs
-    (PickScore / video_pickscore), which run inside unirl Ray actors. Every
-    actor runs ``import unirl``, so disabling cuDNN here routes all convs
-    through PyTorch's native CUDA kernels process-wide. Opt-in via
-    ``UNIRL_DISABLE_CUDNN=1`` (legacy ``DIFFRL_DISABLE_CUDNN=1`` also honored);
-    a no-op (no torch import) otherwise.
-    """
-    if os.environ.get("UNIRL_DISABLE_CUDNN") != "1" and os.environ.get("DIFFRL_DISABLE_CUDNN") != "1":
-        return
-    try:
-        import torch
-
-        torch.backends.cudnn.enabled = False
-        # cudnn.enabled=False does NOT gate the SDPA cuDNN backend — that is a
-        # separate flag. On this stack the cuDNN-SDP kernel aborts the process
-        # (``munmap_chunk(): invalid pointer``) inside diffusers' _native_attention
-        # (the WAN DiT forward). Turn the cuDNN SDPA backend off explicitly so
-        # F.scaled_dot_product_attention falls back to flash / mem-efficient
-        # (both verified OK here). Guarded: the toggle exists on recent torch only.
-        try:
-            torch.backends.cuda.enable_cudnn_sdp(False)
-        except Exception:  # noqa: BLE001
-            pass
-    except Exception:  # noqa: BLE001 — best-effort; torch may be absent in CPU-only utility imports
-        pass
-
-
-_maybe_disable_cudnn()
 
 _LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     # shared types

--- a/unirl/__init__.py
+++ b/unirl/__init__.py
@@ -3,9 +3,47 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Dict, Tuple
 
 __version__ = "0.1.0"
+
+
+def _maybe_disable_cudnn() -> None:
+    """Globally disable cuDNN in this process when requested (opt-in).
+
+    Workaround for a cuDNN forward-compat crash — ``munmap_chunk(): invalid
+    pointer`` / SIGABRT inside conv ``_conv_forward`` — seen on this cluster's
+    cuda-compat-13 + driver-535 stack. It is flaky across worker ids and hits
+    any conv path: sglang's VAE decode (also guarded by
+    ``_patches.patch_vae_decode_safe``) AND the reward models' CLIP convs
+    (PickScore / video_pickscore), which run inside unirl Ray actors. Every
+    actor runs ``import unirl``, so disabling cuDNN here routes all convs
+    through PyTorch's native CUDA kernels process-wide. Opt-in via
+    ``UNIRL_DISABLE_CUDNN=1`` (legacy ``DIFFRL_DISABLE_CUDNN=1`` also honored);
+    a no-op (no torch import) otherwise.
+    """
+    if os.environ.get("UNIRL_DISABLE_CUDNN") != "1" and os.environ.get("DIFFRL_DISABLE_CUDNN") != "1":
+        return
+    try:
+        import torch
+
+        torch.backends.cudnn.enabled = False
+        # cudnn.enabled=False does NOT gate the SDPA cuDNN backend — that is a
+        # separate flag. On this stack the cuDNN-SDP kernel aborts the process
+        # (``munmap_chunk(): invalid pointer``) inside diffusers' _native_attention
+        # (the WAN DiT forward). Turn the cuDNN SDPA backend off explicitly so
+        # F.scaled_dot_product_attention falls back to flash / mem-efficient
+        # (both verified OK here). Guarded: the toggle exists on recent torch only.
+        try:
+            torch.backends.cuda.enable_cudnn_sdp(False)
+        except Exception:  # noqa: BLE001
+            pass
+    except Exception:  # noqa: BLE001 — best-effort; torch may be absent in CPU-only utility imports
+        pass
+
+
+_maybe_disable_cudnn()
 
 _LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     # shared types

--- a/unirl/distributed/weight_sync/full/tensor.py
+++ b/unirl/distributed/weight_sync/full/tensor.py
@@ -62,6 +62,8 @@ class TensorWeightSync(FullWeightSync):
         all-gathers each shard on every rank in lockstep. Each rank talks to
         its own co-located engine, so no cross-rank gather is needed.
         """
+        import os
+
         import torch
 
         # Use SGLang's own reductions when the rollout engine is SGLang-based
@@ -90,6 +92,15 @@ class TensorWeightSync(FullWeightSync):
 
         monkey_patch_torch_reductions()
 
+        # CPU-stage opt-in: the colocate handoff defaults to zero-copy CUDA-IPC,
+        # which needs the ``pidfd_getfd`` syscall (kernel >= 5.6). On older kernels
+        # (5.4) ``update_weights_from_tensor`` dies with "does not support the
+        # pidfd_getfd syscall ... for CUDA tensors". Staging the flattened bucket
+        # through CPU (shared-memory transport) avoids CUDA-IPC entirely — a copy +
+        # re-upload per bucket, but it works where IPC can't. Opt in with
+        # ``UNIRL_SYNC_CPU_STAGE=1``.
+        _cpu_stage = os.environ.get("UNIRL_SYNC_CPU_STAGE") == "1"
+
         for bucket, is_last in self._iter_buckets():
             # Group by dtype, one FlattenedTensorBucket per dtype (matches the
             # receiver's flattened_bucket load_format).
@@ -102,8 +113,11 @@ class TensorWeightSync(FullWeightSync):
             serialized = []
             for grouped in by_dtype.values():
                 flat = FlattenedTensorBucket(named_tensors=grouped)
+                flat_t = flat.get_flattened_tensor()
+                if _cpu_stage:
+                    flat_t = flat_t.cpu()
                 payload = {
-                    "flattened_tensor": flat.get_flattened_tensor(),
+                    "flattened_tensor": flat_t,
                     "metadata": flat.get_metadata(),
                 }
                 serialized.append(MultiprocessingSerializer.serialize(payload, output_str=True))

--- a/unirl/distributed/weight_sync/full/tensor.py
+++ b/unirl/distributed/weight_sync/full/tensor.py
@@ -62,8 +62,6 @@ class TensorWeightSync(FullWeightSync):
         all-gathers each shard on every rank in lockstep. Each rank talks to
         its own co-located engine, so no cross-rank gather is needed.
         """
-        import os
-
         import torch
 
         # Use SGLang's own reductions when the rollout engine is SGLang-based
@@ -92,15 +90,6 @@ class TensorWeightSync(FullWeightSync):
 
         monkey_patch_torch_reductions()
 
-        # CPU-stage opt-in: the colocate handoff defaults to zero-copy CUDA-IPC,
-        # which needs the ``pidfd_getfd`` syscall (kernel >= 5.6). On older kernels
-        # (5.4) ``update_weights_from_tensor`` dies with "does not support the
-        # pidfd_getfd syscall ... for CUDA tensors". Staging the flattened bucket
-        # through CPU (shared-memory transport) avoids CUDA-IPC entirely — a copy +
-        # re-upload per bucket, but it works where IPC can't. Opt in with
-        # ``UNIRL_SYNC_CPU_STAGE=1``.
-        _cpu_stage = os.environ.get("UNIRL_SYNC_CPU_STAGE") == "1"
-
         for bucket, is_last in self._iter_buckets():
             # Group by dtype, one FlattenedTensorBucket per dtype (matches the
             # receiver's flattened_bucket load_format).
@@ -113,11 +102,8 @@ class TensorWeightSync(FullWeightSync):
             serialized = []
             for grouped in by_dtype.values():
                 flat = FlattenedTensorBucket(named_tensors=grouped)
-                flat_t = flat.get_flattened_tensor()
-                if _cpu_stage:
-                    flat_t = flat_t.cpu()
                 payload = {
-                    "flattened_tensor": flat_t,
+                    "flattened_tensor": flat.get_flattened_tensor(),
                     "metadata": flat.get_metadata(),
                 }
                 serialized.append(MultiprocessingSerializer.serialize(payload, output_str=True))

--- a/unirl/distributed/weight_sync/transfer/sgl_compat.py
+++ b/unirl/distributed/weight_sync/transfer/sgl_compat.py
@@ -68,7 +68,13 @@ def monkey_patch_torch_reductions():
 
 def _reduce_tensor_modified(*args, **kwargs):
     output_fn, output_args = reductions._reduce_tensor_original(*args, **kwargs)
-    output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
+    # The device-index arg (and its uuid round-trip on rebuild) exists ONLY on the
+    # CUDA-IPC reduce path. CPU tensors reduce to a SHORTER tuple via a different
+    # rebuild fn — index 6 is out of range there. Guard so CPU-staged tensors
+    # (UNIRL_SYNC_CPU_STAGE, for kernels without pidfd_getfd) pass through
+    # untouched instead of raising ``IndexError: tuple index out of range``.
+    if len(output_args) > _REDUCE_TENSOR_ARG_DEVICE_INDEX:
+        output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
     return output_fn, output_args
 
 

--- a/unirl/distributed/weight_sync/transfer/sgl_compat.py
+++ b/unirl/distributed/weight_sync/transfer/sgl_compat.py
@@ -68,13 +68,7 @@ def monkey_patch_torch_reductions():
 
 def _reduce_tensor_modified(*args, **kwargs):
     output_fn, output_args = reductions._reduce_tensor_original(*args, **kwargs)
-    # The device-index arg (and its uuid round-trip on rebuild) exists ONLY on the
-    # CUDA-IPC reduce path. CPU tensors reduce to a SHORTER tuple via a different
-    # rebuild fn — index 6 is out of range there. Guard so CPU-staged tensors
-    # (UNIRL_SYNC_CPU_STAGE, for kernels without pidfd_getfd) pass through
-    # untouched instead of raising ``IndexError: tuple index out of range``.
-    if len(output_args) > _REDUCE_TENSOR_ARG_DEVICE_INDEX:
-        output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
+    output_args = _modify_tuple(output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid)
     return output_fn, output_args
 
 

--- a/unirl/models/hunyuan_image3/bundle.py
+++ b/unirl/models/hunyuan_image3/bundle.py
@@ -106,6 +106,22 @@ class HunyuanImage3Bundle(Bundle):
         double-prefixed it)."""
         return self.transformer.model
 
+    def prepare_for_expert_parallel(self) -> None:
+        """Make the decoder expert-parallel-ready (backend hook; called only when
+        ``ep_size > 1``, on the meta model, before ``veomni_parallelize``).
+
+        Swaps each decoder layer's ``HunyuanMoE`` (nn.ModuleList experts) for a
+        ``FusedHunyuanMoE`` (fused ``[E,2I,H]`` experts via veomni grouped GEMM +
+        all_to_all) and attaches ``get_parallel_plan`` so VeOmni's EP can
+        ``Shard(0)`` the fused tensors. Flags :meth:`materialize` to fuse the
+        per-expert checkpoint keys and take the EP-sharded load path. Driven
+        solely by ``backend.fsdp_cfg.ep_size`` — there is no separate config flag."""
+        from unirl.train.backend.veomni.ep.models.hi3 import replace_hunyuan_moe_with_fused
+
+        n_swapped = replace_hunyuan_moe_with_fused(self.transformer.model)
+        logger.info("expert-parallel: swapped %d HunyuanMoE layer(s) for FusedHunyuanMoE", n_swapped)
+        self._ep_enabled = True
+
     @classmethod
     def from_config(cls, config: HunyuanImage3PipelineConfig) -> "HunyuanImage3Bundle":
         """Load all HunyuanImage3 components from a HuggingFace checkpoint.
@@ -413,6 +429,15 @@ class HunyuanImage3Bundle(Bundle):
             prefixes = tuple(attr for attr, _ in plan)
             sd = _collect_filtered_state_dict(self.pretrained_path, prefixes=prefixes)
 
+            # Expert parallelism: fuse per-expert checkpoint keys
+            # (model.layers.*.mlp.experts.{j}.{gate_and_up,down}_proj.weight) into
+            # the FusedHunyuanMoE's [E,...] params (gate_and_up half-swapped to
+            # veomni's silu-first convention). Matches prepare_for_expert_parallel's swap.
+            if getattr(self, "_ep_enabled", False):
+                from unirl.train.backend.veomni.ep.models.hi3 import fuse_expert_state_dict
+
+                sd = fuse_expert_state_dict(sd)
+
             # [Bug B fix] LoRA key rename: peft.inject_adapter_in_model wraps
             # q/k/v/o_proj.weight as q/k/v/o_proj.base_layer.weight. The ckpt
             # has original names (*.weight). With strict=False,
@@ -438,7 +463,17 @@ class HunyuanImage3Bundle(Bundle):
         else:
             sd = {}
 
-        # 3. Single DCP load
+        # Expert parallelism: pull the fused expert tensors OUT of the DCP load.
+        # They are EP-sharded DTensors (Shard(0) on the EP mesh); DCP's broadcast
+        # path copies the full [E,...] onto the local [E/ep,...] shard and fails.
+        # load_ep_experts re-shards them with the param's own mesh instead.
+        expert_sd = {}
+        if getattr(self, "_ep_enabled", False):
+            from unirl.train.backend.veomni.ep.models.hi3 import is_fused_expert_key
+
+            expert_sd = {k: sd.pop(k) for k in list(sd) if is_fused_expert_key(k)}
+
+        # 3. Single DCP load (non-expert params: FSDP-sharded + plain heads)
         set_model_state_dict(
             self.transformer,
             sd,
@@ -448,6 +483,38 @@ class HunyuanImage3Bundle(Bundle):
                 strict=False,
             ),
         )
+
+        if getattr(self, "_ep_enabled", False):
+            from unirl.train.backend.veomni.ep import load_ep_experts
+            from unirl.train.backend.veomni.ep.models.hi3 import is_fused_expert_key
+
+            n_exp = load_ep_experts(self.transformer, expert_sd, is_fused_expert_key)
+            if n_exp == 0:
+                raise RuntimeError(
+                    "expert-parallel: load_ep_experts loaded 0 EP-sharded expert params — "
+                    "expert weights would stay meta/uninitialized. Check is_fused_expert_key "
+                    "against the checkpoint keys."
+                )
+            if _current_rank() == 0:
+                logger.info("expert-parallel: loaded %d EP-sharded expert param(s)", n_exp)
+
+            # VeOmni root-shards the non-layer params (wte, ln_f, lm_head) into
+            # DTensors; HI3's ForCausalMM wrapper calls them OUTSIDE the decoder
+            # forward (wte -> inputs_embeds for ViT scatter; ln_f/lm_head -> logits),
+            # hitting `aten.* got mixed Tensor and DTensor`. Hook those three to
+            # all-gather their weights for such direct calls. Pass the whole
+            # transformer so lm_head (on the outer ForCausalMM) is reachable too.
+            from unirl.train.backend.veomni.ep import register_unsharded_param_hooks
+
+            n_hooked = register_unsharded_param_hooks(self.transformer)
+            if n_hooked == 0:
+                raise RuntimeError(
+                    "expert-parallel: register_unsharded_param_hooks hooked 0 root params — "
+                    "wte/ln_f/lm_head would hit mixed Tensor/DTensor at forward. Check the "
+                    "hook targets against the model."
+                )
+            if _current_rank() == 0:
+                logger.info("expert-parallel: hooked root params for direct all-gather: %d", n_hooked)
 
         # [Bug B fix] Post-load validation: verify all LoRA base_layer
         # params are finite and not on meta.

--- a/unirl/models/ltx2/pipeline.py
+++ b/unirl/models/ltx2/pipeline.py
@@ -33,7 +33,7 @@ from .config import (
 from .diffusion import LTX2DiffusionStage, audio_latent_shape
 from .schedule import build_ltx2_schedule_policy
 from .text_embed import LTX2TextEmbedStage
-from .vae import LTX2VAEDecodeStage, LTX2VAEEncodeStage
+from .vae import LTX2AudioDecodeStage, LTX2VAEDecodeStage, LTX2VAEEncodeStage
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +56,14 @@ class LTX2Pipeline(Pipeline):
         vae_decode: LTX2VAEDecodeStage,
         vae_encode: Optional[LTX2VAEEncodeStage],
         config: LTX2PipelineConfig,
+        audio_decode: Optional[LTX2AudioDecodeStage] = None,
     ) -> None:
         self.bundle = bundle
         self.text_embed = text_embed
         self.diffusion = diffusion
         self.vae_decode = vae_decode
         self.vae_encode = vae_encode
+        self.audio_decode = audio_decode
         self.config = config
         # Exposed for the hosting engine (TrainsideRolloutEngine reads
         # ``pipeline.shift`` to build a FlowMatchSchedulePolicy at startup) —
@@ -105,6 +107,9 @@ class LTX2Pipeline(Pipeline):
         )
         vae_decode = LTX2VAEDecodeStage(bundle)
         vae_encode = LTX2VAEEncodeStage(bundle)
+        # Audio decode is only meaningful for LTX-2.3 T2AV (bundle has audio_vae
+        # + vocoder). For T2V it stays None and the audio path is never taken.
+        audio_decode = LTX2AudioDecodeStage(bundle) if bundle.has_audio else None
 
         return cls(
             bundle=bundle,
@@ -113,6 +118,7 @@ class LTX2Pipeline(Pipeline):
             vae_decode=vae_decode,
             vae_encode=vae_encode,
             config=config,
+            audio_decode=audio_decode,
         )
 
     def build_schedule_policy(self):
@@ -311,18 +317,49 @@ class LTX2Pipeline(Pipeline):
         unpacked = self._denormalize_latents(unpacked)
         decoded = self.vae_decode.decode(unpacked)  # → varlen-packed Videos
 
+        # 6b. LTX-2.3 T2AV: decode the jointly-generated audio. The audio latent
+        # trajectory rides on ``segment.aux_latents`` (same sparse indices as
+        # the video latents), so the clean final-step audio is at step T. Decode
+        # it to a waveform and carry it as a parallel ``Audios`` on the track so
+        # the reward service can feed audio scorers (CLAP / ImageBind) alongside
+        # the video. T2V (no audio_decode) skips this entirely.
+        decoded_audio = None
+        audio_sample_rate = None
+        if self.audio_decode is not None and segment.aux_latents is not None:
+            from .diffusion import _LTX2_FRAME_RATE, _audio_num_frames
+
+            audio_t = _audio_num_frames(int(params.num_frames), _LTX2_FRAME_RATE)
+            final_audio = segment.aux_latents_at(int(params.num_inference_steps))
+            waveforms = self.audio_decode.decode(final_audio, audio_latent_length=audio_t)
+            # vocoder output: (B, C, L) or (B, L); package one Audio per sample.
+            from unirl.types.primitives import Audio, Audios
+
+            wf = waveforms.detach().float().cpu()
+            # Store one mono ``[L]`` waveform per sample so ``Audios`` packs
+            # cleanly along its varlen L axis and ``to_list`` recovers ``[L]``.
+            audio_list = []
+            for i in range(int(wf.shape[0])):
+                w = wf[i]
+                if w.ndim == 2:
+                    w = w.mean(dim=0) if w.shape[0] <= w.shape[1] else w.mean(dim=1)
+                audio_list.append(Audio(waveform=w.reshape(-1)))
+            decoded_audio = Audios.from_list(audio_list)
+            audio_sample_rate = int(self.bundle.vocoder.config.output_sampling_rate)
+
         # 7. Build response. ``parent_ids=req.group_ids`` makes sibling samples
         # of one prompt a GRPO group (RolloutTrack.group_ids is a derived
         # read-only property — NOT a constructor arg). ``decoded`` is the single
         # Videos primitive for this track (the reward service reads it directly),
         # not a modality-keyed dict. Track key ``"video"`` matches the WAN21
-        # video convention.
+        # video convention. ``decoded_audio`` (T2AV only) is the parallel audio.
         track = RolloutTrack(
             sample_ids=list(req.sample_ids),
             parent_ids=list(req.group_ids),
             conditions=conditions.to_dict(),
             segment=segment,
             decoded=decoded,
+            decoded_audio=decoded_audio,
+            audio_sample_rate=audio_sample_rate,
         )
 
         return RolloutResp(tracks={"video": track})

--- a/unirl/models/ltx2/vae.py
+++ b/unirl/models/ltx2/vae.py
@@ -92,7 +92,14 @@ class LTX2VAEEncodeStage:
 
 
 class LTX2AudioDecodeStage:
-    """Decode audio latents → waveform via audio VAE + vocoder (LTX-2.3)."""
+    """Decode packed audio latents → waveform via audio VAE + vocoder (LTX-2.3).
+
+    Mirrors diffusers ``LTX2Pipeline`` audio decode (and Flow-Factory's
+    ``decode_latents`` audio branch): the operation order is
+    **denormalize → unpack → audio_vae.decode → vocoder** — note that unlike
+    video, audio is denormalized while still PACKED ``[B, S, D]`` and only then
+    unpacked to the spectrogram layout ``[B, C, L, M]``.
+    """
 
     def __init__(self, bundle: "LTX2Bundle") -> None:
         if bundle.audio_vae is None or bundle.vocoder is None:
@@ -101,20 +108,54 @@ class LTX2AudioDecodeStage:
         self.vocoder = bundle.vocoder
         self.dtype = bundle.dtype
 
+    @staticmethod
+    def _denormalize_audio_latents(
+        latents: torch.Tensor, latents_mean: torch.Tensor, latents_std: torch.Tensor
+    ) -> torch.Tensor:
+        """Inverse of the audio VAE normalization, on the packed ``[B, S, D]``
+        latent (verbatim from diffusers ``_denormalize_audio_latents``)."""
+        latents_mean = latents_mean.to(latents.device, latents.dtype)
+        latents_std = latents_std.to(latents.device, latents.dtype)
+        return latents * latents_std + latents_mean
+
+    @staticmethod
+    def _unpack_audio_latents(latents: torch.Tensor, latent_length: int, num_mel_bins: int) -> torch.Tensor:
+        """Packed ``[B, L, C*M]`` → spectrogram ``[B, C, L, M]`` (verbatim from
+        diffusers ``_unpack_audio_latents``, default no-patch path: implicit
+        ``patch_size = M``, ``patch_size_t = 1``)."""
+        return latents.unflatten(2, (-1, num_mel_bins)).transpose(1, 2)
+
     @torch.no_grad()
-    def decode(self, audio_latents: torch.Tensor) -> torch.Tensor:
-        """Decode audio latents → waveform.
+    def decode(self, audio_latents: torch.Tensor, *, audio_latent_length: int) -> torch.Tensor:
+        """Decode packed audio latents → waveform.
 
         Args:
-            audio_latents: Audio latent tensor from the diffusion stage.
+            audio_latents: Packed audio latents ``[B, S, D]`` (the clean
+                final-step audio from the diffusion stage's ``aux_latents``).
+            audio_latent_length: Number of audio LATENT frames ``L`` (so the
+                unpack can recover ``[B, C, L, M]``).
 
         Returns:
-            Audio waveform tensor.
+            Waveform tensor from the vocoder.
         """
-        # Audio VAE decode → mel spectrogram
-        mel = self.audio_vae.decode(audio_latents.to(self.audio_vae.dtype)).sample
-        # Vocoder → waveform
-        waveform = self.vocoder(mel)
+        # M = latent mel bins = mel_bins // mel_compression_ratio.
+        mel_bins = int(getattr(self.audio_vae.config, "mel_bins", 64))
+        mel_compression = int(getattr(self.audio_vae, "mel_compression_ratio", 4))
+        latent_mel_bins = mel_bins // mel_compression
+
+        # 1. Denormalize FIRST (on the packed latent), then unpack — order
+        #    differs from video (which unpacks first).
+        aud = self._denormalize_audio_latents(
+            audio_latents.float(), self.audio_vae.latents_mean, self.audio_vae.latents_std
+        )
+        # 2. Unpack: [B, L, C*M] -> [B, C, L, M]
+        aud = self._unpack_audio_latents(aud, audio_latent_length, num_mel_bins=latent_mel_bins)
+        # 3. Audio VAE decode -> mel spectrogram (fp32: BigVGAN vocoder uses
+        #    snake activation + Kaiser sinc filters that overflow in bf16).
+        aud = aud.to(torch.float32)
+        mel = self.audio_vae.to(torch.float32).decode(aud, return_dict=False)[0]
+        # 4. Vocoder -> waveform (fp32 for numerical stability)
+        waveform = self.vocoder.to(torch.float32)(mel)
         return waveform
 
 

--- a/unirl/models/wan22/config.py
+++ b/unirl/models/wan22/config.py
@@ -26,7 +26,7 @@ The :class:`WAN21PipelineConfig` schedule fields (``shift``,
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from unirl.models.wan21.config import WAN21PipelineConfig
 
@@ -61,6 +61,20 @@ class WAN22PipelineConfig(WAN21PipelineConfig):
     # subfolder. Defaults to ``None`` → fall back to
     # ``pretrained_model_ckpt_path/transformer_2``.
     transformer_2_pretrained_path: Optional[str] = None
+
+    # Optional LoRA hints for rollout-side engines (sglang in particular).
+    #
+    # Trainer-side LoRA lives in ``cfg.training.policies`` (LoRAPolicy →
+    # PEFT injection on the FSDP-wrapped module). The SGLang rollout server
+    # still needs to know at construction time whether to boot in LoRA mode
+    # and which target modules to wrap — those flags travel through this
+    # model_config. ``None`` / ``False`` are the default (no LoRA). Mirrors
+    # ``SD3PipelineConfig`` so the ``sglang_diffusion`` engine's
+    # ``server_intent`` can read them uniformly across families. Declared here
+    # (not inherited) so WAN 2.2 is self-contained and does not depend on the
+    # WAN 2.1 PR adding the same fields to ``WAN21PipelineConfig``.
+    use_lora: bool = False
+    lora_target_modules: Optional[List[str]] = None
 
 
 __all__ = ["DEFAULT_BOUNDARY_RATIO", "WAN22PipelineConfig"]

--- a/unirl/reward/local/__init__.py
+++ b/unirl/reward/local/__init__.py
@@ -2,16 +2,19 @@
 
 from .aesthetic import AestheticRewardScorer
 from .base import LocalRewardBackend
+from .clap import CLAPRewardScorer
 from .clip import ClipRewardScorer
 from .geneval2 import GenEval2RewardScorer
 from .hpsv2 import HPSv2RewardScorer
 from .hpsv3 import HPSv3RewardScorer
 from .hpsv3pp import HPSv3PPRewardScorer
 from .image_reward import ImageRewardScorer
+from .imagebind import ImageBindRewardScorer
 from .mc_exact_match import MCExactMatchRewardScorer
 from .ocr import OCRRewardScorer
 from .pickscore import PickScoreRewardScorer
 from .registry import available_builtin_reward_models, resolve_builtin_reward_scorer_class
+from .t2av_composite import T2AVCompositeScorer
 from .video import VideoRewardScorer
 from .video_clip_delta import VideoCLIPDeltaScorer
 from .video_pickscore import VideoPickScoreScorer
@@ -20,15 +23,18 @@ from .videoalign import VideoAlignRewardScorer
 __all__ = [
     "AestheticRewardScorer",
     "LocalRewardBackend",
+    "CLAPRewardScorer",
     "ClipRewardScorer",
     "GenEval2RewardScorer",
     "HPSv2RewardScorer",
     "HPSv3RewardScorer",
     "HPSv3PPRewardScorer",
     "ImageRewardScorer",
+    "ImageBindRewardScorer",
     "MCExactMatchRewardScorer",
     "OCRRewardScorer",
     "PickScoreRewardScorer",
+    "T2AVCompositeScorer",
     "VideoCLIPDeltaScorer",
     "VideoAlignRewardScorer",
     "VideoPickScoreScorer",

--- a/unirl/reward/local/clap.py
+++ b/unirl/reward/local/clap.py
@@ -1,0 +1,134 @@
+"""CLAP audio-text alignment reward — LAION CLAP via HuggingFace transformers.
+
+Scores cosine similarity between generated audio and the text prompt. Used for
+LTX-2.3 T2AV where the reward service injects the jointly-generated audio
+waveform into ``request.generated["audio"]`` (a side-channel alongside the
+video in ``request.generated["video"]``). Mirrors Flow-Factory's CLAP reward.
+
+Zero extra dependencies — ``transformers.ClapModel`` is already in the dep tree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import torch
+import torch.nn.functional as F
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.device import resolve_device
+from unirl.types.reward import RewardRequest
+
+from .base import LocalRewardBackend
+
+
+class CLAPRewardScorer(LocalRewardBackend):
+    """Audio-text alignment reward using LAION CLAP.
+
+    ``input_kind = "video"``: the primary decoded media is the video (so the
+    track routes through the video path), and the audio arrives as a parallel
+    side-channel (``request.generated["audio"]`` + ``request.audio_sample_rate``)
+    that the reward service injects when the track has ``decoded_audio``.
+    """
+
+    canonical_model_name = "clap"
+    input_kind = "video"
+    CLAP_SAMPLE_RATE = 48_000
+
+    def __init__(self, *, config: "CLAPSpec", base_device: str) -> None:
+        super().__init__(
+            device=resolve_device(config.device, base_device),
+            batch_size=config.batch_size,
+            model_id=config.model_id,
+        )
+
+    def _load_model(self) -> None:
+        try:
+            from transformers import ClapModel, ClapProcessor
+        except ImportError as e:
+            raise ImportError("transformers with ClapModel/ClapProcessor is required for the CLAP reward") from e
+
+        model_id = self.model_kwargs.get("model_id", "laion/larger_clap_general")
+        # float32 required: CLAP audio encoder uses BatchNorm, which is unstable / unsupported in fp16/bf16.
+        self.model = ClapModel.from_pretrained(model_id).to(self.device).eval()
+        self.model = self.model.to(dtype=torch.float32)
+        self.processor = ClapProcessor.from_pretrained(model_id)
+
+    def _preprocess_audio(self, audio_list: List[torch.Tensor], src_sample_rate: int) -> List["torch.Tensor"]:
+        """Downmix to mono and resample each waveform to CLAP's 48 kHz.
+
+        Accepts per-sample tensors shaped ``[L]``, ``[C, L]``, or ``[L, C]``
+        (the ``Audios`` primitive packs along the leading L axis, so ``to_list``
+        yields ``[L]`` / ``[L, C]``). Returns mono numpy float32 arrays ``[L']``.
+        """
+        import numpy as np
+        import torchaudio.functional as AF
+
+        processed: List[np.ndarray] = []
+        for waveform in audio_list:
+            wf = waveform.detach().float()
+            if wf.isnan().any() or wf.isinf().any():
+                wf = torch.zeros_like(wf)
+            if wf.ndim == 2:
+                # Reduce the channel axis to mono regardless of [C, L] vs [L, C]:
+                # the channel axis is the smaller of the two.
+                ch_axis = 0 if wf.shape[0] <= wf.shape[1] else 1
+                wf = wf.mean(dim=ch_axis)
+            wf = wf.reshape(-1)  # (L,)
+
+            if src_sample_rate != self.CLAP_SAMPLE_RATE:
+                wf = AF.resample(
+                    wf.unsqueeze(0),
+                    orig_freq=int(src_sample_rate),
+                    new_freq=self.CLAP_SAMPLE_RATE,
+                ).squeeze(0)
+
+            processed.append(wf.cpu().numpy())
+        return processed
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        audio = request.audio
+        prompts = request.prompts
+        if audio is None:
+            raise ValueError(
+                "CLAPRewardScorer requires audio in the reward request "
+                "(request.generated['audio']); got none. Ensure the pipeline "
+                "decodes audio into track.decoded_audio for LTX-2.3 T2AV."
+            )
+        if request.audio_sample_rate is None:
+            raise ValueError("CLAPRewardScorer requires request.audio_sample_rate (source Hz); got None.")
+        src_rate = int(request.audio_sample_rate)
+
+        all_rewards: List[float] = []
+        for i in range(0, len(audio), self.batch_size):
+            batch_audio = audio[i : i + self.batch_size]
+            batch_prompts = prompts[i : i + self.batch_size]
+            waveforms_np = self._preprocess_audio(batch_audio, src_rate)
+
+            inputs = self.processor(
+                text=batch_prompts,
+                audios=waveforms_np,
+                sampling_rate=self.CLAP_SAMPLE_RATE,
+                return_tensors="pt",
+                padding=True,
+            )
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+                audio_embeds = F.normalize(outputs.audio_embeds, p=2, dim=-1)
+                text_embeds = F.normalize(outputs.text_embeds, p=2, dim=-1)
+                scores = (audio_embeds * text_embeds).sum(dim=-1)
+            all_rewards.extend(scores.float().cpu().tolist())
+
+        return all_rewards
+
+
+@dataclass
+class CLAPSpec(BaseRewardComponentSpec):
+    """Typed config for the CLAP audio-text reward component."""
+
+    batch_size: int = 8
+    device: str = "auto"
+    model_id: str = "laion/larger_clap_general"

--- a/unirl/reward/local/imagebind.py
+++ b/unirl/reward/local/imagebind.py
@@ -1,0 +1,276 @@
+"""Audio-video / audio-text semantic alignment reward using Meta ImageBind.
+
+Mirrors Flow-Factory's ImageBind reward. Used for LTX-2.3 T2AV where the reward
+service injects the jointly-generated audio into ``request.generated["audio"]``
+alongside the video in ``request.generated["video"]``.
+
+IMPORTANT: ImageBind is licensed under CC-BY-NC-SA 4.0 (NonCommercial). The
+package is NOT a base dependency — it is imported lazily inside ``_load_model``
+so the scorer only pulls it in when a recipe explicitly selects ``imagebind``.
+Install with::
+
+    pip install git+https://github.com/facebookresearch/ImageBind.git
+    pip install git+https://github.com/facebookresearch/pytorchvideo.git
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.device import resolve_device
+from unirl.types.reward import RewardRequest
+
+from .base import LocalRewardBackend
+
+_IMAGEBIND_LICENSE_WARNING = (
+    "ImageBind is licensed under CC-BY-NC-SA 4.0 (NonCommercial). Using it in "
+    "commercial applications may violate the license. "
+    "See https://github.com/facebookresearch/ImageBind/blob/main/LICENSE"
+)
+_IMAGEBIND_INSTALL_MSG = (
+    "ImageBind is not installed. Install with:\n"
+    "  pip install git+https://github.com/facebookresearch/ImageBind.git\n"
+    "  pip install git+https://github.com/facebookresearch/pytorchvideo.git\n"
+    "Note: ImageBind is CC-BY-NC-SA 4.0 (NonCommercial only)."
+)
+
+_IB_AUDIO_SAMPLE_RATE = 16_000
+_IB_AUDIO_NUM_MEL_BINS = 128
+_IB_AUDIO_TARGET_LENGTH = 204
+_IB_AUDIO_CLIP_DURATION = 2
+_IB_AUDIO_CLIPS_PER_SAMPLE = 3
+_IB_AUDIO_MEAN = -4.268
+_IB_AUDIO_STD = 9.138
+
+_IB_VISION_SIZE = 224
+_IB_VISION_MEAN = (0.48145466, 0.4578275, 0.40821073)
+_IB_VISION_STD = (0.26862954, 0.26130258, 0.27577711)
+
+
+class ImageBindRewardScorer(LocalRewardBackend):
+    """Audio-video / audio-text alignment reward using Meta ImageBind.
+
+    Modes (``mode`` on the Spec):
+        - "audio_video" (default): cos_sim(audio, video)
+        - "text_audio":            cos_sim(text, audio)
+        - "text_video":            cos_sim(text, video)
+        - "all":                   weighted sum of all three
+
+    ``input_kind = "video"``: video is the primary decoded media; audio arrives
+    as the parallel side-channel (``request.generated["audio"]``).
+
+    IMPORTANT: ImageBind is CC-BY-NC-SA 4.0 (NonCommercial).
+    """
+
+    canonical_model_name = "imagebind"
+    input_kind = "video"
+    DEFAULT_MODE = "audio_video"
+
+    def __init__(self, *, config: "ImageBindSpec", base_device: str) -> None:
+        self._mode = str(config.mode or self.DEFAULT_MODE)
+        self._weights = dict(config.weights or {"audio_video": 0.5, "text_audio": 0.25, "text_video": 0.25})
+        super().__init__(
+            device=resolve_device(config.device, base_device),
+            batch_size=config.batch_size,
+        )
+
+    def _load_model(self) -> None:
+        warnings.warn(_IMAGEBIND_LICENSE_WARNING, stacklevel=2)
+        try:
+            from imagebind.models import imagebind_model
+        except ImportError as e:
+            raise ImportError(_IMAGEBIND_INSTALL_MSG) from e
+
+        self.model = imagebind_model.imagebind_huge(pretrained=True).to(self.device).eval()
+
+    # ---- audio preprocessing -------------------------------------------------
+
+    def _preprocess_audio_to_melspec(self, audio_list: List[torch.Tensor], src_sample_rate: int) -> torch.Tensor:
+        import torch.nn.functional as Fn
+        import torchaudio.functional as AF
+
+        batch_clips = []
+        samples_per_clip = _IB_AUDIO_CLIP_DURATION * _IB_AUDIO_SAMPLE_RATE
+        for waveform in audio_list:
+            wf = waveform.detach().float()
+            if wf.ndim == 2:
+                ch_axis = 0 if wf.shape[0] <= wf.shape[1] else 1
+                wf = wf.mean(dim=ch_axis)
+            wf = wf.reshape(1, -1)  # (1, T)
+            if src_sample_rate != _IB_AUDIO_SAMPLE_RATE:
+                wf = AF.resample(wf, src_sample_rate, _IB_AUDIO_SAMPLE_RATE)
+
+            duration_s = wf.shape[1] / _IB_AUDIO_SAMPLE_RATE
+            clip_starts = self._compute_clip_starts(duration_s, _IB_AUDIO_CLIP_DURATION, _IB_AUDIO_CLIPS_PER_SAMPLE)
+            mel_clips = []
+            for start_s in clip_starts:
+                start_idx = int(start_s * _IB_AUDIO_SAMPLE_RATE)
+                clip = wf[:, start_idx : start_idx + samples_per_clip]
+                if clip.shape[1] < samples_per_clip:
+                    clip = Fn.pad(clip, (0, samples_per_clip - clip.shape[1]))
+                mel = self._waveform_to_melspec(clip)
+                mel = (mel - _IB_AUDIO_MEAN) / _IB_AUDIO_STD
+                mel_clips.append(mel)
+            batch_clips.append(torch.stack(mel_clips, dim=0))
+        return torch.stack(batch_clips, dim=0).to(self.device)
+
+    @staticmethod
+    def _waveform_to_melspec(waveform: torch.Tensor) -> torch.Tensor:
+        import torch.nn.functional as Fn
+        import torchaudio.compliance.kaldi as kaldi
+
+        waveform = waveform.float()
+        waveform = waveform - waveform.mean()
+        fbank = kaldi.fbank(
+            waveform,
+            htk_compat=True,
+            sample_frequency=_IB_AUDIO_SAMPLE_RATE,
+            use_energy=False,
+            window_type="hanning",
+            num_mel_bins=_IB_AUDIO_NUM_MEL_BINS,
+            dither=0.0,
+            frame_length=25,
+            frame_shift=10,
+        )
+        fbank = fbank.transpose(0, 1)
+        n_frames = fbank.shape[1]
+        if n_frames < _IB_AUDIO_TARGET_LENGTH:
+            fbank = Fn.pad(fbank, (0, _IB_AUDIO_TARGET_LENGTH - n_frames))
+        else:
+            fbank = fbank[:, :_IB_AUDIO_TARGET_LENGTH]
+        return fbank.unsqueeze(0)
+
+    @staticmethod
+    def _compute_clip_starts(duration_s: float, clip_duration: float, num_clips: int) -> List[float]:
+        if duration_s <= clip_duration:
+            return [0.0] * num_clips
+        spacing = (duration_s - clip_duration) / max(num_clips - 1, 1)
+        return [i * spacing for i in range(num_clips)]
+
+    # ---- video preprocessing -------------------------------------------------
+
+    def _preprocess_video(self, video_list: List[torch.Tensor]) -> torch.Tensor:
+        batch_result = []
+        for video in video_list:
+            video_f = video.float() / 255.0 if video.dtype == torch.uint8 else video.float()
+            clips = self._temporal_subsample_clips(video_f, num_clips=5, frames_per_clip=2)
+            all_crops = []
+            for clip in clips:
+                clip = self._resize_short_side(clip, _IB_VISION_SIZE)
+                clip = self._normalize_video_clip(clip)
+                all_crops.extend(self._spatial_crop(clip, _IB_VISION_SIZE))
+            batch_result.append(torch.stack(all_crops, dim=0))
+        return torch.stack(batch_result, dim=0).to(self.device)
+
+    @staticmethod
+    def _temporal_subsample_clips(video: torch.Tensor, num_clips: int, frames_per_clip: int) -> List[torch.Tensor]:
+        T = video.shape[0]
+        clips = []
+        for i in range(num_clips):
+            center = int((i + 0.5) * T / num_clips)
+            indices = torch.linspace(
+                max(0, center - frames_per_clip // 2),
+                min(T - 1, center + frames_per_clip // 2 - 1),
+                frames_per_clip,
+            ).long()
+            clips.append(video[indices].permute(1, 0, 2, 3))
+        return clips
+
+    @staticmethod
+    def _resize_short_side(clip: torch.Tensor, size: int) -> torch.Tensor:
+        C, T, H, W = clip.shape
+        if W <= H:
+            new_w, new_h = size, int(H / W * size)
+        else:
+            new_w, new_h = int(W / H * size), size
+        clip_flat = clip.reshape(C * T, 1, H, W)
+        clip_resized = F.interpolate(clip_flat, size=(new_h, new_w), mode="bilinear", align_corners=False)
+        return clip_resized.reshape(C, T, new_h, new_w)
+
+    @staticmethod
+    def _normalize_video_clip(clip: torch.Tensor) -> torch.Tensor:
+        mean = torch.tensor(_IB_VISION_MEAN, device=clip.device).view(3, 1, 1, 1)
+        std = torch.tensor(_IB_VISION_STD, device=clip.device).view(3, 1, 1, 1)
+        return (clip - mean) / std
+
+    @staticmethod
+    def _spatial_crop(clip: torch.Tensor, crop_size: int) -> List[torch.Tensor]:
+        C, T, H, W = clip.shape
+        crops = []
+        if H > W:
+            offsets = [0, (H - crop_size) // 2, H - crop_size]
+            for y in offsets:
+                crops.append(clip[:, :, y : y + crop_size, :])
+        else:
+            offsets = [0, (W - crop_size) // 2, W - crop_size]
+            for x in offsets:
+                crops.append(clip[:, :, :, x : x + crop_size])
+        return crops
+
+    # ---- scoring -------------------------------------------------------------
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        from imagebind.data import load_and_transform_text
+        from imagebind.models.imagebind_model import ModalityType
+
+        audio = request.audio
+        videos = request.videos
+        prompts = request.prompts
+
+        need_text = self._mode in ("text_audio", "text_video", "all")
+        need_audio = self._mode in ("audio_video", "text_audio", "all")
+        need_video = self._mode in ("audio_video", "text_video", "all")
+
+        if need_audio and audio is None:
+            raise ValueError("ImageBindRewardScorer: mode needs audio but request.generated['audio'] is None.")
+        if need_video and videos is None:
+            raise ValueError("ImageBindRewardScorer: mode needs video but request.generated['video'] is None.")
+
+        src_rate = int(request.audio_sample_rate) if request.audio_sample_rate is not None else _IB_AUDIO_SAMPLE_RATE
+
+        inputs: Dict[str, torch.Tensor] = {}
+        if need_text:
+            inputs[ModalityType.TEXT] = load_and_transform_text(prompts, self.device)
+        if need_audio:
+            inputs[ModalityType.AUDIO] = self._preprocess_audio_to_melspec(audio, src_rate)
+        if need_video:
+            inputs[ModalityType.VISION] = self._preprocess_video(videos)
+
+        with torch.no_grad():
+            embeddings = self.model(inputs)
+        rewards = self._compute_similarity(embeddings, ModalityType)
+        return rewards.float().cpu().tolist()
+
+    def _compute_similarity(self, embeddings: dict, ModalityType) -> torch.Tensor:
+        def cos(a, b):
+            return (F.normalize(a, dim=-1) * F.normalize(b, dim=-1)).sum(dim=-1)
+
+        if self._mode == "audio_video":
+            return cos(embeddings[ModalityType.AUDIO], embeddings[ModalityType.VISION])
+        if self._mode == "text_audio":
+            return cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
+        if self._mode == "text_video":
+            return cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
+        if self._mode == "all":
+            w = self._weights
+            av = cos(embeddings[ModalityType.AUDIO], embeddings[ModalityType.VISION])
+            ta = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
+            tv = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
+            return w["audio_video"] * av + w["text_audio"] * ta + w["text_video"] * tv
+        raise ValueError(f"Unknown ImageBind mode {self._mode!r}; expected audio_video|text_audio|text_video|all.")
+
+
+@dataclass
+class ImageBindSpec(BaseRewardComponentSpec):
+    """Typed config for the ImageBind audio-video reward component (NonCommercial)."""
+
+    batch_size: int = 8
+    device: str = "auto"
+    mode: str = "audio_video"
+    weights: Optional[Dict[str, float]] = field(default=None)

--- a/unirl/reward/local/registry.py
+++ b/unirl/reward/local/registry.py
@@ -30,6 +30,9 @@ _BUILTIN_SCORERS: Dict[str, Tuple[str, str]] = {
     "videoclipdelta": ("unirl.reward.local.video_clip_delta", "VideoCLIPDeltaScorer"),
     "videoalign": ("unirl.reward.local.videoalign", "VideoAlignRewardScorer"),
     "mc_exact_match": ("unirl.reward.local.mc_exact_match", "MCExactMatchRewardScorer"),
+    "clap": ("unirl.reward.local.clap", "CLAPRewardScorer"),
+    "imagebind": ("unirl.reward.local.imagebind", "ImageBindRewardScorer"),
+    "t2av_composite": ("unirl.reward.local.t2av_composite", "T2AVCompositeScorer"),
 }
 
 _BUILTIN_SPECS: Dict[str, Tuple[str, str]] = {
@@ -46,6 +49,9 @@ _BUILTIN_SPECS: Dict[str, Tuple[str, str]] = {
     "videoclipdelta": ("unirl.reward.local.video_clip_delta", "VideoCLIPDeltaSpec"),
     "videoalign": ("unirl.reward.local.videoalign", "VideoAlignSpec"),
     "mc_exact_match": ("unirl.reward.local.mc_exact_match", "MCExactMatchSpec"),
+    "clap": ("unirl.reward.local.clap", "CLAPSpec"),
+    "imagebind": ("unirl.reward.local.imagebind", "ImageBindSpec"),
+    "t2av_composite": ("unirl.reward.local.t2av_composite", "T2AVCompositeSpec"),
 }
 
 

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -1,0 +1,121 @@
+"""T2AV composite reward — weighted blend of video + audio scorers.
+
+For LTX-2.3 text-to-audio-video, a single track carries both the decoded video
+(``request.generated["video"]``) and the jointly-generated audio
+(``request.generated["audio"]``, injected by the reward service from
+``track.decoded_audio``). This composite runs several inner scorers over the
+SAME request and returns their weighted sum, exposing each as a component.
+
+Mirrors ``VideoRewardScorer``'s composite pattern: inner scorers are resolved
+from the built-in registry by name, so any registered scorer (e.g.
+``videopickscore`` for video quality, ``clap`` for audio-text alignment,
+``imagebind`` for audio-video alignment) can be blended.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
+from unirl.types.reward import RewardRequest, RewardResponse
+
+from .registry import resolve_builtin_reward_scorer_class, resolve_builtin_reward_spec_class
+
+
+class T2AVCompositeScorer(RewardBackend):
+    """Weighted blend of inner reward scorers for T2AV (video + audio).
+
+    ``input_kind = "video"``: the track routes through the video path; audio is
+    the parallel side-channel the reward service injects. Each inner scorer
+    reads whichever modality it needs off the shared request.
+    """
+
+    input_kind = "video"
+
+    def __init__(self, *, config: "T2AVCompositeSpec", base_device: str) -> None:
+        super().__init__(model_name="t2av_composite", batch_size=config.batch_size)
+        self.weights: Dict[str, float] = dict(config.weights or {})
+        if not self.weights:
+            raise ValueError("T2AVCompositeScorer requires a non-empty `weights` dict (scorer_name -> weight).")
+
+        self._scorers: Dict[str, RewardBackend] = {}
+        for name in self.weights:
+            inner_cls = resolve_builtin_reward_scorer_class(name)
+            inner_spec_cls = resolve_builtin_reward_spec_class(name)
+            inner_spec = inner_spec_cls()
+            # Propagate batch_size/device to inner specs that accept them.
+            import dataclasses
+
+            overrides = {f: getattr(config, f) for f in ("device", "batch_size") if hasattr(inner_spec, f)}
+            if overrides:
+                inner_spec = dataclasses.replace(inner_spec, **overrides)
+            self._scorers[name] = inner_cls(config=inner_spec, base_device=base_device)
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        start = time.time()
+        bs = request.batch_size
+        try:
+            import torch
+
+            component_rewards: Dict[str, List[float]] = {}
+            total = torch.zeros(bs, dtype=torch.float32)
+            for name, scorer in self._scorers.items():
+                resp = scorer.compute_rewards(request)
+                comp = torch.tensor(list(resp.rewards), dtype=torch.float32)
+                if comp.numel() != bs:
+                    raise RuntimeError(
+                        f"T2AVCompositeScorer: inner scorer {name!r} returned {comp.numel()} rewards "
+                        f"for a batch of {bs}."
+                    )
+                component_rewards[name] = comp.tolist()
+                total = total + float(self.weights[name]) * comp
+
+            return RewardResponse(
+                rewards=total.tolist(),
+                component_rewards=component_rewards,
+                successes=[True] * bs,
+                errors=[None] * bs,
+                compute_time=time.time() - start,
+            )
+        except Exception as e:
+            return RewardResponse(
+                rewards=[0.0] * bs,
+                successes=[False] * bs,
+                errors=[str(e)] * bs,
+                compute_time=time.time() - start,
+            )
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+    def is_available(self) -> bool:
+        return all(s.is_available() for s in self._scorers.values())
+
+    def offload(self) -> None:
+        for s in self._scorers.values():
+            s.offload()
+
+    def onload(self) -> None:
+        for s in self._scorers.values():
+            s.onload()
+
+    def dispose(self) -> None:
+        for s in self._scorers.values():
+            s.dispose()
+
+
+@dataclass
+class T2AVCompositeSpec(BaseRewardComponentSpec):
+    """Typed config for the T2AV composite reward.
+
+    ``weights`` maps inner scorer canonical names (e.g. ``videopickscore``,
+    ``clap``, ``imagebind``) to blend weights. Each named scorer is built from
+    its default Spec with ``device``/``batch_size`` propagated.
+    """
+
+    batch_size: int = 8
+    device: str = "auto"
+    weights: Dict[str, float] = field(default_factory=lambda: {"videopickscore": 0.5, "clap": 0.5})

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -95,9 +95,22 @@ def _build_request_for_track(
         samples_per_prompt=samples_per_prompt,
     )
 
+    # Side-channel: a track may carry a parallel audio stream decoded alongside
+    # the primary media (LTX-2.3 T2AV puts video in ``decoded`` and audio in
+    # ``decoded_audio``). Inject it under ``generated["audio"]`` regardless of
+    # the primary ``reward_input_kind`` so a composite scorer can read both. The
+    # audio source sample rate rides on the track's ``audio_sample_rate``.
+    generated: Dict[str, Any] = {gen_key: decoded}
+    audio_sample_rate: Optional[int] = None
+    if getattr(track, "decoded_audio", None) is not None:
+        generated["audio"] = track.decoded_audio
+        rate = getattr(track, "audio_sample_rate", None)
+        audio_sample_rate = int(rate) if rate is not None else None
+
     return RewardRequest(
         primitives=dict(req_primitives),
-        generated={gen_key: decoded},
+        generated=generated,
+        audio_sample_rate=audio_sample_rate,
         prompt_ids=list(prompt_ids),
         sample_ids=list(sample_ids),
         group_ids=list(group_ids),

--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -48,49 +48,11 @@ class _DiffrlPatchedTarget:
         self._target = target
 
     def __call__(self, *args, **kwargs):
-        # Two independent NCCL hazards in the sglang scheduler subprocess:
-        #
-        # (1) launch_server() deadlock — stale NCCL env vars inherited from the
-        #     Ray worker's train-side FSDP setup (Remote.setup writes them into
-        #     os.environ at remote.py:104). The scheduler subprocess is a fresh
-        #     single-process dist world (num_gpus=1), but it inherits
-        #     NCCL_TOPO_FILE pointing at a parent-process fd (/proc/self/fd/NNN)
-        #     that doesn't exist here → NCCL ``new_group`` →
-        #     ``eager_connect_single_device`` hangs on a dead pipe. The other
-        #     NCCL knobs (SOCKET_IFNAME, BUFFSIZE, ...) are train-mesh-specific
-        #     and have no correct value in this subprocess; let NCCL use
-        #     defaults. gpu_worker.init_device_and_model re-sets MASTER_ADDR/
-        #     MASTER_PORT/WORLD_SIZE/RANK before init_process_group, so those
-        #     are not cleared. This hang is nondeterministic across workers
-        #     (timing of NCCL topo detection), hence only some workers hit it.
-        #
-        # (2) HeartbeatMonitor SIGSEGV — after init_process_group succeeds, the
-        #     NCCL HeartbeatMonitor thread starts and calls glibc ``getenv``
-        #     (via DumpPipe::DumpPipe(int) → getCvarString) on a background
-        #     thread. glibc ``getenv`` is NOT thread-safe: sglang's model-load
-        #     path concurrently calls ``os.environ[k]=v`` (putenv, which may
-        #     realloc the environ array) — e.g. lora_pipeline.py:33 sets
-        #     TOKENIZERS_PARALLELISM at import, gpu_worker.py:126-130 sets
-        #     MASTER_ADDR/MASTER_PORT/... If the windows overlap →
-        #     use-after-free → SIGSEGV in getenv. This is also timing-dependent
-        #     (FlowGRPO 06-24 didn't hit it; NFT 06-25 did). Setting
-        #     TORCH_NCCL_ENABLE_MONITORING=0 (verified against libtorch_cuda.so
-        #     strings) fully disables the monitor thread; the monitor provides
-        #     no value in a single-process (world_size=1) NCCL world.
-        #
-        # NOTE (torch 2.11): ``TORCH_NCCL_ENABLE_MONITORING`` does not exist in
-        # this build (the monitor has no disable flag; only
-        # ``TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC``). The monitor thread therefore
-        # always starts after ``init_process_group``. The remaining race is the
-        # monitor thread's glibc ``getenv`` vs ``os.environ[k]=v`` (``putenv``)
-        # during model load — e.g. ``lora_pipeline.py:33`` sets
-        # ``TOKENIZERS_PARALLELISM`` at *import* time, and the lora module is
-        # imported during model construction (after init_process_group).
-        # Pre-setting ``TOKENIZERS_PARALLELISM`` and pre-importing the lora
-        # pipeline module here (before the scheduler target runs, hence before
-        # ``init_process_group`` starts the monitor) eliminates the concurrent
-        # ``putenv``: by the time the monitor thread calls ``getenv``, no
-        # further ``putenv`` will fire.
+        # SGLang scheduler subprocesses inherit train-side NCCL env vars from
+        # Ray/FSDP. Clear those single-process-incompatible knobs before the
+        # scheduler bootstraps its own NCCL group. Also pre-import the LoRA
+        # pipeline so its TOKENIZERS_PARALLELISM putenv happens before NCCL
+        # background threads can race with later environment writes.
         import os as _os
 
         # PRECONDITION: this scrub assumes the scheduler subprocess hosts a
@@ -116,12 +78,8 @@ class _DiffrlPatchedTarget:
             ):
                 _os.environ.pop(_k, None)
 
-        # Pre-set the env vars that sglang's gpu_worker.py:126-130 and
-        # lora_pipeline.py:33 will (re)set later, so the later ``os.environ[k]=v``
-        # assignments are no-ops on the glibc ``environ`` array only if the value
-        # is unchanged — they still call ``putenv``. The robust guard is to
-        # pre-import lora_pipeline (triggering its module-level ``putenv`` for
-        # TOKENIZERS_PARALLELISM) HERE, before init_process_group.
+        # Pre-import to run lora_pipeline's module-level putenv before NCCL
+        # background threads start.
         _os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
         try:
             import sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline as _lp  # noqa: F401

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
@@ -357,56 +357,26 @@ def _ensure_batched_embed_list(value):
 
 
 def _coalesce_duplicate_single_sample_encodes(value):
-    """Drop duplicate per-output encodes that share a list via ``copy(req)``.
+    """Collapse shallow-copy duplicate prompt encodes.
 
-    ``expand_request_outputs`` builds per-output Reqs with ``copy(req)`` (shallow),
-    so every output Req shares the *same* ``batch.prompt_embeds`` list object. When
-    the text-encoding stage's dedup does NOT collapse the group (e.g. Qwen-Image-
-    Edit-Plus whose condition image is not in the dedup fingerprint, or any
-    single-encoder model whose ``build_dedup_fingerprint`` is per-request unique),
-    each independent encode calls ``batch.prompt_embeds.append(pe)`` on that shared
-    list, accumulating N identical ``(1, seq, hidden)`` tensors — one per output —
-    instead of the correct single ``(1, seq, hidden)`` tensor for this Req's own
-    output. Because the list is shared, every Req ends up holding all N duplicates.
-
-    Downstream ``_merge_conditions`` reads ``len(list)`` as the encoder count, so
-    the N duplicates are misread as N "encoders" and ``fuse_encoder_outputs`` then
-    seq-concatenates them into an oversized sequence that overflows the model's
-    RoPE table (Qwen-Image's 4096-row ``pos_index`` → ``RuntimeError: size of
-    tensor a (4928) must match size of tensor b (4064)`` in the trainside replay).
-
-    The N duplicates are byte-identical encodes of the same prompt+image, so
-    keeping any one of them is correct; ``_merge_conditions`` then batch-concats
-    the per-Req single-sample tensors across the N output Reqs into the proper
-    ``(N, seq, hidden)`` batch.
-
-    The dedup is safe because it only fires when every entry has
-    ``shape[0] == 1`` AND all entries share the exact same shape — a signature
-    unique to the shared-list-accumulation bug. Legitimate multi-encoder models
-    (SD3/FLUX) have per-encoder tensors of *different* shapes (CLIP-L 77×768,
-    CLIP-G 77×1280, T5 256×2048), so they are left untouched. A correctly-batched
-    single-encoder encode is a single ``(B, seq, hidden)`` entry (len 1) — also
-    untouched.
+    Only same-shaped singleton-batch tensors ``[1, seq, hidden]`` are collapsed.
+    Multi-encoder outputs (different shapes), non-tensors, and already-batched
+    tensors are preserved.
     """
     import torch
 
     if not isinstance(value, (list, tuple)) or len(value) <= 1:
         return value
-    tensors = [t for t in value if torch.is_tensor(t)]
-    if len(tensors) != len(value):
-        # Holes (None) present — not the all-tensor duplicate pattern; leave as-is.
+    if not all(torch.is_tensor(t) for t in value):
         return value
-    shapes = {tuple(t.shape) for t in tensors}
-    if len(shapes) != 1:
-        # Differing shapes → genuine multi-encoder; do not dedup.
-        return value
-    first = tensors[0]
-    # Only dedup when dim-0 is the singleton batch axis (the duplicate signature).
+
+    first = value[0]
+    first_shape = tuple(first.shape)
     if first.dim() < 1 or int(first.shape[0]) != 1:
         return value
-    # All entries are identical (1, seq, hidden) encodes of the same prompt+image;
-    # keep one — _merge_conditions batch-concats across output Reqs.
-    return [tensors[0]]
+    if any(tuple(t.shape) != first_shape for t in value[1:]):
+        return value
+    return [first]
 
 
 def _wrap_decoding_stage(DecodingStage) -> None:

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_wan_scheduler.py
@@ -56,3 +56,25 @@ def patch_wan_scheduler() -> None:
 
     initialize_pipeline._unirl_flowmatch_scheduler = True  # type: ignore[attr-defined]
     WanPipeline.initialize_pipeline = initialize_pipeline
+
+    # WAN 2.2-A14B dual-expert: sglang's dual-transformer denoising path wraps the
+    # scheduler/cache so that ``DenoisingStage.prepare_extra_func_kwargs`` inspects a
+    # step with a generic ``**kwargs`` signature. That helper only FILTERS its
+    # {generator, eta, batch} dict when the inspected step has NO var-kwargs, so with
+    # the wrapper it stops filtering and leaks the diffusers-style ``eta`` (= batch.eta)
+    # into the call. The RL-mixin ``step`` has no ``eta`` param — SDE strength comes from
+    # ``batch`` + the driver-pinned σ schedule, not ``eta`` — and raises
+    # "unexpected keyword argument 'eta'". (wan21 single-transformer keeps the explicit
+    # step signature, so eta is filtered and never reaches here.) Drop the stray ``eta``
+    # so the dual-expert path matches wan21 semantics. The wrapper itself takes
+    # ``**kwargs`` and pops only ``eta`` → identical {generator, batch} reaches the real
+    # step for every family; a strict no-op wherever eta was already filtered.
+    step_orig = FlowMatchEulerDiscreteScheduler.step
+    if not getattr(step_orig, "_unirl_drop_eta", False):
+
+        def step(self, *args, **kwargs):
+            kwargs.pop("eta", None)
+            return step_orig(self, *args, **kwargs)
+
+        step._unirl_drop_eta = True  # type: ignore[attr-defined]
+        FlowMatchEulerDiscreteScheduler.step = step

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -118,9 +118,28 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
 
 
 def _apply_fused_param_mapping(module, named_tensors):
-    """Consume separate-projection tensors into their fused params via the model's
-    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    """Apply the model's ``param_names_mapping`` to the incoming named tensors.
+
+    A model's ``param_names_mapping`` (the same dict its checkpoint loader applies)
+    has two entry kinds; a model may use either or both:
+
+    * **fused projections** — ``{regex: (replacement, shard_id, num_shards)}`` —
+      write the trainer's separate-projection tensor into a dim-0 slice of the
+      model's fused param (Z-Image ``to_q/k/v -> to_qkv``, ``w1/w3 -> w13``).
+    * **plain renames** — ``{regex: replacement_str}`` — the model simply renamed
+      a param vs the checkpoint. WAN's mapping is entirely of this kind
+      (``patch_embedding.* -> patch_embedding.proj.*``,
+      ``blocks.N.attn1.to_q.* -> blocks.N.to_q.*``,
+      ``ffn.net.0.proj -> ffn.fc_in``, …). An EMPTY replacement means the model
+      dropped that param (e.g. WAN ``attn2.norm_added_q``) — the tensor is discarded.
+
+    Returns the leftover ``(name, tensor)`` list (renamed where applicable) for the
     exact-match loader. No-op when the module declares no mapping.
+
+    Before this handled the rename kind, simple-rename models (WAN) matched NOTHING
+    in the in-memory update path → 112/113 transformer tensors silently skipped →
+    the rollout engine ran stale base weights → flat reward curve (cross-engine
+    divergence), exactly the fused-model bug one step removed.
     """
     mapping = _resolve_param_names_mapping(module)
     if not mapping:
@@ -128,31 +147,59 @@ def _apply_fused_param_mapping(module, named_tensors):
 
     model_params = dict(module.named_parameters())
     leftover: list = []
-    fused = 0
+    fused = renamed = dropped = 0
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
             continue
         handled = False
         for pat, val in mapping.items():
-            if not isinstance(val, (tuple, list)) or len(val) != 3:
-                continue
             m = re.match(pat, name)
             if m is None:
                 continue
-            replacement, shard_id, num_shards = val
-            target = m.expand(replacement)
-            param = model_params.get(target)
-            if param is None:
-                continue
-            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
-            fused += 1
-            handled = True
-            break
+            if isinstance(val, (tuple, list)) and len(val) == 3:
+                replacement, shard_id, num_shards = val
+                param = model_params.get(m.expand(replacement))
+                if param is None:
+                    continue
+                _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+                fused += 1
+                handled = True
+                break
+            if isinstance(val, str):
+                if val == "":
+                    # model dropped this param — nothing to load.
+                    dropped += 1
+                    handled = True
+                    break
+                target = re.sub(pat, val, name)
+                if target in model_params:
+                    leftover.append((target, tensor))
+                    renamed += 1
+                    handled = True
+                    break
+                # rename produced a non-param name; keep trying other patterns.
         if not handled:
             leftover.append((name, tensor))
-    if fused:
-        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    if fused or renamed or dropped:
+        _log.info(
+            "weight-sync: param_names_mapping applied — %d fused, %d renamed, %d dropped",
+            fused,
+            renamed,
+            dropped,
+        )
+    # A leftover name that is still not a real model param slipped through every
+    # mapping branch (unmatched pattern, or a rename whose target does not exist).
+    # It will silently no-op in the exact-match loader — exactly the stale-weight
+    # failure this mapping is meant to prevent — so surface it loudly instead.
+    unmatched = [n for n, _ in leftover if n not in model_params]
+    if unmatched:
+        _log.warning(
+            "weight-sync: %d tensor(s) matched no model param after param_names_mapping "
+            "(e.g. %s) — likely a mapping gap; these will not update any weight",
+            len(unmatched),
+            unmatched[:5],
+        )
     return leftover
 
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -78,14 +78,24 @@ def _resolve_param_names_mapping(module) -> dict:
 def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int, num_shards: int) -> None:
     """Write ``tensor`` into the ``shard_id``-th slice (dim 0) of a fused param.
 
-    Prefers the param's SGLang ``weight_loader`` when it accepts a shard id (it
-    derives each shard's offset/size from the layer's ``output_sizes`` and is thus
-    TP- and GQA-correct). The manual fallback splits dim 0 into ``num_shards`` EQUAL
-    slices, so it is correct ONLY for equal-sized shards (q==k==v, w1==w3) — which
-    holds for Z-Image base (MHA: ``num_attention_heads == n_kv_heads``) at
-    ``tp_size=1``, the only fused model reaching it here. A future fused GQA model
-    must go through the ``weight_loader`` path (the equal-split fallback would
-    silently corrupt unequal shards).
+    SGLang fused projections pack ``[shard_0 | shard_1 | … | shard_{n-1}]``
+    contiguously along dim 0 in shard-id order. Two layouts occur:
+
+    * **all-equal** — ``q==k==v`` (Z-Image ``to_qkv``), ``w1==w3`` (``w13``): each
+      slice is ``shard_id * size``.
+    * **trailing-unequal** — HunyuanVideo single-block ``linear1 = [q, k, v, mlp]``
+      packs three ``H``-sized attention shards + one ``4H``-sized MLP shard. The
+      leading shards are equal (``shard_id * size``); the LAST shard is larger and
+      sits at the tail (``dim0 - size``).
+
+    Placing the trailing shard at the tail (rather than the legacy ``dim0 //
+    num_shards`` equal split, which slices four ``1.75H`` chunks for ``linear1`` and
+    crashes writing an ``H`` tensor into a ``1.75H`` slot) is exact for both layouts
+    and needs no sibling shards — so it is robust to the sender's bucketing (a
+    block's q/k/v/mlp may arrive in different buckets). It deliberately does NOT
+    support an unequal MIDDLE shard (no SGLang fused param has one). The param's own
+    ``weight_loader`` is tried first when it accepts a shard id (TP-correct); plain
+    ``ReplicatedLinear`` (``tp_size=1``) takes no shard id, so it falls through here.
     """
     wl = getattr(param, "weight_loader", None)
     if wl is not None:
@@ -96,10 +106,15 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
             pass
     data = param.data
     total = int(data.shape[0])
-    if total % num_shards != 0:
-        raise ValueError(f"fused param dim0={total} not divisible by num_shards={num_shards}")
-    s = total // num_shards
-    data[shard_id * s : (shard_id + 1) * s].copy_(tensor.to(param.dtype))
+    size = int(tensor.shape[0])
+    # Leading shards are equal-sized; a (possibly larger) trailing shard sits at the
+    # tail. For all-equal fusions the two formulas coincide (``(n-1)*size == dim0 - size``).
+    offset = total - size if shard_id == num_shards - 1 else shard_id * size
+    if offset < 0 or offset + size > total:
+        raise ValueError(
+            f"fused shard {shard_id}/{num_shards}: size={size} at offset={offset} does not fit fused param dim0={total}"
+        )
+    data[offset : offset + size].copy_(tensor.to(param.dtype))
 
 
 def _apply_fused_param_mapping(module, named_tensors):

--- a/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/__init__.py
@@ -26,6 +26,7 @@ from unirl.rollout.engine.sglang_diffusion.adapters.video import (
     HunyuanVideoAdapter,
     MochiAdapter,
     VideoAdapter,
+    Wan22T2VAdapter,
 )
 from unirl.rollout.engine.sglang_diffusion.adapters.z_image import ZImageAdapter
 
@@ -41,6 +42,7 @@ __all__ = [
     "QwenImageAdapter",
     "VideoAdapter",
     "QwenImageEditPlusAdapter",
+    "Wan22T2VAdapter",
     "MochiAdapter",
     "HunyuanVideoAdapter",
     "ZImageAdapter",

--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -23,7 +23,7 @@ holds; only families with a real video consumer (WAN) move to ``VideoAdapter``.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from unirl.rollout.engine.sglang_diffusion import utils
 from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
@@ -103,4 +103,35 @@ class HunyuanVideoAdapter(ImageAdapter):
     squeeze_single_frame_4d = False
 
 
-__all__ = ["VideoAdapter", "MochiAdapter", "HunyuanVideoAdapter"]
+@register_adapter("wan22")
+class Wan22T2VAdapter(VideoAdapter):
+    """WAN 2.2-A14B T2V — DUAL-EXPERT (high-noise / low-noise) MoE.
+
+    WAN 2.2-A14B runs two ``WanTransformer3DModel`` experts switched at a sigma
+    boundary (``boundary_ratio=0.875``): high-noise for ``sigma >= boundary``
+    (coarse structure, early steps), low-noise for ``sigma < boundary`` (detail).
+    The entire dual-expert mechanism lives ENGINE-SIDE in sglang and needs no
+    adapter work: ``composed_pipeline_base.load_modules`` auto-loads ``transformer_2``
+    when the checkpoint's ``model_index.json`` carries ``boundary_ratio`` + both
+    ``transformer``/``transformer_2`` (the A14B-Diffusers ckpt does), and the generic
+    ``DenoisingStage._select_and_manage_model`` routes per-step by the boundary
+    timestep (and applies ``guidance_scale_2`` to the low-noise branch). So the
+    UniRL side is byte-identical to WAN 2.1 — same UMT5 single-text fuse, same 6-D
+    video trajectory + ``video_pickscore`` consumer, same segment contract (no aux
+    audio). The trainside ``WAN22DiffusionStage`` replays with the SAME boundary
+    routing, so rollout↔replay stays aligned.
+
+    ``build_sampling`` additionally forwards ``guidance_scale_2`` so the engine's
+    low-noise CFG branch matches the trainside; it is omitted (engine falls back to
+    ``guidance_scale``) when unset, so a ``guidance_scale=1.0`` smoke is unaffected.
+    """
+
+    def build_sampling(self, req: RolloutReq, *, diffusion: Any) -> Dict[str, Any]:
+        kwargs = super().build_sampling(req, diffusion=diffusion)
+        g2 = getattr(diffusion, "guidance_scale_2", None)
+        if g2 is not None:
+            kwargs["guidance_scale_2"] = float(g2)
+        return kwargs
+
+
+__all__ = ["VideoAdapter", "MochiAdapter", "HunyuanVideoAdapter", "Wan22T2VAdapter"]

--- a/unirl/rollout/engine/vllm_omni/patches/runtime.py
+++ b/unirl/rollout/engine/vllm_omni/patches/runtime.py
@@ -230,6 +230,69 @@ def patch_ar_lora_loader() -> None:
     setattr(WorkerLoRAManager, "_load_adapter", hijack_ar__load_adapter)
 
 
+def patch_ar_merged_lora_fused_tensor() -> None:
+    """Accept a single fused lora_b [q+k+v, rank] in MergedQKV set_lora.
+
+    HI3 trains LoRA on a fused qkv_proj; vLLM expects a list [lora_b_q, lora_b_k,
+    lora_b_v]. The checkpoint qkv_proj is GQA-interleaved, training loads it as-is,
+    so lora_b rows are interleaved. vLLM base is block [q;k;v] after _split_qkv_weight
+    — we mirror that reshape-split on lora_b. Falls back to plain split if the base
+    layer lacks head_size/total_num_kv_heads.
+    """
+    try:
+        import torch
+        from vllm.lora.layers import column_parallel_linear as _cpl
+    except (ImportError, AttributeError):
+        return
+
+    def _deinterleave_gqa(lora_b, output_sizes, base_layer):
+        if len(output_sizes) != 3:
+            return None
+        head_size = getattr(base_layer, "head_size", None)
+        num_kv_heads = getattr(base_layer, "total_num_kv_heads", None)
+        if head_size is None or num_kv_heads is None:
+            return None
+        q_size, k_size, _v = output_sizes
+        groups = q_size // k_size
+        if groups * k_size != q_size or k_size != num_kv_heads * head_size:
+            return None
+        rank = lora_b.shape[1]
+        try:
+            lora_b_r = lora_b.reshape(num_kv_heads, groups + 2, head_size, rank)
+        except RuntimeError:
+            return None
+        q_b, k_b, v_b = torch.split(lora_b_r, (groups, 1, 1), dim=1)
+        return [q_b.reshape(-1, rank), k_b.reshape(-1, rank), v_b.reshape(-1, rank)]
+
+    def _make(orig):
+        def _set_lora(self, index, lora_a, lora_b, *args, _orig=orig, **kwargs):
+            if isinstance(lora_b, torch.Tensor):
+                output_sizes = list(getattr(self.base_layer, "output_sizes", []) or [])
+                if output_sizes and int(lora_b.shape[0]) == sum(output_sizes):
+                    slices = _deinterleave_gqa(lora_b, output_sizes, self.base_layer)
+                    lora_b = slices if slices is not None else list(torch.split(lora_b, output_sizes, dim=0))
+                    if isinstance(lora_a, torch.Tensor):
+                        lora_a = [lora_a] * self.n_slices
+            return _orig(self, index, lora_a, lora_b, *args, **kwargs)
+
+        _set_lora._diffrl_fused_merged_tolerant = True  # type: ignore[attr-defined]
+        return _set_lora
+
+    # Patch every merged class that defines its own ``set_lora``; subclasses that
+    # only inherit it are covered transitively by the base-class patch.
+    for _name in (
+        "MergedColumnParallelLinearWithLoRA",
+        "MergedQKVParallelLinearWithLoRA",
+    ):
+        cls = getattr(_cpl, _name, None)
+        if cls is None or "set_lora" not in cls.__dict__:
+            continue
+        orig = cls.__dict__["set_lora"]
+        if getattr(orig, "_diffrl_fused_merged_tolerant", False):
+            continue
+        cls.set_lora = _make(orig)
+
+
 def patch_fp32_skip() -> None:
     """Patch ``vllm.lora.utils.from_layer`` to skip non-fp16/bf16 layers.
 
@@ -601,6 +664,7 @@ class VLLMOmniHijack:
 
         patch_dit_lora_loader()
         patch_ar_lora_loader()
+        patch_ar_merged_lora_fused_tensor()
         patch_fp32_skip()
         patch_lora_request_passthrough()
         patch_per_request_ar_seed()

--- a/unirl/train/backend/veomni/backend.py
+++ b/unirl/train/backend/veomni/backend.py
@@ -107,15 +107,48 @@ class VeOmniBackend(BaseFSDP2Backend):
         self._sp_size = int(getattr(fsdp_cfg, "sp_size", 1) or 1)
         if world % self._sp_size != 0:
             raise ValueError(f"VeOmniBackend: world_size {world} not divisible by sp_size {self._sp_size}")
+        # Expert parallelism, folded in as a VeOmni "extra parallel": a SEPARATE
+        # (ep, ep_fsdp) DeviceMesh over the full world, orthogonal to the
+        # dp_shard x ulysses FSDP mesh (so only world % ep_size matters, no dp_size
+        # compensation). ep_size>1 makes the EP branch in parallelize_model_fsdp2
+        # fire and REQUIRE model.get_parallel_plan() (asserted by VeOmni): the
+        # trainable model must name its fused expert tensors (dim-0 = expert axis)
+        # -> Shard(0), like VeOmni's qwen3_moe plan.
+        #
+        # ep_size=1 (the default for every VeOmni-backed model) omits the
+        # extra_parallel_* kwargs entirely, so the call is byte-identical to the
+        # pre-EP path and never depends on the installed veomni accepting them.
+        self._ep_size = int(getattr(fsdp_cfg, "ep_size", 1) or 1)
+        if world % self._ep_size != 0:
+            raise ValueError(f"VeOmniBackend: world_size {world} not divisible by ep_size {self._ep_size}")
+        extra_parallel_kwargs = (
+            {"extra_parallel_sizes": (self._ep_size,), "extra_parallel_names": ("ep",)} if self._ep_size > 1 else {}
+        )
         init_parallel_state(
             dp_size=world // self._sp_size,
             ulysses_size=self._sp_size,
             dp_mode="fsdp2",
             device_type=self._device.type,
+            **extra_parallel_kwargs,
         )
 
         self._bundle = bundle
         model = resolve_trainable_module(bundle, trainable_attr)
+
+        # Expert parallelism is driven solely by ep_size: when >1 the bundle must
+        # make its trainable model EP-ready (e.g. fuse MoE experts + attach
+        # get_parallel_plan) on meta, BEFORE structural injection / veomni_parallelize.
+        # A bundle that doesn't implement the hook can't run with ep_size>1 — fail
+        # fast rather than let VeOmni assert a missing get_parallel_plan deeper in.
+        if self._ep_size > 1:
+            prepare_ep = getattr(bundle, "prepare_for_expert_parallel", None)
+            if not callable(prepare_ep):
+                raise ValueError(
+                    f"VeOmniBackend: ep_size={self._ep_size} requires the bundle to support "
+                    f"expert parallelism via prepare_for_expert_parallel(); "
+                    f"{type(bundle).__name__} does not implement it."
+                )
+            prepare_ep()
 
         # Structural injection on the meta module (the documented
         # unirl.train.deferred contract: mutate on meta, stamp resets).

--- a/unirl/train/backend/veomni/ep/__init__.py
+++ b/unirl/train/backend/veomni/ep/__init__.py
@@ -1,0 +1,15 @@
+"""Expert parallelism (EP) for the VeOmni backend (package).
+
+Public API only. The model-agnostic EP-sharded weight loader lives in
+:mod:`.load`; per-model EP wiring (fused-expert module + checkpoint converter +
+parallel plan + meta-swap) lives in :mod:`.models` (e.g. :mod:`.models.hi3`).
+A meta-init bundle's ``materialize`` calls :func:`load_ep_experts` to fill the
+EP-sharded fused expert params that DCP's ``set_model_state_dict`` cannot.
+"""
+
+from unirl.train.backend.veomni.ep.load import (
+    load_ep_experts,
+    register_unsharded_param_hooks,
+)
+
+__all__ = ["load_ep_experts", "register_unsharded_param_hooks"]

--- a/unirl/train/backend/veomni/ep/load.py
+++ b/unirl/train/backend/veomni/ep/load.py
@@ -1,0 +1,148 @@
+"""EP-sharded expert weight loading for the VeOmni backend.
+
+Why this can't go through DCP: VeOmni shards a fused ``[E,...]`` expert tensor so
+each rank's param dim-0 is ALREADY its local experts (``E/ep`` — the EP split sits
+*outside* the DTensor; the DTensor only carries the ``ep_fsdp`` shard on dim 1).
+``set_model_state_dict``'s broadcast then copies the full ``[E,...]`` straight onto
+the local ``[E/ep,...]`` shard and fails (size ``E`` vs ``E/ep``). So load here:
+broadcast rank-0's full tensor, slice this rank's expert block by ``ep_rank``, and
+re-shard that block with the param's own mesh/placement.
+
+Model-agnostic: any model whose fused expert tensors are EP-sharded loads them the
+same way. The per-model bits — which params are experts, and the per-expert ->
+fused conversion — stay in the model package (:mod:`.models`) and are passed in
+(the ``is_expert_key`` predicate + the already-fused ``expert_state_dict``).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+import torch
+from torch import nn
+
+
+def load_ep_experts(
+    model: nn.Module,
+    expert_state_dict: Dict[str, torch.Tensor],
+    is_expert_key: Callable[[str], bool],
+) -> int:
+    """Load fused expert weights into EP-sharded DTensor params.
+
+    ``expert_state_dict`` is the rank-0 full dict (``{}`` on other ranks);
+    ``is_expert_key`` selects which of ``model``'s params are EP experts (the
+    model package owns the naming). Returns the number of expert params loaded.
+    """
+    import torch.distributed as dist
+    from torch.distributed.tensor import DTensor, distribute_tensor
+    from veomni.distributed.parallel_state import get_parallel_state
+
+    rank0 = (not dist.is_initialized()) or dist.get_rank() == 0
+    ps = get_parallel_state()
+    ep_rank = ps.extra_parallel_rank("ep")  # this rank's index in the EP group
+    ep_size = ps.ep_size
+    n = 0
+    for name, param in model.named_parameters():
+        if not is_expert_key(name):
+            continue
+        if not isinstance(param, DTensor):  # ep_size==1: plain replicated param
+            if rank0:
+                param.data.copy_(expert_state_dict[name].to(device=param.device, dtype=param.dtype))
+            n += 1
+            continue
+        # The param's dim-0 is ALREADY this rank's local experts (E/ep). Send each
+        # ep_rank's [E/ep,...] block separately (one broadcast per EP group) and keep
+        # only the block this rank owns, then re-shard it with the param's own
+        # mesh/placement (handles the dim-1 ep_fsdp shard). Per-block (not full-[E,...])
+        # so every rank's transient stays [E/ep,...] — the EP memory saving must hold
+        # at LOAD time too, else an 80B model OOMs here even when the sharded steady
+        # state fits. Broadcast-only (no scatter) to work on every NCCL build.
+        local_experts = param.shape[0]
+        block_shape = (local_experts, *param.shape[1:])
+        full = expert_state_dict[name].to(device=param.device, dtype=param.dtype) if rank0 else None
+        my_block = None
+        for j in range(ep_size):
+            block = (
+                full[j * local_experts : (j + 1) * local_experts].contiguous()
+                if rank0
+                else torch.empty(block_shape, dtype=param.dtype, device=param.device)
+            )
+            if dist.is_initialized():
+                dist.broadcast(block, src=0)
+            if ep_rank == j:
+                my_block = block
+        sharded = distribute_tensor(my_block, param.device_mesh, param.placements)
+        param.to_local().copy_(sharded.to_local())
+        del full, my_block, sharded
+        n += 1
+    return n
+
+
+def register_unsharded_param_hooks(model: nn.Module) -> Dict[str, int]:
+    """All-gather sharded weights for root modules called OUTSIDE the FSDP forward.
+
+    VeOmni's root ``fully_shard`` turns the model's root-level params — the token
+    embedding (``wte``), the final norm (``ln_f``) and the output head
+    (``lm_head``) — into DTensors. Only the wrapped decoder *layers* get their own
+    FSDP forward hook that all-gathers their params; these root params are not in
+    any layer, so when HI3's ``ForCausalMM`` wrapper calls them directly (build
+    ``inputs_embeds = wte(input_ids)`` for the ViT scatter; ``ln_f``/``lm_head``
+    to read out logits) the weight is still a sharded DTensor while the activation
+    is a plain tensor → ``aten.* got mixed Tensor and DTensor``.
+
+    Register forward pre/post hooks on exactly those three (wte, ln_f, lm_head)
+    that swap the DTensor weight for its full all-gathered tensor for the call's
+    duration (cached once — all three are frozen under LoRA), then restore it. A
+    no-op when the weight is already a plain tensor (so it never double-gathers).
+    Returns a per-kind count of the modules hooked.
+
+    The full and sharded weights are cached OFF the module (in closure dicts keyed
+    by ``id(module)``), not as module attributes: assigning an ``nn.Parameter`` to
+    a module silently registers it, so a ``_full_w`` attribute would leak a full,
+    unsharded duplicate of wte/ln_f/lm_head into ``named_parameters()`` /
+    ``state_dict()`` (polluting checkpoint + weight-sync enumeration). ``m.weight``
+    itself is still swapped (FSDP's forward reads ``self.weight``), but only for
+    the call's duration; the persistent ``_parameters['weight']`` is always the
+    sharded DTensor.
+    """
+    from torch.distributed.tensor import DTensor
+
+    full_cache: Dict[int, nn.Parameter] = {}  # id(module) -> full all-gathered weight
+    sharded_cache: Dict[int, nn.Parameter] = {}  # id(module) -> sharded weight (mid-call only)
+
+    def _pre(m, args):
+        w = m.weight
+        if isinstance(w, DTensor):
+            full = full_cache.get(id(m))
+            if full is None:
+                full = nn.Parameter(w.full_tensor(), requires_grad=False)
+                full_cache[id(m)] = full
+            sharded_cache[id(m)] = w
+            m.weight = full
+
+    def _post(m, args, output):
+        w = sharded_cache.pop(id(m), None)
+        if w is not None:
+            m.weight = w
+
+    counts = {"wte": 0, "ln_f": 0, "lm_head": 0}
+    for name, mod in model.named_modules():
+        w = getattr(mod, "weight", None)
+        if not isinstance(w, DTensor):
+            continue
+        leaf = name.rsplit(".", 1)[-1]
+        if isinstance(mod, nn.Embedding):
+            kind = "wte"
+        elif leaf == "ln_f":  # the model's final RMSNorm (per-layer norms unshard via FSDP)
+            kind = "ln_f"
+        elif leaf == "lm_head":
+            kind = "lm_head"
+        else:
+            continue
+        mod.register_forward_pre_hook(_pre)
+        mod.register_forward_hook(_post)
+        counts[kind] += 1
+    return counts
+
+
+__all__ = ["load_ep_experts", "register_unsharded_param_hooks"]

--- a/unirl/train/backend/veomni/ep/models/__init__.py
+++ b/unirl/train/backend/veomni/ep/models/__init__.py
@@ -1,0 +1,8 @@
+"""Per-model EP wiring for the VeOmni backend.
+
+Each module here adapts one model family's MoE to VeOmni expert parallelism
+(fused-expert module + checkpoint converter + parallel plan + the meta-swap),
+and feeds the generic loader in :mod:`unirl.train.backend.veomni.ep` (which
+shards the fused expert weights model-agnostically). e.g. :mod:`.hi3` for
+HunyuanImage 3.0.
+"""

--- a/unirl/train/backend/veomni/ep/models/hi3.py
+++ b/unirl/train/backend/veomni/ep/models/hi3.py
@@ -1,0 +1,213 @@
+"""HunyuanImage 3.0 expert-parallel (EP) wiring for the VeOmni backend.
+
+HI3 ships its 64 experts as an ``nn.ModuleList`` of per-expert ``HunyuanMLP``
+(``...mlp.experts.{j}.gate_and_up_proj.weight`` / ``...down_proj.weight``).
+VeOmni's EP shards a *fused* expert tensor whose dim-0 is the expert axis via
+``Shard(0)`` — so the per-expert weights are stacked into
+``...mlp.experts.gate_and_up_proj`` ``[E, 2I, H]`` and
+``...mlp.experts.down_proj`` ``[E, H, I]`` (I = moe_intermediate_size).
+
+Pieces (all GPU-verified — see jobs/hi3_ep/):
+
+* :class:`FusedHunyuanMoE` — drop-in replacement for ``HunyuanMoE`` whose expert
+  compute routes through veomni's ``group_gemm_fused_moe_forward`` (Triton
+  grouped GEMM + all_to_all dispatch under EP). Reuses the original router
+  (``gate``) and shared expert (``shared_mlp``) — neither is expert-parallel.
+* :func:`fuse_expert_state_dict` — checkpoint converter (per-expert -> fused),
+  applied at load time.
+* :func:`get_hi3_parallel_plan` — the ``ParallelPlan`` naming the fused tensors
+  with ``Shard(0)``; ``VeOmniBackend`` asserts ``get_parallel_plan()`` exists
+  when ``ep_size > 1``.
+
+The HALF-SWAP (critical, verified): HI3 computes ``x1 * silu(x2)`` (silu on the
+SECOND half of gate_and_up); veomni's merged-fc1 computes ``silu(first)*second``
+(silu on the FIRST half). So gate_and_up's two halves are swapped when producing
+the fused weight — without it, outputs diverge (~0.22 rel). down_proj is unchanged.
+
+The generic EP-sharded weight load lives in :func:`unirl.train.backend.veomni.ep.load_ep_experts`;
+this module supplies the HI3 expert-key predicate (:func:`is_fused_expert_key`)
+and the per-expert -> fused converter it consumes.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Optional
+
+import torch
+from torch import nn
+
+# Per-expert weight key: <prefix>.experts.{idx}.{gate_and_up_proj|down_proj}.weight
+_EXPERT_RE = re.compile(r"^(?P<prefix>.*\.experts)\.(?P<idx>\d+)\.(?P<proj>gate_and_up_proj|down_proj)\.weight$")
+
+# FQN globs relative to the module VeOmniBackend wraps (the bare decoder,
+# transformer.model) -> ``layers.*`` (NOT ``model.layers.*``).
+_EP_PLAN = {
+    "layers.*.mlp.experts.gate_and_up_proj": 0,
+    "layers.*.mlp.experts.down_proj": 0,
+}
+
+
+def _swap_gate_up_halves(gate_and_up: torch.Tensor) -> torch.Tensor:
+    """Swap the two output halves of a fused gate_and_up tensor ``[..., 2I, H]``.
+
+    HI3 (silu on 2nd half) -> veomni merged-fc1 (silu on 1st half). Verified
+    necessary: jobs/hi3_ep/stage2a_level2_kernel.py.
+    """
+    half = gate_and_up.shape[-2] // 2
+    return torch.cat([gate_and_up[..., half:, :], gate_and_up[..., :half, :]], dim=-2)
+
+
+def fuse_expert_state_dict(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """Stack per-expert weights into fused ``[E, ...]`` tensors (load-time converter).
+
+    ``<prefix>.experts.{j}.{proj}.weight`` -> ``<prefix>.experts.{proj}`` of shape
+    ``[E, *weight.shape]`` (experts stacked in index order). ``gate_and_up_proj`` is
+    additionally half-swapped to veomni's silu-first convention; ``down_proj`` keeps
+    its layout. Non-expert keys (router, shared_mlp, attention, norms) pass through.
+    """
+    groups: Dict[tuple, Dict[int, torch.Tensor]] = {}
+    out: Dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        m = _EXPERT_RE.match(key)
+        if m is None:
+            out[key] = value
+            continue
+        groups.setdefault((m["prefix"], m["proj"]), {})[int(m["idx"])] = value
+
+    for (prefix, proj), per_idx in groups.items():
+        indices = sorted(per_idx)
+        if indices != list(range(len(indices))):
+            raise ValueError(
+                f"fuse_expert_state_dict: non-contiguous experts for {prefix}.{proj}: "
+                f"got {indices[:8]}{'...' if len(indices) > 8 else ''}"
+            )
+        stacked = torch.stack([per_idx[j] for j in indices], dim=0)  # [E, *wshape]
+        if proj == "gate_and_up_proj":
+            stacked = _swap_gate_up_halves(stacked).contiguous()
+        out[f"{prefix}.{proj}"] = stacked
+    return out
+
+
+def get_hi3_parallel_plan():
+    """Return the VeOmni ``ParallelPlan`` for HI3 expert parallelism (Shard(0))."""
+    from torch.distributed._tensor import Shard
+    from veomni.distributed.parallel_plan import ParallelPlan
+
+    ep_plan = {fqn: Shard(dim) for fqn, dim in _EP_PLAN.items()}
+    return ParallelPlan(extra_parallel_plan={"ep": ep_plan})
+
+
+class FusedExperts(nn.Module):
+    """Holds the fused expert weights so their FQN is ``experts.gate_and_up_proj``
+    / ``experts.down_proj`` (what :data:`_EP_PLAN` + the converter target)."""
+
+    def __init__(self, num_experts: int, hidden: int, inter: int, dtype, device):
+        super().__init__()
+        self.gate_and_up_proj = nn.Parameter(torch.empty(num_experts, 2 * inter, hidden, dtype=dtype, device=device))
+        self.down_proj = nn.Parameter(torch.empty(num_experts, hidden, inter, dtype=dtype, device=device))
+
+
+class FusedHunyuanMoE(nn.Module):
+    """EP drop-in for HI3's ``HunyuanMoE``: fused experts via veomni grouped GEMM
+    + all_to_all; original router + shared expert reused verbatim.
+
+    Routing matches HI3's training path (dropless ``easy_topk``). Requires
+    ``veomni.distributed.parallel_state`` initialized (ep_size>=1) — the backend
+    does this before wrapping.
+    """
+
+    def __init__(
+        self,
+        gate: nn.Module,
+        shared_mlp: Optional[nn.Module],
+        num_experts: int,
+        hidden: int,
+        inter: int,
+        dtype,
+        device,
+    ):
+        super().__init__()
+        self.gate = gate
+        self.shared_mlp = shared_mlp
+        self.num_experts = num_experts
+        self.experts = FusedExperts(num_experts, hidden, inter, dtype, device)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        from torch.distributed.tensor import DTensor
+        from veomni.ops.kernels.moe.group_gemm import group_gemm_fused_moe_forward
+
+        bsz, seq, hidden = hidden_states.shape
+        shared = self.shared_mlp(hidden_states) if self.shared_mlp is not None else None
+        topk_weights, topk_idx = self.gate(hidden_states, topk_impl="easy")
+        topk_weights = topk_weights.to(hidden_states.dtype)
+        # The EP-sharded expert params are DTensors (each rank's local experts).
+        # The Triton grouped-GEMM kernel needs raw local tensors, not DTensors.
+        gate_up = self.experts.gate_and_up_proj
+        down = self.experts.down_proj
+        if isinstance(gate_up, DTensor):
+            gate_up = gate_up.to_local()
+        if isinstance(down, DTensor):
+            down = down.to_local()
+        y = group_gemm_fused_moe_forward(
+            num_experts=self.num_experts,
+            routing_weights=topk_weights,
+            selected_experts=topk_idx,
+            hidden_states=hidden_states.reshape(-1, hidden).contiguous(),
+            fc1_1_weight=None,
+            fc1_2_weight=None,
+            fc2_weight=down,
+            fc1_1_2_weight=gate_up,
+        ).view(bsz, seq, hidden)
+        return y + shared if shared is not None else y
+
+
+def is_fused_expert_key(key: str) -> bool:
+    """A fused-expert param key (``*.experts.gate_and_up_proj`` / ``.down_proj``).
+
+    HI3-specific naming; passed to the generic
+    ``unirl.train.backend.veomni.ep.load_ep_experts`` as its expert selector.
+    """
+    return key.endswith((".experts.gate_and_up_proj", ".experts.down_proj"))
+
+
+def replace_hunyuan_moe_with_fused(decoder: nn.Module) -> int:
+    """In-place: swap every ``HunyuanMoE`` ``mlp`` in ``decoder.layers`` for a
+    :class:`FusedHunyuanMoE`, and attach ``get_parallel_plan`` to ``decoder``.
+
+    Meta-safe — builds the fused module from the original's dims/dtype/device
+    (read off ``experts[0]`` without materializing), adopting the original
+    ``gate`` / ``shared_mlp`` submodules so their checkpoint keys are unchanged.
+    Run on the meta model BEFORE ``veomni_parallelize`` so the fused expert
+    params (not the per-expert ModuleList) are what FSDP/EP shards. Returns the
+    number of layers swapped.
+    """
+    n = 0
+    for layer in getattr(decoder, "layers", []):
+        mlp = getattr(layer, "mlp", None)
+        if type(mlp).__name__ != "HunyuanMoE":
+            continue
+        w = mlp.experts[0].gate_and_up_proj.weight  # [2I, H]
+        two_i, hidden = w.shape
+        layer.mlp = FusedHunyuanMoE(
+            gate=mlp.gate,
+            shared_mlp=getattr(mlp, "shared_mlp", None),
+            num_experts=mlp.num_experts,
+            hidden=hidden,
+            inter=two_i // 2,
+            dtype=w.dtype,
+            device=w.device,
+        )
+        n += 1
+    decoder.get_parallel_plan = get_hi3_parallel_plan  # type: ignore[attr-defined]
+    return n
+
+
+__all__ = [
+    "fuse_expert_state_dict",
+    "get_hi3_parallel_plan",
+    "FusedHunyuanMoE",
+    "FusedExperts",
+    "replace_hunyuan_moe_with_fused",
+    "is_fused_expert_key",
+]

--- a/unirl/train/backend/veomni/wrap.py
+++ b/unirl/train/backend/veomni/wrap.py
@@ -98,6 +98,13 @@ def veomni_parallelize(
 
     block_instances = _enumerate_block_instances(model, block_class_names)
 
+    if activation_checkpointing and not block_instances:
+        raise RuntimeError(
+            "veomni_parallelize: activation_checkpointing=True but no blocks of class "
+            f"{tuple(block_class_names)!r} matched — AC would silently be a no-op and "
+            "training would OOM. Check block_class_names against the model."
+        )
+
     if activation_checkpointing:
         from torch.utils import checkpoint as _ckpt
 
@@ -136,7 +143,10 @@ def _enumerate_block_instances(
     if not class_names:
         return ()
     names = set(class_names)
-    return tuple(m for _, m in model.named_modules() if type(m).__name__ in names)
+    # ``parallelize_model_fsdp2`` (run before this) ``fully_shard``s each block,
+    # which renames its class to ``FSDP<OriginalName>``; strip that prefix before
+    # matching (a no-op when absent) so AC actually finds the post-shard blocks.
+    return tuple(m for _, m in model.named_modules() if type(m).__name__.removeprefix("FSDP") in names)
 
 
 def _current_rank() -> int:

--- a/unirl/train/configs.py
+++ b/unirl/train/configs.py
@@ -98,6 +98,9 @@ class FSDPConfig:
     # Must divide the world size and the model's attention head count. Only the
     # VeOmni backend honors it; FSDPBackend ignores it.
     sp_size: int = 1
+    # Expert-parallel degree (default 1 = disabled); when >1 the VeOmni backend shards fused
+    # experts over a separate mesh and requires the model to expose get_parallel_plan(). VeOmni only.
+    ep_size: int = 1
 
 
 __all__ = [

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -87,3 +87,38 @@ optimizer or LR schedule is a branch in `factories.py` plus fields on
   skips backward (an all-empty micro) while earlier ones ran, `TrainStack.train`
   raises instead of silently stepping on never-synced grads (which would also
   leak the stale accumulation into the next step's reduce-scatter).
+
+## Profiling → Perfetto
+
+Opt-in `torch.profiler` (`unirl/utils/profiling.py`): one env var writes a gzipped Perfetto
+trace to `outputs/profiler/` on rank 0 (no-op otherwise). Training compute only (not rollout).
+
+Both capture **one snapshot of a single train step** (after a short warmup, then off — one
+trace, not one per step; training keeps running). They differ in *which slice* they record:
+
+- **`one-update`** — one optimizer update (forward + backward + optimizer) with its cross-GPU
+  comm. Skips the anchor forward; small; **for compute/comm overlap**.
+- **`train`** — the whole step: anchor forward (recompute old-policy log-probs; for diffusion
+  it replays the denoising trajectory, so it's large) + all updates. **For step-time breakdown.**
+
+> The unified-model stack (HI3, AR+image) only supports `train` — it fuses each step into a
+> single update, so there is no per-update boundary for `one-update` to wrap (a warning is
+> logged and no trace is produced).
+
+```bash
+UNIRL_PROFILE=one-update  python -m unirl.train_diffusion --config-name=<recipe> ...
+UNIRL_PROFILE=train       python -m unirl.train_diffusion --config-name=<recipe> ...
+```
+
+Download the `.gz` to your local machine, then <https://ui.perfetto.dev/> → *Open trace file*.
+
+### Configurable env vars (defaults are fine)
+
+| var | what it does | default |
+|-----|--------------|---------|
+| `UNIRL_PROFILE` | `one-update` / `train` (unset = off) | off |
+| `UNIRL_PROFILE_DIR` | where the trace is written (auto-created) | `outputs/profiler` |
+| `UNIRL_PROFILE_RANKS` | which ranks profile: `0`, `all`, or a list like `0,8` | `0` |
+| `UNIRL_PROFILE_CUDA` | record GPU kernels; `0` = CPU-only trace | `1` |
+| `UNIRL_PROFILE_WARMUP` | skip the first few iterations before recording (avoids the one-time first-iter compile / alloc) — one-update: skip N updates; train: schedule warmup | `2` / `1` |
+| `UNIRL_PROFILE_MEMORY` | also record CUDA memory alloc/free (memory-over-time; bigger trace) | off |

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -41,6 +41,7 @@ update shares the same PPO anchor; this is only correct for algorithms with
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Dict, List, Mapping, Optional, Tuple
 
@@ -345,10 +346,28 @@ class TrainStack(Remote):
             num_updates=self.num_updates_per_batch,
             micro_batch_size=self.micro_batch_size,
         )
-        self.prepare_segment(resp_track, plans=plans)
-        result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
+        # Opt-in profiler (UNIRL_PROFILE=train profiles this whole step; one-update is
+        # handled in _run_updates). See unirl/train/readme.md.
+        from unirl.utils.profiling import profile_scope
+
+        profiler = self._train_step_profiler() if profile_scope() == "train" else None
+        with profiler.record("train_track") if profiler is not None else nullcontext():
+            self.prepare_segment(resp_track, plans=plans)
+            result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
+        if profiler is not None:
+            profiler.step()
         self.on_rollout_end()
         return result
+
+    def _train_step_profiler(self):
+        """Lazily build the per-worker train-step profiler (None unless UNIRL_PROFILE)."""
+        cached = getattr(self, "_profiler_cache", "unset")
+        if cached == "unset":
+            from unirl.utils.profiling import maybe_build_train_profiler
+
+            cached = maybe_build_train_profiler(int(getattr(self.fsdp_backend, "_rank", 0)))
+            self._profiler_cache = cached
+        return cached
 
     def _run_updates(
         self,
@@ -369,7 +388,21 @@ class TrainStack(Remote):
         each update's own metrics are attached on ``per_update`` (see
         :func:`_aggregate_update_results`).
         """
-        results = [self._run_update(resp_track, micros=micros, training_progress=training_progress) for micros in plans]
+        # UNIRL_PROFILE=one-update: wrap each optimizer update in a one-shot profiler
+        # (fires once, on rank0, past warmup) so the trace captures ONLY one update
+        # (forward + backward + cross-GPU comm + optimizer) — the compute/comm overlap window.
+        from unirl.utils.profiling import maybe_profile_update, profile_scope
+
+        scope_update = profile_scope() == "one-update"
+        results = []
+        for micros in plans:
+            cm = (
+                maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0)))
+                if scope_update
+                else nullcontext()
+            )
+            with cm:
+                results.append(self._run_update(resp_track, micros=micros, training_progress=training_progress))
         if len(results) == 1:
             return results[0]
         aggregated = _aggregate_update_results(results)

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -34,6 +34,7 @@ optimizer step, in contrast to the single-stage ``TrainStack``.
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from dataclasses import replace
 from typing import Dict, List, Mapping, Tuple
 
@@ -272,6 +273,16 @@ class UnifiedModelTrainStack(Remote):
         """Per-rollout-boundary hook — delegates to the FSDPBackend's EMA."""
         self.fsdp_backend.on_rollout_end()
 
+    def _train_step_profiler(self):
+        """Lazily build the per-worker train-step profiler (None unless UNIRL_PROFILE)."""
+        cached = getattr(self, "_profiler_cache", "unset")
+        if cached == "unset":
+            from unirl.utils.profiling import maybe_build_train_profiler
+
+            cached = maybe_build_train_profiler(int(getattr(self.fsdp_backend, "_rank", 0)))
+            self._profiler_cache = cached
+        return cached
+
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
     def train_track(
         self,
@@ -302,18 +313,37 @@ class UnifiedModelTrainStack(Remote):
         ar_track = ar_track.to_device(device)
         image_track = image_track.to_device(device)
 
-        tracks = {"ar": ar_track, "image": image_track}
-        # Freeze each track's π_old anchor once, before the multi-update loop.
-        for name in self.algorithms:
-            self.prepare_segment(name, tracks[name])
+        # Only UNIRL_PROFILE=train applies here (one-update lives in TrainStack._run_updates);
+        # warn if one-update was set so it isn't silently ignored.
+        from unirl.utils.profiling import profile_scope
 
-        # N optimizer steps over disjoint mini-batches (each track sliced by the same
-        # shared _optimizer_step_slices; M=1 keeps ar/image 1:1 and equally sized).
-        steps_by_track = {name: self._optimizer_step_slices(int(tracks[name].batch_size)) for name in self.algorithms}
-        per_update: List[Dict[str, TrainStepResult]] = []
-        for u in range(self.num_updates_per_batch):
-            slices_by_track = {name: steps_by_track[name][u] for name in self.algorithms}
-            per_update.append(self._train_one_step(tracks, slices_by_track, training_progress=float(training_progress)))
+        scope = profile_scope()
+        if scope == "one-update" and not getattr(self, "_warned_one_update", False):
+            self._warned_one_update = True
+            logger.warning(
+                "UNIRL_PROFILE=one-update is not supported on the unified-model stack "
+                "(no _run_updates loop); use UNIRL_PROFILE=train. No trace produced."
+            )
+        profiler = self._train_step_profiler() if scope == "train" else None
+        with profiler.record("train_track") if profiler is not None else nullcontext():
+            tracks = {"ar": ar_track, "image": image_track}
+            # Freeze each track's π_old anchor once, before the multi-update loop.
+            for name in self.algorithms:
+                self.prepare_segment(name, tracks[name])
+
+            # N optimizer steps over disjoint mini-batches (each track sliced by the same
+            # shared _optimizer_step_slices; M=1 keeps ar/image 1:1 and equally sized).
+            steps_by_track = {
+                name: self._optimizer_step_slices(int(tracks[name].batch_size)) for name in self.algorithms
+            }
+            per_update: List[Dict[str, TrainStepResult]] = []
+            for u in range(self.num_updates_per_batch):
+                slices_by_track = {name: steps_by_track[name][u] for name in self.algorithms}
+                per_update.append(
+                    self._train_one_step(tracks, slices_by_track, training_progress=float(training_progress))
+                )
+        if profiler is not None:
+            profiler.step()
 
         self.on_rollout_end()
 

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -445,6 +445,10 @@ class DiffusionTrainer(BaseTrainer):
             # Hydrate in place so the wandb reward/advantage stats reuse this
             # fetch instead of re-pulling the TensorRef from the worker.
             track.rewards = hydrate(track.rewards)
+            # component_rewards values are also TensorRef after DP_SCATTER;
+            # hydrate them so wandb_metrics can read real tensors.
+            if isinstance(track.component_rewards, dict):
+                track.component_rewards = {k: hydrate(v) for k, v in track.component_rewards.items()}
             mean_reward = float(track.rewards.to(torch.float32).mean().item())
             break  # single-track for now; revisit if multi-track lands
 

--- a/unirl/types/media_preview.py
+++ b/unirl/types/media_preview.py
@@ -55,6 +55,13 @@ class MediaPreview(Batch):
 
     images: List[Any] = concat_field(default_factory=list)
     videos: List[Any] = concat_field(default_factory=list)
+    # Per-sample audio waveforms (mono [L] float32 CPU tensors) for muxing into
+    # the mp4 upload. Parallel to ``videos`` — same length. ``None``/empty for
+    # non-audio tracks.
+    audios: List[Any] = concat_field(default_factory=list)
+    # Source sample rate of the waveforms in ``audios``. Batch-shared (one rate
+    # per preview). None when audios is empty.
+    audio_sample_rate: Optional[int] = None
     prompts: List[str] = concat_field(default_factory=list)
     rewards: List[float] = concat_field(default_factory=list)
 
@@ -63,6 +70,7 @@ class MediaPreview(Batch):
         for name, val in (
             ("images", self.images),
             ("videos", self.videos),
+            ("audios", self.audios),
             ("prompts", self.prompts),
             ("rewards", self.rewards),
         ):
@@ -227,11 +235,33 @@ def build_media_preview_for_track(
     if not selected_indices:
         return None
 
+    # T2AV: extract per-sample audio waveforms for muxing into the mp4 upload.
+    audios_out: List[Any] = []
+    audio_sr: Optional[int] = None
+    decoded_audio = getattr(track, "decoded_audio", None)
+    if decoded_audio is not None and hasattr(decoded_audio, "to_list"):
+        from unirl.distributed.tensor import hydrate, map_tree
+
+        decoded_audio = map_tree(decoded_audio, hydrate)
+        audio_list = decoded_audio.to_list()
+        for idx in selected_indices:
+            if idx < len(audio_list):
+                audios_out.append(audio_list[idx].waveform.detach().cpu().float())
+            else:
+                audios_out.append(None)
+        audio_sr = getattr(track, "audio_sample_rate", None)
+        # Drop audio if none of the selected samples have it
+        if all(a is None for a in audios_out):
+            audios_out = []
+            audio_sr = None
+
     prompts_out = [str(prompt_texts[i]) if i < len(prompt_texts) else "" for i in selected_indices]
     reward_values = [float(rewards_flat[i]) if i < len(rewards_flat) else 0.0 for i in selected_indices]
     return MediaPreview(
         images=images,
         videos=videos,
+        audios=audios_out,
+        audio_sample_rate=int(audio_sr) if audio_sr is not None else None,
         prompts=prompts_out,
         rewards=reward_values,
     )

--- a/unirl/types/reward.py
+++ b/unirl/types/reward.py
@@ -47,6 +47,11 @@ class RewardRequest:
     group_ids: Optional[List[str]] = None
     reward_types: List[RewardType] = field(default_factory=lambda: [RewardType.IMAGE_TEXT_ALIGNMENT])
     return_components: bool = False
+    # Source sample rate (Hz) of any waveforms in ``generated["audio"]``. Set by
+    # the reward service when a track carries a parallel audio stream (LTX-2.3
+    # T2AV). ``None`` for non-audio requests. Audio reward scorers (CLAP /
+    # ImageBind) read it to resample to their model's expected rate.
+    audio_sample_rate: Optional[int] = None
 
     @property
     def prompts(self) -> List[str]:
@@ -79,6 +84,19 @@ class RewardRequest:
         return list(prim.texts)
 
     @property
+    def audio(self) -> Optional[List[torch.Tensor]]:
+        """Generated audio waveforms, one ``[C, L]`` (or ``[L]``) tensor per sample.
+
+        Populated when a track carries a parallel audio stream (LTX-2.3 T2AV);
+        the reward service places the decoded ``Audios`` under
+        ``generated["audio"]``. ``None`` for non-audio requests.
+        """
+        prim = self.generated.get("audio")
+        if prim is None:
+            return None
+        return [a.waveform for a in prim.to_list()]
+
+    @property
     def batch_size(self) -> int:
         for v in self.generated.values():
             if v is not None:
@@ -91,6 +109,10 @@ class RewardRequest:
     @property
     def is_video(self) -> bool:
         return "video" in self.generated
+
+    @property
+    def has_audio(self) -> bool:
+        return "audio" in self.generated
 
 
 @dataclass

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -100,6 +100,17 @@ class RolloutTrack(Batch):
     conditions: Dict[str, Condition] = field(kind=FieldKind.CONCAT, default_factory=dict)
     segment: Optional[Segment] = field(kind=FieldKind.CONCAT, default=None)
     decoded: Optional[Decoded] = field(kind=FieldKind.CONCAT, default=None)
+    # Parallel secondary media decoded alongside ``decoded`` for the SAME samples
+    # (not a separate track — keeps GRPO grouping / advantage alignment intact).
+    # First consumer: LTX-2.3 T2AV, where ``decoded`` holds the video and
+    # ``decoded_audio`` the jointly-generated audio waveform. The reward service
+    # injects it into the reward request as a side-channel so a composite scorer
+    # can read video + audio together. ``None`` for every single-modality track.
+    decoded_audio: Optional[Audios] = field(kind=FieldKind.CONCAT, default=None)
+    # Source sample rate (Hz) of ``decoded_audio`` waveforms (e.g. the LTX-2
+    # vocoder's output rate). Batch-shared metadata — one rate per track. The
+    # reward service forwards it to audio scorers via RewardRequest.audio_sample_rate.
+    audio_sample_rate: Optional[int] = shared_field(default=None)
     media_preview: Optional[MediaPreview] = concat_field(default=None)
 
     rewards: Optional[torch.Tensor] = concat_field(default=None)
@@ -127,6 +138,7 @@ class RolloutTrack(Batch):
         light.conditions = {}
         light.segment = None
         light.decoded = None
+        light.decoded_audio = None
         return light
 
     @property

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -1,0 +1,301 @@
+"""Opt-in torch.profiler harness for the worker-side training step.
+
+UniRL is an RL framework (rollout → reward → advantage → optimizer step). To
+profile *only* the training compute (forward / loss / backward / optimizer) of a
+backend — without the SGLang/vLLM rollout — wrap the per-rollout train call on
+the worker with :class:`TrainStepProfiler`. The rollout runs in a separate engine
+phase, so the profiled region here is the pure train step.
+
+Entirely env-gated; a no-op unless ``UNIRL_PROFILE`` is set, so it can ship in the
+hot path. ONE switch, whose value names the region recorded:
+
+* ``UNIRL_PROFILE=one-update`` — profile ONE optimizer update (forward + backward +
+  cross-GPU comm + optimizer), excluding the big anchor/SDE-replay forward. Small trace; for
+  compute/comm OVERLAP. Exports ``update_rank0.pt.trace.json.gz`` (opens directly in Perfetto).
+* ``UNIRL_PROFILE=train`` — profile the WHOLE train step (anchor forward + all N
+  updates). Big trace; the complete picture of one training step.
+
+Optional knobs (sensible defaults; override any one):
+
+* ``UNIRL_PROFILE_DIR``     — trace output dir (default ``outputs/profiler``, auto-created).
+* ``UNIRL_PROFILE_RANKS``   — ``0`` (default), ``all``, or a comma list ``0,8``.
+* ``UNIRL_PROFILE_CUDA``    — record CUDA kernels (default ``1``; ``0`` = CPU-only trace).
+* ``UNIRL_PROFILE_WARMUP``  — one-update: skip N updates before capturing (default ``2``);
+                              train: schedule warmup steps (default ``1``).
+* ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — train schedule (default ``1``/``1``/``1``
+                              = capture exactly ONE full step).
+* ``UNIRL_PROFILE_MEMORY``  — also record CUDA memory alloc/free (default off; bigger trace).
+
+Both modes export a gzipped Chrome/Perfetto trace, one file per profiled rank.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _truthy(value: Optional[str], *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("profiling: %s=%r is not an int; using default %d", name, raw, default)
+        return default
+
+
+def _rank_enabled(rank: int) -> bool:
+    spec = os.environ.get("UNIRL_PROFILE_RANKS", "0").strip().lower()
+    if spec in ("all", "*"):
+        return True
+    try:
+        return rank in {int(p) for p in spec.split(",") if p.strip()}
+    except ValueError:
+        logger.warning("profiling: UNIRL_PROFILE_RANKS=%r unparseable; defaulting to rank 0 only", spec)
+        return rank == 0
+
+
+_MODE_WARNED: set = set()
+
+
+def profile_mode() -> str:
+    """Resolve the single switch ``UNIRL_PROFILE``. The value names the region recorded:
+
+    * ``one-update`` — profile ONE optimizer update (forward + backward + cross-GPU comm +
+      optimizer), excluding the big anchor/SDE-replay forward. Small trace; for OVERLAP.
+    * ``train``  — profile the WHOLE train step (anchor forward + all N updates).
+      Big trace; the complete picture of one training step.
+    * unset / ``0`` / ``false`` / ``off`` — disabled (a no-op).
+
+    Any other value is unrecognized -> disabled (warned once). Individual ``UNIRL_PROFILE_*``
+    knobs (DIR, RANKS, CUDA, WARMUP, ...) still tune the run.
+    """
+    v = os.environ.get("UNIRL_PROFILE", "").strip().lower()
+    if v in ("", "0", "false", "no", "off"):
+        return "off"
+    if v in ("one-update", "train"):
+        return v
+    if v not in _MODE_WARNED:
+        _MODE_WARNED.add(v)
+        logger.warning("UNIRL_PROFILE=%r not recognized; use 'one-update' or 'train'. Profiling disabled.", v)
+    return "off"
+
+
+def profile_enabled() -> bool:
+    return profile_mode() != "off"
+
+
+def profile_scope() -> str:
+    """The region being profiled: ``one-update`` or ``train`` (or ``off``).
+
+    Identical to the ``UNIRL_PROFILE`` value — the switch *is* the scope, no separate knob.
+    """
+    return profile_mode()
+
+
+def _out_dir() -> str:
+    """Trace output dir. Defaults to ``outputs/profiler`` (relative to cwd, created if
+    missing); set ``UNIRL_PROFILE_DIR`` to write elsewhere. NOTE: writing a very large
+    (multi-GB) trace to a network FS can stall the export — point ``UNIRL_PROFILE_DIR``
+    at a node-local path for whole-step captures."""
+    return os.environ.get("UNIRL_PROFILE_DIR", "").strip() or "outputs/profiler"
+
+
+class TrainStepProfiler:
+    """Thin wrapper: a torch profiler stepped once per rollout train call."""
+
+    def __init__(self, prof: "torch.profiler.profile", total_steps: int, out_dir: str) -> None:
+        self._prof = prof
+        self._total = total_steps
+        self._out_dir = out_dir
+        self._n = 0
+        self._stopped = False
+        prof.start()
+
+    def step(self) -> None:
+        """Advance the schedule by one rollout; auto-stop + export after the window.
+        Export is best-effort — a failure is logged, never raised into training."""
+        if self._stopped:
+            return
+        try:
+            self._prof.step()  # may trigger on_trace_ready (export) at the active->done edge
+            self._n += 1
+            if self._n >= self._total:
+                self._prof.stop()
+                self._stopped = True
+                logger.info("TrainStepProfiler: %d steps profiled; trace written to %s", self._n, self._out_dir)
+        except Exception:
+            self._stopped = True
+            try:
+                self._prof.stop()  # release CUPTI hooks so later steps carry no overhead
+            except Exception:
+                pass
+            logger.warning("TrainStepProfiler: profiling/export failed; training continues", exc_info=True)
+
+    @contextmanager
+    def record(self, name: str) -> Iterator[None]:
+        with torch.profiler.record_function(name):
+            yield
+
+
+def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
+    """Build a :class:`TrainStepProfiler` from env, or ``None`` if disabled.
+
+    Called lazily on the worker the first time a train step runs (so the device
+    is bound and the profiler attaches to the right CUDA context).
+    """
+    if not profile_enabled():
+        return None
+    # The caller passes a backend-specific rank that is 0 on every worker for some
+    # backends (e.g. FSDP colocate lacks `_rank`). Prefer the true global rank from
+    # the process group so UNIRL_PROFILE_RANKS actually restricts to one worker —
+    # profiling every rank makes 8 CUPTI trace-flushes contend and stall the export.
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        rank = dist.get_rank()
+    if not _rank_enabled(int(rank)):
+        return None
+
+    # Default = capture ONE full step (wait1 + warmup1 + active1) so a bare
+    # UNIRL_PROFILE=train already produces a small, Perfetto-loadable trace.
+    wait = _int_env("UNIRL_PROFILE_WAIT", 1)
+    warmup = _int_env("UNIRL_PROFILE_WARMUP", 1)
+    active = _int_env("UNIRL_PROFILE_ACTIVE", 1)
+    repeat = _int_env("UNIRL_PROFILE_REPEAT", 1)
+    out_dir = _out_dir()
+    os.makedirs(out_dir, exist_ok=True)
+
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    # CUDA (CUPTI) activity can be disabled with UNIRL_PROFILE_CUDA=0. On some
+    # torch/driver/CUPTI combos the CUDA kineto trace-finalize (stop_trace) hangs
+    # the export; a CPU-only trace still opens in Perfetto and shows the step
+    # structure + cudaLaunchKernel timeline.
+    if _truthy(os.environ.get("UNIRL_PROFILE_CUDA"), default=True) and torch.cuda.is_available():
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+
+    sched = torch.profiler.schedule(wait=wait, warmup=warmup, active=active, repeat=repeat)
+    prof = torch.profiler.profile(
+        activities=activities,
+        schedule=sched,
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(out_dir, worker_name=f"rank{int(rank)}", use_gzip=True),
+        record_shapes=False,
+        profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
+        with_stack=False,
+    )
+    total = max(1, (wait + warmup + active) * max(1, repeat))
+    logger.info(
+        "TrainStepProfiler[rank%d]: enabled (wait=%d warmup=%d active=%d repeat=%d) -> %s",
+        int(rank),
+        wait,
+        warmup,
+        active,
+        repeat,
+        out_dir,
+    )
+    try:
+        return TrainStepProfiler(prof, total_steps=total, out_dir=out_dir)  # __init__ calls prof.start()
+    except Exception:
+        logger.warning("TrainStepProfiler: profiler start failed (CUPTI init?); not profiling this run", exc_info=True)
+        return None
+
+
+@contextmanager
+def maybe_profile_update(owner, rank: int) -> Iterator[None]:
+    """One-shot profiler around a SINGLE ``_run_update`` (``UNIRL_PROFILE=one-update``).
+
+    torch.profiler records continuously while active, so the schedule-based
+    :class:`TrainStepProfiler` (which spans a whole rollout) always sweeps in the big
+    SDE-replay ``prepare_segment`` too. For compute/comm OVERLAP analysis we want just
+    one optimizer update — forward + backward + cross-GPU comm + optimizer_step.
+    This wraps exactly that region in its own profiler and exports immediately, so the
+    trace is small and contains only the overlap-relevant window.
+
+    Fires once, on rank0 (true global rank), after skipping ``UNIRL_PROFILE_WARMUP``
+    updates (default 2) so the profiled step is past first-iter compile/allocation.
+    A no-op context otherwise.
+    """
+    enabled = profile_enabled()
+    if enabled:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            rank = dist.get_rank()
+        enabled = _rank_enabled(int(rank))
+
+    n = getattr(owner, "_prof_update_seen", 0)
+    owner._prof_update_seen = n + 1
+    skip = _int_env("UNIRL_PROFILE_WARMUP", 2)
+    if not enabled or getattr(owner, "_prof_update_done", False) or n != skip:
+        yield
+        return
+
+    out_dir = _out_dir()
+    os.makedirs(out_dir, exist_ok=True)
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    if _truthy(os.environ.get("UNIRL_PROFILE_CUDA"), default=True) and torch.cuda.is_available():
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+    prof = torch.profiler.profile(
+        activities=activities,
+        record_shapes=False,
+        profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
+        with_stack=False,
+    )
+    try:
+        prof.start()
+    except Exception:
+        owner._prof_update_done = True
+        logger.warning(
+            "maybe_profile_update[rank%d]: profiler start failed (CUPTI init?); update unprofiled",
+            int(rank),
+            exc_info=True,
+        )
+        yield
+        return
+    logger.info("maybe_profile_update[rank%d]: profiling one optimizer update -> %s", int(rank), out_dir)
+    try:
+        yield
+    finally:
+        # Best-effort export: mark done, then log-and-swallow failures (never kill training).
+        owner._prof_update_done = True
+        try:
+            prof.stop()
+            raw = os.path.join(out_dir, f"update_rank{int(rank)}.pt.trace.json")
+            prof.export_chrome_trace(raw)
+            # gzip in place -> opens directly in Perfetto and is small enough to download
+            import gzip
+            import shutil
+
+            out = raw + ".gz"
+            with open(raw, "rb") as fin, gzip.open(out, "wb") as fout:
+                shutil.copyfileobj(fin, fout)
+            os.remove(raw)
+            logger.info("maybe_profile_update[rank%d]: trace written to %s", int(rank), out)
+        except Exception:
+            logger.warning(
+                "maybe_profile_update[rank%d]: trace export failed; training continues", int(rank), exc_info=True
+            )
+
+
+__all__ = [
+    "TrainStepProfiler",
+    "maybe_build_train_profiler",
+    "maybe_profile_update",
+    "profile_mode",
+    "profile_enabled",
+    "profile_scope",
+]

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -40,6 +40,90 @@ if TYPE_CHECKING:
 module_logger = logging.getLogger(__name__)
 
 
+def _write_video_with_audio(
+    frames: Any,
+    fps: int,
+    audio: torch.Tensor,
+    audio_sample_rate: int,
+) -> str:
+    """Mux video frames + audio waveform into a single mp4 file using PyAV.
+
+    Mirrors Flow-Factory's ``LogVideo._write_mp4_with_audio``. Video is H.264,
+    audio is AAC. Returns the temp file path (caller passes to ``wandb.Video``).
+    Falls back to writing video-only if PyAV is unavailable.
+    """
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".mp4")
+    os.close(fd)
+    try:
+        from fractions import Fraction
+
+        import av
+
+        container = av.open(path, mode="w")
+        video_stream = container.add_stream("libx264", rate=int(fps))
+        video_stream.width = int(frames.shape[2])
+        video_stream.height = int(frames.shape[1])
+        video_stream.pix_fmt = "yuv420p"
+
+        audio_stream = container.add_stream("aac", rate=audio_sample_rate)
+        audio_stream.codec_context.sample_rate = audio_sample_rate
+        audio_stream.codec_context.layout = "stereo"
+        audio_stream.codec_context.time_base = Fraction(1, audio_sample_rate)
+
+        for frame_array in frames:
+            frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            for packet in video_stream.encode(frame):
+                container.mux(packet)
+        for packet in video_stream.encode():
+            container.mux(packet)
+
+        samples = audio.float().cpu()
+        if samples.ndim == 1:
+            samples = samples.unsqueeze(0)
+        if samples.shape[0] == 1:
+            samples = samples.expand(2, -1)
+        samples = samples.T  # (T, 2)
+        samples = torch.clamp(samples, -1.0, 1.0)
+        int16_samples = (samples * 32767.0).to(torch.int16)
+
+        audio_frame = av.AudioFrame.from_ndarray(
+            int16_samples.contiguous().reshape(1, -1).numpy(),
+            format="s16",
+            layout="stereo",
+        )
+        audio_frame.sample_rate = audio_sample_rate
+
+        target_format = audio_stream.codec_context.format or "fltp"
+        target_layout = audio_stream.codec_context.layout or "stereo"
+        resampler = av.audio.resampler.AudioResampler(
+            format=target_format,
+            layout=target_layout,
+            rate=audio_sample_rate,
+        )
+        audio_next_pts = 0
+        for rframe in resampler.resample(audio_frame):
+            if rframe.pts is None:
+                rframe.pts = audio_next_pts
+            audio_next_pts += rframe.samples
+            rframe.sample_rate = audio_sample_rate
+            container.mux(audio_stream.encode(rframe))
+        for packet in audio_stream.encode():
+            container.mux(packet)
+
+        container.close()
+    except ImportError:
+        module_logger.warning("PyAV (av) not installed; writing video without audio. Install with: pip install av")
+        os.unlink(path)
+        fd2, path = tempfile.mkstemp(suffix=".mp4")
+        os.close(fd2)
+        import imageio
+
+        imageio.mimwrite(path, frames, fps=fps, format="FFMPEG", codec="libx264", pixelformat="yuv420p")
+    return path
+
+
 class PhaseTimer:
     """Per-phase wall-clock timer for one train step.
 
@@ -546,6 +630,8 @@ class UniRLWandBLogger:
             else:
                 video_key = f"{key}/videos"
 
+        # Temp mp4 files written by the audio-mux path; unlinked after upload.
+        _muxed_paths: List[str] = []
         try:
             n = max(len(images) if has_images else 0, len(videos) if has_videos else 0)
 
@@ -565,6 +651,9 @@ class UniRLWandBLogger:
 
             if has_videos:
                 wandb_videos: List[Any] = []
+                # Per-sample audio waveforms for muxing (T2AV); empty list if none.
+                audios = getattr(media_preview, "audios", None) or []
+                audio_sr = getattr(media_preview, "audio_sample_rate", None)
                 for idx in range(min(len(videos), n)):
                     vid = videos[idx]
                     if not torch.is_tensor(vid):
@@ -587,13 +676,31 @@ class UniRLWandBLogger:
                         .permute(1, 0, 2, 3)  # [C, T, H, W] -> [T, C, H, W]
                         .numpy()
                     )
-                    wandb_videos.append(wandb.Video(arr, caption=_caption_for(idx), fps=int(video_fps)))
+                    # Mux audio into mp4 when available (T2AV); otherwise plain array.
+                    audio_wf = audios[idx] if idx < len(audios) else None
+                    if audio_wf is not None and audio_sr is not None and torch.is_tensor(audio_wf):
+                        # PyAV expects (T, H, W, C) RGB24 frames; arr is (T, C, H, W).
+                        arr_hwc = arr.transpose(0, 2, 3, 1)  # (T, C, H, W) -> (T, H, W, C)
+                        path = _write_video_with_audio(arr_hwc, int(video_fps), audio_wf, int(audio_sr))
+                        _muxed_paths.append(path)
+                        wandb_videos.append(wandb.Video(path, caption=_caption_for(idx), format="mp4"))
+                    else:
+                        wandb_videos.append(wandb.Video(arr, caption=_caption_for(idx), fps=int(video_fps)))
                 if wandb_videos:
                     payload[video_key] = wandb_videos
 
             wandb.log(payload)
         except Exception as e:
             print(f"Warning: Failed to log generated media: {e}")
+        finally:
+            # wandb.Video copies the file into the run dir on construction, so the
+            # temp mp4s are safe to remove once logging is done. Avoids leaking a
+            # /tmp mp4 per muxed sample every media-log step.
+            for _p in _muxed_paths:
+                try:
+                    os.unlink(_p)
+                except OSError:
+                    pass
 
     def log_eval(
         self,


### PR DESCRIPTION
## Summary

Adds **WAN 2.2-A14B T2V** (dual-expert MoE) to the `sglang_diffusion` rollout engine (full-FT + LoRA); rollout aligned at **ratio = 1.0000**.

WAN 2.2-A14B runs two experts (high-noise / low-noise) switched at a sigma boundary (`boundary_ratio = 0.875`). sglang's multimodal_gen **already serves this** (auto-loads `transformer_2` when the checkpoint `model_index.json` carries `boundary_ratio` + both transformers; `DenoisingStage._select_and_manage_model` routes per-step), so the unirl side is thin:
- `Wan22T2VAdapter` — a thin `VideoAdapter` subclass forwarding `guidance_scale_2` for the low-noise CFG branch; the dual-expert lives entirely engine-side.
- **`patch_wan_scheduler` eta-drop guard** — the dual-expert denoise wraps `scheduler.step` with `**kwargs`, defeating sglang's kwarg filtering so the diffusers-style `eta` leaked into the RL-mixin `step` (which has no `eta`); drop the stray `eta` (matches the single-transformer path).
- Config: `wan22_t2v_14b_sglang.yaml` (layerwise expert offload for the 27B colocate).

## Related Issue

Engine support matrix — #127. Depends on the foundation #135.

## Test Plan

- `py_compile` + import smoke (registers as `wan22`; `Wan22T2VAdapter` subclasses `VideoAdapter`) — passes.
- GRPO smoke (256x448x5, layerwise offload): both experts load + LoRA, 10/10 dual-expert denoise, VAE decode, reward, replay -> **rollout 1 ratio = 1.0000 +/- 0.0000**, reward 0.78.

## Compatibility / Risk

Additive. The scheduler `eta`-drop is a no-op everywhere `eta` was already filtered. **Known limitation:** multi-rollout weight-sync OOMs on a single 8-GPU node (the 27B dual-expert + sync staging after the first optimizer step) — needs sync-time HBM headroom (smaller LoRA rank / more offload / multi-node); rollout alignment itself is proven.

## Reviewer Notes

Independent of #136/#137/#138. `Wan22T2VAdapter` subclasses `VideoAdapter` directly (NOT Wan21), so this PR does not depend on the WAN 2.1 PR.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.

## EXP
WAN22 LORA
<img width="474" height="315" alt="截屏2026-07-03 07 23 08" src="https://github.com/user-attachments/assets/d9e29b6a-9b29-4f56-bc66-246e03c8e6cd" />

WAN22 FULL
<img width="435" height="309" alt="截屏2026-07-03 07 25 14" src="https://github.com/user-attachments/assets/60cddf0a-b6d6-4ac2-ad11-343de288bd37" />
