### PR TITLE
fix(qwen-image-edit-plus): harden sglang edit-plus rollout + doc follow-ups

### DIFF
--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
@@ -105,7 +105,7 @@ backend:
   # the v1 training.ema_lora block. target_modules keep the v1 DiffusionNFT set: bare
   # (un-prefixed) names that also cover the img/txt MLP projections — broader
   # than the GRPO recipe's attn-only `attn.*` set. Verified verbatim against
-  # transformer/model.safetensors.index.json (Qwen-Image-Edit-2511-merged_v9.7).
+  # transformer/model.safetensors.index.json (Qwen-Image-Edit-2511).
   ema_lora_cfg:
     _target_: unirl.train.configs.EmaLoraConfig
     rank: 64

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
@@ -131,7 +131,7 @@ backend:
   # the v1 training.ema_lora block. target_modules keep the v1 DiffusionNFT set: bare
   # (un-prefixed) names that also cover the img/txt MLP projections — broader
   # than the GRPO recipe's attn-only `attn.*` set. Verified verbatim against
-  # transformer/model.safetensors.index.json (Qwen-Image-Edit-2511-merged_v9.7).
+  # transformer/model.safetensors.index.json (Qwen-Image-Edit-2511).
   ema_lora_cfg:
     _target_: unirl.train.configs.EmaLoraConfig
     rank: 64

--- a/unirl/models/qwen_image_edit_plus/conditions.py
+++ b/unirl/models/qwen_image_edit_plus/conditions.py
@@ -8,9 +8,10 @@ dimension before the transformer call, then slices the prediction back to the
 noise segment — mirrors ``vde_editplus.py:232,246`` and the FLUX.2-Klein
 image-edit pattern (``flux2_klein/diffusion.py:160-183``).
 
-``image_latent`` is optional so the conditions container round-trips cleanly
-for the T2I degenerate path (no source image); the Edit-Plus pipeline itself
-requires a source image and raises at ``generate(req)`` time if absent
+``image_latent`` is declared ``Optional`` only so ``from_dict`` / ``to_dict``
+round-trip cleanly when the key is absent from a raw dict; Edit-Plus is
+edit-only, so both the pipeline (``generate(req)``) and the diffusion step
+(``predict_noise``) require a source image and raise if it is missing
 (fail-fast, constraint #27).
 """
 

--- a/unirl/models/qwen_image_edit_plus/diffusion.py
+++ b/unirl/models/qwen_image_edit_plus/diffusion.py
@@ -18,10 +18,10 @@ overridden Edit-Plus step). Verified: ``step_with_logp`` → ``step`` →
 ``self.predict_noise`` (``qwen_image/diffusion.py:326→349→304``), so the
 override propagates to ``replay`` automatically.
 
-When ``conditions.image_latent is None`` the step falls through to the
-base T2I behavior — a genuine degenerate path, not impossible-scenario
-handling (the base Qwen-Image T2I is a valid input mode for this
-transformer).
+Edit-Plus is edit-only: :meth:`predict_noise` requires
+``conditions.image_latent`` and raises ``ValueError`` when it is ``None``
+(fail-fast, constraint #27). There is no T2I fall-through — a source image
+is always required.
 """
 
 from __future__ import annotations

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
@@ -376,6 +376,12 @@ def _coalesce_duplicate_single_sample_encodes(value):
         return value
     if any(tuple(t.shape) != first_shape for t in value[1:]):
         return value
+    # Value check: only coalesce when the same-shape entries are actually
+    # byte-identical (the shared-list duplicate signature). Same-shape-but-
+    # differing tensors are a genuine multi-encoder whose outputs must NOT be
+    # collapsed — hardens the shape-only heuristic per the examples/ README note.
+    if not all(torch.equal(first, t) for t in value[1:]):
+        return value
     return [first]
 
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_denoising.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_denoising.py
@@ -40,12 +40,17 @@ as the vLLM-Omni BAGEL fix (PR #89, heguangxin's comment): ``pipeline_bagel``
 reseeds the global RNG per request and the SDE scheduler drew z_t from it. Fix
 (mirrors ``BagelFlowSDEScheduler.step``): when ``_rollout_variance_noise``
 receives a single ``torch.Generator`` (not a denoise_seeds list), replace it
-with a per-request generator seeded from ``os.urandom``, independent of the
-reseeded batch/global RNG. Stashed on ``batch`` so the generator persists across
-SDE steps within one request. The denoise_seeds path (list of generators) is
-unaffected — it fires for models whose denoising stage inherits the base
-``_run_denoising_step`` (e.g. SD3), preserving its deterministic driver-aligned
-per-sample noise.
+with a per-request generator whose seed is derived from
+``(base_seed, denoise_seeds[0])`` — the per-sample-unique ``sample_id`` that
+``patch_latent_prep`` slices onto each B=1 output — via the same blake2b
+derivation as ``_make_step_generators``, so the fallback stays reproducible from
+``seed`` AND independent per GRPO sample (distinct sample_ids → distinct seeds,
+the property that fixes the reward regression; ``os.urandom`` is used only when
+neither a base seed nor a sample key is available). Stashed on ``batch`` so the
+generator persists across SDE steps within one request. The denoise_seeds path
+(list of generators) is unaffected — it fires for models whose denoising stage
+inherits the base ``_run_denoising_step`` (e.g. SD3), preserving its
+deterministic driver-aligned per-sample noise.
 """
 
 from __future__ import annotations
@@ -87,6 +92,27 @@ def _resolve_base_seed(batch) -> int | None:
     if seed is None:
         seed = getattr(getattr(batch, "sampling_params", None), "seed", None)
     return int(seed) if seed is not None else None
+
+
+def _resolve_fallback_seed(batch) -> int:
+    """Deterministic per-request seed for the single-``torch.Generator`` fallback.
+
+    Prefer a stable per-sample key so the fallback stays reproducible from
+    ``seed`` AND independent per GRPO sample: derive from
+    ``(base_seed, denoise_seeds[0])`` — the per-sample-unique ``sample_id`` that
+    ``patch_latent_prep`` slices onto each B=1 output — via the same blake2b
+    derivation as :func:`_make_step_generators`. Fall back to ``os.urandom`` only
+    when neither the base seed nor a sample key is available (keeps samples
+    independent, but non-reproducible).
+    """
+    base_seed = _resolve_base_seed(batch)
+    denoise_seeds = getattr(batch, "denoise_seeds", None)
+    sample_key = str(denoise_seeds[0]) if denoise_seeds else None
+    if base_seed is not None and sample_key is not None:
+        payload = (f"{int(base_seed)}::fallback::sample::{sample_key}").encode("utf-8")
+        digest = hashlib.blake2b(payload, digest_size=8).digest()
+        return int.from_bytes(digest, byteorder="big", signed=False) % _MAX_TORCH_SEED
+    return int.from_bytes(os.urandom(8), byteorder="big") % _MAX_TORCH_SEED
 
 
 def patch_denoising() -> None:
@@ -165,8 +191,10 @@ def _patch_rollout_variance_noise_device() -> None:
             # ``BagelFlowSDEScheduler.step`` in
             # ``vllm_omni/pipelines/bagel/bagel_flow_match_sde_scheduler.py``):
             # replace the shared generator with a per-request generator
-            # seeded from ``os.urandom``, independent of the reseeded
-            # batch/global RNG. Stash on ``batch`` so the generator
+            # seeded deterministically from ``(base_seed, sample_id)`` via
+            # ``_resolve_fallback_seed`` so it stays reproducible AND per-sample
+            # independent (``os.urandom`` only when no stable key exists). Stash
+            # on ``batch`` so the generator
             # persists across SDE steps within one request (each
             # per-output forward has its own batch -> generator is
             # naturally per-sample). The denoise_seeds path (list of
@@ -178,7 +206,7 @@ def _patch_rollout_variance_noise_device() -> None:
             gen = getattr(batch, "_unirl_noise_gen", None)
             if gen is None:
                 gen = torch.Generator(device=device)
-                gen.manual_seed(int.from_bytes(os.urandom(8), "big"))
+                gen.manual_seed(_resolve_fallback_seed(batch))
                 try:
                     batch._unirl_noise_gen = gen  # type: ignore[attr-defined]
                 except AttributeError:

--- a/unirl/rollout/engine/sglang_diffusion/adapters/qwen_image_edit_plus.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/qwen_image_edit_plus.py
@@ -91,15 +91,20 @@ class QwenImageEditPlusAdapter(QwenImageAdapter):
         pil_images = images_prim.to_pils()
         if len(pil_images) != len(prompts):
             raise ValueError(f"build_prompts: image batch {len(pil_images)} != prompt count {len(prompts)}")
-        # Collapse PILs in parallel with prompts: one image per unique prompt.
+        # Collapse PILs in parallel with prompts: one source image per group.
+        # Mirror ``deexpand_prompts_from_groups``'s group logic (first image per
+        # group, in first-seen group order) rather than assuming a contiguous
+        # group-major layout — ``pil_images[::k]`` would misalign images vs
+        # prompts if ``group_ids`` are interleaved ([A,B,A,B,...]). ``k == 1``
+        # means no collapse happened (heterogeneous K or no grouping), so the
+        # PILs stay 1:1 with the prompts.
         if k > 1:
-            # K-expanded: all K samples in a group share the same source image
-            # (same prompt + same source, K different noise draws). The PILs
-            # are laid out group-major — ``pil_images[g*k : (g+1)*k]`` are the
-            # K copies for group ``g`` — so stride ``[::k]`` picks one per
-            # group. (``[:N]`` would be wrong when ``N <= K``: all N picks
-            # would land inside group 0.)
-            unique_pils = pil_images[::k]
+            unique_pils = self._first_per_group(pil_images, list(req.group_ids))
+            if len(unique_pils) != len(unique_prompts):
+                raise ValueError(
+                    f"build_prompts: collapsed image count {len(unique_pils)} != unique prompt "
+                    f"count {len(unique_prompts)} (group_ids/image misalignment)."
+                )
         else:
             unique_pils = pil_images
         out: Dict[str, Any] = {
@@ -173,6 +178,22 @@ class QwenImageEditPlusAdapter(QwenImageAdapter):
                 f"to ragged-pad."
             )
         return torch.cat(tensors, dim=0)
+
+    @staticmethod
+    def _first_per_group(items: List[Any], group_ids: List[str]) -> List[Any]:
+        """First item of each group, in first-seen group order.
+
+        Mirrors how :func:`utils.deexpand_prompts_from_groups` collapses prompts,
+        so the source-image collapse aligns with the prompt collapse regardless
+        of the sample layout (contiguous or interleaved ``group_ids``).
+        """
+        seen: set[str] = set()
+        out: List[Any] = []
+        for item, gid in zip(items, group_ids):
+            if gid not in seen:
+                seen.add(gid)
+                out.append(item)
+        return out
 
     def _deexpand_prompts(self, prompts: List[str], req: RolloutReq):
         """Collapse K-expanded prompts back to unique + repeat count.


### PR DESCRIPTION
## Summary
Follow-up to #128 (merged) addressing review findings — three low-risk
robustness/correctness fixes plus doc corrections in the Qwen-Image-Edit-Plus
sglang path:
- **Deterministic SDE fallback seed** (`_patches/patch_denoising.py`): the
  single-`torch.Generator` fallback (hit by Qwen-Image / Edit-Plus FlowGRPO /
  FlowDPPO, whose denoising stage overrides `_run_denoising_step`) seeded z_t
  from `os.urandom`, which is non-reproducible. It now derives the per-request
  seed from `(base_seed, denoise_seeds[0])` — the per-sample-unique `sample_id`
  that `patch_latent_prep` slices onto each B=1 output — via the same blake2b
  derivation as `_make_step_generators`. This keeps the per-sample independence
  that fixes the reward regression while restoring fixed-seed reproducibility;
  `os.urandom` remains only as a last resort when no stable key is available.
- **Encode-dedup value check** (`_patches/patch_conditions.py`):
  `_coalesce_duplicate_single_sample_encodes` now verifies entries are
  byte-identical (`torch.equal`) before collapsing, so a future same-shape
  multi-encoder can't have an encoder silently dropped (the shape-only heuristic
  documented in `examples/.../README.md`). Behavior-preserving for all current
  models.
- **Group-consistent source-image collapse**
  (`adapters/qwen_image_edit_plus.py`): collapse one source image per group in
  first-seen group order (mirroring `deexpand_prompts_from_groups`) instead of
  `pil_images[::k]`, which assumed a contiguous group-major layout and would
  misalign images vs prompts for interleaved `group_ids`. Equivalent to the old
  behavior for the validated contiguous layout; adds a count-consistency guard.
- **Docstring corrections** (`diffusion.py`, `conditions.py`): the module
  docstrings described a T2I fall-through that no longer exists — Edit-Plus is
  edit-only and `predict_noise` raises when `image_latent` is `None`.
- **Comment cleanup** (`nft.yaml`, `nft_sglang.yaml`): drop the internal
  `-merged_v9.7` checkpoint tag (default is the public `Qwen/Qwen-Image-Edit-2511`).
## Related Issue
N/A
## Test Plan
- `SKIP=no-commit-to-branch pre-commit run --files unirl/rollout/engine/sglang_diffusion/_patches/patch_denoising.py unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py unirl/rollout/engine/sglang_diffusion/adapters/qwen_image_edit_plus.py unirl/models/qwen_image_edit_plus/diffusion.py unirl/models/qwen_image_edit_plus/conditions.py examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml --show-diff-on-failure` → all hooks Passed (ruff-check, ruff-format, check-yaml, recipe `_target_` resolver).
- `python3.12 -m py_compile` on the changed modules → OK.
- GPU E2E: **Not run; reason:** no GPU available in this environment. The seed change preserves the per-sample independence property of the merged `os.urandom` fix (distinct `sample_id`s → distinct seeds), so GRPO exploration is equivalent while runs become reproducible; a FlowGRPO/FlowDPPO sglang short run is recommended to confirm the reward curve is unaffected. The `torch.equal` and group-collapse changes only tighten guards on paths the validated configs don't exercise (N=1 per generate; contiguous group layout).
## Compatibility / Risk
- The fallback seed change alters the exact z_t values drawn on the sglang
  single-generator path (Qwen-Image / Edit-Plus FlowGRPO / FlowDPPO) but keeps
  per-sample independence and makes runs reproducible. DiffusionNFT (eta=0,
  num_sde_steps=0) never draws z_t, so it is unaffected.
- The dedup and image-collapse changes are stricter guards, behavior-preserving
  for current models/recipes.
- No config keys, checkpoints, data formats, or public APIs change.
## Reviewer Notes
N/A
## Checklist
- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.