### PR TITLE
fix(sglang weight-sync): SafeUnpickler allowlist + fused-shard/rename mapping

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -153,6 +153,9 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_rollout_trajectory import (
             patch_rollout_trajectory,
         )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_safe_unpickler import (
+            patch_safe_unpickler,
+        )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_sampling_io import (
             patch_sampling_io,
         )
@@ -198,5 +201,6 @@ class SglangDiffusionHijack:
             patch_dance,
             patch_set_timesteps,
             patch_vae_decode_safe,
+            patch_safe_unpickler,
         ):
             _safe_apply(patch)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
@@ -1,0 +1,33 @@
+"""Allow unirl's trusted tensor-rebuild classes through sglang's SafeUnpickler.
+
+Full-weight sync ships serialized CUDA tensors whose reduction references unirl's
+``_rebuild_cuda_tensor_modified`` (``weight_sync.transfer.sgl_compat``). sglang's
+own ``SafeUnpickler`` (``srt/utils/common.py``, the CVE-2025-10164 mitigation)
+allowlists only ``builtins``/``torch``/``multiprocessing``/… — NOT ``unirl.`` —
+so ``update_weights_from_tensor`` raises ``Blocked unsafe class loading
+(unirl…._rebuild_cuda_tensor_modified)`` and the sync (hence the whole full-FT
+sglang run) dies at the first weight push.
+
+unirl's payload is internally produced and trusted (unirl's OWN SafeUnpickler in
+``sgl_compat`` already allowlists ``unirl.``), so the fix is to teach sglang's
+unpickler the same: add the ``unirl.`` prefix to its class allowlist. Idempotent;
+import-safe (sglang imported inside the fn). This must run in every process that
+deserializes the payload — installed via the patch suite's ``hijack()`` (which
+re-installs in spawned SRT children too).
+"""
+
+from __future__ import annotations
+
+
+def patch_safe_unpickler() -> None:
+    try:
+        from sglang.srt.utils.common import SafeUnpickler
+    except Exception:  # noqa: BLE001 — older sglang without the SafeUnpickler shim
+        return
+    prefixes = getattr(SafeUnpickler, "ALLOWED_MODULE_PREFIXES", None)
+    if prefixes is None:
+        return
+    # ``ALLOWED_MODULE_PREFIXES`` is a class-level set; mutating it covers every
+    # instance. Matches sglang's own ``(module + ".").startswith(prefix)`` check.
+    if "unirl." not in prefixes:
+        prefixes.add("unirl.")

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_weights_updater.py
@@ -78,14 +78,24 @@ def _resolve_param_names_mapping(module) -> dict:
 def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int, num_shards: int) -> None:
     """Write ``tensor`` into the ``shard_id``-th slice (dim 0) of a fused param.
 
-    Prefers the param's SGLang ``weight_loader`` when it accepts a shard id (it
-    derives each shard's offset/size from the layer's ``output_sizes`` and is thus
-    TP- and GQA-correct). The manual fallback splits dim 0 into ``num_shards`` EQUAL
-    slices, so it is correct ONLY for equal-sized shards (q==k==v, w1==w3) — which
-    holds for Z-Image base (MHA: ``num_attention_heads == n_kv_heads``) at
-    ``tp_size=1``, the only fused model reaching it here. A future fused GQA model
-    must go through the ``weight_loader`` path (the equal-split fallback would
-    silently corrupt unequal shards).
+    SGLang fused projections pack ``[shard_0 | shard_1 | … | shard_{n-1}]``
+    contiguously along dim 0 in shard-id order. Two layouts occur:
+
+    * **all-equal** — ``q==k==v`` (Z-Image ``to_qkv``), ``w1==w3`` (``w13``): each
+      slice is ``shard_id * size``.
+    * **trailing-unequal** — HunyuanVideo single-block ``linear1 = [q, k, v, mlp]``
+      packs three ``H``-sized attention shards + one ``4H``-sized MLP shard. The
+      leading shards are equal (``shard_id * size``); the LAST shard is larger and
+      sits at the tail (``dim0 - size``).
+
+    Placing the trailing shard at the tail (rather than the legacy ``dim0 //
+    num_shards`` equal split, which slices four ``1.75H`` chunks for ``linear1`` and
+    crashes writing an ``H`` tensor into a ``1.75H`` slot) is exact for both layouts
+    and needs no sibling shards — so it is robust to the sender's bucketing (a
+    block's q/k/v/mlp may arrive in different buckets). It deliberately does NOT
+    support an unequal MIDDLE shard (no SGLang fused param has one). The param's own
+    ``weight_loader`` is tried first when it accepts a shard id (TP-correct); plain
+    ``ReplicatedLinear`` (``tp_size=1``) takes no shard id, so it falls through here.
     """
     wl = getattr(param, "weight_loader", None)
     if wl is not None:
@@ -96,16 +106,40 @@ def _write_fused_shard(param: torch.Tensor, tensor: torch.Tensor, shard_id: int,
             pass
     data = param.data
     total = int(data.shape[0])
-    if total % num_shards != 0:
-        raise ValueError(f"fused param dim0={total} not divisible by num_shards={num_shards}")
-    s = total // num_shards
-    data[shard_id * s : (shard_id + 1) * s].copy_(tensor.to(param.dtype))
+    size = int(tensor.shape[0])
+    # Leading shards are equal-sized; a (possibly larger) trailing shard sits at the
+    # tail. For all-equal fusions the two formulas coincide (``(n-1)*size == dim0 - size``).
+    offset = total - size if shard_id == num_shards - 1 else shard_id * size
+    if offset < 0 or offset + size > total:
+        raise ValueError(
+            f"fused shard {shard_id}/{num_shards}: size={size} at offset={offset} does not fit fused param dim0={total}"
+        )
+    data[offset : offset + size].copy_(tensor.to(param.dtype))
 
 
 def _apply_fused_param_mapping(module, named_tensors):
-    """Consume separate-projection tensors into their fused params via the model's
-    ``param_names_mapping``; return the leftover ``(name, tensor)`` list for the
+    """Apply the model's ``param_names_mapping`` to the incoming named tensors.
+
+    A model's ``param_names_mapping`` (the same dict its checkpoint loader applies)
+    has two entry kinds; a model may use either or both:
+
+    * **fused projections** — ``{regex: (replacement, shard_id, num_shards)}`` —
+      write the trainer's separate-projection tensor into a dim-0 slice of the
+      model's fused param (Z-Image ``to_q/k/v -> to_qkv``, ``w1/w3 -> w13``).
+    * **plain renames** — ``{regex: replacement_str}`` — the model simply renamed
+      a param vs the checkpoint. WAN's mapping is entirely of this kind
+      (``patch_embedding.* -> patch_embedding.proj.*``,
+      ``blocks.N.attn1.to_q.* -> blocks.N.to_q.*``,
+      ``ffn.net.0.proj -> ffn.fc_in``, …). An EMPTY replacement means the model
+      dropped that param (e.g. WAN ``attn2.norm_added_q``) — the tensor is discarded.
+
+    Returns the leftover ``(name, tensor)`` list (renamed where applicable) for the
     exact-match loader. No-op when the module declares no mapping.
+
+    Before this handled the rename kind, simple-rename models (WAN) matched NOTHING
+    in the in-memory update path → 112/113 transformer tensors silently skipped →
+    the rollout engine ran stale base weights → flat reward curve (cross-engine
+    divergence), exactly the fused-model bug one step removed.
     """
     mapping = _resolve_param_names_mapping(module)
     if not mapping:
@@ -113,31 +147,47 @@ def _apply_fused_param_mapping(module, named_tensors):
 
     model_params = dict(module.named_parameters())
     leftover: list = []
-    fused = 0
+    fused = renamed = dropped = 0
     for name, tensor in named_tensors:
         if name in model_params:
             leftover.append((name, tensor))
             continue
         handled = False
         for pat, val in mapping.items():
-            if not isinstance(val, (tuple, list)) or len(val) != 3:
-                continue
             m = re.match(pat, name)
             if m is None:
                 continue
-            replacement, shard_id, num_shards = val
-            target = m.expand(replacement)
-            param = model_params.get(target)
-            if param is None:
-                continue
-            _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
-            fused += 1
-            handled = True
-            break
+            if isinstance(val, (tuple, list)) and len(val) == 3:
+                replacement, shard_id, num_shards = val
+                param = model_params.get(m.expand(replacement))
+                if param is None:
+                    continue
+                _write_fused_shard(param, tensor, int(shard_id), int(num_shards))
+                fused += 1
+                handled = True
+                break
+            if isinstance(val, str):
+                if val == "":
+                    # model dropped this param — nothing to load.
+                    dropped += 1
+                    handled = True
+                    break
+                target = re.sub(pat, val, name)
+                if target in model_params:
+                    leftover.append((target, tensor))
+                    renamed += 1
+                    handled = True
+                    break
+                # rename produced a non-param name; keep trying other patterns.
         if not handled:
             leftover.append((name, tensor))
-    if fused:
-        _log.info("weight-sync: loaded %d fused shard(s) (e.g. qkv/w13) via param_names_mapping", fused)
+    if fused or renamed or dropped:
+        _log.info(
+            "weight-sync: param_names_mapping applied — %d fused, %d renamed, %d dropped",
+            fused,
+            renamed,
+            dropped,
+        )
     return leftover
 
 


### PR DESCRIPTION
## Summary

Model-agnostic **full-weight-sync fixes** for the `sglang_diffusion` engine, split out of the video-rollout PR (#135) — they are unrelated to video output; any full-FT + sglang run needs them.

- **`patch_safe_unpickler` (new)**: sglang's `SafeUnpickler` (the CVE-2025-10164 mitigation in `srt/utils/common.py`) allowlists `torch.` / `peft.` / `sglang.srt.*` but **not** `unirl.`. Full-weight sync ships serialized CUDA tensors whose reduction references unirl's own `_rebuild_cuda_tensor_modified` (a cross-node rebuild that swaps device index for device UUID, working around pytorch/pytorch#149248), so `update_weights_from_tensor` raises `Blocked unsafe class loading (unirl..._rebuild_cuda_tensor_modified)` and the run dies at the first weight push. This adds the trusted `unirl.` prefix to the allowlist (import-safe, idempotent, no-op on older sglang). The payload is unirl-internal and trusted — this does not weaken the CVE mitigation against untrusted data.
- **`patch_weights_updater`**: `_apply_fused_param_mapping` now also applies a model's **plain string renames** and **empty-string drops** from `param_names_mapping`, not just fused (tuple) entries — rename-based models (WAN) otherwise matched nothing in the in-memory update path → the rollout engine ran **stale base weights** (flat reward / cross-engine divergence). `_write_fused_shard` handles the **trailing-unequal** layout (HunyuanVideo `linear1=[q,k,v,mlp]`) via tail placement.
- **`hijack`**: register `patch_safe_unpickler` in the patch suite.

## Background

**Why it surfaced now.** The sglang `SafeUnpickler` lock landed upstream on 2025-10-24 (CVE-2025-10164) and has always been present in this fork; the trigger is new — unirl PR #74 (2026-06-19) rewrote weight-sync and introduced the custom `_rebuild_cuda_tensor_modified`. So the lock was never the change — the payload that trips it is.

**Why #74's tests missed it.** #74 is an LLM-engine PR whose test plan exercised LoRA push, while the bug lives in the shared full-weight-sync layer that only `sglang_diffusion` full-FT walks; #74 also dropped its CPU unit suite and didn't rerun GPU e2e after final fixes. Notably #74 *did* allowlist `unirl.` on unirl's own unpickler — it just omitted the symmetric sglang-side allowlist, which this PR completes.

**What actually trips it (measured).** The block is caused specifically by unirl's own full-weight-sync path (`full/tensor.py` + `sgl_compat.monkey_patch_torch_reductions`), whose reduction pickles a reference into the non-allowlisted `unirl.` namespace. LoRA and sglang's official `update_weights_from_tensor` path use sglang's own rebuild (`sglang.srt.*`, allowlisted) and do NOT trip it — so this is about *which rebuild is used*, not LLM-vs-diffusion.

## Test Plan

- The `SafeUnpickler` block was **reproduced directly on the deployed sglang (`0.5.12.post1`)**: a pickle whose reduction references `unirl...._rebuild_cuda_tensor_modified` raises the exact `Blocked unsafe class loading` error without the patch; with the `unirl.` prefix added, the allowlist check passes.
- **Path comparison verified on the deployed engine**: after unirl's `monkey_patch_torch_reductions`, `reductions.rebuild_cuda_tensor` points into `unirl.` (blocked); after sglang's official patch it points into `sglang.srt.*` (allowlisted, not blocked) — confirming only the unirl full-weight-sync path is affected.
- `py_compile` + `ruff` (check + format) pass on all three changed files.
