### PR TITLE
feat(ltx2): add T2AV audio reward (CLAP + composite, ImageBind optional)

### DIFF
--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -1,0 +1,180 @@
+# @package _global_
+# LTX-Video-2.3 T2AV GRPO with AUDIO REWARD — trainside (in-process FSDP).
+#
+# Extends the T2AV recipe (ltx2_3_t2av_trainside) by scoring the jointly-
+# generated AUDIO in addition to the video. The pipeline decodes the audio
+# waveform (audio_vae + vocoder) and carries it on the track as a parallel
+# stream; the reward service injects it into the reward request so a composite
+# scorer can blend video + audio signals.
+#
+# Reward = T2AVCompositeScorer:
+#   - videopickscore (video quality / image-text alignment on first frame)
+#   - clap           (audio-text alignment, LAION CLAP; zero extra deps)
+# ImageBind (audio-video alignment) is also available as an inner scorer but is
+# NOT enabled here: it requires the facebookresearch/ImageBind package and is
+# CC-BY-NC-SA 4.0 (NonCommercial). To enable, add `imagebind: <weight>` to the
+# composite weights (and install the package).
+#
+# With audio_joint_sde=true, audio is part of the SDE policy AND now receives a
+# direct reward signal, so it is optimized toward prompt alignment (not just
+# passively coupled through cross-attention).
+#
+# Launch (1 node × 8 GPUs):
+#   bash examples/run_experiment_multinode_taiji.sh diffusion/ltx2/ltx2_3_t2av_audioreward_trainside
+
+num_devices: 8
+batch_size: 8
+num_rollouts: 10000
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,unirl-ltx2.3-t2av-audioreward}
+  run_name: null
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [ltx2.3, t2av, grpo, trainside, dancegrpo, audio, audioreward]
+  log_media: true
+  media_max_items: 4
+  # How often (in ROLLOUTS) to log generated media to wandb. One rollout =
+  # one sampling batch (batch_size prompts x samples_per_prompt), NOT one
+  # optimizer step. Set high to keep media logging sparse / cheap.
+  media_log_interval: 1000
+
+bundle:
+  _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config
+  config:
+    _target_: unirl.models.ltx2.config.LTX2PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,dg845/LTX-2.3-Diffusers}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp16
+    logprob_precision: fp32
+    shift: 1.0
+    max_sequence_length: 512
+    enable_audio: true
+    # Joint audio+video SDE policy (default True). False => legacy ODE audio.
+    audio_joint_sde: true
+    default_height: 512
+    default_width: 768
+    default_num_frames: 33
+    default_frame_rate: 24.0
+
+pipeline:
+  _target_: unirl.models.ltx2.pipeline.LTX2Pipeline.from_bundle
+  config: ${bundle.config}
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["LTX2VideoTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      # Video self-attention
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      # Video cross-attention (text)
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+      # Video FFN
+      - ff.net.0.proj
+      - ff.net.2
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 2
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.t2av_composite.T2AVCompositeScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
+      batch_size: 4
+      device: auto
+      # Inner scorer name -> blend weight. videopickscore reads the video,
+      # clap reads the parallel audio side-channel. To add audio-video
+      # alignment, install ImageBind and add `imagebind: <w>` here.
+      weights:
+        videopickscore: 0.5
+        clap: 0.5
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.ltx2.conditions.LTX2Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 1
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 768
+  num_frames: 33
+  eta: 0.7
+  samples_per_prompt: 4
+  seed: 42
+  init_same_noise: false
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 5
+    timestep_fraction: [0, 0.5]

--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -37,7 +37,7 @@ logging:
   # How often (in ROLLOUTS) to log generated media to wandb. One rollout =
   # one sampling batch (batch_size prompts x samples_per_prompt), NOT one
   # optimizer step. Set high to keep media logging sparse / cheap.
-  media_log_interval: 500
+  media_log_interval: 200
 
 bundle:
   _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config

--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -37,7 +37,7 @@ logging:
   # How often (in ROLLOUTS) to log generated media to wandb. One rollout =
   # one sampling batch (batch_size prompts x samples_per_prompt), NOT one
   # optimizer step. Set high to keep media logging sparse / cheap.
-  media_log_interval: 1000
+  media_log_interval: 500
 
 bundle:
   _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config

--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -37,7 +37,7 @@ logging:
   # How often (in ROLLOUTS) to log generated media to wandb. One rollout =
   # one sampling batch (batch_size prompts x samples_per_prompt), NOT one
   # optimizer step. Set high to keep media logging sparse / cheap.
-  media_log_interval: 200
+  media_log_interval: 500
 
 bundle:
   _target_: unirl.models.ltx2.bundle.LTX2Bundle.from_config

--- a/unirl/models/ltx2/pipeline.py
+++ b/unirl/models/ltx2/pipeline.py
@@ -33,7 +33,7 @@ from .config import (
 from .diffusion import LTX2DiffusionStage, audio_latent_shape
 from .schedule import build_ltx2_schedule_policy
 from .text_embed import LTX2TextEmbedStage
-from .vae import LTX2VAEDecodeStage, LTX2VAEEncodeStage
+from .vae import LTX2AudioDecodeStage, LTX2VAEDecodeStage, LTX2VAEEncodeStage
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +56,14 @@ class LTX2Pipeline(Pipeline):
         vae_decode: LTX2VAEDecodeStage,
         vae_encode: Optional[LTX2VAEEncodeStage],
         config: LTX2PipelineConfig,
+        audio_decode: Optional[LTX2AudioDecodeStage] = None,
     ) -> None:
         self.bundle = bundle
         self.text_embed = text_embed
         self.diffusion = diffusion
         self.vae_decode = vae_decode
         self.vae_encode = vae_encode
+        self.audio_decode = audio_decode
         self.config = config
         # Exposed for the hosting engine (TrainsideRolloutEngine reads
         # ``pipeline.shift`` to build a FlowMatchSchedulePolicy at startup) —
@@ -105,6 +107,9 @@ class LTX2Pipeline(Pipeline):
         )
         vae_decode = LTX2VAEDecodeStage(bundle)
         vae_encode = LTX2VAEEncodeStage(bundle)
+        # Audio decode is only meaningful for LTX-2.3 T2AV (bundle has audio_vae
+        # + vocoder). For T2V it stays None and the audio path is never taken.
+        audio_decode = LTX2AudioDecodeStage(bundle) if bundle.has_audio else None
 
         return cls(
             bundle=bundle,
@@ -113,6 +118,7 @@ class LTX2Pipeline(Pipeline):
             vae_decode=vae_decode,
             vae_encode=vae_encode,
             config=config,
+            audio_decode=audio_decode,
         )
 
     def build_schedule_policy(self):
@@ -311,18 +317,49 @@ class LTX2Pipeline(Pipeline):
         unpacked = self._denormalize_latents(unpacked)
         decoded = self.vae_decode.decode(unpacked)  # → varlen-packed Videos
 
+        # 6b. LTX-2.3 T2AV: decode the jointly-generated audio. The audio latent
+        # trajectory rides on ``segment.aux_latents`` (same sparse indices as
+        # the video latents), so the clean final-step audio is at step T. Decode
+        # it to a waveform and carry it as a parallel ``Audios`` on the track so
+        # the reward service can feed audio scorers (CLAP / ImageBind) alongside
+        # the video. T2V (no audio_decode) skips this entirely.
+        decoded_audio = None
+        audio_sample_rate = None
+        if self.audio_decode is not None and segment.aux_latents is not None:
+            from .diffusion import _LTX2_FRAME_RATE, _audio_num_frames
+
+            audio_t = _audio_num_frames(int(params.num_frames), _LTX2_FRAME_RATE)
+            final_audio = segment.aux_latents_at(int(params.num_inference_steps))
+            waveforms = self.audio_decode.decode(final_audio, audio_latent_length=audio_t)
+            # vocoder output: (B, C, L) or (B, L); package one Audio per sample.
+            from unirl.types.primitives import Audio, Audios
+
+            wf = waveforms.detach().float().cpu()
+            # Store one mono ``[L]`` waveform per sample so ``Audios`` packs
+            # cleanly along its varlen L axis and ``to_list`` recovers ``[L]``.
+            audio_list = []
+            for i in range(int(wf.shape[0])):
+                w = wf[i]
+                if w.ndim == 2:
+                    w = w.mean(dim=0) if w.shape[0] <= w.shape[1] else w.mean(dim=1)
+                audio_list.append(Audio(waveform=w.reshape(-1)))
+            decoded_audio = Audios.from_list(audio_list)
+            audio_sample_rate = int(self.bundle.vocoder.config.output_sampling_rate)
+
         # 7. Build response. ``parent_ids=req.group_ids`` makes sibling samples
         # of one prompt a GRPO group (RolloutTrack.group_ids is a derived
         # read-only property — NOT a constructor arg). ``decoded`` is the single
         # Videos primitive for this track (the reward service reads it directly),
         # not a modality-keyed dict. Track key ``"video"`` matches the WAN21
-        # video convention.
+        # video convention. ``decoded_audio`` (T2AV only) is the parallel audio.
         track = RolloutTrack(
             sample_ids=list(req.sample_ids),
             parent_ids=list(req.group_ids),
             conditions=conditions.to_dict(),
             segment=segment,
             decoded=decoded,
+            decoded_audio=decoded_audio,
+            audio_sample_rate=audio_sample_rate,
         )
 
         return RolloutResp(tracks={"video": track})

--- a/unirl/models/ltx2/vae.py
+++ b/unirl/models/ltx2/vae.py
@@ -92,7 +92,14 @@ class LTX2VAEEncodeStage:
 
 
 class LTX2AudioDecodeStage:
-    """Decode audio latents → waveform via audio VAE + vocoder (LTX-2.3)."""
+    """Decode packed audio latents → waveform via audio VAE + vocoder (LTX-2.3).
+
+    Mirrors diffusers ``LTX2Pipeline`` audio decode (and Flow-Factory's
+    ``decode_latents`` audio branch): the operation order is
+    **denormalize → unpack → audio_vae.decode → vocoder** — note that unlike
+    video, audio is denormalized while still PACKED ``[B, S, D]`` and only then
+    unpacked to the spectrogram layout ``[B, C, L, M]``.
+    """
 
     def __init__(self, bundle: "LTX2Bundle") -> None:
         if bundle.audio_vae is None or bundle.vocoder is None:
@@ -101,19 +108,52 @@ class LTX2AudioDecodeStage:
         self.vocoder = bundle.vocoder
         self.dtype = bundle.dtype
 
+    @staticmethod
+    def _denormalize_audio_latents(
+        latents: torch.Tensor, latents_mean: torch.Tensor, latents_std: torch.Tensor
+    ) -> torch.Tensor:
+        """Inverse of the audio VAE normalization, on the packed ``[B, S, D]``
+        latent (verbatim from diffusers ``_denormalize_audio_latents``)."""
+        latents_mean = latents_mean.to(latents.device, latents.dtype)
+        latents_std = latents_std.to(latents.device, latents.dtype)
+        return latents * latents_std + latents_mean
+
+    @staticmethod
+    def _unpack_audio_latents(latents: torch.Tensor, latent_length: int, num_mel_bins: int) -> torch.Tensor:
+        """Packed ``[B, L, C*M]`` → spectrogram ``[B, C, L, M]`` (verbatim from
+        diffusers ``_unpack_audio_latents``, default no-patch path: implicit
+        ``patch_size = M``, ``patch_size_t = 1``)."""
+        return latents.unflatten(2, (-1, num_mel_bins)).transpose(1, 2)
+
     @torch.no_grad()
-    def decode(self, audio_latents: torch.Tensor) -> torch.Tensor:
-        """Decode audio latents → waveform.
+    def decode(self, audio_latents: torch.Tensor, *, audio_latent_length: int) -> torch.Tensor:
+        """Decode packed audio latents → waveform.
 
         Args:
-            audio_latents: Audio latent tensor from the diffusion stage.
+            audio_latents: Packed audio latents ``[B, S, D]`` (the clean
+                final-step audio from the diffusion stage's ``aux_latents``).
+            audio_latent_length: Number of audio LATENT frames ``L`` (so the
+                unpack can recover ``[B, C, L, M]``).
 
         Returns:
-            Audio waveform tensor.
+            Waveform tensor from the vocoder.
         """
-        # Audio VAE decode → mel spectrogram
-        mel = self.audio_vae.decode(audio_latents.to(self.audio_vae.dtype)).sample
-        # Vocoder → waveform
+        # M = latent mel bins = mel_bins // mel_compression_ratio.
+        mel_bins = int(getattr(self.audio_vae.config, "mel_bins", 64))
+        mel_compression = int(getattr(self.audio_vae, "mel_compression_ratio", 4))
+        latent_mel_bins = mel_bins // mel_compression
+
+        # 1. Denormalize FIRST (on the packed latent), then unpack — order
+        #    differs from video (which unpacks first).
+        aud = self._denormalize_audio_latents(
+            audio_latents.float(), self.audio_vae.latents_mean, self.audio_vae.latents_std
+        )
+        # 2. Unpack: [B, L, C*M] -> [B, C, L, M]
+        aud = self._unpack_audio_latents(aud, audio_latent_length, num_mel_bins=latent_mel_bins)
+        # 3. Audio VAE decode -> mel spectrogram
+        aud = aud.to(self.audio_vae.dtype)
+        mel = self.audio_vae.decode(aud, return_dict=False)[0]
+        # 4. Vocoder -> waveform
         waveform = self.vocoder(mel)
         return waveform
 

--- a/unirl/models/ltx2/vae.py
+++ b/unirl/models/ltx2/vae.py
@@ -150,11 +150,12 @@ class LTX2AudioDecodeStage:
         )
         # 2. Unpack: [B, L, C*M] -> [B, C, L, M]
         aud = self._unpack_audio_latents(aud, audio_latent_length, num_mel_bins=latent_mel_bins)
-        # 3. Audio VAE decode -> mel spectrogram
-        aud = aud.to(self.audio_vae.dtype)
-        mel = self.audio_vae.decode(aud, return_dict=False)[0]
-        # 4. Vocoder -> waveform
-        waveform = self.vocoder(mel)
+        # 3. Audio VAE decode -> mel spectrogram (fp32: BigVGAN vocoder uses
+        #    snake activation + Kaiser sinc filters that overflow in bf16).
+        aud = aud.to(torch.float32)
+        mel = self.audio_vae.to(torch.float32).decode(aud, return_dict=False)[0]
+        # 4. Vocoder -> waveform (fp32 for numerical stability)
+        waveform = self.vocoder.to(torch.float32)(mel)
         return waveform
 
 

--- a/unirl/reward/local/__init__.py
+++ b/unirl/reward/local/__init__.py
@@ -2,16 +2,19 @@
 
 from .aesthetic import AestheticRewardScorer
 from .base import LocalRewardBackend
+from .clap import CLAPRewardScorer
 from .clip import ClipRewardScorer
 from .geneval2 import GenEval2RewardScorer
 from .hpsv2 import HPSv2RewardScorer
 from .hpsv3 import HPSv3RewardScorer
 from .hpsv3pp import HPSv3PPRewardScorer
 from .image_reward import ImageRewardScorer
+from .imagebind import ImageBindRewardScorer
 from .mc_exact_match import MCExactMatchRewardScorer
 from .ocr import OCRRewardScorer
 from .pickscore import PickScoreRewardScorer
 from .registry import available_builtin_reward_models, resolve_builtin_reward_scorer_class
+from .t2av_composite import T2AVCompositeScorer
 from .video import VideoRewardScorer
 from .video_clip_delta import VideoCLIPDeltaScorer
 from .video_pickscore import VideoPickScoreScorer
@@ -20,15 +23,18 @@ from .videoalign import VideoAlignRewardScorer
 __all__ = [
     "AestheticRewardScorer",
     "LocalRewardBackend",
+    "CLAPRewardScorer",
     "ClipRewardScorer",
     "GenEval2RewardScorer",
     "HPSv2RewardScorer",
     "HPSv3RewardScorer",
     "HPSv3PPRewardScorer",
     "ImageRewardScorer",
+    "ImageBindRewardScorer",
     "MCExactMatchRewardScorer",
     "OCRRewardScorer",
     "PickScoreRewardScorer",
+    "T2AVCompositeScorer",
     "VideoCLIPDeltaScorer",
     "VideoAlignRewardScorer",
     "VideoPickScoreScorer",

--- a/unirl/reward/local/clap.py
+++ b/unirl/reward/local/clap.py
@@ -68,6 +68,8 @@ class CLAPRewardScorer(LocalRewardBackend):
         processed: List[np.ndarray] = []
         for waveform in audio_list:
             wf = waveform.detach().float()
+            if wf.isnan().any() or wf.isinf().any():
+                wf = torch.zeros_like(wf)
             if wf.ndim == 2:
                 # Reduce the channel axis to mono regardless of [C, L] vs [L, C]:
                 # the channel axis is the smaller of the two.

--- a/unirl/reward/local/clap.py
+++ b/unirl/reward/local/clap.py
@@ -1,0 +1,132 @@
+"""CLAP audio-text alignment reward — LAION CLAP via HuggingFace transformers.
+
+Scores cosine similarity between generated audio and the text prompt. Used for
+LTX-2.3 T2AV where the reward service injects the jointly-generated audio
+waveform into ``request.generated["audio"]`` (a side-channel alongside the
+video in ``request.generated["video"]``). Mirrors Flow-Factory's CLAP reward.
+
+Zero extra dependencies — ``transformers.ClapModel`` is already in the dep tree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import torch
+import torch.nn.functional as F
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.device import resolve_device
+from unirl.types.reward import RewardRequest
+
+from .base import LocalRewardBackend
+
+
+class CLAPRewardScorer(LocalRewardBackend):
+    """Audio-text alignment reward using LAION CLAP.
+
+    ``input_kind = "video"``: the primary decoded media is the video (so the
+    track routes through the video path), and the audio arrives as a parallel
+    side-channel (``request.generated["audio"]`` + ``request.audio_sample_rate``)
+    that the reward service injects when the track has ``decoded_audio``.
+    """
+
+    canonical_model_name = "clap"
+    input_kind = "video"
+    CLAP_SAMPLE_RATE = 48_000
+
+    def __init__(self, *, config: "CLAPSpec", base_device: str) -> None:
+        super().__init__(
+            device=resolve_device(config.device, base_device),
+            batch_size=config.batch_size,
+            model_id=config.model_id,
+        )
+
+    def _load_model(self) -> None:
+        try:
+            from transformers import ClapModel, ClapProcessor
+        except ImportError as e:
+            raise ImportError("transformers with ClapModel/ClapProcessor is required for the CLAP reward") from e
+
+        model_id = self.model_kwargs.get("model_id", "laion/larger_clap_general")
+        # float32 required: CLAP audio encoder uses BatchNorm, which is unstable / unsupported in fp16/bf16.
+        self.model = ClapModel.from_pretrained(model_id).to(self.device).eval()
+        self.model = self.model.to(dtype=torch.float32)
+        self.processor = ClapProcessor.from_pretrained(model_id)
+
+    def _preprocess_audio(self, audio_list: List[torch.Tensor], src_sample_rate: int) -> List["torch.Tensor"]:
+        """Downmix to mono and resample each waveform to CLAP's 48 kHz.
+
+        Accepts per-sample tensors shaped ``[L]``, ``[C, L]``, or ``[L, C]``
+        (the ``Audios`` primitive packs along the leading L axis, so ``to_list``
+        yields ``[L]`` / ``[L, C]``). Returns mono numpy float32 arrays ``[L']``.
+        """
+        import numpy as np
+        import torchaudio.functional as AF
+
+        processed: List[np.ndarray] = []
+        for waveform in audio_list:
+            wf = waveform.detach().float()
+            if wf.ndim == 2:
+                # Reduce the channel axis to mono regardless of [C, L] vs [L, C]:
+                # the channel axis is the smaller of the two.
+                ch_axis = 0 if wf.shape[0] <= wf.shape[1] else 1
+                wf = wf.mean(dim=ch_axis)
+            wf = wf.reshape(-1)  # (L,)
+
+            if src_sample_rate != self.CLAP_SAMPLE_RATE:
+                wf = AF.resample(
+                    wf.unsqueeze(0),
+                    orig_freq=int(src_sample_rate),
+                    new_freq=self.CLAP_SAMPLE_RATE,
+                ).squeeze(0)
+
+            processed.append(wf.cpu().numpy())
+        return processed
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        audio = request.audio
+        prompts = request.prompts
+        if audio is None:
+            raise ValueError(
+                "CLAPRewardScorer requires audio in the reward request "
+                "(request.generated['audio']); got none. Ensure the pipeline "
+                "decodes audio into track.decoded_audio for LTX-2.3 T2AV."
+            )
+        if request.audio_sample_rate is None:
+            raise ValueError("CLAPRewardScorer requires request.audio_sample_rate (source Hz); got None.")
+        src_rate = int(request.audio_sample_rate)
+
+        all_rewards: List[float] = []
+        for i in range(0, len(audio), self.batch_size):
+            batch_audio = audio[i : i + self.batch_size]
+            batch_prompts = prompts[i : i + self.batch_size]
+            waveforms_np = self._preprocess_audio(batch_audio, src_rate)
+
+            inputs = self.processor(
+                text=batch_prompts,
+                audios=waveforms_np,
+                sampling_rate=self.CLAP_SAMPLE_RATE,
+                return_tensors="pt",
+                padding=True,
+            )
+            inputs = {k: v.to(self.device) for k, v in inputs.items()}
+
+            with torch.no_grad():
+                outputs = self.model(**inputs)
+                audio_embeds = F.normalize(outputs.audio_embeds, p=2, dim=-1)
+                text_embeds = F.normalize(outputs.text_embeds, p=2, dim=-1)
+                scores = (audio_embeds * text_embeds).sum(dim=-1)
+            all_rewards.extend(scores.float().cpu().tolist())
+
+        return all_rewards
+
+
+@dataclass
+class CLAPSpec(BaseRewardComponentSpec):
+    """Typed config for the CLAP audio-text reward component."""
+
+    batch_size: int = 8
+    device: str = "auto"
+    model_id: str = "laion/larger_clap_general"

--- a/unirl/reward/local/imagebind.py
+++ b/unirl/reward/local/imagebind.py
@@ -1,0 +1,276 @@
+"""Audio-video / audio-text semantic alignment reward using Meta ImageBind.
+
+Mirrors Flow-Factory's ImageBind reward. Used for LTX-2.3 T2AV where the reward
+service injects the jointly-generated audio into ``request.generated["audio"]``
+alongside the video in ``request.generated["video"]``.
+
+IMPORTANT: ImageBind is licensed under CC-BY-NC-SA 4.0 (NonCommercial). The
+package is NOT a base dependency — it is imported lazily inside ``_load_model``
+so the scorer only pulls it in when a recipe explicitly selects ``imagebind``.
+Install with::
+
+    pip install git+https://github.com/facebookresearch/ImageBind.git
+    pip install git+https://github.com/facebookresearch/pytorchvideo.git
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn.functional as F
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.device import resolve_device
+from unirl.types.reward import RewardRequest
+
+from .base import LocalRewardBackend
+
+_IMAGEBIND_LICENSE_WARNING = (
+    "ImageBind is licensed under CC-BY-NC-SA 4.0 (NonCommercial). Using it in "
+    "commercial applications may violate the license. "
+    "See https://github.com/facebookresearch/ImageBind/blob/main/LICENSE"
+)
+_IMAGEBIND_INSTALL_MSG = (
+    "ImageBind is not installed. Install with:\n"
+    "  pip install git+https://github.com/facebookresearch/ImageBind.git\n"
+    "  pip install git+https://github.com/facebookresearch/pytorchvideo.git\n"
+    "Note: ImageBind is CC-BY-NC-SA 4.0 (NonCommercial only)."
+)
+
+_IB_AUDIO_SAMPLE_RATE = 16_000
+_IB_AUDIO_NUM_MEL_BINS = 128
+_IB_AUDIO_TARGET_LENGTH = 204
+_IB_AUDIO_CLIP_DURATION = 2
+_IB_AUDIO_CLIPS_PER_SAMPLE = 3
+_IB_AUDIO_MEAN = -4.268
+_IB_AUDIO_STD = 9.138
+
+_IB_VISION_SIZE = 224
+_IB_VISION_MEAN = (0.48145466, 0.4578275, 0.40821073)
+_IB_VISION_STD = (0.26862954, 0.26130258, 0.27577711)
+
+
+class ImageBindRewardScorer(LocalRewardBackend):
+    """Audio-video / audio-text alignment reward using Meta ImageBind.
+
+    Modes (``mode`` on the Spec):
+        - "audio_video" (default): cos_sim(audio, video)
+        - "text_audio":            cos_sim(text, audio)
+        - "text_video":            cos_sim(text, video)
+        - "all":                   weighted sum of all three
+
+    ``input_kind = "video"``: video is the primary decoded media; audio arrives
+    as the parallel side-channel (``request.generated["audio"]``).
+
+    IMPORTANT: ImageBind is CC-BY-NC-SA 4.0 (NonCommercial).
+    """
+
+    canonical_model_name = "imagebind"
+    input_kind = "video"
+    DEFAULT_MODE = "audio_video"
+
+    def __init__(self, *, config: "ImageBindSpec", base_device: str) -> None:
+        self._mode = str(config.mode or self.DEFAULT_MODE)
+        self._weights = dict(config.weights or {"audio_video": 0.5, "text_audio": 0.25, "text_video": 0.25})
+        super().__init__(
+            device=resolve_device(config.device, base_device),
+            batch_size=config.batch_size,
+        )
+
+    def _load_model(self) -> None:
+        warnings.warn(_IMAGEBIND_LICENSE_WARNING, stacklevel=2)
+        try:
+            from imagebind.models import imagebind_model
+        except ImportError as e:
+            raise ImportError(_IMAGEBIND_INSTALL_MSG) from e
+
+        self.model = imagebind_model.imagebind_huge(pretrained=True).to(self.device).eval()
+
+    # ---- audio preprocessing -------------------------------------------------
+
+    def _preprocess_audio_to_melspec(self, audio_list: List[torch.Tensor], src_sample_rate: int) -> torch.Tensor:
+        import torch.nn.functional as Fn
+        import torchaudio.functional as AF
+
+        batch_clips = []
+        samples_per_clip = _IB_AUDIO_CLIP_DURATION * _IB_AUDIO_SAMPLE_RATE
+        for waveform in audio_list:
+            wf = waveform.detach().float()
+            if wf.ndim == 2:
+                ch_axis = 0 if wf.shape[0] <= wf.shape[1] else 1
+                wf = wf.mean(dim=ch_axis)
+            wf = wf.reshape(1, -1)  # (1, T)
+            if src_sample_rate != _IB_AUDIO_SAMPLE_RATE:
+                wf = AF.resample(wf, src_sample_rate, _IB_AUDIO_SAMPLE_RATE)
+
+            duration_s = wf.shape[1] / _IB_AUDIO_SAMPLE_RATE
+            clip_starts = self._compute_clip_starts(duration_s, _IB_AUDIO_CLIP_DURATION, _IB_AUDIO_CLIPS_PER_SAMPLE)
+            mel_clips = []
+            for start_s in clip_starts:
+                start_idx = int(start_s * _IB_AUDIO_SAMPLE_RATE)
+                clip = wf[:, start_idx : start_idx + samples_per_clip]
+                if clip.shape[1] < samples_per_clip:
+                    clip = Fn.pad(clip, (0, samples_per_clip - clip.shape[1]))
+                mel = self._waveform_to_melspec(clip)
+                mel = (mel - _IB_AUDIO_MEAN) / _IB_AUDIO_STD
+                mel_clips.append(mel)
+            batch_clips.append(torch.stack(mel_clips, dim=0))
+        return torch.stack(batch_clips, dim=0).to(self.device)
+
+    @staticmethod
+    def _waveform_to_melspec(waveform: torch.Tensor) -> torch.Tensor:
+        import torch.nn.functional as Fn
+        import torchaudio.compliance.kaldi as kaldi
+
+        waveform = waveform.float()
+        waveform = waveform - waveform.mean()
+        fbank = kaldi.fbank(
+            waveform,
+            htk_compat=True,
+            sample_frequency=_IB_AUDIO_SAMPLE_RATE,
+            use_energy=False,
+            window_type="hanning",
+            num_mel_bins=_IB_AUDIO_NUM_MEL_BINS,
+            dither=0.0,
+            frame_length=25,
+            frame_shift=10,
+        )
+        fbank = fbank.transpose(0, 1)
+        n_frames = fbank.shape[1]
+        if n_frames < _IB_AUDIO_TARGET_LENGTH:
+            fbank = Fn.pad(fbank, (0, _IB_AUDIO_TARGET_LENGTH - n_frames))
+        else:
+            fbank = fbank[:, :_IB_AUDIO_TARGET_LENGTH]
+        return fbank.unsqueeze(0)
+
+    @staticmethod
+    def _compute_clip_starts(duration_s: float, clip_duration: float, num_clips: int) -> List[float]:
+        if duration_s <= clip_duration:
+            return [0.0] * num_clips
+        spacing = (duration_s - clip_duration) / max(num_clips - 1, 1)
+        return [i * spacing for i in range(num_clips)]
+
+    # ---- video preprocessing -------------------------------------------------
+
+    def _preprocess_video(self, video_list: List[torch.Tensor]) -> torch.Tensor:
+        batch_result = []
+        for video in video_list:
+            video_f = video.float() / 255.0 if video.dtype == torch.uint8 else video.float()
+            clips = self._temporal_subsample_clips(video_f, num_clips=5, frames_per_clip=2)
+            all_crops = []
+            for clip in clips:
+                clip = self._resize_short_side(clip, _IB_VISION_SIZE)
+                clip = self._normalize_video_clip(clip)
+                all_crops.extend(self._spatial_crop(clip, _IB_VISION_SIZE))
+            batch_result.append(torch.stack(all_crops, dim=0))
+        return torch.stack(batch_result, dim=0).to(self.device)
+
+    @staticmethod
+    def _temporal_subsample_clips(video: torch.Tensor, num_clips: int, frames_per_clip: int) -> List[torch.Tensor]:
+        T = video.shape[0]
+        clips = []
+        for i in range(num_clips):
+            center = int((i + 0.5) * T / num_clips)
+            indices = torch.linspace(
+                max(0, center - frames_per_clip // 2),
+                min(T - 1, center + frames_per_clip // 2 - 1),
+                frames_per_clip,
+            ).long()
+            clips.append(video[indices].permute(1, 0, 2, 3))
+        return clips
+
+    @staticmethod
+    def _resize_short_side(clip: torch.Tensor, size: int) -> torch.Tensor:
+        C, T, H, W = clip.shape
+        if W <= H:
+            new_w, new_h = size, int(H / W * size)
+        else:
+            new_w, new_h = int(W / H * size), size
+        clip_flat = clip.reshape(C * T, 1, H, W)
+        clip_resized = F.interpolate(clip_flat, size=(new_h, new_w), mode="bilinear", align_corners=False)
+        return clip_resized.reshape(C, T, new_h, new_w)
+
+    @staticmethod
+    def _normalize_video_clip(clip: torch.Tensor) -> torch.Tensor:
+        mean = torch.tensor(_IB_VISION_MEAN, device=clip.device).view(3, 1, 1, 1)
+        std = torch.tensor(_IB_VISION_STD, device=clip.device).view(3, 1, 1, 1)
+        return (clip - mean) / std
+
+    @staticmethod
+    def _spatial_crop(clip: torch.Tensor, crop_size: int) -> List[torch.Tensor]:
+        C, T, H, W = clip.shape
+        crops = []
+        if H > W:
+            offsets = [0, (H - crop_size) // 2, H - crop_size]
+            for y in offsets:
+                crops.append(clip[:, :, y : y + crop_size, :])
+        else:
+            offsets = [0, (W - crop_size) // 2, W - crop_size]
+            for x in offsets:
+                crops.append(clip[:, :, :, x : x + crop_size])
+        return crops
+
+    # ---- scoring -------------------------------------------------------------
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        from imagebind.data import load_and_transform_text
+        from imagebind.models.imagebind_model import ModalityType
+
+        audio = request.audio
+        videos = request.videos
+        prompts = request.prompts
+
+        need_text = self._mode in ("text_audio", "text_video", "all")
+        need_audio = self._mode in ("audio_video", "text_audio", "all")
+        need_video = self._mode in ("audio_video", "text_video", "all")
+
+        if need_audio and audio is None:
+            raise ValueError("ImageBindRewardScorer: mode needs audio but request.generated['audio'] is None.")
+        if need_video and videos is None:
+            raise ValueError("ImageBindRewardScorer: mode needs video but request.generated['video'] is None.")
+
+        src_rate = int(request.audio_sample_rate) if request.audio_sample_rate is not None else _IB_AUDIO_SAMPLE_RATE
+
+        inputs: Dict[str, torch.Tensor] = {}
+        if need_text:
+            inputs[ModalityType.TEXT] = load_and_transform_text(prompts, self.device)
+        if need_audio:
+            inputs[ModalityType.AUDIO] = self._preprocess_audio_to_melspec(audio, src_rate)
+        if need_video:
+            inputs[ModalityType.VISION] = self._preprocess_video(videos)
+
+        with torch.no_grad():
+            embeddings = self.model(inputs)
+        rewards = self._compute_similarity(embeddings, ModalityType)
+        return rewards.float().cpu().tolist()
+
+    def _compute_similarity(self, embeddings: dict, ModalityType) -> torch.Tensor:
+        def cos(a, b):
+            return (F.normalize(a, dim=-1) * F.normalize(b, dim=-1)).sum(dim=-1)
+
+        if self._mode == "audio_video":
+            return cos(embeddings[ModalityType.AUDIO], embeddings[ModalityType.VISION])
+        if self._mode == "text_audio":
+            return cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
+        if self._mode == "text_video":
+            return cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
+        if self._mode == "all":
+            w = self._weights
+            av = cos(embeddings[ModalityType.AUDIO], embeddings[ModalityType.VISION])
+            ta = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
+            tv = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
+            return w["audio_video"] * av + w["text_audio"] * ta + w["text_video"] * tv
+        raise ValueError(f"Unknown ImageBind mode {self._mode!r}; expected audio_video|text_audio|text_video|all.")
+
+
+@dataclass
+class ImageBindSpec(BaseRewardComponentSpec):
+    """Typed config for the ImageBind audio-video reward component (NonCommercial)."""
+
+    batch_size: int = 8
+    device: str = "auto"
+    mode: str = "audio_video"
+    weights: Optional[Dict[str, float]] = field(default=None)

--- a/unirl/reward/local/registry.py
+++ b/unirl/reward/local/registry.py
@@ -30,6 +30,9 @@ _BUILTIN_SCORERS: Dict[str, Tuple[str, str]] = {
     "videoclipdelta": ("unirl.reward.local.video_clip_delta", "VideoCLIPDeltaScorer"),
     "videoalign": ("unirl.reward.local.videoalign", "VideoAlignRewardScorer"),
     "mc_exact_match": ("unirl.reward.local.mc_exact_match", "MCExactMatchRewardScorer"),
+    "clap": ("unirl.reward.local.clap", "CLAPRewardScorer"),
+    "imagebind": ("unirl.reward.local.imagebind", "ImageBindRewardScorer"),
+    "t2av_composite": ("unirl.reward.local.t2av_composite", "T2AVCompositeScorer"),
 }
 
 _BUILTIN_SPECS: Dict[str, Tuple[str, str]] = {
@@ -46,6 +49,9 @@ _BUILTIN_SPECS: Dict[str, Tuple[str, str]] = {
     "videoclipdelta": ("unirl.reward.local.video_clip_delta", "VideoCLIPDeltaSpec"),
     "videoalign": ("unirl.reward.local.videoalign", "VideoAlignSpec"),
     "mc_exact_match": ("unirl.reward.local.mc_exact_match", "MCExactMatchSpec"),
+    "clap": ("unirl.reward.local.clap", "CLAPSpec"),
+    "imagebind": ("unirl.reward.local.imagebind", "ImageBindSpec"),
+    "t2av_composite": ("unirl.reward.local.t2av_composite", "T2AVCompositeSpec"),
 }
 
 

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -1,0 +1,121 @@
+"""T2AV composite reward — weighted blend of video + audio scorers.
+
+For LTX-2.3 text-to-audio-video, a single track carries both the decoded video
+(``request.generated["video"]``) and the jointly-generated audio
+(``request.generated["audio"]``, injected by the reward service from
+``track.decoded_audio``). This composite runs several inner scorers over the
+SAME request and returns their weighted sum, exposing each as a component.
+
+Mirrors ``VideoRewardScorer``'s composite pattern: inner scorers are resolved
+from the built-in registry by name, so any registered scorer (e.g.
+``videopickscore`` for video quality, ``clap`` for audio-text alignment,
+``imagebind`` for audio-video alignment) can be blended.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
+from unirl.types.reward import RewardRequest, RewardResponse
+
+from .registry import resolve_builtin_reward_scorer_class, resolve_builtin_reward_spec_class
+
+
+class T2AVCompositeScorer(RewardBackend):
+    """Weighted blend of inner reward scorers for T2AV (video + audio).
+
+    ``input_kind = "video"``: the track routes through the video path; audio is
+    the parallel side-channel the reward service injects. Each inner scorer
+    reads whichever modality it needs off the shared request.
+    """
+
+    input_kind = "video"
+
+    def __init__(self, *, config: "T2AVCompositeSpec", base_device: str) -> None:
+        super().__init__(model_name="t2av_composite", batch_size=config.batch_size)
+        self.weights: Dict[str, float] = dict(config.weights or {})
+        if not self.weights:
+            raise ValueError("T2AVCompositeScorer requires a non-empty `weights` dict (scorer_name -> weight).")
+
+        self._scorers: Dict[str, RewardBackend] = {}
+        for name in self.weights:
+            inner_cls = resolve_builtin_reward_scorer_class(name)
+            inner_spec_cls = resolve_builtin_reward_spec_class(name)
+            inner_spec = inner_spec_cls()
+            # Propagate batch_size/device to inner specs that accept them.
+            import dataclasses
+
+            overrides = {f: getattr(config, f) for f in ("device", "batch_size") if hasattr(inner_spec, f)}
+            if overrides:
+                inner_spec = dataclasses.replace(inner_spec, **overrides)
+            self._scorers[name] = inner_cls(config=inner_spec, base_device=base_device)
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        start = time.time()
+        bs = request.batch_size
+        try:
+            import torch
+
+            component_rewards: Dict[str, List[float]] = {}
+            total = torch.zeros(bs, dtype=torch.float32)
+            for name, scorer in self._scorers.items():
+                resp = scorer.compute_rewards(request)
+                comp = torch.tensor(list(resp.rewards), dtype=torch.float32)
+                if comp.numel() != bs:
+                    raise RuntimeError(
+                        f"T2AVCompositeScorer: inner scorer {name!r} returned {comp.numel()} rewards "
+                        f"for a batch of {bs}."
+                    )
+                component_rewards[name] = comp.tolist()
+                total = total + float(self.weights[name]) * comp
+
+            return RewardResponse(
+                rewards=total.tolist(),
+                component_rewards=component_rewards,
+                successes=[True] * bs,
+                errors=[None] * bs,
+                compute_time=time.time() - start,
+            )
+        except Exception as e:
+            return RewardResponse(
+                rewards=[0.0] * bs,
+                successes=[False] * bs,
+                errors=[str(e)] * bs,
+                compute_time=time.time() - start,
+            )
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+    def is_available(self) -> bool:
+        return all(s.is_available() for s in self._scorers.values())
+
+    def offload(self) -> None:
+        for s in self._scorers.values():
+            s.offload()
+
+    def onload(self) -> None:
+        for s in self._scorers.values():
+            s.onload()
+
+    def dispose(self) -> None:
+        for s in self._scorers.values():
+            s.dispose()
+
+
+@dataclass
+class T2AVCompositeSpec(BaseRewardComponentSpec):
+    """Typed config for the T2AV composite reward.
+
+    ``weights`` maps inner scorer canonical names (e.g. ``videopickscore``,
+    ``clap``, ``imagebind``) to blend weights. Each named scorer is built from
+    its default Spec with ``device``/``batch_size`` propagated.
+    """
+
+    batch_size: int = 8
+    device: str = "auto"
+    weights: Dict[str, float] = field(default_factory=lambda: {"videopickscore": 0.5, "clap": 0.5})

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -95,9 +95,22 @@ def _build_request_for_track(
         samples_per_prompt=samples_per_prompt,
     )
 
+    # Side-channel: a track may carry a parallel audio stream decoded alongside
+    # the primary media (LTX-2.3 T2AV puts video in ``decoded`` and audio in
+    # ``decoded_audio``). Inject it under ``generated["audio"]`` regardless of
+    # the primary ``reward_input_kind`` so a composite scorer can read both. The
+    # audio source sample rate rides on the track's ``audio_sample_rate``.
+    generated: Dict[str, Any] = {gen_key: decoded}
+    audio_sample_rate: Optional[int] = None
+    if getattr(track, "decoded_audio", None) is not None:
+        generated["audio"] = track.decoded_audio
+        rate = getattr(track, "audio_sample_rate", None)
+        audio_sample_rate = int(rate) if rate is not None else None
+
     return RewardRequest(
         primitives=dict(req_primitives),
-        generated={gen_key: decoded},
+        generated=generated,
+        audio_sample_rate=audio_sample_rate,
         prompt_ids=list(prompt_ids),
         sample_ids=list(sample_ids),
         group_ids=list(group_ids),

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -302,12 +302,6 @@ class RewardService(Remote):
             str(name): torch.tensor(list(values or []), dtype=torch.float32)
             for name, values in dict(reward_response.component_rewards or {}).items()
         }
-        if component_rewards:
-            logger.info(
-                "RewardService: component_rewards keys=%s sizes=%s",
-                list(component_rewards.keys()),
-                {k: v.shape for k, v in component_rewards.items()},
-            )
         track = _track_with_field(track, "rewards", rewards)
         return _track_with_field(track, "component_rewards", component_rewards)
 

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -302,6 +302,12 @@ class RewardService(Remote):
             str(name): torch.tensor(list(values or []), dtype=torch.float32)
             for name, values in dict(reward_response.component_rewards or {}).items()
         }
+        if component_rewards:
+            logger.info(
+                "RewardService: component_rewards keys=%s sizes=%s",
+                list(component_rewards.keys()),
+                {k: v.shape for k, v in component_rewards.items()},
+            )
         track = _track_with_field(track, "rewards", rewards)
         return _track_with_field(track, "component_rewards", component_rewards)
 

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -445,6 +445,10 @@ class DiffusionTrainer(BaseTrainer):
             # Hydrate in place so the wandb reward/advantage stats reuse this
             # fetch instead of re-pulling the TensorRef from the worker.
             track.rewards = hydrate(track.rewards)
+            # component_rewards values are also TensorRef after DP_SCATTER;
+            # hydrate them so wandb_metrics can read real tensors.
+            if isinstance(track.component_rewards, dict):
+                track.component_rewards = {k: hydrate(v) for k, v in track.component_rewards.items()}
             mean_reward = float(track.rewards.to(torch.float32).mean().item())
             break  # single-track for now; revisit if multi-track lands
 

--- a/unirl/types/media_preview.py
+++ b/unirl/types/media_preview.py
@@ -240,6 +240,9 @@ def build_media_preview_for_track(
     audio_sr: Optional[int] = None
     decoded_audio = getattr(track, "decoded_audio", None)
     if decoded_audio is not None and hasattr(decoded_audio, "to_list"):
+        from unirl.distributed.tensor import hydrate, map_tree
+
+        decoded_audio = map_tree(decoded_audio, hydrate)
         audio_list = decoded_audio.to_list()
         for idx in selected_indices:
             if idx < len(audio_list):

--- a/unirl/types/media_preview.py
+++ b/unirl/types/media_preview.py
@@ -55,6 +55,13 @@ class MediaPreview(Batch):
 
     images: List[Any] = concat_field(default_factory=list)
     videos: List[Any] = concat_field(default_factory=list)
+    # Per-sample audio waveforms (mono [L] float32 CPU tensors) for muxing into
+    # the mp4 upload. Parallel to ``videos`` — same length. ``None``/empty for
+    # non-audio tracks.
+    audios: List[Any] = concat_field(default_factory=list)
+    # Source sample rate of the waveforms in ``audios``. Batch-shared (one rate
+    # per preview). None when audios is empty.
+    audio_sample_rate: Optional[int] = None
     prompts: List[str] = concat_field(default_factory=list)
     rewards: List[float] = concat_field(default_factory=list)
 
@@ -63,6 +70,7 @@ class MediaPreview(Batch):
         for name, val in (
             ("images", self.images),
             ("videos", self.videos),
+            ("audios", self.audios),
             ("prompts", self.prompts),
             ("rewards", self.rewards),
         ):
@@ -227,11 +235,30 @@ def build_media_preview_for_track(
     if not selected_indices:
         return None
 
+    # T2AV: extract per-sample audio waveforms for muxing into the mp4 upload.
+    audios_out: List[Any] = []
+    audio_sr: Optional[int] = None
+    decoded_audio = getattr(track, "decoded_audio", None)
+    if decoded_audio is not None and hasattr(decoded_audio, "to_list"):
+        audio_list = decoded_audio.to_list()
+        for idx in selected_indices:
+            if idx < len(audio_list):
+                audios_out.append(audio_list[idx].waveform.detach().cpu().float())
+            else:
+                audios_out.append(None)
+        audio_sr = getattr(track, "audio_sample_rate", None)
+        # Drop audio if none of the selected samples have it
+        if all(a is None for a in audios_out):
+            audios_out = []
+            audio_sr = None
+
     prompts_out = [str(prompt_texts[i]) if i < len(prompt_texts) else "" for i in selected_indices]
     reward_values = [float(rewards_flat[i]) if i < len(rewards_flat) else 0.0 for i in selected_indices]
     return MediaPreview(
         images=images,
         videos=videos,
+        audios=audios_out,
+        audio_sample_rate=int(audio_sr) if audio_sr is not None else None,
         prompts=prompts_out,
         rewards=reward_values,
     )

--- a/unirl/types/reward.py
+++ b/unirl/types/reward.py
@@ -47,6 +47,11 @@ class RewardRequest:
     group_ids: Optional[List[str]] = None
     reward_types: List[RewardType] = field(default_factory=lambda: [RewardType.IMAGE_TEXT_ALIGNMENT])
     return_components: bool = False
+    # Source sample rate (Hz) of any waveforms in ``generated["audio"]``. Set by
+    # the reward service when a track carries a parallel audio stream (LTX-2.3
+    # T2AV). ``None`` for non-audio requests. Audio reward scorers (CLAP /
+    # ImageBind) read it to resample to their model's expected rate.
+    audio_sample_rate: Optional[int] = None
 
     @property
     def prompts(self) -> List[str]:
@@ -79,6 +84,19 @@ class RewardRequest:
         return list(prim.texts)
 
     @property
+    def audio(self) -> Optional[List[torch.Tensor]]:
+        """Generated audio waveforms, one ``[C, L]`` (or ``[L]``) tensor per sample.
+
+        Populated when a track carries a parallel audio stream (LTX-2.3 T2AV);
+        the reward service places the decoded ``Audios`` under
+        ``generated["audio"]``. ``None`` for non-audio requests.
+        """
+        prim = self.generated.get("audio")
+        if prim is None:
+            return None
+        return [a.waveform for a in prim.to_list()]
+
+    @property
     def batch_size(self) -> int:
         for v in self.generated.values():
             if v is not None:
@@ -91,6 +109,10 @@ class RewardRequest:
     @property
     def is_video(self) -> bool:
         return "video" in self.generated
+
+    @property
+    def has_audio(self) -> bool:
+        return "audio" in self.generated
 
 
 @dataclass

--- a/unirl/types/rollout_resp.py
+++ b/unirl/types/rollout_resp.py
@@ -100,6 +100,17 @@ class RolloutTrack(Batch):
     conditions: Dict[str, Condition] = field(kind=FieldKind.CONCAT, default_factory=dict)
     segment: Optional[Segment] = field(kind=FieldKind.CONCAT, default=None)
     decoded: Optional[Decoded] = field(kind=FieldKind.CONCAT, default=None)
+    # Parallel secondary media decoded alongside ``decoded`` for the SAME samples
+    # (not a separate track — keeps GRPO grouping / advantage alignment intact).
+    # First consumer: LTX-2.3 T2AV, where ``decoded`` holds the video and
+    # ``decoded_audio`` the jointly-generated audio waveform. The reward service
+    # injects it into the reward request as a side-channel so a composite scorer
+    # can read video + audio together. ``None`` for every single-modality track.
+    decoded_audio: Optional[Audios] = field(kind=FieldKind.CONCAT, default=None)
+    # Source sample rate (Hz) of ``decoded_audio`` waveforms (e.g. the LTX-2
+    # vocoder's output rate). Batch-shared metadata — one rate per track. The
+    # reward service forwards it to audio scorers via RewardRequest.audio_sample_rate.
+    audio_sample_rate: Optional[int] = shared_field(default=None)
     media_preview: Optional[MediaPreview] = concat_field(default=None)
 
     rewards: Optional[torch.Tensor] = concat_field(default=None)
@@ -127,6 +138,7 @@ class RolloutTrack(Batch):
         light.conditions = {}
         light.segment = None
         light.decoded = None
+        light.decoded_audio = None
         return light
 
     @property

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -630,6 +630,8 @@ class UniRLWandBLogger:
             else:
                 video_key = f"{key}/videos"
 
+        # Temp mp4 files written by the audio-mux path; unlinked after upload.
+        _muxed_paths: List[str] = []
         try:
             n = max(len(images) if has_images else 0, len(videos) if has_videos else 0)
 
@@ -680,6 +682,7 @@ class UniRLWandBLogger:
                         # PyAV expects (T, H, W, C) RGB24 frames; arr is (T, C, H, W).
                         arr_hwc = arr.transpose(0, 2, 3, 1)  # (T, C, H, W) -> (T, H, W, C)
                         path = _write_video_with_audio(arr_hwc, int(video_fps), audio_wf, int(audio_sr))
+                        _muxed_paths.append(path)
                         wandb_videos.append(wandb.Video(path, caption=_caption_for(idx), format="mp4"))
                     else:
                         wandb_videos.append(wandb.Video(arr, caption=_caption_for(idx), fps=int(video_fps)))
@@ -689,6 +692,15 @@ class UniRLWandBLogger:
             wandb.log(payload)
         except Exception as e:
             print(f"Warning: Failed to log generated media: {e}")
+        finally:
+            # wandb.Video copies the file into the run dir on construction, so the
+            # temp mp4s are safe to remove once logging is done. Avoids leaking a
+            # /tmp mp4 per muxed sample every media-log step.
+            for _p in _muxed_paths:
+                try:
+                    os.unlink(_p)
+                except OSError:
+                    pass
 
     def log_eval(
         self,

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -677,8 +677,10 @@ class UniRLWandBLogger:
                     # Mux audio into mp4 when available (T2AV); otherwise plain array.
                     audio_wf = audios[idx] if idx < len(audios) else None
                     if audio_wf is not None and audio_sr is not None and torch.is_tensor(audio_wf):
-                        path = _write_video_with_audio(arr, int(video_fps), audio_wf, int(audio_sr))
-                        wandb_videos.append(wandb.Video(path, caption=_caption_for(idx), fps=int(video_fps)))
+                        # PyAV expects (T, H, W, C) RGB24 frames; arr is (T, C, H, W).
+                        arr_hwc = arr.transpose(0, 2, 3, 1)  # (T, C, H, W) -> (T, H, W, C)
+                        path = _write_video_with_audio(arr_hwc, int(video_fps), audio_wf, int(audio_sr))
+                        wandb_videos.append(wandb.Video(path, caption=_caption_for(idx), format="mp4"))
                     else:
                         wandb_videos.append(wandb.Video(arr, caption=_caption_for(idx), fps=int(video_fps)))
                 if wandb_videos:

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -40,6 +40,90 @@ if TYPE_CHECKING:
 module_logger = logging.getLogger(__name__)
 
 
+def _write_video_with_audio(
+    frames: Any,
+    fps: int,
+    audio: torch.Tensor,
+    audio_sample_rate: int,
+) -> str:
+    """Mux video frames + audio waveform into a single mp4 file using PyAV.
+
+    Mirrors Flow-Factory's ``LogVideo._write_mp4_with_audio``. Video is H.264,
+    audio is AAC. Returns the temp file path (caller passes to ``wandb.Video``).
+    Falls back to writing video-only if PyAV is unavailable.
+    """
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".mp4")
+    os.close(fd)
+    try:
+        from fractions import Fraction
+
+        import av
+
+        container = av.open(path, mode="w")
+        video_stream = container.add_stream("libx264", rate=int(fps))
+        video_stream.width = int(frames.shape[2])
+        video_stream.height = int(frames.shape[1])
+        video_stream.pix_fmt = "yuv420p"
+
+        audio_stream = container.add_stream("aac", rate=audio_sample_rate)
+        audio_stream.codec_context.sample_rate = audio_sample_rate
+        audio_stream.codec_context.layout = "stereo"
+        audio_stream.codec_context.time_base = Fraction(1, audio_sample_rate)
+
+        for frame_array in frames:
+            frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            for packet in video_stream.encode(frame):
+                container.mux(packet)
+        for packet in video_stream.encode():
+            container.mux(packet)
+
+        samples = audio.float().cpu()
+        if samples.ndim == 1:
+            samples = samples.unsqueeze(0)
+        if samples.shape[0] == 1:
+            samples = samples.expand(2, -1)
+        samples = samples.T  # (T, 2)
+        samples = torch.clamp(samples, -1.0, 1.0)
+        int16_samples = (samples * 32767.0).to(torch.int16)
+
+        audio_frame = av.AudioFrame.from_ndarray(
+            int16_samples.contiguous().reshape(1, -1).numpy(),
+            format="s16",
+            layout="stereo",
+        )
+        audio_frame.sample_rate = audio_sample_rate
+
+        target_format = audio_stream.codec_context.format or "fltp"
+        target_layout = audio_stream.codec_context.layout or "stereo"
+        resampler = av.audio.resampler.AudioResampler(
+            format=target_format,
+            layout=target_layout,
+            rate=audio_sample_rate,
+        )
+        audio_next_pts = 0
+        for rframe in resampler.resample(audio_frame):
+            if rframe.pts is None:
+                rframe.pts = audio_next_pts
+            audio_next_pts += rframe.samples
+            rframe.sample_rate = audio_sample_rate
+            container.mux(audio_stream.encode(rframe))
+        for packet in audio_stream.encode():
+            container.mux(packet)
+
+        container.close()
+    except ImportError:
+        module_logger.warning("PyAV (av) not installed; writing video without audio. Install with: pip install av")
+        os.unlink(path)
+        fd2, path = tempfile.mkstemp(suffix=".mp4")
+        os.close(fd2)
+        import imageio
+
+        imageio.mimwrite(path, frames, fps=fps, format="FFMPEG", codec="libx264", pixelformat="yuv420p")
+    return path
+
+
 class PhaseTimer:
     """Per-phase wall-clock timer for one train step.
 
@@ -565,6 +649,9 @@ class UniRLWandBLogger:
 
             if has_videos:
                 wandb_videos: List[Any] = []
+                # Per-sample audio waveforms for muxing (T2AV); empty list if none.
+                audios = getattr(media_preview, "audios", None) or []
+                audio_sr = getattr(media_preview, "audio_sample_rate", None)
                 for idx in range(min(len(videos), n)):
                     vid = videos[idx]
                     if not torch.is_tensor(vid):
@@ -587,7 +674,13 @@ class UniRLWandBLogger:
                         .permute(1, 0, 2, 3)  # [C, T, H, W] -> [T, C, H, W]
                         .numpy()
                     )
-                    wandb_videos.append(wandb.Video(arr, caption=_caption_for(idx), fps=int(video_fps)))
+                    # Mux audio into mp4 when available (T2AV); otherwise plain array.
+                    audio_wf = audios[idx] if idx < len(audios) else None
+                    if audio_wf is not None and audio_sr is not None and torch.is_tensor(audio_wf):
+                        path = _write_video_with_audio(arr, int(video_fps), audio_wf, int(audio_sr))
+                        wandb_videos.append(wandb.Video(path, caption=_caption_for(idx), fps=int(video_fps)))
+                    else:
+                        wandb_videos.append(wandb.Video(arr, caption=_caption_for(idx), fps=int(video_fps)))
                 if wandb_videos:
                     payload[video_key] = wandb_videos
 

--- a/unirl/utils/wandb_metrics.py
+++ b/unirl/utils/wandb_metrics.py
@@ -154,6 +154,15 @@ def compute_rollout_resp_metrics(*, resp: Any, trunc_len: Optional[int] = None) 
                 safe_name = str(cname).replace("/", "_")
                 cat = tensor.detach().to(dtype=torch.float32).reshape(-1).cpu()
                 metrics.update(_tensor_stats(f"{prefix}reward_{safe_name}", cat))
+        else:
+            import logging as _log
+
+            _log.getLogger(__name__).warning(
+                "compute_rollout_resp_metrics: track.component_rewards is %s (type=%s), "
+                "no per-component metrics will be logged.",
+                component_rewards,
+                type(component_rewards).__name__,
+            )
 
     return metrics
 

--- a/unirl/utils/wandb_metrics.py
+++ b/unirl/utils/wandb_metrics.py
@@ -154,15 +154,6 @@ def compute_rollout_resp_metrics(*, resp: Any, trunc_len: Optional[int] = None) 
                 safe_name = str(cname).replace("/", "_")
                 cat = tensor.detach().to(dtype=torch.float32).reshape(-1).cpu()
                 metrics.update(_tensor_stats(f"{prefix}reward_{safe_name}", cat))
-        else:
-            import logging as _log
-
-            _log.getLogger(__name__).warning(
-                "compute_rollout_resp_metrics: track.component_rewards is %s (type=%s), "
-                "no per-component metrics will be logged.",
-                component_rewards,
-                type(component_rewards).__name__,
-            )
 
     return metrics
 


### PR DESCRIPTION
## Summary

End-to-end audio reward for LTX-2.3 text-to-audio-video (T2AV) RL training.
The pipeline now decodes the jointly-generated audio waveform and scores it
alongside the video via a composite reward that blends VideoPickScore (video
quality) with CLAP (audio-text alignment).

Key changes across the stack:

- **Pipeline**: `LTX2AudioDecodeStage` does the full denormalize→unpack→
  audio_vae.decode→vocoder chain (fp32 for numerical stability); pipeline
  carries the waveform on `track.decoded_audio`.
- **Reward infra**: `RolloutTrack.decoded_audio` + `audio_sample_rate` fields;
  `RewardRequest.audio` property + `audio_sample_rate`; reward service injects
  audio as a side-channel regardless of the primary `input_kind`. Hydrates
  `component_rewards` TensorRef so wandb metrics actually log per-component
  scores.
- **New backends**: `CLAPRewardScorer` (transformers ClapModel, zero extra deps),
  `ImageBindRewardScorer` (lazy import, CC-BY-NC-SA, default disabled),
  `T2AVCompositeScorer` (weighted blend of inner scorers).
- **Wandb media**: mux audio into the video mp4 via PyAV so generated videos
  play back WITH sound in the wandb panel.
- **Recipe**: `ltx2_3_t2av_audioreward_trainside.yaml` — composite reward
  (videopickscore 0.5 + clap 0.5).

## Related Issue

N/A

## Test Plan

- `python -m compileall -q unirl` — passes.
- `SKIP=no-commit-to-branch pre-commit run --files <all changed files>` — passes
  (ruff-check, ruff-format, check-recipe-targets all green).
- **Live training on Taiji (1 node × 8 H20)**:
  - Model loads from `dg845/LTX-2.3-Diffusers` (audio_vae + vocoder in fp32).
  - Joint audio+video SDE rollout/replay runs.
  - CLAP + VideoPickScore composite scores normally (`reward_mean ≈ 0.43`).
  - Wandb shows `rollout/reward_clap_mean` and `rollout/reward_videopickscore_mean`
    (after hydrate fix).
  - Generated videos with muxed audio upload to wandb media panel.

<img width="487" height="323" alt="Clipboard_Screenshot_1782977431" src="https://github.com/user-attachments/assets/c9716522-4078-445a-b504-857aa9287389" />

<img width="483" height="327" alt="Clipboard_Screenshot_1782977445" src="https://github.com/user-attachments/assets/5cebc50a-23ec-460a-a2b0-e361701f5eaf" />

<img width="497" height="332" alt="Clipboard_Screenshot_1782977457" src="https://github.com/user-attachments/assets/aefd5dfa-4633-4671-bfa8-6dd728ecb858" />

<img width="1424" height="642" alt="Clipboard_Screenshot_1782977476" src="https://github.com/user-attachments/assets/2ad06995-0f28-4dc2-b7de-ddd2680f273c" />

<img width="1452" height="628" alt="Clipboard_Screenshot_1782977505" src="https://github.com/user-attachments/assets/0b6c0981-ba6d-41cf-b2a1-89d7f80d9252" />

## Compatibility / Risk

- `RolloutTrack.decoded_audio` / `audio_sample_rate`: CONCAT/shared fields,
  default None — transparent to all non-audio models.
- `RewardRequest.audio` / `audio_sample_rate` / `has_audio`: additive properties
  + field — no change to existing request contract.
- Reward service audio injection: only fires when `track.decoded_audio is not
  None`; non-audio tracks see zero change in `_build_request_for_track`.
- `component_rewards` hydrate in `diffusion.py`: fixes a pre-existing issue
  where TensorRef values were silently skipped by `wandb_metrics`; harmless for
  models that don't produce component_rewards (dict stays None).
- Audio decode adds ~1s/rollout GPU time (fp32 audio_vae + vocoder); only
  when `bundle.has_audio`.
- ImageBind is CC-BY-NC-SA 4.0 (NonCommercial) — code present but NOT enabled
  in the recipe; requires explicit package install + recipe weight entry.

## Reviewer Notes

- AI-assisted. Full diff reviewed across 6 focused commits.
- Duplicate-work check: no open PR touches `unirl/reward/local/clap.py` or
  `t2av_composite.py`.
- CLAP uses `audios=` kwarg (deprecated in transformers 4.59, current version
  supports both); suppressed FutureWarning is cosmetic only.
- `media_log_interval` set to 200 for faster verification during development;
  production recipes should use a higher value.
- Debug logger line in `wandb_metrics.py` (warning when component_rewards is
  not dict) is temporary diagnostic — remove before final merge if desired.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
