### PR TITLE
fix(reward): correct HPSv3 reward() arg order + add SD3.5 recipe

### DIFF
--- a/examples/diffusion/sd3/sd3_dancegrpo_hpsv3.yaml
+++ b/examples/diffusion/sd3/sd3_dancegrpo_hpsv3.yaml
@@ -1,0 +1,150 @@
+# @package _global_
+# DanceGRPO-Fast SD3.5 trainside (FSDP) colocate, v2 trainer, 2x8 — HPSv3 reward.
+#
+# Identical to sd3_dancegrpo.yaml except the reward backend: the local PickScore
+# scorer is replaced by HPSv3 (the original wide-spectrum HPS model, Qwen2-VL-7B
+# + RankNet, outputs [mu, sigma]; we use mu/15). HPSv3RewardInferencer self-loads
+# its checkpoint (downloads MizzenAI/HPSv3), so no path knobs are needed.
+#
+# The reward worker needs the `hpsv3` package importable. IMPORTANT: PyPI
+# `hpsv3` 1.0.0 pins transformers==4.45.2, which CONFLICTS with the SD3 diffusers
+# stack (diffusers 0.38 needs transformers>=~4.48). So for LOCAL colocation,
+# install HPSv3 from the `upgrade_transformers_version` branch
+# (github.com/MizzenAI/HPSv3; transformers>=4.45.2 — verified loading+scoring on
+# transformers==4.57.0) so the reward and SD3 share one tf 4.57 env. The 7B
+# reward loads per DP rank. For tight memory — or sglang/vllm recipes (engine
+# pins a newer transformers) — host HPSv3 out-of-process via the remote
+# RewardService instead (see sd3_nft_reward_service.yaml, which multiplexes hpsv3).
+
+num_devices: 16               # 2 nodes x 8 GPUs (v1 actor_count 16)
+batch_size: 48                # prompts_per_rollout
+adv_use_global_std: true     # advantage: divide by ONE batch-wide std (v1 parity), not per-group
+num_rollouts: 10000
+
+bundle:
+  _target_: unirl.models.sd3.bundle.SD3Bundle.from_config
+  config:
+    _target_: unirl.models.sd3.config.SD3PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,stabilityai/stable-diffusion-3.5-medium}
+    model_precision: bf16
+    shift: 3.0
+
+pipeline:
+  _target_: unirl.models.sd3.pipeline.SD3Pipeline
+  shift: 3.0
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  # DanceGRPO: Dance SDE kernel (the one algorithmic difference from FlowGRPO).
+  strategy:
+    _target_: unirl.sde.kernels.DanceSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["JointTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: false  # SD3.5-medium is small (~5 GB bf16 full); keep params gathered, skip bwd re-gather
+    activation_checkpointing: false  # v1 base flowgrpo_fast_sd3_trainside = bf16_full_noac
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn.add_k_proj
+      - attn.add_q_proj
+      - attn.add_v_proj
+      - attn.to_add_out
+      - attn.to_k
+      - attn.to_out.0
+      - attn.to_q
+      - attn.to_v
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 8            # v1 flowgrpo_fast_sd3_trainside
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.hpsv3.HPSv3RewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.hpsv3.HPSv3Spec
+      batch_size: 8
+      device: auto
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.sd3.conditions.SD3Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 8
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2      # PPO mini-batches per rollout (π_old frozen once); v1 parity
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]   # SDE steps drawn from the first half (v1)
+    num_sde_steps: 3
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-dancegrpo}
+  run_name: ${oc.env:WANDB_RUN_NAME,sd3_dancegrpo_hpsv3}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["sd3.5", "dancegrpo", "grpo", "trainside", "v2", "hpsv3"]
+  log_media: true
+  media_max_items: 8
+  media_log_interval: 1

--- a/unirl/reward/local/hpsv3.py
+++ b/unirl/reward/local/hpsv3.py
@@ -62,7 +62,11 @@ class HPSv3RewardScorer(LocalRewardBackend):
                     pil_images.append(Image.fromarray(img).convert("RGB"))
 
             with torch.no_grad():
-                scores = self._hpsv3_inferencer.reward(batch_prompts, pil_images)
+                # Pass by keyword: the hpsv3 package's reward() is
+                # ``reward(image_paths, prompts)`` (PyPI 1.0.0) but later source
+                # reorders to ``reward(prompts, image_paths)`` — keywords are
+                # correct under both. (Images accept PIL directly.)
+                scores = self._hpsv3_inferencer.reward(prompts=batch_prompts, image_paths=pil_images)
                 # scores shape: [B, 2] (mu, sigma); take mu
                 if scores.ndim == 2:
                     scores = scores[:, 0]


### PR DESCRIPTION
## Summary

Makes the in‑tree **HPSv3** local reward actually run, and adds an SD3.5 recipe for it.

While bringing up HPSv3 end‑to‑end I found a real bug: `unirl/reward/local/hpsv3.py` calls the inferencer as `reward(batch_prompts, pil_images)`, but the `hpsv3` package's signature is `reward(self, image_paths, prompts)` (PyPI 1.0.0) — i.e. **images first**. As written it passes the prompt *string* where an image path is expected and crashes (`Image.open('<prompt text>')`). Fixed by calling with **keyword args** (`reward(prompts=…, image_paths=…)`), which is correct regardless of positional order across `hpsv3` versions.

- `unirl/reward/local/hpsv3.py` — one‑line correctness fix (keyword args; comment explains the version skew).
- `examples/diffusion/sd3/sd3_dancegrpo_hpsv3.yaml` — SD3.5 DanceGRPO recipe using the local HPSv3 scorer (analog of the PickScore recipe).

This is separate from the HPSv3++ work (PR #142).

## Related Issue

N/A

## Test Plan

- Static: `python -m py_compile unirl/reward/local/hpsv3.py`; recipe parses.
- **Reward smoke (1× H20):** `HPSv3RewardInferencer(device="cuda").reward(prompts=…, image_paths=…)` loads (Qwen2‑VL‑7B + RankNet, downloads `MizzenAI/HPSv3`) and scores; μ = `[-0.1208, -0.2048]` on gradient test images (low/negative as expected for non‑aesthetic inputs). Verified under **both** PyPI `hpsv3` 1.0.0 (transformers 4.45.2) **and** the `upgrade_transformers_version` branch (transformers 4.57.0) — identical μ (deterministic).
- **SD3.5 + HPSv3 colocated smoke (1 GPU, tf 4.57, upgrade‑branch hpsv3):** `PRETRAINED_MODEL=<local sd3.5-medium> bash examples/run_experiment_single_node.sh diffusion/sd3/sd3_dancegrpo_hpsv3 num_devices=1 +devices_per_node=1 batch_size=2 sampling.samples_per_prompt=4 sampling.num_inference_steps=8 num_rollouts=1 stack.micro_batch_size=4 stack.num_updates_per_batch=1 rollout.forward_batch_size=4 reward.backend.config.batch_size=4` — passed (`rc=0`): `rollout 1/1 reward=0.0357 loss=0.0000 gn=0.0002 lr=3.00e-04 ratio=1.0000±0.0000`. Full path ran — SD3.5 rollout → HPSv3 scoring → FlowGRPO advantage → FSDP train step (gradient computed) — with the reward computed and consumed.

## Compatibility / Risk

- The code change is a one‑line correctness fix; no public API change.
- HPSv3 needs the `hpsv3` package. **PyPI `hpsv3` 1.0.0 pins transformers==4.45.2**, which conflicts with the SD3 diffusers 0.38 stack (needs transformers ≥ ~4.48) — so PyPI hpsv3 cannot colocate with SD3 training. For local colocation, install HPSv3 from the `upgrade_transformers_version` branch (verified on transformers 4.57.0). For sglang/vllm recipes or tight memory, use the remote RewardService (`sd3_nft_reward_service.yaml` already multiplexes hpsv3).

## Reviewer Notes

AI‑assisted. The arg‑order bug was found by actually running the scorer (it had never been verified end‑to‑end). Duplicate‑work check: no open PR touches `hpsv3.py`; HPSv3++ is the separate PR #142.
