### PR TITLE
feat(profiler): opt-in train-step profiler exporting Perfetto traces

### DIFF
--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -101,6 +101,10 @@ trace, not one per step; training keeps running). They differ in *which slice* t
 - **`train`** — the whole step: anchor forward (recompute old-policy log-probs; for diffusion
   it replays the denoising trajectory, so it's large) + all updates. **For step-time breakdown.**
 
+> The unified-model stack (HI3, AR+image) only supports `train` — it fuses each step into a
+> single update, so there is no per-update boundary for `one-update` to wrap (a warning is
+> logged and no trace is produced).
+
 ```bash
 UNIRL_PROFILE=one-update  python -m unirl.train_diffusion --config-name=<recipe> ...
 UNIRL_PROFILE=train       python -m unirl.train_diffusion --config-name=<recipe> ...

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -87,3 +87,34 @@ optimizer or LR schedule is a branch in `factories.py` plus fields on
   skips backward (an all-empty micro) while earlier ones ran, `TrainStack.train`
   raises instead of silently stepping on never-synced grads (which would also
   leak the stale accumulation into the next step's reduce-scatter).
+
+## Profiling → Perfetto
+
+Opt-in `torch.profiler` (`unirl/utils/profiling.py`): one env var writes a gzipped Perfetto
+trace to `outputs/profiler/` on rank 0 (no-op otherwise). Training compute only (not rollout).
+
+Both capture **one snapshot of a single train step** (after a short warmup, then off — one
+trace, not one per step; training keeps running). They differ in *which slice* they record:
+
+- **`one-update`** — one optimizer update (forward + backward + optimizer) with its cross-GPU
+  comm. Skips the anchor forward; small; **for compute/comm overlap**.
+- **`train`** — the whole step: anchor forward (recompute old-policy log-probs; for diffusion
+  it replays the denoising trajectory, so it's large) + all updates. **For step-time breakdown.**
+
+```bash
+UNIRL_PROFILE=one-update  python -m unirl.train_diffusion --config-name=<recipe> ...
+UNIRL_PROFILE=train       python -m unirl.train_diffusion --config-name=<recipe> ...
+```
+
+Download the `.gz` to your local machine, then <https://ui.perfetto.dev/> → *Open trace file*.
+
+### Configurable env vars (defaults are fine)
+
+| var | what it does | default |
+|-----|--------------|---------|
+| `UNIRL_PROFILE` | `one-update` / `train` (unset = off) | off |
+| `UNIRL_PROFILE_DIR` | where the trace is written (auto-created) | `outputs/profiler` |
+| `UNIRL_PROFILE_RANKS` | which ranks profile: `0`, `all`, or a list like `0,8` | `0` |
+| `UNIRL_PROFILE_CUDA` | record GPU kernels; `0` = CPU-only trace | `1` |
+| `UNIRL_PROFILE_WARMUP` | skip the first few iterations before recording (avoids the one-time first-iter compile / alloc) — one-update: skip N updates; train: schedule warmup | `2` / `1` |
+| `UNIRL_PROFILE_MEMORY` | also record CUDA memory alloc/free (memory-over-time; bigger trace) | off |

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -346,12 +346,8 @@ class TrainStack(Remote):
             num_updates=self.num_updates_per_batch,
             micro_batch_size=self.micro_batch_size,
         )
-        # Opt-in profiler, region selected by UNIRL_PROFILE:
-        #   train  — profile the whole train compute (anchor-freeze forward + the N
-        #                optimizer updates); one profiler step() per rollout.
-        #   one-update — profile only one optimizer update inside _run_update (backward +
-        #                FSDP comm + optimizer), excluding the big SDE-replay prepare_segment.
-        #                Smaller trace + the right window for compute/comm OVERLAP analysis.
+        # Opt-in profiler (UNIRL_PROFILE=train profiles this whole step; one-update is
+        # handled in _run_updates). See unirl/train/readme.md.
         from unirl.utils.profiling import profile_scope
 
         profiler = self._train_step_profiler() if profile_scope() == "train" else None
@@ -393,14 +389,18 @@ class TrainStack(Remote):
         :func:`_aggregate_update_results`).
         """
         # UNIRL_PROFILE=one-update: wrap each optimizer update in a one-shot profiler
-        # (fires once, on rank0, past warmup) so the trace captures ONLY the
-        # backward + FSDP comm + optimizer region — the compute/comm overlap window.
+        # (fires once, on rank0, past warmup) so the trace captures ONLY one update
+        # (forward + backward + cross-GPU comm + optimizer) — the compute/comm overlap window.
         from unirl.utils.profiling import maybe_profile_update, profile_scope
 
         scope_update = profile_scope() == "one-update"
         results = []
         for micros in plans:
-            cm = maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0))) if scope_update else nullcontext()
+            cm = (
+                maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0)))
+                if scope_update
+                else nullcontext()
+            )
             with cm:
                 results.append(self._run_update(resp_track, micros=micros, training_progress=training_progress))
         if len(results) == 1:

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -41,7 +41,6 @@ update shares the same PPO anchor; this is only correct for algorithms with
 from __future__ import annotations
 
 import logging
-import os
 from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Dict, List, Mapping, Optional, Tuple
@@ -354,12 +353,13 @@ class TrainStack(Remote):
         #                      (backward + FSDP comm + optimizer), excluding the big
         #                      SDE-replay prepare_segment. Smaller trace + the right
         #                      window for compute/comm OVERLAP analysis.
-        profiler = self._train_step_profiler()
-        step_scope = profiler is not None and os.environ.get("UNIRL_PROFILE_SCOPE", "step").strip().lower() == "step"
-        with profiler.record("train_track") if step_scope else nullcontext():
+        from unirl.utils.profiling import profile_scope
+
+        profiler = self._train_step_profiler() if profile_scope() == "step" else None
+        with profiler.record("train_track") if profiler is not None else nullcontext():
             self.prepare_segment(resp_track, plans=plans)
             result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
-        if step_scope:
+        if profiler is not None:
             profiler.step()
         self.on_rollout_end()
         return result
@@ -396,15 +396,12 @@ class TrainStack(Remote):
         # UNIRL_PROFILE_SCOPE=update: wrap each optimizer update in a one-shot profiler
         # (fires once, on rank0, past warmup) so the trace captures ONLY the
         # backward + FSDP comm + optimizer region — the compute/comm overlap window.
-        scope_update = os.environ.get("UNIRL_PROFILE_SCOPE", "step").strip().lower() == "update"
+        from unirl.utils.profiling import maybe_profile_update, profile_scope
+
+        scope_update = profile_scope() == "update"
         results = []
         for micros in plans:
-            if scope_update:
-                from unirl.utils.profiling import maybe_profile_update
-
-                cm = maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0)))
-            else:
-                cm = nullcontext()
+            cm = maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0))) if scope_update else nullcontext()
             with cm:
                 results.append(self._run_update(resp_track, micros=micros, training_progress=training_progress))
         if len(results) == 1:

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -347,14 +347,14 @@ class TrainStack(Remote):
             micro_batch_size=self.micro_batch_size,
         )
         # Opt-in profiler, region selected by UNIRL_PROFILE:
-        #   full-step  — profile the whole train compute (anchor-freeze forward + the N
+        #   train  — profile the whole train compute (anchor-freeze forward + the N
         #                optimizer updates); one profiler step() per rollout.
         #   one-update — profile only one optimizer update inside _run_update (backward +
         #                FSDP comm + optimizer), excluding the big SDE-replay prepare_segment.
         #                Smaller trace + the right window for compute/comm OVERLAP analysis.
         from unirl.utils.profiling import profile_scope
 
-        profiler = self._train_step_profiler() if profile_scope() == "full-step" else None
+        profiler = self._train_step_profiler() if profile_scope() == "train" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             self.prepare_segment(resp_track, plans=plans)
             result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -346,16 +346,15 @@ class TrainStack(Remote):
             num_updates=self.num_updates_per_batch,
             micro_batch_size=self.micro_batch_size,
         )
-        # Opt-in profiler (UNIRL_PROFILE=1). Scope selected by UNIRL_PROFILE_SCOPE:
-        #   step   (default) — profile the whole train compute (anchor-freeze forward
-        #                      + the N optimizer updates); one step() per rollout.
-        #   update           — profile only one optimizer update inside _run_update
-        #                      (backward + FSDP comm + optimizer), excluding the big
-        #                      SDE-replay prepare_segment. Smaller trace + the right
-        #                      window for compute/comm OVERLAP analysis.
+        # Opt-in profiler, region selected by UNIRL_PROFILE:
+        #   full-step  — profile the whole train compute (anchor-freeze forward + the N
+        #                optimizer updates); one profiler step() per rollout.
+        #   one-update — profile only one optimizer update inside _run_update (backward +
+        #                FSDP comm + optimizer), excluding the big SDE-replay prepare_segment.
+        #                Smaller trace + the right window for compute/comm OVERLAP analysis.
         from unirl.utils.profiling import profile_scope
 
-        profiler = self._train_step_profiler() if profile_scope() == "step" else None
+        profiler = self._train_step_profiler() if profile_scope() == "full-step" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             self.prepare_segment(resp_track, plans=plans)
             result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
@@ -393,12 +392,12 @@ class TrainStack(Remote):
         each update's own metrics are attached on ``per_update`` (see
         :func:`_aggregate_update_results`).
         """
-        # UNIRL_PROFILE_SCOPE=update: wrap each optimizer update in a one-shot profiler
+        # UNIRL_PROFILE=one-update: wrap each optimizer update in a one-shot profiler
         # (fires once, on rank0, past warmup) so the trace captures ONLY the
         # backward + FSDP comm + optimizer region — the compute/comm overlap window.
         from unirl.utils.profiling import maybe_profile_update, profile_scope
 
-        scope_update = profile_scope() == "update"
+        scope_update = profile_scope() == "one-update"
         results = []
         for micros in plans:
             cm = maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0))) if scope_update else nullcontext()

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -41,6 +41,7 @@ update shares the same PPO anchor; this is only correct for algorithms with
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Dict, List, Mapping, Optional, Tuple
@@ -346,14 +347,19 @@ class TrainStack(Remote):
             num_updates=self.num_updates_per_batch,
             micro_batch_size=self.micro_batch_size,
         )
-        # Opt-in profiler (UNIRL_PROFILE=1): wraps ONLY the train compute
-        # (anchor-freeze forward + the N optimizer-step updates) — the rollout ran
-        # in the engine phase before this call, so this region is the pure train step.
+        # Opt-in profiler (UNIRL_PROFILE=1). Scope selected by UNIRL_PROFILE_SCOPE:
+        #   step   (default) — profile the whole train compute (anchor-freeze forward
+        #                      + the N optimizer updates); one step() per rollout.
+        #   update           — profile only one optimizer update inside _run_update
+        #                      (backward + FSDP comm + optimizer), excluding the big
+        #                      SDE-replay prepare_segment. Smaller trace + the right
+        #                      window for compute/comm OVERLAP analysis.
         profiler = self._train_step_profiler()
-        with profiler.record("train_track") if profiler is not None else nullcontext():
+        step_scope = profiler is not None and os.environ.get("UNIRL_PROFILE_SCOPE", "step").strip().lower() == "step"
+        with profiler.record("train_track") if step_scope else nullcontext():
             self.prepare_segment(resp_track, plans=plans)
             result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
-        if profiler is not None:
+        if step_scope:
             profiler.step()
         self.on_rollout_end()
         return result
@@ -387,7 +393,20 @@ class TrainStack(Remote):
         each update's own metrics are attached on ``per_update`` (see
         :func:`_aggregate_update_results`).
         """
-        results = [self._run_update(resp_track, micros=micros, training_progress=training_progress) for micros in plans]
+        # UNIRL_PROFILE_SCOPE=update: wrap each optimizer update in a one-shot profiler
+        # (fires once, on rank0, past warmup) so the trace captures ONLY the
+        # backward + FSDP comm + optimizer region — the compute/comm overlap window.
+        scope_update = os.environ.get("UNIRL_PROFILE_SCOPE", "step").strip().lower() == "update"
+        results = []
+        for micros in plans:
+            if scope_update:
+                from unirl.utils.profiling import maybe_profile_update
+
+                cm = maybe_profile_update(self, int(getattr(self.fsdp_backend, "_rank", 0)))
+            else:
+                cm = nullcontext()
+            with cm:
+                results.append(self._run_update(resp_track, micros=micros, training_progress=training_progress))
         if len(results) == 1:
             return results[0]
         aggregated = _aggregate_update_results(results)

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -41,6 +41,7 @@ update shares the same PPO anchor; this is only correct for algorithms with
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Dict, List, Mapping, Optional, Tuple
 
@@ -345,10 +346,27 @@ class TrainStack(Remote):
             num_updates=self.num_updates_per_batch,
             micro_batch_size=self.micro_batch_size,
         )
-        self.prepare_segment(resp_track, plans=plans)
-        result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
+        # Opt-in profiler (UNIRL_PROFILE=1): wraps ONLY the train compute
+        # (anchor-freeze forward + the N optimizer-step updates) — the rollout ran
+        # in the engine phase before this call, so this region is the pure train step.
+        profiler = self._train_step_profiler()
+        with profiler.record("train_track") if profiler is not None else nullcontext():
+            self.prepare_segment(resp_track, plans=plans)
+            result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
+        if profiler is not None:
+            profiler.step()
         self.on_rollout_end()
         return result
+
+    def _train_step_profiler(self):
+        """Lazily build the per-worker train-step profiler (None unless UNIRL_PROFILE)."""
+        cached = getattr(self, "_profiler_cache", "unset")
+        if cached == "unset":
+            from unirl.utils.profiling import maybe_build_train_profiler
+
+            cached = maybe_build_train_profiler(int(getattr(self.fsdp_backend, "_rank", 0)))
+            self._profiler_cache = cached
+        return cached
 
     def _run_updates(
         self,

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -313,14 +313,18 @@ class UnifiedModelTrainStack(Remote):
         ar_track = ar_track.to_device(device)
         image_track = image_track.to_device(device)
 
-        # Opt-in profiler: wraps ONLY the train compute (both algorithms' backward +
-        # the single optimizer step) — the rollout ran in the engine phase before this
-        # call, so this region is the pure train step. Only the whole-step scope applies
-        # here (the update-scope one-shot is wired in TrainStack._run_updates, which this
-        # unified stack does not use); UNIRL_PROFILE=one-update therefore no-ops here.
+        # Only UNIRL_PROFILE=train applies here (one-update lives in TrainStack._run_updates);
+        # warn if one-update was set so it isn't silently ignored.
         from unirl.utils.profiling import profile_scope
 
-        profiler = self._train_step_profiler() if profile_scope() == "train" else None
+        scope = profile_scope()
+        if scope == "one-update" and not getattr(self, "_warned_one_update", False):
+            self._warned_one_update = True
+            logger.warning(
+                "UNIRL_PROFILE=one-update is not supported on the unified-model stack "
+                "(no _run_updates loop); use UNIRL_PROFILE=train. No trace produced."
+            )
+        profiler = self._train_step_profiler() if scope == "train" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             tracks = {"ar": ar_track, "image": image_track}
             # Freeze each track's π_old anchor once, before the multi-update loop.

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -34,6 +34,7 @@ optimizer step, in contrast to the single-stage ``TrainStack``.
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from dataclasses import replace
 from typing import Dict, List, Mapping, Tuple
 
@@ -272,6 +273,16 @@ class UnifiedModelTrainStack(Remote):
         """Per-rollout-boundary hook — delegates to the FSDPBackend's EMA."""
         self.fsdp_backend.on_rollout_end()
 
+    def _train_step_profiler(self):
+        """Lazily build the per-worker train-step profiler (None unless UNIRL_PROFILE)."""
+        cached = getattr(self, "_profiler_cache", "unset")
+        if cached == "unset":
+            from unirl.utils.profiling import maybe_build_train_profiler
+
+            cached = maybe_build_train_profiler(int(getattr(self.fsdp_backend, "_rank", 0)))
+            self._profiler_cache = cached
+        return cached
+
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
     def train_track(
         self,
@@ -302,18 +313,25 @@ class UnifiedModelTrainStack(Remote):
         ar_track = ar_track.to_device(device)
         image_track = image_track.to_device(device)
 
-        tracks = {"ar": ar_track, "image": image_track}
-        # Freeze each track's π_old anchor once, before the multi-update loop.
-        for name in self.algorithms:
-            self.prepare_segment(name, tracks[name])
+        # Opt-in profiler (UNIRL_PROFILE=1): wraps ONLY the train compute
+        # (both algorithms' backward + the optimizer steps) — the rollout ran
+        # in the engine phase before this call, so this region is the pure train step.
+        profiler = self._train_step_profiler()
+        with profiler.record("train_track") if profiler is not None else nullcontext():
+            tracks = {"ar": ar_track, "image": image_track}
+            # Freeze each track's π_old anchor once, before the multi-update loop.
+            for name in self.algorithms:
+                self.prepare_segment(name, tracks[name])
 
-        # N optimizer steps over disjoint mini-batches (each track sliced by the same
-        # shared _optimizer_step_slices; M=1 keeps ar/image 1:1 and equally sized).
-        steps_by_track = {name: self._optimizer_step_slices(int(tracks[name].batch_size)) for name in self.algorithms}
-        per_update: List[Dict[str, TrainStepResult]] = []
-        for u in range(self.num_updates_per_batch):
-            slices_by_track = {name: steps_by_track[name][u] for name in self.algorithms}
-            per_update.append(self._train_one_step(tracks, slices_by_track, training_progress=float(training_progress)))
+            # N optimizer steps over disjoint mini-batches (each track sliced by the same
+            # shared _optimizer_step_slices; M=1 keeps ar/image 1:1 and equally sized).
+            steps_by_track = {name: self._optimizer_step_slices(int(tracks[name].batch_size)) for name in self.algorithms}
+            per_update: List[Dict[str, TrainStepResult]] = []
+            for u in range(self.num_updates_per_batch):
+                slices_by_track = {name: steps_by_track[name][u] for name in self.algorithms}
+                per_update.append(self._train_one_step(tracks, slices_by_track, training_progress=float(training_progress)))
+        if profiler is not None:
+            profiler.step()
 
         self.on_rollout_end()
 

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -333,11 +333,15 @@ class UnifiedModelTrainStack(Remote):
 
             # N optimizer steps over disjoint mini-batches (each track sliced by the same
             # shared _optimizer_step_slices; M=1 keeps ar/image 1:1 and equally sized).
-            steps_by_track = {name: self._optimizer_step_slices(int(tracks[name].batch_size)) for name in self.algorithms}
+            steps_by_track = {
+                name: self._optimizer_step_slices(int(tracks[name].batch_size)) for name in self.algorithms
+            }
             per_update: List[Dict[str, TrainStepResult]] = []
             for u in range(self.num_updates_per_batch):
                 slices_by_track = {name: steps_by_track[name][u] for name in self.algorithms}
-                per_update.append(self._train_one_step(tracks, slices_by_track, training_progress=float(training_progress)))
+                per_update.append(
+                    self._train_one_step(tracks, slices_by_track, training_progress=float(training_progress))
+                )
         if profiler is not None:
             profiler.step()
 

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -317,10 +317,10 @@ class UnifiedModelTrainStack(Remote):
         # the single optimizer step) — the rollout ran in the engine phase before this
         # call, so this region is the pure train step. Only the whole-step scope applies
         # here (the update-scope one-shot is wired in TrainStack._run_updates, which this
-        # unified stack does not use); UNIRL_PROFILE=overlap therefore no-ops here.
+        # unified stack does not use); UNIRL_PROFILE=one-update therefore no-ops here.
         from unirl.utils.profiling import profile_scope
 
-        profiler = self._train_step_profiler() if profile_scope() == "step" else None
+        profiler = self._train_step_profiler() if profile_scope() == "full-step" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             tracks = {"ar": ar_track, "image": image_track}
             # Freeze each track's π_old anchor once, before the multi-update loop.

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -320,7 +320,7 @@ class UnifiedModelTrainStack(Remote):
         # unified stack does not use); UNIRL_PROFILE=one-update therefore no-ops here.
         from unirl.utils.profiling import profile_scope
 
-        profiler = self._train_step_profiler() if profile_scope() == "full-step" else None
+        profiler = self._train_step_profiler() if profile_scope() == "train" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             tracks = {"ar": ar_track, "image": image_track}
             # Freeze each track's π_old anchor once, before the multi-update loop.

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -313,10 +313,14 @@ class UnifiedModelTrainStack(Remote):
         ar_track = ar_track.to_device(device)
         image_track = image_track.to_device(device)
 
-        # Opt-in profiler (UNIRL_PROFILE=1): wraps ONLY the train compute
-        # (both algorithms' backward + the optimizer steps) — the rollout ran
-        # in the engine phase before this call, so this region is the pure train step.
-        profiler = self._train_step_profiler()
+        # Opt-in profiler: wraps ONLY the train compute (both algorithms' backward +
+        # the single optimizer step) — the rollout ran in the engine phase before this
+        # call, so this region is the pure train step. Only the whole-step scope applies
+        # here (the update-scope one-shot is wired in TrainStack._run_updates, which this
+        # unified stack does not use); UNIRL_PROFILE=overlap therefore no-ops here.
+        from unirl.utils.profiling import profile_scope
+
+        profiler = self._train_step_profiler() if profile_scope() == "step" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             tracks = {"ar": ar_track, "image": image_track}
             # Freeze each track's π_old anchor once, before the multi-update loop.

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -140,6 +140,10 @@ class TrainStepProfiler:
                 logger.info("TrainStepProfiler: %d steps profiled; trace written to %s", self._n, self._out_dir)
         except Exception:
             self._stopped = True
+            try:
+                self._prof.stop()  # release CUPTI hooks so later steps carry no overhead
+            except Exception:
+                pass
             logger.warning("TrainStepProfiler: profiling/export failed; training continues", exc_info=True)
 
     @contextmanager
@@ -203,7 +207,11 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
         repeat,
         out_dir,
     )
-    return TrainStepProfiler(prof, total_steps=total, out_dir=out_dir)
+    try:
+        return TrainStepProfiler(prof, total_steps=total, out_dir=out_dir)  # __init__ calls prof.start()
+    except Exception:
+        logger.warning("TrainStepProfiler: profiler start failed (CUPTI init?); not profiling this run", exc_info=True)
+        return None
 
 
 @contextmanager
@@ -247,8 +255,18 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
         profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
         with_stack=False,
     )
+    try:
+        prof.start()
+    except Exception:
+        owner._prof_update_done = True
+        logger.warning(
+            "maybe_profile_update[rank%d]: profiler start failed (CUPTI init?); update unprofiled",
+            int(rank),
+            exc_info=True,
+        )
+        yield
+        return
     logger.info("maybe_profile_update[rank%d]: profiling one optimizer update -> %s", int(rank), out_dir)
-    prof.start()
     try:
         yield
     finally:

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -9,9 +9,9 @@ phase, so the profiled region here is the pure train step.
 Entirely env-gated; a no-op unless ``UNIRL_PROFILE`` is set, so it can ship in the
 hot path. ONE switch, whose value names the region recorded:
 
-* ``UNIRL_PROFILE=one-update`` — profile ONE optimizer update (backward + FSDP comm +
-  optimizer), excluding the big anchor/SDE-replay forward. Small trace; for compute/comm
-  OVERLAP analysis. Exports ``update_rank0.pt.trace.json.gz`` (opens directly in Perfetto).
+* ``UNIRL_PROFILE=one-update`` — profile ONE optimizer update (forward + backward +
+  cross-GPU comm + optimizer), excluding the big anchor/SDE-replay forward. Small trace; for
+  compute/comm OVERLAP. Exports ``update_rank0.pt.trace.json.gz`` (opens directly in Perfetto).
 * ``UNIRL_PROFILE=train`` — profile the WHOLE train step (anchor forward + all N
   updates). Big trace; the complete picture of one training step.
 
@@ -24,8 +24,7 @@ Optional knobs (sensible defaults; override any one):
                               train: schedule warmup steps (default ``1``).
 * ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — train schedule (default ``1``/``1``/``1``
                               = capture exactly ONE full step).
-* ``UNIRL_PROFILE_MEMORY`` / ``_SHAPES`` / ``_STACK`` — extra recording, OFF by default in both
-                              modes (each balloons the trace; opt in only when you need it).
+* ``UNIRL_PROFILE_MEMORY``  — also record CUDA memory alloc/free (default off; bigger trace).
 
 Both modes export a gzipped Chrome/Perfetto trace, one file per profiled rank.
 """
@@ -76,8 +75,8 @@ _MODE_WARNED: set = set()
 def profile_mode() -> str:
     """Resolve the single switch ``UNIRL_PROFILE``. The value names the region recorded:
 
-    * ``one-update`` — profile ONE optimizer update (backward + FSDP comm + optimizer),
-      excluding the big anchor/SDE-replay forward. Small trace; for compute/comm OVERLAP.
+    * ``one-update`` — profile ONE optimizer update (forward + backward + cross-GPU comm +
+      optimizer), excluding the big anchor/SDE-replay forward. Small trace; for OVERLAP.
     * ``train``  — profile the WHOLE train step (anchor forward + all N updates).
       Big trace; the complete picture of one training step.
     * unset / ``0`` / ``false`` / ``off`` — disabled (a no-op).
@@ -185,9 +184,9 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
         activities=activities,
         schedule=sched,
         on_trace_ready=torch.profiler.tensorboard_trace_handler(out_dir, worker_name=f"rank{int(rank)}", use_gzip=True),
-        record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=False),
+        record_shapes=False,
         profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
-        with_stack=_truthy(os.environ.get("UNIRL_PROFILE_STACK"), default=False),
+        with_stack=False,
     )
     total = max(1, (wait + warmup + active) * max(1, repeat))
     logger.info(
@@ -209,7 +208,7 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
     torch.profiler records continuously while active, so the schedule-based
     :class:`TrainStepProfiler` (which spans a whole rollout) always sweeps in the big
     SDE-replay ``prepare_segment`` too. For compute/comm OVERLAP analysis we want just
-    one optimizer update — backward + FSDP reduce-scatter/all-gather + optimizer_step.
+    one optimizer update — forward + backward + cross-GPU comm + optimizer_step.
     This wraps exactly that region in its own profiler and exports immediately, so the
     trace is small and contains only the overlap-relevant window.
 
@@ -239,9 +238,9 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
         activities.append(torch.profiler.ProfilerActivity.CUDA)
     prof = torch.profiler.profile(
         activities=activities,
-        record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=False),
+        record_shapes=False,
         profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
-        with_stack=_truthy(os.environ.get("UNIRL_PROFILE_STACK"), default=False),
+        with_stack=False,
     )
     logger.info("maybe_profile_update[rank%d]: profiling one optimizer update -> %s", int(rank), out_dir)
     prof.start()

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -12,7 +12,7 @@ hot path. ONE switch, whose value names the region recorded:
 * ``UNIRL_PROFILE=one-update`` — profile ONE optimizer update (backward + FSDP comm +
   optimizer), excluding the big anchor/SDE-replay forward. Small trace; for compute/comm
   OVERLAP analysis. Exports ``update_rank0.pt.trace.json.gz`` (opens directly in Perfetto).
-* ``UNIRL_PROFILE=full-step`` — profile the WHOLE train step (anchor forward + all N
+* ``UNIRL_PROFILE=train`` — profile the WHOLE train step (anchor forward + all N
   updates). Big trace; the complete picture of one training step.
 
 Optional knobs (sensible defaults; override any one):
@@ -21,8 +21,8 @@ Optional knobs (sensible defaults; override any one):
 * ``UNIRL_PROFILE_RANKS``   — ``0`` (default), ``all``, or a comma list ``0,8``.
 * ``UNIRL_PROFILE_CUDA``    — record CUDA kernels (default ``1``; ``0`` = CPU-only trace).
 * ``UNIRL_PROFILE_WARMUP``  — one-update: skip N updates before capturing (default ``2``);
-                              full-step: schedule warmup steps (default ``1``).
-* ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — full-step schedule (default ``1``/``1``/``1``
+                              train: schedule warmup steps (default ``1``).
+* ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — train schedule (default ``1``/``1``/``1``
                               = capture exactly ONE full step).
 * ``UNIRL_PROFILE_MEMORY`` / ``_SHAPES`` / ``_STACK`` — extra recording, OFF by default in both
                               modes (each balloons the trace; opt in only when you need it).
@@ -78,7 +78,7 @@ def profile_mode() -> str:
 
     * ``one-update`` — profile ONE optimizer update (backward + FSDP comm + optimizer),
       excluding the big anchor/SDE-replay forward. Small trace; for compute/comm OVERLAP.
-    * ``full-step``  — profile the WHOLE train step (anchor forward + all N updates).
+    * ``train``  — profile the WHOLE train step (anchor forward + all N updates).
       Big trace; the complete picture of one training step.
     * unset / ``0`` / ``false`` / ``off`` — disabled (a no-op).
 
@@ -88,11 +88,11 @@ def profile_mode() -> str:
     v = os.environ.get("UNIRL_PROFILE", "").strip().lower()
     if v in ("", "0", "false", "no", "off"):
         return "off"
-    if v in ("one-update", "full-step"):
+    if v in ("one-update", "train"):
         return v
     if v not in _MODE_WARNED:
         _MODE_WARNED.add(v)
-        logger.warning("UNIRL_PROFILE=%r not recognized; use 'one-update' or 'full-step'. Profiling disabled.", v)
+        logger.warning("UNIRL_PROFILE=%r not recognized; use 'one-update' or 'train'. Profiling disabled.", v)
     return "off"
 
 
@@ -101,7 +101,7 @@ def profile_enabled() -> bool:
 
 
 def profile_scope() -> str:
-    """The region being profiled: ``one-update`` or ``full-step`` (or ``off``).
+    """The region being profiled: ``one-update`` or ``train`` (or ``off``).
 
     Identical to the ``UNIRL_PROFILE`` value — the switch *is* the scope, no separate knob.
     """
@@ -164,7 +164,7 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
         return None
 
     # Default = capture ONE full step (wait1 + warmup1 + active1) so a bare
-    # UNIRL_PROFILE=full-step already produces a small, Perfetto-loadable trace.
+    # UNIRL_PROFILE=train already produces a small, Perfetto-loadable trace.
     wait = _int_env("UNIRL_PROFILE_WAIT", 1)
     warmup = _int_env("UNIRL_PROFILE_WARMUP", 1)
     active = _int_env("UNIRL_PROFILE_ACTIVE", 1)

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -7,29 +7,25 @@ the worker with :class:`TrainStepProfiler`. The rollout runs in a separate engin
 phase, so the profiled region here is the pure train step.
 
 Entirely env-gated; a no-op unless ``UNIRL_PROFILE`` is set, so it can ship in the
-hot path. ONE switch selects a fully-configured preset:
+hot path. ONE switch, whose value names the region recorded:
 
-* ``UNIRL_PROFILE=overlap`` — one optimizer update only (backward + FSDP comm +
-  optimizer), CUDA on, memory/shapes off, rank0. Best for compute/comm OVERLAP
-  analysis; small trace. Output goes to ``outputs/profiler`` (or ``UNIRL_PROFILE_DIR``).
-* ``UNIRL_PROFILE=1`` (or ``step``) — whole train step (anchor forward + updates).
+* ``UNIRL_PROFILE=one-update`` — profile ONE optimizer update (backward + FSDP comm +
+  optimizer), excluding the big anchor/SDE-replay forward. Small trace; for compute/comm
+  OVERLAP analysis. Exports ``update_rank0.pt.trace.json.gz`` (opens directly in Perfetto).
+* ``UNIRL_PROFILE=full-step`` — profile the WHOLE train step (anchor forward + all N
+  updates). Big trace; the complete picture of one training step.
 
-Everything below is auto-set by the preset but can still be overridden:
+Optional knobs (sensible defaults; override any one):
 
-* ``UNIRL_PROFILE``         — ``overlap`` / ``1`` / ``step`` to enable (default off).
-* ``UNIRL_PROFILE_DIR``     — trace output dir (default ``outputs/profiler``).
+* ``UNIRL_PROFILE_DIR``     — trace output dir (default ``outputs/profiler``, auto-created).
 * ``UNIRL_PROFILE_RANKS``   — ``0`` (default), ``all``, or a comma list ``0,8``.
-* ``UNIRL_PROFILE_WAIT``    — schedule wait steps   (default ``2``).
-* ``UNIRL_PROFILE_WARMUP``  — schedule warmup steps (default ``2``).
-* ``UNIRL_PROFILE_ACTIVE``  — schedule active steps (default ``3``).
-* ``UNIRL_PROFILE_REPEAT``  — schedule repeat cycles (default ``1``).
-* ``UNIRL_PROFILE_MEMORY``  — record CUDA mem (default ``1``).
-* ``UNIRL_PROFILE_SHAPES``  — record op input shapes (default ``1``).
-* ``UNIRL_PROFILE_STACK``   — record python stacks (default ``0``; heavy).
+* ``UNIRL_PROFILE_CUDA``    — record CUDA kernels (default ``1``; ``0`` = CPU-only trace).
+* ``UNIRL_PROFILE_WARMUP``  — one-update: skip N updates before capturing (default ``2``);
+                              full-step: schedule warmup steps.
+* ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — full-step schedule (default 2/3/1).
+* ``UNIRL_PROFILE_MEMORY`` / ``_SHAPES`` / ``_STACK`` — extra recording (heavier; off for one-update).
 
-One profiler ``step()`` = one rollout's train call. After ``(wait+warmup+active)*
-repeat`` steps the trace is exported (Chrome/TensorBoard JSON, one file per rank
-worker) and the profiler stops itself — later steps are cheap no-ops.
+Both modes export a gzipped Chrome/Perfetto trace, one file per profiled rank.
 """
 
 from __future__ import annotations
@@ -72,18 +68,30 @@ def _rank_enabled(rank: int) -> bool:
         return rank == 0
 
 
-def profile_mode() -> str:
-    """Resolve the single-switch mode from ``UNIRL_PROFILE``.
+_MODE_WARNED: set = set()
 
-    A single env var is all a caller needs: ``UNIRL_PROFILE=overlap`` auto-configures
-    the whole compute/comm-overlap preset (one optimizer update, CUDA on, memory/shapes
-    off, rank0, local output dir); ``UNIRL_PROFILE=1``/``step``/``true`` is the whole-step
-    preset; anything falsy/unset is off. Individual ``UNIRL_PROFILE_*`` vars still override.
+
+def profile_mode() -> str:
+    """Resolve the single switch ``UNIRL_PROFILE``. The value names the region recorded:
+
+    * ``one-update`` — profile ONE optimizer update (backward + FSDP comm + optimizer),
+      excluding the big anchor/SDE-replay forward. Small trace; for compute/comm OVERLAP.
+    * ``full-step``  — profile the WHOLE train step (anchor forward + all N updates).
+      Big trace; the complete picture of one training step.
+    * unset / ``0`` / ``false`` / ``off`` — disabled (a no-op).
+
+    Any other value is unrecognized -> disabled (warned once). Individual ``UNIRL_PROFILE_*``
+    knobs (DIR, RANKS, CUDA, WARMUP, ...) still tune the run.
     """
     v = os.environ.get("UNIRL_PROFILE", "").strip().lower()
     if v in ("", "0", "false", "no", "off"):
         return "off"
-    return "overlap" if v == "overlap" else "step"
+    if v in ("one-update", "full-step"):
+        return v
+    if v not in _MODE_WARNED:
+        _MODE_WARNED.add(v)
+        logger.warning("UNIRL_PROFILE=%r not recognized; use 'one-update' or 'full-step'. Profiling disabled.", v)
+    return "off"
 
 
 def profile_enabled() -> bool:
@@ -91,14 +99,11 @@ def profile_enabled() -> bool:
 
 
 def profile_scope() -> str:
-    """``step`` (whole train_track) or ``update`` (one optimizer update, for overlap).
+    """The region being profiled: ``one-update`` or ``full-step`` (or ``off``).
 
-    Explicit ``UNIRL_PROFILE_SCOPE`` wins; otherwise ``overlap`` mode implies ``update``.
+    Identical to the ``UNIRL_PROFILE`` value — the switch *is* the scope, no separate knob.
     """
-    s = os.environ.get("UNIRL_PROFILE_SCOPE", "").strip().lower()
-    if s in ("step", "update"):
-        return s
-    return "update" if profile_mode() == "overlap" else "step"
+    return profile_mode()
 
 
 def _out_dir() -> str:

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -21,9 +21,11 @@ Optional knobs (sensible defaults; override any one):
 * ``UNIRL_PROFILE_RANKS``   — ``0`` (default), ``all``, or a comma list ``0,8``.
 * ``UNIRL_PROFILE_CUDA``    — record CUDA kernels (default ``1``; ``0`` = CPU-only trace).
 * ``UNIRL_PROFILE_WARMUP``  — one-update: skip N updates before capturing (default ``2``);
-                              full-step: schedule warmup steps.
-* ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — full-step schedule (default 2/3/1).
-* ``UNIRL_PROFILE_MEMORY`` / ``_SHAPES`` / ``_STACK`` — extra recording (heavier; off for one-update).
+                              full-step: schedule warmup steps (default ``1``).
+* ``UNIRL_PROFILE_WAIT`` / ``_ACTIVE`` / ``_REPEAT`` — full-step schedule (default ``1``/``1``/``1``
+                              = capture exactly ONE full step).
+* ``UNIRL_PROFILE_MEMORY`` / ``_SHAPES`` / ``_STACK`` — extra recording, OFF by default in both
+                              modes (each balloons the trace; opt in only when you need it).
 
 Both modes export a gzipped Chrome/Perfetto trace, one file per profiled rank.
 """
@@ -161,9 +163,11 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     if not _rank_enabled(int(rank)):
         return None
 
-    wait = _int_env("UNIRL_PROFILE_WAIT", 2)
-    warmup = _int_env("UNIRL_PROFILE_WARMUP", 2)
-    active = _int_env("UNIRL_PROFILE_ACTIVE", 3)
+    # Default = capture ONE full step (wait1 + warmup1 + active1) so a bare
+    # UNIRL_PROFILE=full-step already produces a small, Perfetto-loadable trace.
+    wait = _int_env("UNIRL_PROFILE_WAIT", 1)
+    warmup = _int_env("UNIRL_PROFILE_WARMUP", 1)
+    active = _int_env("UNIRL_PROFILE_ACTIVE", 1)
     repeat = _int_env("UNIRL_PROFILE_REPEAT", 1)
     out_dir = _out_dir()
     os.makedirs(out_dir, exist_ok=True)
@@ -181,8 +185,8 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
         activities=activities,
         schedule=sched,
         on_trace_ready=torch.profiler.tensorboard_trace_handler(out_dir, worker_name=f"rank{int(rank)}", use_gzip=True),
-        record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=True),
-        profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=True),
+        record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=False),
+        profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
         with_stack=_truthy(os.environ.get("UNIRL_PROFILE_STACK"), default=False),
     )
     total = max(1, (wait + warmup + active) * max(1, repeat))

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -1,0 +1,140 @@
+"""Opt-in torch.profiler harness for the worker-side training step.
+
+UniRL is an RL framework (rollout → reward → advantage → optimizer step). To
+profile *only* the training compute (forward / loss / backward / optimizer) of a
+backend — without the SGLang/vLLM rollout — wrap the per-rollout train call on
+the worker with :class:`TrainStepProfiler`. The rollout runs in a separate engine
+phase, so the profiled region here is the pure train step.
+
+Entirely env-gated; a no-op unless ``UNIRL_PROFILE`` is truthy, so it can ship in
+the hot path. Knobs (all optional):
+
+* ``UNIRL_PROFILE``         — ``1``/``true`` to enable (default off).
+* ``UNIRL_PROFILE_DIR``     — trace output dir (default ``outputs/profiler``).
+* ``UNIRL_PROFILE_RANKS``   — ``0`` (default), ``all``, or a comma list ``0,8``.
+* ``UNIRL_PROFILE_WAIT``    — schedule wait steps   (default ``2``).
+* ``UNIRL_PROFILE_WARMUP``  — schedule warmup steps (default ``2``).
+* ``UNIRL_PROFILE_ACTIVE``  — schedule active steps (default ``3``).
+* ``UNIRL_PROFILE_REPEAT``  — schedule repeat cycles (default ``1``).
+* ``UNIRL_PROFILE_MEMORY``  — record CUDA mem (default ``1``).
+* ``UNIRL_PROFILE_SHAPES``  — record op input shapes (default ``1``).
+* ``UNIRL_PROFILE_STACK``   — record python stacks (default ``0``; heavy).
+
+One profiler ``step()`` = one rollout's train call. After ``(wait+warmup+active)*
+repeat`` steps the trace is exported (Chrome/TensorBoard JSON, one file per rank
+worker) and the profiler stops itself — later steps are cheap no-ops.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _truthy(value: Optional[str], *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("profiling: %s=%r is not an int; using default %d", name, raw, default)
+        return default
+
+
+def _rank_enabled(rank: int) -> bool:
+    spec = os.environ.get("UNIRL_PROFILE_RANKS", "0").strip().lower()
+    if spec in ("all", "*"):
+        return True
+    try:
+        return rank in {int(p) for p in spec.split(",") if p.strip()}
+    except ValueError:
+        logger.warning("profiling: UNIRL_PROFILE_RANKS=%r unparseable; defaulting to rank 0 only", spec)
+        return rank == 0
+
+
+class TrainStepProfiler:
+    """Thin wrapper: a torch profiler stepped once per rollout train call."""
+
+    def __init__(self, prof: "torch.profiler.profile", total_steps: int, out_dir: str) -> None:
+        self._prof = prof
+        self._total = total_steps
+        self._out_dir = out_dir
+        self._n = 0
+        self._stopped = False
+        prof.start()
+
+    def step(self) -> None:
+        """Advance the schedule by one rollout; auto-stop + export after the window."""
+        if self._stopped:
+            return
+        self._prof.step()
+        self._n += 1
+        if self._n >= self._total:
+            self._prof.stop()
+            self._stopped = True
+            logger.info("TrainStepProfiler: %d steps profiled; trace written to %s", self._n, self._out_dir)
+
+    @contextmanager
+    def record(self, name: str) -> Iterator[None]:
+        with torch.profiler.record_function(name):
+            yield
+
+
+def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
+    """Build a :class:`TrainStepProfiler` from env, or ``None`` if disabled.
+
+    Called lazily on the worker the first time a train step runs (so the device
+    is bound and the profiler attaches to the right CUDA context).
+    """
+    if not _truthy(os.environ.get("UNIRL_PROFILE")):
+        return None
+    if not _rank_enabled(int(rank)):
+        return None
+
+    wait = _int_env("UNIRL_PROFILE_WAIT", 2)
+    warmup = _int_env("UNIRL_PROFILE_WARMUP", 2)
+    active = _int_env("UNIRL_PROFILE_ACTIVE", 3)
+    repeat = _int_env("UNIRL_PROFILE_REPEAT", 1)
+    out_dir = os.environ.get("UNIRL_PROFILE_DIR", "outputs/profiler").strip() or "outputs/profiler"
+    os.makedirs(out_dir, exist_ok=True)
+
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    if torch.cuda.is_available():
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+
+    sched = torch.profiler.schedule(wait=wait, warmup=warmup, active=active, repeat=repeat)
+    prof = torch.profiler.profile(
+        activities=activities,
+        schedule=sched,
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(out_dir, worker_name=f"rank{int(rank)}"),
+        record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=True),
+        profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=True),
+        with_stack=_truthy(os.environ.get("UNIRL_PROFILE_STACK"), default=False),
+    )
+    total = max(1, (wait + warmup + active) * max(1, repeat))
+    logger.info(
+        "TrainStepProfiler[rank%d]: enabled (wait=%d warmup=%d active=%d repeat=%d) -> %s",
+        int(rank),
+        wait,
+        warmup,
+        active,
+        repeat,
+        out_dir,
+    )
+    return TrainStepProfiler(prof, total_steps=total, out_dir=out_dir)
+
+
+__all__ = ["TrainStepProfiler", "maybe_build_train_profiler"]

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -6,10 +6,17 @@ backend — without the SGLang/vLLM rollout — wrap the per-rollout train call 
 the worker with :class:`TrainStepProfiler`. The rollout runs in a separate engine
 phase, so the profiled region here is the pure train step.
 
-Entirely env-gated; a no-op unless ``UNIRL_PROFILE`` is truthy, so it can ship in
-the hot path. Knobs (all optional):
+Entirely env-gated; a no-op unless ``UNIRL_PROFILE`` is set, so it can ship in the
+hot path. ONE switch selects a fully-configured preset:
 
-* ``UNIRL_PROFILE``         — ``1``/``true`` to enable (default off).
+* ``UNIRL_PROFILE=overlap`` — one optimizer update only (backward + FSDP comm +
+  optimizer), CUDA on, memory/shapes off, rank0. Best for compute/comm OVERLAP
+  analysis; small trace. Output goes to ``outputs/profiler`` (or ``UNIRL_PROFILE_DIR``).
+* ``UNIRL_PROFILE=1`` (or ``step``) — whole train step (anchor forward + updates).
+
+Everything below is auto-set by the preset but can still be overridden:
+
+* ``UNIRL_PROFILE``         — ``overlap`` / ``1`` / ``step`` to enable (default off).
 * ``UNIRL_PROFILE_DIR``     — trace output dir (default ``outputs/profiler``).
 * ``UNIRL_PROFILE_RANKS``   — ``0`` (default), ``all``, or a comma list ``0,8``.
 * ``UNIRL_PROFILE_WAIT``    — schedule wait steps   (default ``2``).
@@ -65,6 +72,43 @@ def _rank_enabled(rank: int) -> bool:
         return rank == 0
 
 
+def profile_mode() -> str:
+    """Resolve the single-switch mode from ``UNIRL_PROFILE``.
+
+    A single env var is all a caller needs: ``UNIRL_PROFILE=overlap`` auto-configures
+    the whole compute/comm-overlap preset (one optimizer update, CUDA on, memory/shapes
+    off, rank0, local output dir); ``UNIRL_PROFILE=1``/``step``/``true`` is the whole-step
+    preset; anything falsy/unset is off. Individual ``UNIRL_PROFILE_*`` vars still override.
+    """
+    v = os.environ.get("UNIRL_PROFILE", "").strip().lower()
+    if v in ("", "0", "false", "no", "off"):
+        return "off"
+    return "overlap" if v == "overlap" else "step"
+
+
+def profile_enabled() -> bool:
+    return profile_mode() != "off"
+
+
+def profile_scope() -> str:
+    """``step`` (whole train_track) or ``update`` (one optimizer update, for overlap).
+
+    Explicit ``UNIRL_PROFILE_SCOPE`` wins; otherwise ``overlap`` mode implies ``update``.
+    """
+    s = os.environ.get("UNIRL_PROFILE_SCOPE", "").strip().lower()
+    if s in ("step", "update"):
+        return s
+    return "update" if profile_mode() == "overlap" else "step"
+
+
+def _out_dir() -> str:
+    """Trace output dir. Defaults to ``outputs/profiler`` (relative to cwd, created if
+    missing); set ``UNIRL_PROFILE_DIR`` to write elsewhere. NOTE: writing a very large
+    (multi-GB) trace to a network FS can stall the export — point ``UNIRL_PROFILE_DIR``
+    at a node-local path for whole-step captures."""
+    return os.environ.get("UNIRL_PROFILE_DIR", "").strip() or "outputs/profiler"
+
+
 class TrainStepProfiler:
     """Thin wrapper: a torch profiler stepped once per rollout train call."""
 
@@ -99,7 +143,7 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     Called lazily on the worker the first time a train step runs (so the device
     is bound and the profiler attaches to the right CUDA context).
     """
-    if not _truthy(os.environ.get("UNIRL_PROFILE")):
+    if not profile_enabled():
         return None
     # The caller passes a backend-specific rank that is 0 on every worker for some
     # backends (e.g. FSDP colocate lacks `_rank`). Prefer the true global rank from
@@ -116,7 +160,7 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     warmup = _int_env("UNIRL_PROFILE_WARMUP", 2)
     active = _int_env("UNIRL_PROFILE_ACTIVE", 3)
     repeat = _int_env("UNIRL_PROFILE_REPEAT", 1)
-    out_dir = os.environ.get("UNIRL_PROFILE_DIR", "outputs/profiler").strip() or "outputs/profiler"
+    out_dir = _out_dir()
     os.makedirs(out_dir, exist_ok=True)
 
     activities = [torch.profiler.ProfilerActivity.CPU]
@@ -131,7 +175,7 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     prof = torch.profiler.profile(
         activities=activities,
         schedule=sched,
-        on_trace_ready=torch.profiler.tensorboard_trace_handler(out_dir, worker_name=f"rank{int(rank)}"),
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(out_dir, worker_name=f"rank{int(rank)}", use_gzip=True),
         record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=True),
         profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=True),
         with_stack=_truthy(os.environ.get("UNIRL_PROFILE_STACK"), default=False),
@@ -164,7 +208,7 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
     updates (default 2) so the profiled step is past first-iter compile/allocation.
     A no-op context otherwise.
     """
-    enabled = _truthy(os.environ.get("UNIRL_PROFILE"))
+    enabled = profile_enabled()
     if enabled:
         import torch.distributed as dist
 
@@ -179,7 +223,7 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
         yield
         return
 
-    out_dir = os.environ.get("UNIRL_PROFILE_DIR", "outputs/profiler").strip() or "outputs/profiler"
+    out_dir = _out_dir()
     os.makedirs(out_dir, exist_ok=True)
     activities = [torch.profiler.ProfilerActivity.CPU]
     if _truthy(os.environ.get("UNIRL_PROFILE_CUDA"), default=True) and torch.cuda.is_available():
@@ -197,9 +241,24 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
     finally:
         prof.stop()
         owner._prof_update_done = True
-        out = os.path.join(out_dir, f"update_rank{int(rank)}.pt.trace.json")
-        prof.export_chrome_trace(out)
+        raw = os.path.join(out_dir, f"update_rank{int(rank)}.pt.trace.json")
+        prof.export_chrome_trace(raw)
+        # gzip in place -> opens directly in Perfetto and is small enough to download
+        import gzip
+        import shutil
+
+        out = raw + ".gz"
+        with open(raw, "rb") as fin, gzip.open(out, "wb") as fout:
+            shutil.copyfileobj(fin, fout)
+        os.remove(raw)
         logger.info("maybe_profile_update[rank%d]: trace written to %s", int(rank), out)
 
 
-__all__ = ["TrainStepProfiler", "maybe_build_train_profiler", "maybe_profile_update"]
+__all__ = [
+    "TrainStepProfiler",
+    "maybe_build_train_profiler",
+    "maybe_profile_update",
+    "profile_mode",
+    "profile_enabled",
+    "profile_scope",
+]

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -101,6 +101,14 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     """
     if not _truthy(os.environ.get("UNIRL_PROFILE")):
         return None
+    # The caller passes a backend-specific rank that is 0 on every worker for some
+    # backends (e.g. FSDP colocate lacks `_rank`). Prefer the true global rank from
+    # the process group so UNIRL_PROFILE_RANKS actually restricts to one worker —
+    # profiling every rank makes 8 CUPTI trace-flushes contend and stall the export.
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        rank = dist.get_rank()
     if not _rank_enabled(int(rank)):
         return None
 
@@ -112,7 +120,11 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     os.makedirs(out_dir, exist_ok=True)
 
     activities = [torch.profiler.ProfilerActivity.CPU]
-    if torch.cuda.is_available():
+    # CUDA (CUPTI) activity can be disabled with UNIRL_PROFILE_CUDA=0. On some
+    # torch/driver/CUPTI combos the CUDA kineto trace-finalize (stop_trace) hangs
+    # the export; a CPU-only trace still opens in Perfetto and shows the step
+    # structure + cudaLaunchKernel timeline.
+    if _truthy(os.environ.get("UNIRL_PROFILE_CUDA"), default=True) and torch.cuda.is_available():
         activities.append(torch.profiler.ProfilerActivity.CUDA)
 
     sched = torch.profiler.schedule(wait=wait, warmup=warmup, active=active, repeat=repeat)
@@ -137,4 +149,57 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
     return TrainStepProfiler(prof, total_steps=total, out_dir=out_dir)
 
 
-__all__ = ["TrainStepProfiler", "maybe_build_train_profiler"]
+@contextmanager
+def maybe_profile_update(owner, rank: int) -> Iterator[None]:
+    """One-shot profiler around a SINGLE ``_run_update`` (``UNIRL_PROFILE_SCOPE=update``).
+
+    torch.profiler records continuously while active, so the schedule-based
+    :class:`TrainStepProfiler` (which spans a whole rollout) always sweeps in the big
+    SDE-replay ``prepare_segment`` too. For compute/comm OVERLAP analysis we want just
+    one optimizer update — backward + FSDP reduce-scatter/all-gather + optimizer_step.
+    This wraps exactly that region in its own profiler and exports immediately, so the
+    trace is small and contains only the overlap-relevant window.
+
+    Fires once, on rank0 (true global rank), after skipping ``UNIRL_PROFILE_WARMUP``
+    updates (default 2) so the profiled step is past first-iter compile/allocation.
+    A no-op context otherwise.
+    """
+    enabled = _truthy(os.environ.get("UNIRL_PROFILE"))
+    if enabled:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            rank = dist.get_rank()
+        enabled = _rank_enabled(int(rank))
+
+    n = getattr(owner, "_prof_update_seen", 0)
+    owner._prof_update_seen = n + 1
+    skip = _int_env("UNIRL_PROFILE_WARMUP", 2)
+    if not enabled or getattr(owner, "_prof_update_done", False) or n != skip:
+        yield
+        return
+
+    out_dir = os.environ.get("UNIRL_PROFILE_DIR", "outputs/profiler").strip() or "outputs/profiler"
+    os.makedirs(out_dir, exist_ok=True)
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    if _truthy(os.environ.get("UNIRL_PROFILE_CUDA"), default=True) and torch.cuda.is_available():
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+    prof = torch.profiler.profile(
+        activities=activities,
+        record_shapes=_truthy(os.environ.get("UNIRL_PROFILE_SHAPES"), default=False),
+        profile_memory=_truthy(os.environ.get("UNIRL_PROFILE_MEMORY"), default=False),
+        with_stack=_truthy(os.environ.get("UNIRL_PROFILE_STACK"), default=False),
+    )
+    logger.info("maybe_profile_update[rank%d]: profiling one optimizer update -> %s", int(rank), out_dir)
+    prof.start()
+    try:
+        yield
+    finally:
+        prof.stop()
+        owner._prof_update_done = True
+        out = os.path.join(out_dir, f"update_rank{int(rank)}.pt.trace.json")
+        prof.export_chrome_trace(out)
+        logger.info("maybe_profile_update[rank%d]: trace written to %s", int(rank), out)
+
+
+__all__ = ["TrainStepProfiler", "maybe_build_train_profiler", "maybe_profile_update"]

--- a/unirl/utils/profiling.py
+++ b/unirl/utils/profiling.py
@@ -127,15 +127,20 @@ class TrainStepProfiler:
         prof.start()
 
     def step(self) -> None:
-        """Advance the schedule by one rollout; auto-stop + export after the window."""
+        """Advance the schedule by one rollout; auto-stop + export after the window.
+        Export is best-effort — a failure is logged, never raised into training."""
         if self._stopped:
             return
-        self._prof.step()
-        self._n += 1
-        if self._n >= self._total:
-            self._prof.stop()
+        try:
+            self._prof.step()  # may trigger on_trace_ready (export) at the active->done edge
+            self._n += 1
+            if self._n >= self._total:
+                self._prof.stop()
+                self._stopped = True
+                logger.info("TrainStepProfiler: %d steps profiled; trace written to %s", self._n, self._out_dir)
+        except Exception:
             self._stopped = True
-            logger.info("TrainStepProfiler: %d steps profiled; trace written to %s", self._n, self._out_dir)
+            logger.warning("TrainStepProfiler: profiling/export failed; training continues", exc_info=True)
 
     @contextmanager
     def record(self, name: str) -> Iterator[None]:
@@ -203,7 +208,7 @@ def maybe_build_train_profiler(rank: int) -> Optional[TrainStepProfiler]:
 
 @contextmanager
 def maybe_profile_update(owner, rank: int) -> Iterator[None]:
-    """One-shot profiler around a SINGLE ``_run_update`` (``UNIRL_PROFILE_SCOPE=update``).
+    """One-shot profiler around a SINGLE ``_run_update`` (``UNIRL_PROFILE=one-update``).
 
     torch.profiler records continuously while active, so the schedule-based
     :class:`TrainStepProfiler` (which spans a whole rollout) always sweeps in the big
@@ -247,19 +252,25 @@ def maybe_profile_update(owner, rank: int) -> Iterator[None]:
     try:
         yield
     finally:
-        prof.stop()
+        # Best-effort export: mark done, then log-and-swallow failures (never kill training).
         owner._prof_update_done = True
-        raw = os.path.join(out_dir, f"update_rank{int(rank)}.pt.trace.json")
-        prof.export_chrome_trace(raw)
-        # gzip in place -> opens directly in Perfetto and is small enough to download
-        import gzip
-        import shutil
+        try:
+            prof.stop()
+            raw = os.path.join(out_dir, f"update_rank{int(rank)}.pt.trace.json")
+            prof.export_chrome_trace(raw)
+            # gzip in place -> opens directly in Perfetto and is small enough to download
+            import gzip
+            import shutil
 
-        out = raw + ".gz"
-        with open(raw, "rb") as fin, gzip.open(out, "wb") as fout:
-            shutil.copyfileobj(fin, fout)
-        os.remove(raw)
-        logger.info("maybe_profile_update[rank%d]: trace written to %s", int(rank), out)
+            out = raw + ".gz"
+            with open(raw, "rb") as fin, gzip.open(out, "wb") as fout:
+                shutil.copyfileobj(fin, fout)
+            os.remove(raw)
+            logger.info("maybe_profile_update[rank%d]: trace written to %s", int(rank), out)
+        except Exception:
+            logger.warning(
+                "maybe_profile_update[rank%d]: trace export failed; training continues", int(rank), exc_info=True
+            )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Opt-in `torch.profiler` for the train step, exporting a gzipped Perfetto trace. One env var:

- `UNIRL_PROFILE=one-update` — profile a single optimizer update (forward + backward + comm + optimizer), excluding the anchor forward. Small trace, for compute/comm overlap analysis.
- `UNIRL_PROFILE=train` — profile the whole train step (anchor forward + all updates), for step-time breakdown.

Captures one snapshot on rank 0 after a short warmup, then switches off; training continues normally. Output goes to `outputs/profiler/*.pt.trace.json.gz` (override with `UNIRL_PROFILE_DIR`), opening directly in Perfetto. Off by default; zero impact unless `UNIRL_PROFILE` is set.

**What each file does:**

- `unirl/utils/profiling.py` (new) — the profiler core: parses the `UNIRL_PROFILE` switch and knobs (`_DIR`/`_RANKS`/`_CUDA`/`_WARMUP`/`_MEMORY`), restricts to the true global rank 0 (`dist.get_rank()`), builds the two profilers — a schedule-based one for `train` and a one-shot context manager for `one-update` — and exports the gzipped trace. All of start / step / export are guarded: a profiler failure (e.g. CUPTI init on odd driver/torch combos, slow-FS export) logs a warning and degrades to "not profiled" instead of crashing training.
- `unirl/train/stack/base.py` — hooks the shared `TrainStack` (all diffusion/AR backends): `train_track` wraps the whole step (`prepare_segment` + `_run_updates`) for `train` mode; `_run_updates` wraps a single `_run_update` for `one-update` mode. A lazily-built, cached per-worker profiler; original training logic untouched.
- `unirl/train/unified_model_stack.py` — same hook for the unified AR+image stack (HI3). It fuses each step into one update, so only `train` applies; setting `one-update` logs a warning instead of silently producing nothing.
- `unirl/train/readme.md` — usage docs: the two modes, how to open the trace in Perfetto, and the knob table.

## Related Issue

N/A

## Test Plan

- `python -m unirl.train_diffusion --config-name=diffusion/sd3/sd3_trainside num_devices=8 --cfg job --resolve`
- SD3.5 FlowGRPO 1x8 H20: `one-update` produced an 82 MB trace, `train` a 59 MB trace; both open in Perfetto and show FSDP all-gather/reduce-scatter vs compute streams.
- HI3-80B VeOmni EP (unified stack, `train`): 162 MB trace with EP all-to-all (`ncclDevKernel_SendRecv`) visible.

## Compatibility / Risk

No behavior change unless `UNIRL_PROFILE` is set. No config/checkpoint/API changes.

## Reviewer Notes

AI-assisted; no overlapping PRs found. Unified-model stack supports `train` mode only (warns on `one-update`).

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
