### PR TITLE
feat(sglang lora): deliver LoRA scale via adapter-level alpha

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/_patches/lora_req.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/lora_req.py
@@ -15,7 +15,7 @@ import needed, so this module is import-safe on any interpreter).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List, Optional, Union
 
 
 @dataclass
@@ -24,3 +24,8 @@ class SetLoraFromTensorsReq:
     lora_tensors: dict  # dict[str, torch.Tensor]
     target: Union[str, List[str]] = "all"
     strength: Union[float, List[float]] = 1.0
+    # Optional adapter-level LoRA alpha (one value for the whole adapter), forwarded
+    # to the fork's ``LoRAPipeline.set_lora(lora_alpha=...)``. Supplies the scale
+    # (alpha / rank) for layers whose per-layer ``<layer>.alpha`` key was stranded by
+    # param renaming. ``None`` leaves the pipeline on its existing per-layer path.
+    lora_alpha: Optional[float] = None

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_gpu_worker.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_gpu_worker.py
@@ -33,7 +33,7 @@ See the module-level RISKS docstring at the bottom for upstream gaps.
 
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 import torch
 
@@ -395,20 +395,35 @@ def _set_lora_from_tensors(
     lora_tensors: dict,
     target: Union[str, List[str]] = "all",
     strength: Union[float, List[float]] = 1.0,
+    lora_alpha: Optional[float] = None,
 ):
-    """Set LoRA adapter from in-memory tensors."""
+    """Set LoRA adapter from in-memory tensors.
+
+    ``lora_alpha`` (optional) is forwarded to the fork's ``set_lora`` as an
+    adapter-level alpha; ``None`` leaves the pipeline on its per-layer path.
+    Passed positionally-safe via keyword so an older fork ``set_lora`` without
+    the parameter is not broken (guarded by the try/except below).
+    """
     from sglang.multimodal_gen.runtime.pipelines_core import LoRAPipeline
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 
     if not isinstance(self.pipeline, LoRAPipeline):
         return OutputBatch(error="Lora is not enabled")
-    self.pipeline.set_lora(
-        lora_nickname,
+    kwargs = dict(
         lora_path=None,
         target=target,
         strength=strength,
         lora_tensors=lora_tensors,
     )
+    if lora_alpha is not None:
+        kwargs["lora_alpha"] = lora_alpha
+    try:
+        self.pipeline.set_lora(lora_nickname, **kwargs)
+    except TypeError:
+        # Older fork whose set_lora predates the lora_alpha kwarg: retry without it
+        # (falls back to the pipeline's per-layer alpha path).
+        kwargs.pop("lora_alpha", None)
+        self.pipeline.set_lora(lora_nickname, **kwargs)
     return OutputBatch()
 
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_gpu_worker.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_gpu_worker.py
@@ -401,29 +401,20 @@ def _set_lora_from_tensors(
 
     ``lora_alpha`` (optional) is forwarded to the fork's ``set_lora`` as an
     adapter-level alpha; ``None`` leaves the pipeline on its per-layer path.
-    Passed positionally-safe via keyword so an older fork ``set_lora`` without
-    the parameter is not broken (guarded by the try/except below).
     """
     from sglang.multimodal_gen.runtime.pipelines_core import LoRAPipeline
     from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 
     if not isinstance(self.pipeline, LoRAPipeline):
         return OutputBatch(error="Lora is not enabled")
-    kwargs = dict(
+    self.pipeline.set_lora(
+        lora_nickname,
         lora_path=None,
         target=target,
         strength=strength,
         lora_tensors=lora_tensors,
+        lora_alpha=lora_alpha,
     )
-    if lora_alpha is not None:
-        kwargs["lora_alpha"] = lora_alpha
-    try:
-        self.pipeline.set_lora(lora_nickname, **kwargs)
-    except TypeError:
-        # Older fork whose set_lora predates the lora_alpha kwarg: retry without it
-        # (falls back to the pipeline's per-layer alpha path).
-        kwargs.pop("lora_alpha", None)
-        self.pipeline.set_lora(lora_nickname, **kwargs)
     return OutputBatch()
 
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_lora_tensors.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_lora_tensors.py
@@ -77,6 +77,17 @@ _INIT_SENTINEL = "_unirl_lora_online_init"
 _METHODS_SENTINEL = "_unirl_lora_from_tensors_methods"
 _SETLORA_SENTINEL = "_unirl_lora_tensors_param"
 _LAYER_SENTINEL = "_unirl_lora_online_layer"
+_APPLY_SENTINEL = "_unirl_adapter_alpha_expand"
+
+# Reserved key for an adapter-level LoRA alpha, stored alongside the per-layer
+# weight keys in ``lora_adapters[nickname]``. Real entries are per-layer names
+# (``<layer>.lora_A`` / ``.lora_B`` / ``.alpha``); the double-underscore prefix
+# cannot collide with any transformer layer name. It holds one alpha for the
+# whole adapter; the ``_apply_lora_to_layers`` wrapper (below) expands it into
+# the per-layer ``<layer>.alpha`` keys upstream already reads, using the exact
+# layer names upstream iterates — so no per-layer name alignment is needed and
+# rename-based param mappings can't strand it.
+_ADAPTER_ALPHA_KEY = "__adapter_alpha__"
 
 
 def patch_lora_tensors() -> None:
@@ -151,8 +162,17 @@ def patch_lora_tensors() -> None:
             lora_nickname: str,
             lora_path,
             rank: int,
+            adapter_alpha=None,
         ) -> None:
-            """Shared logic: normalize names, merge fused params, store in lora_adapters."""
+            """Shared logic: normalize names, merge fused params, store in lora_adapters.
+
+            ``adapter_alpha`` (optional) is one alpha for the whole adapter, stored
+            once under ``_ADAPTER_ALPHA_KEY`` and consumed by the fork's
+            ``_apply_lora_to_layers`` as the scale (alpha / rank) for every layer.
+            This is the rename-robust path: unlike a per-layer ``<layer>.alpha`` key
+            (whose name must survive param-renaming to line up with its weight), one
+            adapter-level value needs no name alignment at all.
+            """
             if lora_nickname in self.lora_adapters:
                 self.lora_adapters[lora_nickname].clear()
 
@@ -168,6 +188,11 @@ def patch_lora_tensors() -> None:
             to_merge_params: defaultdict[Hashable, dict[Any, Any]] = defaultdict(dict)
             for name, weight in lora_state_dict.items():
                 name = name.replace("diffusion_model.", "")
+                # LoRA scale is delivered adapter-wide via ``adapter_alpha`` (below),
+                # not as per-layer ``<layer>.alpha`` wire keys. Drop any stray alpha
+                # key so it is not mis-handled as a weight by the mapping/merge path.
+                if name.endswith(".alpha"):
+                    continue
                 name = name.replace(".weight", "")
                 # misc-format -> HF-format
                 name, _, _ = lora_param_names_mapping_fn(name)
@@ -190,6 +215,11 @@ def patch_lora_tensors() -> None:
                         f"Dit target weight name {target_name} already exists in lora_adapters[{lora_nickname}]"
                     )
                 self.lora_adapters[lora_nickname][target_name] = weight.to(self.device)
+            if adapter_alpha is not None:
+                # One alpha for the whole adapter; the _apply_lora_to_layers wrapper
+                # expands it into the per-layer "<layer>.alpha" keys upstream reads
+                # (scale = alpha / rank).
+                self.lora_adapters[lora_nickname][_ADAPTER_ALPHA_KEY] = torch.tensor(float(adapter_alpha))
             if lora_path is not None:
                 self.loaded_adapter_paths[lora_nickname] = lora_path
             logger.info("Rank %d: registered LoRA adapter %s", rank, lora_path or lora_nickname)
@@ -199,10 +229,11 @@ def patch_lora_tensors() -> None:
             lora_tensors: dict,
             lora_nickname: str,
             rank: int,
+            adapter_alpha=None,
         ) -> None:
             """Load LoRA adapter from in-memory tensors instead of a file path."""
             lora_state_dict = normalize_lora_state_dict(lora_tensors, logger=logger)
-            self._register_lora_state_dict(lora_state_dict, lora_nickname, None, rank)
+            self._register_lora_state_dict(lora_state_dict, lora_nickname, None, rank, adapter_alpha=adapter_alpha)
 
         def handle_weight_sync(self, updated_module_names: set) -> None:
             """Handle LoRA state after ALL weight sync buckets have been applied.
@@ -273,6 +304,7 @@ def patch_lora_tensors() -> None:
             merge_weights=None,
             merge_mode=None,
             lora_tensors=None,
+            lora_alpha=None,
         ):
             """Upstream ``set_lora`` + a fork ``lora_tensors=`` in-memory branch.
 
@@ -281,6 +313,10 @@ def patch_lora_tensors() -> None:
             config so upstream re-applies them (LoRA weights change every step),
             then delegate to upstream ``set_lora`` with ``lora_path=None``.
             Otherwise behaviour is byte-for-byte upstream.
+
+            ``lora_alpha`` (optional) is the adapter-level alpha for the in-memory
+            path; it is stored once per adapter and used as the scale source by
+            ``_apply_lora_to_layers``. ``None`` leaves the scale at alpha == rank.
             """
             if lora_tensors is not None:
                 # set_lora always pre-wraps layers when uninitialized, but the
@@ -296,7 +332,7 @@ def patch_lora_tensors() -> None:
                         self.convert_to_lora_layers()
                 # Always reload from tensors — LoRA weights change after each
                 # training step and must be refreshed on every sync.
-                self.load_lora_adapter_from_tensors(lora_tensors, nickname, rank)
+                self.load_lora_adapter_from_tensors(lora_tensors, nickname, rank, adapter_alpha=lora_alpha)
                 # Invalidate cached config so _check_lora_config_matches does not
                 # short-circuit re-application of the (changed) adapter.
                 tgt_list = target if isinstance(target, list) else [target]
@@ -339,6 +375,33 @@ def patch_lora_tensors() -> None:
                 return dist.get_rank() if dist.is_initialized() else 0
 
             LoRAPipeline._distributed_rank = _distributed_rank
+
+    # --- (e) AROUND-wrap _apply_lora_to_layers: expand adapter-level alpha -----
+    # Upstream reads a per-layer "<layer>.alpha" key (scale = alpha/rank) keyed by
+    # the layer name it iterates. We store ONE adapter-level alpha under
+    # _ADAPTER_ALPHA_KEY (see _register_lora_state_dict); expand it here into the
+    # per-layer keys upstream expects, using the SAME layer names upstream will
+    # iterate — so alignment is exact and rename-based mappings can't strand it.
+    # A real per-layer "<layer>.alpha" (if ever present) is left untouched and
+    # still wins. Then delegate to upstream unchanged (args/signature passthrough).
+    if not getattr(LoRAPipeline._apply_lora_to_layers, _APPLY_SENTINEL, False):
+        _orig_apply = LoRAPipeline._apply_lora_to_layers
+
+        def _apply_lora_to_layers(self, lora_layers, lora_nicknames, *args, **kwargs):
+            for nickname in lora_nicknames:
+                adapter = self.lora_adapters.get(nickname)
+                if not adapter or _ADAPTER_ALPHA_KEY not in adapter:
+                    continue
+                adapter_alpha = adapter[_ADAPTER_ALPHA_KEY]
+                for name in lora_layers:
+                    # Only for layers this adapter actually carries weights for,
+                    # and don't clobber a real per-layer alpha if one exists.
+                    if name + ".lora_A" in adapter and name + ".alpha" not in adapter:
+                        adapter[name + ".alpha"] = adapter_alpha
+            return _orig_apply(self, lora_layers, lora_nicknames, *args, **kwargs)
+
+        _apply_lora_to_layers._unirl_adapter_alpha_expand = True  # type: ignore[attr-defined]
+        LoRAPipeline._apply_lora_to_layers = _apply_lora_to_layers
 
     # --- (f) layers/lora/linear.py: snapshot refresh + forward REPLACE --------
     _patch_lora_linear()

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_scheduler.py
@@ -87,7 +87,7 @@ def patch_scheduler() -> None:
                 req.lora_tensors,
                 req.target,
                 req.strength,
-                lora_alpha=getattr(req, "lora_alpha", None),
+                lora_alpha=req.lora_alpha,
             )
 
         def _handle_get_weights_detail(self, reqs: List[Any]) -> OutputBatch:

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_scheduler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_scheduler.py
@@ -82,7 +82,13 @@ def patch_scheduler() -> None:
 
         def _handle_set_lora_from_tensors(self, reqs: List[Any]) -> OutputBatch:
             req = reqs[0]
-            return self.worker.set_lora_from_tensors(req.lora_nickname, req.lora_tensors, req.target, req.strength)
+            return self.worker.set_lora_from_tensors(
+                req.lora_nickname,
+                req.lora_tensors,
+                req.target,
+                req.strength,
+                lora_alpha=getattr(req, "lora_alpha", None),
+            )
 
         def _handle_get_weights_detail(self, reqs: List[Any]) -> OutputBatch:
             """Handle get_weights_detail request — per-param names, shapes, checksums."""

--- a/unirl/rollout/engine/sglang_diffusion/backends/base.py
+++ b/unirl/rollout/engine/sglang_diffusion/backends/base.py
@@ -115,7 +115,13 @@ class Backend(Protocol):
     ) -> None: ...
     def destroy_weights_group(self, *, group_name: str) -> None: ...
     def set_lora(
-        self, *, lora_nickname: str, lora_tensors: Dict[str, Any], target: str = "all", strength: float = 1.0
+        self,
+        *,
+        lora_nickname: str,
+        lora_tensors: Dict[str, Any],
+        target: str = "all",
+        strength: float = 1.0,
+        lora_alpha: Optional[float] = None,
     ) -> None: ...
     def weights_checksum(self, *, module_names: List[str]) -> dict: ...
 

--- a/unirl/rollout/engine/sglang_diffusion/backends/native.py
+++ b/unirl/rollout/engine/sglang_diffusion/backends/native.py
@@ -302,12 +302,14 @@ class SGLangBackend:
         lora_tensors: Dict[str, Any],
         target: str = "all",
         strength: float = 1.0,
+        lora_alpha: Optional[float] = None,
     ) -> None:
         request = self._rt["SetLoraFromTensorsReq"](
             lora_nickname=str(lora_nickname),
             lora_tensors=lora_tensors,
             target=target,
             strength=strength,
+            lora_alpha=lora_alpha,
         )
         response = self._rt["sync_scheduler_client"].forward(request)
         error = getattr(response, "error", None)

--- a/unirl/rollout/engine/sglang_diffusion/weight_sync.py
+++ b/unirl/rollout/engine/sglang_diffusion/weight_sync.py
@@ -141,15 +141,27 @@ class WeightSync:
         would strand one GPU-resident adapter copy (~34 MB/sync measured).
         """
         # Canonical wire keys are "<pipeline_prefix><module>.lora_A.weight"; SGLang's
-        # lora_layers dict is keyed from inside the transformer, so strip the prefix
-        # and inject ".alpha" keys (scale = alpha/rank).
+        # lora_layers dict is keyed from inside the transformer, so strip the prefix.
+        # We do NOT inject per-layer ".alpha" keys anymore (no peft_config here): the
+        # LoRA scale is delivered adapter-wide via ``lora_alpha`` below, which needs
+        # no per-layer name alignment and so is robust to param renaming.
         stripped = adapt_lora_for_sglang(
             lora_tensors,
             pipeline_prefix=self._pipeline_prefix,
-            peft_config=peft_config,
         )
         nickname = adapter_name
-        self._backend.set_lora(lora_nickname=nickname, lora_tensors=stripped)
+        # Adapter-level LoRA alpha (one value for the whole adapter). The engine
+        # stores it once and uses it as the scale source (alpha / rank) for every
+        # layer via _apply_lora_to_layers. Harmless on an older fork whose set_lora
+        # ignores the kwarg (the backend then forwards lora_alpha=None).
+        adapter_alpha = None
+        if peft_config is not None:
+            adapter_alpha = peft_config.get("lora_alpha")
+        self._backend.set_lora(
+            lora_nickname=nickname,
+            lora_tensors=stripped,
+            lora_alpha=(float(adapter_alpha) if adapter_alpha is not None else None),
+        )
         self._active_adapter = nickname
         self._lora_loaded = True
 


### PR DESCRIPTION
## Summary

Delivers the LoRA scale (`alpha / rank`) to the SGLang diffusion rollout engine as a **single adapter-level alpha**, threaded end-to-end, instead of per-layer `<layer>.alpha` wire keys that must be re-aligned to their renamed weight names engine-side.

The per-layer scheme is fragile: for any model whose `param_names_mapping` renames layers, the `.alpha` key (which has no `lora_A`/`lora_B` structure) is not rewritten by the mapping, strands under the old name, the lookup misses, and the layer silently falls back to `alpha == rank` (scale 1.0) regardless of the configured alpha. See #155.

## Self-contained (no engine change)

unirl already monkey-patches `LoRAPipeline`, so this rides the same patch — **no sglang source change, works on the deployed engine as-is**. The engine-side handling is an AROUND-wrap of `_apply_lora_to_layers`: before delegating upstream, it expands the one adapter-level alpha into the per-layer `<layer>.alpha` keys upstream already reads, keyed by the **exact layer names upstream iterates**. Because the injected names come from upstream's own iteration, alignment is exact and rename-based mappings cannot strand them. A real per-layer alpha, if ever present, is left untouched and still wins.

## Changes

- **weight_sync**: read `peft_config["lora_alpha"]` and pass it as an adapter-level value; `adapt_lora_for_sglang` no longer injects per-layer `.alpha` keys.
- **wire it through**: `SetLoraFromTensorsReq.lora_alpha` → scheduler handler → `GPUWorker.set_lora_from_tensors` → `backend.set_lora` → `pipeline.set_lora(lora_alpha=...)`.
- **patch_lora_tensors**: `set_lora` / `load_lora_adapter_from_tensors` / `_register_lora_state_dict` take `adapter_alpha` and store it once under the reserved `"__adapter_alpha__"` key; any stray `.alpha` wire key is dropped. `_apply_lora_to_layers` is AROUND-wrapped to expand that key per-layer.

## Compatibility

Backward-compatible. Every new parameter defaults to `None`; the reserved key is only written when an adapter alpha is supplied; the wrapper is a no-op without it. All existing paths — disk load, per-layer-alpha checkpoints, callers that pass no alpha — are unaffected.

## Test Plan

- `py_compile` + `ruff` (format + check) on all changed files — passes.
- **End-to-end on the deployed sglang (`0.5.12.post1`), unchanged**, via the unirl patch:
  - adapter-level alpha 128 / rank 64 → effective alpha 128 (scale 2.0)
  - no alpha → `alpha == rank` (scale 1.0)
  - a per-layer alpha overrides the adapter-level one
