### PR TITLE
fix(reward): HPSv3++ score_scale is training-invariant under GRPO; default to raw mu

### DIFF
--- a/examples/diffusion/sd3/sd3_dancegrpo_hpsv3pp.yaml
+++ b/examples/diffusion/sd3/sd3_dancegrpo_hpsv3pp.yaml
@@ -101,10 +101,12 @@ reward:
       # RL-iteration condition in [0, 1]; 0.0 = pre-RL preference scoring. The
       # paper ramps 0.3 -> 1.0 over RL training (per-step ramp needs step plumbing).
       rl_iteration: 0.0
-      # Reward is divided by score_scale (raw mu is ~7-11). 15.0 matches the
-      # hpsv3 scorer's /15.0, landing this in ~0-1 like the PickScore baseline
-      # these (otherwise unchanged) hyperparams — esp. clip_range 1e-4 — assume.
-      score_scale: 15.0
+      # score_scale is a divisor on the raw mu (reward = mu / score_scale).
+      # GRPO normalizes advantages by (reward - mean)/std, so the scale cancels
+      # and training is invariant to this value — 1.0 keeps the raw HPSv3++ mu
+      # (~7-11), which is directly comparable to the scores reported in the
+      # paper / HPSv3 benchmark. Set it only to rescale what wandb logs.
+      score_scale: 1.0
 
 algorithm:
   _target_: unirl.algorithms.flowgrpo.FlowGRPO

--- a/unirl/reward/local/hpsv3pp.py
+++ b/unirl/reward/local/hpsv3pp.py
@@ -142,8 +142,11 @@ class HPSv3PPSpec(BaseRewardComponentSpec):
     auto-downloads ``Junjun2333/HPSv3-PlusPlus/hpsv3++.pth``.
 
     ``score_scale`` is a *divisor* applied to the raw mu (which is ~7-11): the
-    reward is ``mu / score_scale``. Use ~15.0 to land it in ~0-1 (parity with
-    the ``hpsv3`` scorer); leave at 1.0 only if downstream wants the raw scale.
+    reward is ``mu / score_scale``. GRPO normalizes advantages by
+    ``(reward - mean) / std``, so a global scale cancels and training is
+    invariant to this value; the default 1.0 keeps the raw mu, which is
+    directly comparable to scores reported in the paper / HPSv3 benchmark.
+    Set it only to rescale what gets logged.
     """
 
     batch_size: int = 8


### PR DESCRIPTION
## Summary

Corrects the `score_scale` of the HPSv3++ recipe added in #142 and documents what the knob actually does.

In #142 a follow-up commit set `examples/diffusion/sd3/sd3_dancegrpo_hpsv3pp.yaml`'s `score_scale` to `15.0`, framed as "PickScore-baseline parity" (raw mu is ~7-11 vs PickScore ~1). **That framing was wrong.** This recipe trains with FlowGRPO, and GRPO normalizes advantages by `(reward - mean) / std` (`RolloutTrack.compute_advantages`, `adv_use_global_std: true`). A global scale on the reward cancels in that ratio, so **training is invariant to `score_scale`**:

- No KL penalty is added to the reward in the diffusion trainer (the only reward consumer is `compute_advantages`), so there is no `reward - beta*KL` term whose effective beta would shift with scale.
- `clip_range: 1e-4` bounds the **policy ratio** `pi_new/pi_old`, not the reward — it is unrelated to reward magnitude.
- The only scale-dependent term is the `eps = 1e-8` added outside `std`; with HPSv3++ group std ~O(1), its effect is ~1e-7 — negligible.

So `1.0` (the original author value) and `15.0` produce effectively bit-identical advantages and gradients. There was no parity bug to fix.

## Changes

- `examples/diffusion/sd3/sd3_dancegrpo_hpsv3pp.yaml` — revert `score_scale` to `1.0`. Keeping the raw mu (~7-11) makes logged rewards directly comparable to the scores reported in the HPSv3++ paper / HPSv3 benchmark. Comment rewritten to state the GRPO scale-invariance.
- `unirl/reward/local/hpsv3pp.py` — `HPSv3PPSpec` docstring rewritten: `score_scale` is a divisor that is training-invariant under GRPO normalization and only rescales what wandb logs.

No code-path / behavior change (training is invariant); this is a config-default + documentation correction.

## Test Plan

- `python -m py_compile unirl/reward/local/hpsv3pp.py`; recipe parses (`yaml.safe_load`).
- Reasoning verified against source: `unirl/algorithms/flowgrpo.py` (ratio-clip only, takes pre-computed advantages), `unirl/types/rollout_resp.py::compute_advantages` (`(reward - mean)/(std + eps)`), `unirl/trainer/diffusion.py` (sole reward consumer is `compute_advantages`; no KL-to-reward term).

## Compatibility / Risk

Config default + docs only; training is mathematically invariant to the changed value. No public API change.
