### PR TITLE
fix(sglang weight-sync): allowlist unirl. in sglang SafeUnpickler

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/hijack.py
@@ -153,6 +153,9 @@ class SglangDiffusionHijack:
         from unirl.rollout.engine.sglang_diffusion._patches.patch_rollout_trajectory import (
             patch_rollout_trajectory,
         )
+        from unirl.rollout.engine.sglang_diffusion._patches.patch_safe_unpickler import (
+            patch_safe_unpickler,
+        )
         from unirl.rollout.engine.sglang_diffusion._patches.patch_sampling_io import (
             patch_sampling_io,
         )
@@ -198,5 +201,6 @@ class SglangDiffusionHijack:
             patch_dance,
             patch_set_timesteps,
             patch_vae_decode_safe,
+            patch_safe_unpickler,
         ):
             _safe_apply(patch)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_safe_unpickler.py
@@ -1,0 +1,33 @@
+"""Allow unirl's trusted tensor-rebuild classes through sglang's SafeUnpickler.
+
+Full-weight sync ships serialized CUDA tensors whose reduction references unirl's
+``_rebuild_cuda_tensor_modified`` (``weight_sync.transfer.sgl_compat``). sglang's
+own ``SafeUnpickler`` (``srt/utils/common.py``, the CVE-2025-10164 mitigation)
+allowlists only ``builtins``/``torch``/``multiprocessing``/… — NOT ``unirl.`` —
+so ``update_weights_from_tensor`` raises ``Blocked unsafe class loading
+(unirl…._rebuild_cuda_tensor_modified)`` and the sync (hence the whole full-FT
+sglang run) dies at the first weight push.
+
+unirl's payload is internally produced and trusted (unirl's OWN SafeUnpickler in
+``sgl_compat`` already allowlists ``unirl.``), so the fix is to teach sglang's
+unpickler the same: add the ``unirl.`` prefix to its class allowlist. Idempotent;
+import-safe (sglang imported inside the fn). This must run in every process that
+deserializes the payload — installed via the patch suite's ``hijack()`` (which
+re-installs in spawned SRT children too).
+"""
+
+from __future__ import annotations
+
+
+def patch_safe_unpickler() -> None:
+    try:
+        from sglang.srt.utils.common import SafeUnpickler
+    except Exception:  # noqa: BLE001 — older sglang without the SafeUnpickler shim
+        return
+    prefixes = getattr(SafeUnpickler, "ALLOWED_MODULE_PREFIXES", None)
+    if prefixes is None:
+        return
+    # ``ALLOWED_MODULE_PREFIXES`` is a class-level set; mutating it covers every
+    # instance. Matches sglang's own ``(module + ".").startswith(prefix)`` check.
+    if "unirl." not in prefixes:
+        prefixes.add("unirl.")


### PR DESCRIPTION
## Summary

Full-weight sync ships serialized CUDA tensors whose reduction references unirl's own `_rebuild_cuda_tensor_modified` (`weight_sync.transfer.sgl_compat` — a cross-node rebuild that swaps device index for device UUID, working around pytorch/pytorch#149248). sglang's `SafeUnpickler` (`srt/utils/common.py`, the CVE-2025-10164 mitigation) allowlists `torch.` / `peft.` / `sglang.srt.*` but **not** `unirl.`, so `update_weights_from_tensor` raises `Blocked unsafe class loading (unirl..._rebuild_cuda_tensor_modified)` and the full-FT run dies at the first weight push.

This adds the trusted `unirl.` prefix to sglang's allowlist (import-safe, idempotent, no-op on older sglang). The payload is unirl-internal and trusted — unirl's own `SafeUnpickler` in `sgl_compat` already allowlists `unirl.`; this completes the symmetric sglang-side allowlisting that introducing the custom rebuild (#74) omitted. It does not weaken the CVE mitigation against untrusted data.

`hijack` registers `patch_safe_unpickler` in the patch suite.

## Test Plan

- **Reproduced on the deployed sglang (`0.5.12.post1`)**: a pickle whose reduction references `unirl...._rebuild_cuda_tensor_modified` raises the exact `Blocked unsafe class loading` error without the patch; with the `unirl.` prefix added, the allowlist check passes.
- Confirmed only unirl's full-weight-sync path is affected: after unirl's `monkey_patch_torch_reductions`, `reductions.rebuild_cuda_tensor` points into `unirl.` (blocked); sglang's official patch points into `sglang.srt.*` (allowlisted). So LoRA / sglang's own weight-update path is unaffected.
- `py_compile` + `ruff` (check + format) pass.
