### PR TITLE
fix(gitignore): drop redundant force-includes that re-expose build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ outputs/
 logs/
 local/
 !unirl/reward/local/
-!unirl/reward/local/**
 **/rollout_data/
 **/buffer_stats/
 *.out
@@ -94,14 +93,8 @@ settings.json
 .DS_Store
 .claude/*
 !.claude/skills/
-!.claude/skills/**
 .cursor/*
 !.cursor/skills/
-!.cursor/skills/**
 !.cursor/rules/
-!.cursor/rules/**
 REFACTOR_LOG.md
 uv.lock
-
-# Re-assert bytecode ignore after the force-includes above (last match wins)
-__pycache__/


### PR DESCRIPTION
## Summary

The four `!<path>/**` force-includes (`unirl/reward/local`, `.claude/skills`, `.cursor/skills`, `.cursor/rules`) are redundant and over-broad:

- Each already has a directory-level un-ignore right above it (e.g. `!unirl/reward/local/`). The parent ignore that made a negation necessary (`local/`, `.claude/*`, `.cursor/*`) matches only one path segment, so git already descends and tracks the source **without** the `/**`.
- The `/**` additionally re-includes exactly what the global rules mean to drop — `__pycache__/`, `*.so`, `*.out`, `*.pkl`, `*.log`, `*.egg-info/` — inside those subtrees.

#123 fixed only the `__pycache__` symptom by re-asserting `__pycache__/` at the bottom of the file (last-match-wins). This removes the **root cause** instead: delete the four redundant `/**` lines so the global ignores apply naturally, and drop the now-unnecessary bottom `__pycache__/` re-assert. Net effect vs. current `main`: source stays tracked, and *all* build artifacts (not just pycache) are ignored again.

## Related Issue

N/A (follow-up to #123)

## Test Plan

`git check-ignore` verification on a real checkout, across all four subtrees:

- Source tracked: `unirl/reward/local/pickscore.py`, `.claude/skills/development/add-model-bundle/SKILL.md`, `.cursor/skills/pr-workflow/SKILL.md`, `.cursor/rules/pr-workflow/SKILL.md`
- Artifacts ignored: `__pycache__/*.pyc` under each subtree (plus `unirl/reward/local/*.so`, which leaks on current `main`)
- `git ls-files` for the four subtrees (24 files) unchanged, and none becomes ignored: `git ls-files unirl/reward/local .claude/skills .cursor/skills .cursor/rules | git check-ignore --stdin` returns empty
- `pre-commit` ran via the commit hook (passed)

## Compatibility / Risk

Low, `.gitignore`-only. A gitignore change never untracks already-committed files, and no currently-tracked file under these subtrees becomes ignored (verified). The only behavior change: build artifacts (`*.so`/`*.out`/`*.pkl`/`*.log`/pycache) under these four subtrees are ignored again, as originally intended.

## Reviewer Notes

Supersedes the band-aid from #123 (removes its trailing `__pycache__/` re-assert, now redundant). AI-assisted; duplicate-work check done — #123 is the only related gitignore PR and this is a deliberate follow-up, not a duplicate.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not (N/A: .gitignore only).