### PR TITLE
perf(qwen-vl): enable FA2 + FSDP2 forward-prefetch for geo3k MC recipes

### DIFF
--- a/examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml
@@ -55,6 +55,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true # train the LLM only; ViT frozen
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -84,6 +85,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false # bundle already enables HF gradient checkpointing
     use_torch_compile: false
   optimizer_cfg:

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_4x8_lora.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_4x8_lora.yaml
@@ -33,6 +33,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true # train the LLM only; ViT frozen
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -52,6 +53,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false # bundle already enables HF gradient checkpointing
     use_torch_compile: false
   optimizer_cfg:

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8.yaml
@@ -43,6 +43,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -62,6 +63,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false
     use_torch_compile: false
   optimizer_cfg:

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8_lora.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8_lora.yaml
@@ -34,6 +34,7 @@ bundle:
     _target_: unirl.models.qwen_vl.config.QwenVLPipelineConfig
     pretrained_model_ckpt_path: ${oc.env:QWEN_VL_PATH,Qwen/Qwen2.5-VL-7B-Instruct}
     model_precision: bf16
+    attn_implementation: flash_attention_2
     freeze_vision_tower: true
     use_gradient_checkpointing: true
     max_prompt_length: 2048
@@ -53,6 +54,7 @@ backend:
     mixed_precision: true
     fsdp_mode: full
     reshard_after_forward: true
+    forward_prefetch: true
     activation_checkpointing: false
     use_torch_compile: false
   optimizer_cfg:


### PR DESCRIPTION
## Summary

Enable two throughput knobs across the four geo3k multiple-choice QwenVL recipes (full/LoRA × trainside/sglang):

- `attn_implementation: flash_attention_2` on the QwenVL bundle.
- `forward_prefetch: true` on the FSDP backend, to overlap the next all-gather with compute.

Both are existing, supported config fields (`QwenVLPipelineConfig.attn_implementation`, `FSDPConfig.forward_prefetch`); this only turns them on in these recipes.

## Related Issue

N/A

## Test Plan

- `yaml.safe_load` parse of all four edited recipes — passes.
- pre-commit (recipe `_target_` resolve, trailing-whitespace, eof) — passed on commit and push.
- Not run; reason: no GPU in this environment — qwen-vl geo3k training was not executed.

## Compatibility / Risk

- `forward_prefetch: true` requires `root_wrap: true` (the `FSDPConfig.root_wrap` default, which these recipes use).
- `attn_implementation: flash_attention_2` requires a FlashAttention-2-capable install; falls back to errors only if FA2 is unavailable.
- No checkpoint/data-format impact.

## Reviewer Notes

- AI-assisted; the submitter reviewed the full diff.
- Duplicate-work check: no open PR touches these recipes.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.