### PR TITLE
fix: LTX2 forward-kwarg guard + qwen-vl geo3k FA2/forward-prefetch

### DIFF
--- a/examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml
@@ -55,6 +55,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true # train the LLM only; ViT frozen
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -84,6 +85,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false # bundle already enables HF gradient checkpointing
     use_torch_compile: false
   optimizer_cfg:

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_4x8_lora.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_4x8_lora.yaml
@@ -33,6 +33,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true # train the LLM only; ViT frozen
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -52,6 +53,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false # bundle already enables HF gradient checkpointing
     use_torch_compile: false
   optimizer_cfg:

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8.yaml
@@ -43,6 +43,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -62,6 +63,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false
     use_torch_compile: false
   optimizer_cfg:

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8_lora.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8_lora.yaml
@@ -34,6 +34,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -53,6 +54,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false
     use_torch_compile: false
   optimizer_cfg:

--- a/unirl/models/ltx2/diffusion.py
+++ b/unirl/models/ltx2/diffusion.py
@@ -18,6 +18,7 @@ LTX2-specific deviations from other models:
 
 from __future__ import annotations
 
+import inspect
 from contextlib import nullcontext
 from typing import ClassVar, List, Optional, Set, Tuple
 
@@ -158,17 +159,13 @@ class LTX2DiffusionStep(DiffusionStep[LTX2Bundle, LTX2Conditions]):
         audio_encoder_attention_mask = audio_text_cond.attn_mask
 
         def _run(v_in, a_in, ts_in, enc_hs, enc_mask, a_enc_hs, a_enc_mask):
-            out = transformer(
+            kwargs = dict(
                 hidden_states=v_in,
                 audio_hidden_states=a_in,
                 encoder_hidden_states=enc_hs,
                 audio_encoder_hidden_states=a_enc_hs,
                 timestep=ts_in,
                 audio_timestep=ts_in,
-                # ``sigma``/``audio_sigma`` are consumed only by LTX-2.3 prompt
-                # modulation; harmless for 2.0 and required by 2.3 — pass them.
-                sigma=ts_in,
-                audio_sigma=ts_in,
                 encoder_attention_mask=enc_mask,
                 audio_encoder_attention_mask=a_enc_mask,
                 num_frames=latent_num_frames,
@@ -176,9 +173,20 @@ class LTX2DiffusionStep(DiffusionStep[LTX2Bundle, LTX2Conditions]):
                 width=latent_width,
                 fps=_LTX2_FRAME_RATE,
                 audio_num_frames=audio_num_frames,
-                isolate_modalities=False,
                 return_dict=False,
             )
+            # ``sigma``/``audio_sigma`` (LTX-2.3 prompt modulation) and
+            # ``isolate_modalities`` only exist on newer LTX-2.3 transformer
+            # forwards. Older diffusers (e.g. 0.37's LTX2VideoTransformer3DModel)
+            # don't accept them and would raise TypeError, so only pass each kwarg
+            # when the loaded transformer's forward signature declares it.
+            fwd_params = set(inspect.signature(transformer.forward).parameters)
+            if "sigma" in fwd_params:
+                kwargs["sigma"] = ts_in
+                kwargs["audio_sigma"] = ts_in
+            if "isolate_modalities" in fwd_params:
+                kwargs["isolate_modalities"] = False
+            out = transformer(**kwargs)
             # forward returns (video_out, audio_out).
             return out[0], out[1]
 


### PR DESCRIPTION
## Summary

Two independent training-recipe fixes, bundled per request:

- **`fix(ltx2)`**: `LTX2DiffusionStep` called `transformer(... sigma=, audio_sigma=, isolate_modalities=...)` unconditionally. Those kwargs only exist on newer LTX-2.3 transformer forwards. On diffusers `0.37.0`, `LTX2VideoTransformer3DModel.forward` does not declare them and has no `**kwargs`, so the call raises `TypeError: forward() got an unexpected keyword argument 'sigma'` and the LTX2 trainside step crashes. The step now introspects `transformer.forward` and only injects `sigma`/`audio_sigma` and `isolate_modalities` when the loaded model's signature declares them — works across LTX-2.0/2.3 and diffusers versions.
- **`perf(qwen-vl)`**: enable `attn_implementation: flash_attention_2` (QwenVL bundle) and `forward_prefetch: true` (FSDP backend) across the four geo3k multiple-choice recipes (full/LoRA × trainside/sglang) to overlap the next all-gather with compute.

## Related Issue

N/A

## Test Plan

- `python -m py_compile unirl/models/ltx2/diffusion.py` — passes.
- `ruff check unirl/models/ltx2/diffusion.py` — passes; pre-commit (ruff, ruff-format, recipe `_target_` resolve) passed on both commits and on push.
- YAML parse of all four edited recipes via `yaml.safe_load` — passes.
- Bug repro/fix evidence: `inspect.signature(diffusers.LTX2VideoTransformer3DModel.forward)` on diffusers `0.37.0` shows no `sigma`/`audio_sigma`/`isolate_modalities` and no `**kwargs`; the guard skips them so the call no longer raises.
- Not run; reason: no GPU in this environment — LTX2 trainside training and qwen-vl geo3k training were not executed.

## Compatibility / Risk

- LTX2 change is backward-compatible: on LTX-2.3 / diffusers versions whose forward declares those params, behavior is unchanged (the kwargs are still passed); it only stops passing kwargs the model can't accept.
- Config changes: `forward_prefetch: true` requires `root_wrap: true` (the `FSDPConfig.root_wrap` default, which these recipes use); `attn_implementation: flash_attention_2` requires a FlashAttention-2-capable install.

## Reviewer Notes

- This PR bundles two logically separate changes (an LTX2 correctness fix and qwen-vl recipe perf knobs) at the author's request.
- Duplicate-work check: scanned open upstream PRs; the only LTX2-adjacent one (#138, sglang rollout) does not touch the trainside `diffusion.py` `_run`, so no overlap.
- AI-assisted; the submitter reviewed the full diff.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.