### PR TITLE
fix(distributed): import PlacementGroupSchedulingStrategy from its canonical module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   # Engine-agnostic only. torch intentionally absent: it enters via exactly
   # one engine extra below, which is what allows the per-engine CUDA stacks.
   "numpy>=1.24,<3",
-  "ray[default]>=2.9,<2.55",  # 2.55 removed the ray.util.placement_group re-export of PlacementGroupSchedulingStrategy that unirl/distributed/utils.py imports
+  "ray[default]>=2.9",
   "diffusers>=0.38.0",  # LTX-2 needs 0.38: transformer.forward gained sigma/audio_sigma/isolate_modalities/use_cross_timestep, connector gained padding_side, calculate_shift now pins image_seq_len to max_image_seq_len. (>=0.37 was already required for Qwen-Image RoPE text-len-from-mask; 0.38 verified to keep that + every other model API unchanged.)
   "hydra-core>=1.3",
   "omegaconf>=2.3",

--- a/unirl/distributed/utils.py
+++ b/unirl/distributed/utils.py
@@ -112,7 +112,7 @@ def get_node_ip_and_port(pg, bundle_index: int = 0) -> Tuple[str, int]:
     controller-vs-worker mismatch. Uses a lightweight probe actor.
     """
     import ray
-    from ray.util.placement_group import PlacementGroupSchedulingStrategy
+    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
     @ray.remote(num_cpus=0)
     class _Probe:


### PR DESCRIPTION
## Summary

PlacementGroupSchedulingStrategy is canonically defined in ray.util.scheduling_strategies. The previous import from ray.util.placement_group only worked by accident: on ray 2.51.1 that module re-imports the symbol at module top-level, leaking it into its namespace. Ray 2.56.0 moved this to a function-local import, so the name is no longer exposed on ray.util.placement_group and the old path raises ImportError.

Switch to the canonical, version-stable import path. Verified working on both ray 2.51.1 and 2.56.0; no version guard / try-except needed since PlacementGroupSchedulingStrategy has lived in scheduling_strategies since it was introduced.
## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan
Not run; reason: This is a documentation update that requires no testing.
<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
