### PR TITLE
feat(utils): verl-parity GPU memory monitoring

### DIFF
--- a/unirl/distributed/group/remote.py
+++ b/unirl/distributed/group/remote.py
@@ -195,18 +195,11 @@ class Remote:
         empty_cache: bool = False,
         dump_snapshot_tag: Optional[str] = None,
     ) -> Dict[str, float]:
-        """Worker-side memory probe — the driver's only window into GPU memory.
+        """Worker-side memory probe reached by the CUDA-less driver via BROADCAST.
 
-        Trainers run on a CUDA-less Ray driver, so ``utils.memory_monitor``
-        gathers all readings through this BROADCAST (one dict per rank back on
-        the driver). Inherited by every role handle, like ``_cleanup_all_grads``.
-
-        One probe can bundle the boundary chores so a hand-off costs a single
-        RPC: read (always, BEFORE any reset so peaks survive), then optionally
-        log a ``[mem] stage=...`` line into this worker's log, run
-        :func:`aggressive_empty_cache` (never on the default monitoring path),
-        reset the peak counters (the caller owns the reset protocol — see
-        memory_monitor), and dump a memory snapshot if this process records one.
+        Reads always happen BEFORE any reset so peaks survive; optional chores
+        (log line, empty_cache, peak reset, snapshot dump) are bundled so a
+        hand-off costs one RPC. See ``utils.memory_monitor`` for orchestration.
         """
         if not torch.cuda.is_available():
             return {}

--- a/unirl/distributed/group/remote.py
+++ b/unirl/distributed/group/remote.py
@@ -215,8 +215,11 @@ class Remote:
             aggressive_empty_cache()
         if reset_peak:
             torch.cuda.reset_peak_memory_stats()
+        out = {**info, "rank": float(self.rank_info.rank)}
         if dump_snapshot_tag:
             sampler = get_process_snapshot_sampler()
             if sampler is not None:
-                sampler.dump(dump_snapshot_tag)
-        return {**info, "rank": float(self.rank_info.rank)}
+                report = sampler.dump(dump_snapshot_tag)
+                if report:  # carried to the driver so it lands in the training console
+                    out["snapshot_report"] = report
+        return out

--- a/unirl/distributed/group/remote.py
+++ b/unirl/distributed/group/remote.py
@@ -186,3 +186,44 @@ class Remote:
         """
         self._grad_inputs.clear()
         self._grad_outputs.clear()
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST)
+    def get_memory_stats(
+        self,
+        reset_peak: bool = False,
+        log_stage: Optional[str] = None,
+        empty_cache: bool = False,
+        dump_snapshot_tag: Optional[str] = None,
+    ) -> Dict[str, float]:
+        """Worker-side memory probe — the driver's only window into GPU memory.
+
+        Trainers run on a CUDA-less Ray driver, so ``utils.memory_monitor``
+        gathers all readings through this BROADCAST (one dict per rank back on
+        the driver). Inherited by every role handle, like ``_cleanup_all_grads``.
+
+        One probe can bundle the boundary chores so a hand-off costs a single
+        RPC: read (always, BEFORE any reset so peaks survive), then optionally
+        log a ``[mem] stage=...`` line into this worker's log, run
+        :func:`aggressive_empty_cache` (never on the default monitoring path),
+        reset the peak counters (the caller owns the reset protocol — see
+        memory_monitor), and dump a memory snapshot if this process records one.
+        """
+        if not torch.cuda.is_available():
+            return {}
+        from unirl.utils.memory_utils import (
+            aggressive_empty_cache,
+            get_memory_info,
+            get_process_snapshot_sampler,
+            log_memory_usage,
+        )
+
+        info = log_memory_usage(log_stage) if log_stage else get_memory_info()
+        if empty_cache:
+            aggressive_empty_cache()
+        if reset_peak:
+            torch.cuda.reset_peak_memory_stats()
+        if dump_snapshot_tag:
+            sampler = get_process_snapshot_sampler()
+            if sampler is not None:
+                sampler.dump(dump_snapshot_tag)
+        return {**info, "rank": float(self.rank_info.rank)}

--- a/unirl/distributed/group/worker.py
+++ b/unirl/distributed/group/worker.py
@@ -67,9 +67,8 @@ class Worker:
         else:
             self.device = "cpu"
 
-        # Allocator snapshot recording (UNIRL_MEMSNAP=1, default off) must start
-        # in THIS process — allocations happen here, not on the driver. Dumps
-        # are triggered later through Remote.get_memory_stats.
+        # Snapshot recording (UNIRL_MEMSNAP=1) must start in this process; dumps
+        # fire later via Remote.get_memory_stats.
         from unirl.utils.memory_utils import init_process_snapshot_sampler
 
         init_process_snapshot_sampler(rank=nccl_rank if nccl_rank is not None else device_id)

--- a/unirl/distributed/group/worker.py
+++ b/unirl/distributed/group/worker.py
@@ -67,6 +67,13 @@ class Worker:
         else:
             self.device = "cpu"
 
+        # Allocator snapshot recording (UNIRL_MEMSNAP=1, default off) must start
+        # in THIS process — allocations happen here, not on the driver. Dumps
+        # are triggered later through Remote.get_memory_stats.
+        from unirl.utils.memory_utils import init_process_snapshot_sampler
+
+        init_process_snapshot_sampler(rank=nccl_rank if nccl_rank is not None else device_id)
+
         self.worker_id = f"dw{device_id}" if slot == 0 else f"dw{device_id}_s{slot}"
 
         # Backend dependencies: tw (gpu) is injected after spawn via

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -129,6 +129,14 @@ class BaseTrainer:
 
         install_phase_timing(self)
 
+        # verl-parity memory monitoring (perf/max_memory_* + [mem] boundary
+        # lines). Only constructed here — the collaborators to wrap don't exist
+        # until the subclass __init__ finishes, so install() runs in _init_wandb.
+        # None when disabled (logging.memory.enabled=false / UNIRL_MEM_MONITOR=0).
+        from unirl.utils.memory_monitor import install_memory_monitoring
+
+        self._memory_monitor = install_memory_monitoring(self)
+
     # ---- transport buffer reclaim (shared by all v2 trainers) --------------
 
     def _install_train_step_reset_hook(self) -> None:
@@ -219,6 +227,12 @@ class BaseTrainer:
         )
         if self.wandb_logger.initialized:
             logger.info("WandB initialized: project=%s run=%s", project, cfg.get("run_name"))
+
+        # Every trainer calls _init_wandb at the top of train(): the subclass
+        # __init__ has finished (collaborators exist) and the live logger is in
+        # place — wrap the hand-off boundaries with memory probes here, once.
+        if self._memory_monitor is not None:
+            self._memory_monitor.install(self)
 
     def _drop_decoded(
         self,
@@ -317,7 +331,13 @@ class BaseTrainer:
         base_dir = os.path.abspath(save_dir) if save_dir else os.path.join(os.getcwd(), "checkpoints")
         path = os.path.join(base_dir, f"checkpoint-{step}")
         logger.info("Saving checkpoint at rollout %d/%d -> %s", step, num_rollouts, path)
+        # Checkpoint saving gathers a full state_dict — a memory spike worth
+        # bracketing (the one hand-off boundary outside the per-step phases).
+        if self._memory_monitor is not None:
+            self._memory_monitor.boundary("ckpt_save:begin", self.backend)
         self.backend.save(path, step=step, mode=save_mode)
+        if self._memory_monitor is not None:
+            self._memory_monitor.boundary("ckpt_save:end", self.backend)
         # Driver-owned state rides beside the worker-written checkpoint.pt:
         # the wandb run id + train/ step axis let a resume append to the SAME
         # wandb run instead of starting a fresh, misaligned one.

--- a/unirl/utils/README.md
+++ b/unirl/utils/README.md
@@ -22,7 +22,7 @@ the GPUs), orchestration on the CUDA-less Ray driver.
 
 **Opt-in (off by default), observation-only** (no cache clears, no syncs) — each
 wrapped phase spends two blocking BROADCAST probes, so you turn it on when you
-want it: `logging.memory.enabled=true` (or `UNIRL_MEM_MONITOR=1`, or just
+want it: `+logging.memory.enabled=true` (or `UNIRL_MEM_MONITOR=1`, or just
 `UNIRL_MEMSNAP=1` which auto-enables it). Once on, every step it logs four peak
 metrics to wandb on the `rollout/step` axis, **max-across-ranks** (OOM dies on
 the worst rank):
@@ -38,9 +38,15 @@ the worst rank):
 
 | Level | Turn on with | Answers |
 |---|---|---|
-| **0 — curves** | `logging.memory.enabled=true` (or `UNIRL_MEM_MONITOR=1`) | *Is there a problem? Growing?* |
-| **1 — boundary logs** | above + `logging.memory.log_boundaries=true` | *Which phase spikes?* |
+| **0 — curves** | `+logging.memory.enabled=true` (or `UNIRL_MEM_MONITOR=1`) | *Is there a problem? Growing?* |
+| **1 — boundary logs** | above + `+logging.memory.log_boundaries=true` | *Which phase spikes?* |
 | **2 — snapshots** | `UNIRL_MEMSNAP=1` (env; auto-enables the monitor) | *Which line of code allocated it?* |
+
+> These keys aren't in the base config, so as Hydra CLI overrides they need the
+> `+` prefix (`+logging.memory.enabled=true`) — a bare `logging.memory.enabled=true`
+> fails config composition in struct mode. No `+` needed if you add the
+> [`logging.memory`](#configuration) block to your recipe yaml instead. The
+> `UNIRL_*` env vars need neither.
 
 **Level 1** emits a `[mem]` line at each phase's entry/exit. `peak_alloc` is that
 phase's own peak (counter reset on entry); `(rankN, min …)` shows the worst rank

--- a/unirl/utils/README.md
+++ b/unirl/utils/README.md
@@ -1,0 +1,104 @@
+# Utils
+
+> **Where it fits:** shared helpers used across the loop. Full map:
+> [`../README.md`](../README.md).
+
+`utils/` is a grab-bag — each module is a small helper documented by its own
+docstring (`timing.py`, `wandb_logger.py`, `hydra.py`, `media.py`, `misc.py`,
+`profiling.py`, …). Read the module you need directly. The one exception
+documented here is **GPU memory monitoring**, because it spans two files
+(`memory_utils.py` + `memory_monitor.py`) and three subsystems (sampling on the
+workers, orchestration here, hooks in the trainer).
+
+---
+
+# GPU Memory Monitoring
+
+verl-parity GPU memory observability. Answers one question fast: **when a run
+OOMs (or creeps toward it), which phase and which tensor is to blame?** It wraps
+every trainer's hand-off boundaries (`wake_up → weight_sync → generate → sleep →
+reward → train`, plus checkpoint save); sampling runs on the workers (which hold
+the GPUs), orchestration on the CUDA-less Ray driver.
+
+**Opt-in (off by default), observation-only** (no cache clears, no syncs) — each
+wrapped phase spends two blocking BROADCAST probes, so you turn it on when you
+want it: `logging.memory.enabled=true` (or `UNIRL_MEM_MONITOR=1`, or just
+`UNIRL_MEMSNAP=1` which auto-enables it). Once on, every step it logs four peak
+metrics to wandb on the `rollout/step` axis, **max-across-ranks** (OOM dies on
+the worst rank):
+
+| Metric | Meaning |
+|---|---|
+| `perf/max_memory_allocated_gb` | tensors actually in use (peak) — rising = leak |
+| `perf/max_memory_reserved_gb` | PyTorch's reserved pool (peak); minus allocated = fragmentation |
+| `perf/device_memory_used_gb` | whole-device (`mem_get_info`) — **sees the colocated SGLang process** the allocator can't |
+| `perf/cpu_memory_used_gb` | process RSS (host-side leaks) |
+
+## Three levels (matches the OOM triage flow)
+
+| Level | Turn on with | Answers |
+|---|---|---|
+| **0 — curves** | `logging.memory.enabled=true` (or `UNIRL_MEM_MONITOR=1`) | *Is there a problem? Growing?* |
+| **1 — boundary logs** | above + `logging.memory.log_boundaries=true` | *Which phase spikes?* |
+| **2 — snapshots** | `UNIRL_MEMSNAP=1` (env; auto-enables the monitor) | *Which line of code allocated it?* |
+
+**Level 1** emits a `[mem]` line at each phase's entry/exit. `peak_alloc` is that
+phase's own peak (counter reset on entry); `(rankN, min …)` shows the worst rank
+and the spread (large spread = one rank doing more):
+
+```
+[mem] stage=train peak_alloc=39.80 (rank7, min 27.09) reserved=45.10 device_used=84.0 (GB)
+```
+
+**Level 2** records every allocation's call stack, dumps a pickle, and **logs a
+ranked report automatically** — the top call sites holding live memory land in
+the training log inline, no separate file, no manual step:
+
+```bash
+UNIRL_MEMSNAP=1 UNIRL_MEMSNAP_STEPS="2:4" python -m unirl.train_... <recipe>
+```
+```
+memory: snapshot step2 (rank 0)
+live GPU allocations: 15.43 GB across 4180 blocks
+top 15 call sites by live bytes:
+  14.07 GB  x1847   transformers/modeling_utils.py:3722:to      ← model weights
+   0.52 GB  x1274   unirl/train/backend/fsdp/wrap.py:123:fsdp_wrap
+memory: snapshot dumped to outputs/memsnap/memsnap_step2_rank0.pickle
+```
+
+Each line is `<live GB> x<count> <file:line:func>`. **To find a leak**, dump two
+steps (`"2:8"`) and compare — the call site whose GB grew is the leak. The pickle
+is kept for a memory_viz deep-dive or a later re-run of `summarize_snapshot(path)`
+(it reads the plain-dict pickle **without torch/CUDA**, anywhere). Recording hooks
+every allocation (real overhead, big dumps), so it's off by default, rank-0 only,
+step-ranged.
+
+## Configuration
+
+```yaml
+logging:
+  memory:
+    enabled: false         # step curves + phase probes (default OFF — opt-in)
+    log_boundaries: false  # the [mem] lines (default off)
+    empty_cache_at: []     # phases to run aggressive_empty_cache at — the ONE
+                           # behaviour-changing knob (default empty = never).
+                           # e.g. ["sleep"] to test a fragmentation-OOM fix.
+```
+
+Env vars (same family as `UNIRL_PROFILE_*`): `UNIRL_MEM_MONITOR=0/1` overrides
+`enabled` without editing yaml; `UNIRL_MEMSNAP=1` + `UNIRL_MEMSNAP_STEPS="2:4"` +
+`UNIRL_MEMSNAP_DIR` / `UNIRL_MEMSNAP_RANKS` (default `0`) / `_MAX_ENTRIES` drive
+snapshots.
+
+Off entirely: `enabled=false` or `UNIRL_MEM_MONITOR=0` installs **nothing** —
+byte-identical to an unpatched run.
+
+## Reading the curves
+
+- `max_allocated` flat = healthy; **rising every step = leak** → Level 1 to find
+  the phase, Level 2 for the line.
+- OOM but `allocated` flat/comfortable = not a true OOM → suspect **fragmentation**
+  (`reserved − allocated` large) or the colocated engine (`device_used ≫ reserved`).
+- `cpu_memory_used` climbing = host-side leak (data loading/caching, not the model).
+- One rank ≫ the rest (Level-1 `min`/`max` spread) = imbalance; investigate it.
+- **Check the y-axis range first** — wandb auto-zooms a flat 40 MB wobble into a mountain.

--- a/unirl/utils/memory_monitor.py
+++ b/unirl/utils/memory_monitor.py
@@ -1,0 +1,253 @@
+"""Driver-side GPU memory monitoring — verl-parity observability for UniRL.
+
+Reuses the ``install_phase_timing`` pattern (wandb_logger.py): monkey-patch the
+step collaborators' methods once at startup so every trainer gets memory
+probes at the train/rollout hand-off boundaries with zero per-trainer edits.
+Where the timing wrapper adds a stopwatch, this one brackets each phase with a
+``Remote.get_memory_stats`` BROADCAST probe (remote.py) — UniRL's trainers run
+on a CUDA-less Ray driver, so readings must come from the workers.
+
+Outputs (granularity mirrors verl):
+
+* wandb, once per step via :meth:`MemoryMonitor.step_summary` (consumed by
+  ``log_rollout_step``): ``perf/max_memory_allocated_gb`` /
+  ``perf/max_memory_reserved_gb`` / ``perf/cpu_memory_used_gb`` (verl's trio)
+  plus ``perf/device_memory_used_gb`` — the device-level view that still sees
+  a colocated SGLang server process the workers' allocators cannot.
+* logs, per phase begin/end, only when ``logging.memory.log_boundaries`` is
+  on: one aggregated ``[mem]`` driver line + per-rank worker lines (the verl
+  ``log_gpu_memory_usage("After switch ...")`` equivalent).
+
+Peak-counter protocol: torch keeps ONE high-water mark per process. Phase
+wrappers own the reset chain — reset on phase entry, read on exit — so each
+phase's ``max_allocated`` is its own peak. Phases are serial (handle dispatch
+is a blocking barrier), so resets never interleave. Step-level peaks are the
+driver-side max over all probe readings; the closing probe in
+:meth:`step_summary` re-arms the counter for the next step. On paths with no
+wrapped phases (async_ar) the closing probe alone still spans the whole step.
+
+Behaviour-neutral by design: ``logging.memory.enabled=false`` (or
+``UNIRL_MEM_MONITOR=0``) installs nothing; ``empty_cache_at`` is empty by
+default so no cleanup is ever triggered by monitoring.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from unirl.utils.memory_utils import _cpu_rss_gb, _truthy
+
+logger = logging.getLogger(__name__)
+
+#: Memory-probe phase specs: ``(trainer attr path, method, phase name)``.
+#: Deliberately separate from wandb_logger's ``_STEP_PHASE_SPECS`` (timing) so
+#: the two systems evolve independently; dotted paths reach nested handles
+#: (PE's per-track stacks). Missing/uncallable attrs are skipped, so one table
+#: covers all five trainers.
+_MEM_PHASE_SPECS: Tuple[Tuple[str, str, str], ...] = (
+    ("rollout", "wake_up", "wake_up"),
+    ("rollout", "generate", "generate"),
+    ("rollout", "sleep", "sleep"),
+    ("weight_sync", "sync", "weight_sync"),
+    ("weight_sync", "extract", "ws_extract"),  # unified_model
+    ("weight_sync", "push", "ws_push"),  # unified_model
+    ("backend", "offload", "offload"),  # diffusion / unified_model
+    ("backend", "onload", "onload"),
+    ("reward", "score_and_attach", "reward"),
+    ("stack", "train_track", "train"),
+    ("diffusion.stack", "train_track", "diffusion_train"),  # pe
+    ("ar.stack", "train_track", "ar_train"),  # pe
+)
+
+#: worker-probe key → wandb key (fold = running max across probes and ranks)
+_FOLD_KEYS = {
+    "max_allocated_gb": "max_memory_allocated_gb",
+    "max_reserved_gb": "max_memory_reserved_gb",
+    "device_used_gb": "device_memory_used_gb",
+    "cpu_rss_gb": "cpu_memory_used_gb",
+}
+
+
+def _resolve_attr(root: Any, path: str) -> Any:
+    obj = root
+    for part in path.split("."):
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    return obj
+
+
+def _parse_step_range(spec: Optional[str]) -> Optional[Tuple[int, int]]:
+    """``"2:4"`` → (2, 4) inclusive; ``"3"`` → (3, 3); None/invalid → None."""
+    if not spec or not spec.strip():
+        return None
+    try:
+        if ":" in spec:
+            lo, hi = spec.split(":", 1)
+            return int(lo), int(hi)
+        step = int(spec)
+        return step, step
+    except ValueError:
+        logger.warning("memory: UNIRL_MEMSNAP_STEPS=%r unparseable; snapshot dumps disabled", spec)
+        return None
+
+
+class MemoryMonitor:
+    """Orchestrates worker memory probes; aggregates per step for wandb."""
+
+    def __init__(
+        self,
+        *,
+        log_boundaries: bool = False,
+        empty_cache_at: Sequence[str] = (),
+    ) -> None:
+        self.log_boundaries = bool(log_boundaries)
+        self.empty_cache_at = tuple(empty_cache_at or ())
+        self._step_max: Dict[str, float] = {}
+        self._fallback = None  # closing-probe / snapshot-dump target handle
+        self._installed = False
+        self._memsnap_steps = _parse_step_range(os.environ.get("UNIRL_MEMSNAP_STEPS"))
+
+    # ── probing ──────────────────────────────────────────────────────────
+
+    def _probe(self, handle: Any, **kwargs: Any) -> List[Dict[str, float]]:
+        """One BROADCAST probe; returns per-rank dicts ({} for CUDA-less ranks)."""
+        try:
+            results = handle.get_memory_stats(**kwargs)
+        except Exception:  # diagnostics must never break training
+            logger.warning("memory: probe failed", exc_info=True)
+            return []
+        if isinstance(results, dict):  # single-worker handles may not wrap in a list
+            results = [results]
+        return [r for r in (results or []) if r]
+
+    def _fold(self, readings: List[Dict[str, float]]) -> None:
+        for r in readings:
+            for src, dst in _FOLD_KEYS.items():
+                if src in r:
+                    self._step_max[dst] = max(self._step_max.get(dst, 0.0), float(r[src]))
+
+    def _log_line(self, stage: str, readings: List[Dict[str, float]]) -> None:
+        if not readings:
+            return
+        alloc = [(r.get("max_allocated_gb", 0.0), int(r.get("rank", -1))) for r in readings]
+        hi, hi_rank = max(alloc)
+        lo = min(a for a, _ in alloc)
+        any_r = max(readings, key=lambda r: r.get("max_allocated_gb", 0.0))
+        logger.info(
+            "[mem] stage=%s peak_alloc=%.2f (rank%d, min %.2f) reserved=%.2f device_used=%.1f (GB)",
+            stage,
+            hi,
+            hi_rank,
+            lo,
+            any_r.get("reserved_gb", 0.0),
+            any_r.get("device_used_gb", 0.0),
+        )
+
+    # ── phase wrapping (install_phase_timing pattern) ────────────────────
+
+    def _wrap(self, handle: Any, fn: Callable, phase: str) -> Callable:
+        @functools.wraps(fn)
+        def _probed(*args: Any, **kwargs: Any):
+            begin = self._probe(
+                handle,
+                reset_peak=True,
+                log_stage=f"{phase}:begin" if self.log_boundaries else None,
+            )
+            self._fold(begin)  # pre-reset reading also covers the gap since the last probe
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                end = self._probe(
+                    handle,
+                    log_stage=f"{phase}:end" if self.log_boundaries else None,
+                    empty_cache=phase in self.empty_cache_at,
+                )
+                self._fold(end)
+                if self.log_boundaries:
+                    self._log_line(phase, end)
+
+        _probed._unirl_mem_wrapped = True  # type: ignore[attr-defined]
+        return _probed
+
+    def install(self, trainer: Any) -> None:
+        """Wrap the collaborator methods and register with the live wandb logger.
+
+        Called from ``BaseTrainer._init_wandb`` — the collaborators are built by
+        the subclass ``__init__`` (after the base one), and the live logger has
+        just replaced the null-object, so both are ready here.
+        """
+        if self._installed:
+            return
+        for attr_path, method, phase in _MEM_PHASE_SPECS:
+            handle = _resolve_attr(trainer, attr_path)
+            if handle is None:
+                continue
+            fn = getattr(handle, method, None)
+            if not callable(fn) or getattr(fn, "_unirl_mem_wrapped", False):
+                continue
+            if not callable(getattr(handle, "get_memory_stats", None)):
+                continue  # local (non-Remote) collaborator — nothing to probe
+            setattr(handle, method, self._wrap(handle, fn, phase))
+        for attr in ("stack", "backend"):
+            handle = getattr(trainer, attr, None)
+            if handle is not None and callable(getattr(handle, "get_memory_stats", None)):
+                self._fallback = handle
+                break
+        trainer.wandb_logger.memory_monitor = self
+        self._installed = True
+
+    # ── per-step summary (consumed by log_rollout_step) ──────────────────
+
+    def step_summary(self, step: Optional[int] = None) -> Dict[str, float]:
+        """Fold the step's probes into verl-parity wandb keys; re-arm for the next step."""
+        if self._fallback is not None:
+            dump_tag = None
+            if (
+                step is not None
+                and self._memsnap_steps is not None
+                and self._memsnap_steps[0] <= step <= self._memsnap_steps[1]
+            ):
+                dump_tag = f"step{step}"
+            closing = self._probe(self._fallback, reset_peak=True, dump_snapshot_tag=dump_tag)
+            self._fold(closing)
+        summary = dict(self._step_max)
+        driver_rss = _cpu_rss_gb()
+        if driver_rss is not None:
+            summary["cpu_memory_used_gb"] = max(summary.get("cpu_memory_used_gb", 0.0), driver_rss)
+        self._step_max.clear()
+        return summary
+
+    # ── one-off boundaries (checkpoint save, ad-hoc) ──────────────────────
+
+    def boundary(self, stage: str, handle: Any) -> None:
+        if handle is None or not callable(getattr(handle, "get_memory_stats", None)):
+            return
+        readings = self._probe(handle, log_stage=stage)
+        self._fold(readings)
+        self._log_line(stage, readings)
+
+
+def install_memory_monitoring(trainer: Any) -> Optional[MemoryMonitor]:
+    """Build a monitor from the trainer's ``logging.memory`` block (or env override).
+
+    Returns None when disabled — in that case nothing is ever wrapped and the
+    system is byte-identical to an unpatched tree. ``UNIRL_MEM_MONITOR=0/1``
+    overrides ``logging.memory.enabled`` (default: enabled).
+    """
+    logging_cfg = getattr(trainer, "logging_cfg", None) or {}
+    mem_cfg = logging_cfg.get("memory") if hasattr(logging_cfg, "get") else None
+    mem_cfg = mem_cfg or {}
+    enabled = bool(mem_cfg.get("enabled", True))
+    env_override = os.environ.get("UNIRL_MEM_MONITOR")
+    if env_override is not None:
+        enabled = _truthy(env_override, default=enabled)
+    if not enabled:
+        return None
+    return MemoryMonitor(
+        log_boundaries=bool(mem_cfg.get("log_boundaries", False)),
+        empty_cache_at=tuple(mem_cfg.get("empty_cache_at", ()) or ()),
+    )

--- a/unirl/utils/memory_monitor.py
+++ b/unirl/utils/memory_monitor.py
@@ -232,6 +232,10 @@ class MemoryMonitor:
                 dump_tag = f"step{step}"
             closing = self._probe(self._fallback, reset_peak=True, dump_snapshot_tag=dump_tag)
             self._fold(closing)
+            for r in closing:  # driver-side log so the report reaches the training console
+                report = r.get("snapshot_report")
+                if report:
+                    logger.info("memory: snapshot %s (rank %d)\n%s", dump_tag, int(r.get("rank", 0)), report)
         summary = dict(self._step_max)
         driver_rss = _cpu_rss_gb()
         if driver_rss is not None:

--- a/unirl/utils/memory_monitor.py
+++ b/unirl/utils/memory_monitor.py
@@ -170,28 +170,30 @@ class MemoryMonitor:
                 if self.log_boundaries:
                     self._log_line(phase, end)
 
-        _probed._unirl_mem_wrapped = True  # type: ignore[attr-defined]
         return _probed
 
-    def install(self, trainer: Any) -> None:
-        """Wrap the collaborator methods and register with the live wandb logger.
-
-        Called from ``BaseTrainer._init_wandb`` — the collaborators are built by
-        the subclass ``__init__`` (after the base one), and the live logger has
-        just replaced the null-object, so both are ready here.
-        """
-        if self._installed:
-            return
+    def _wrap_collaborators(self, trainer: Any) -> None:
         for attr_path, method, phase in _MEM_PHASE_SPECS:
             handle = _resolve_attr(trainer, attr_path)
             if handle is None:
                 continue
             fn = getattr(handle, method, None)
-            if not callable(fn) or getattr(fn, "_unirl_mem_wrapped", False):
+            if not callable(fn):
                 continue
             if not callable(getattr(handle, "get_memory_stats", None)):
                 continue  # local (non-Remote) collaborator — nothing to probe
             setattr(handle, method, self._wrap(handle, fn, phase))
+
+    def install(self, trainer: Any) -> None:
+        """Register with the live logger now; defer collaborator wrapping to step 1.
+
+        Called from ``BaseTrainer._init_wandb``. Wrapping is deferred until after
+        the first ``train_step`` so it lands OUTSIDE ``install_phase_timing``'s
+        wrappers (which install lazily on step 1) — the memory probes then stay
+        out of ``perf/<phase>_time_s`` (step 1 itself is unmonitored).
+        """
+        if self._installed:
+            return
         for attr in ("stack", "backend"):
             handle = getattr(trainer, attr, None)
             if handle is not None and callable(getattr(handle, "get_memory_stats", None)):
@@ -199,6 +201,22 @@ class MemoryMonitor:
                 break
         trainer.wandb_logger.memory_monitor = self
         self._installed = True
+
+        inner = getattr(trainer, "train_step", None)
+        if not callable(inner):
+            self._wrap_collaborators(trainer)
+            return
+
+        @functools.wraps(inner)
+        def _wrap_after_first_step(*args: Any, **kwargs: Any):
+            try:
+                return inner(*args, **kwargs)
+            finally:
+                self._wrap_collaborators(trainer)
+                if trainer.train_step is _wrap_after_first_step:
+                    trainer.train_step = inner
+
+        trainer.train_step = _wrap_after_first_step
 
     # ── per-step summary (consumed by log_rollout_step) ──────────────────
 
@@ -234,17 +252,28 @@ class MemoryMonitor:
 def install_memory_monitoring(trainer: Any) -> Optional[MemoryMonitor]:
     """Build a monitor from the trainer's ``logging.memory`` block (or env override).
 
-    Returns None when disabled — in that case nothing is ever wrapped and the
-    system is byte-identical to an unpatched tree. ``UNIRL_MEM_MONITOR=0/1``
-    overrides ``logging.memory.enabled`` (default: enabled).
+    Returns None when disabled — nothing is wrapped and the tree is unpatched.
+    Disabled by default (opt-in): even the folding path spends two blocking
+    BROADCAST probes per wrapped phase. ``UNIRL_MEM_MONITOR=0/1`` overrides
+    ``logging.memory.enabled``. ``UNIRL_MEMSNAP=1`` force-enables the monitor
+    (snapshots dump only through its closing probe), unless ``UNIRL_MEM_MONITOR=0``
+    explicitly wins.
     """
     logging_cfg = getattr(trainer, "logging_cfg", None) or {}
     mem_cfg = logging_cfg.get("memory") if hasattr(logging_cfg, "get") else None
     mem_cfg = mem_cfg or {}
-    enabled = bool(mem_cfg.get("enabled", True))
+    enabled = bool(mem_cfg.get("enabled", False))
     env_override = os.environ.get("UNIRL_MEM_MONITOR")
     if env_override is not None:
         enabled = _truthy(env_override, default=enabled)
+    if _truthy(os.environ.get("UNIRL_MEMSNAP")):
+        if env_override is not None and not enabled:
+            logger.warning(
+                "memory: UNIRL_MEMSNAP=1 but UNIRL_MEM_MONITOR is off — snapshots will "
+                "record (overhead) but never dump; set UNIRL_MEM_MONITOR=1 to dump them."
+            )
+        else:
+            enabled = True
     if not enabled:
         return None
     return MemoryMonitor(

--- a/unirl/utils/memory_monitor.py
+++ b/unirl/utils/memory_monitor.py
@@ -244,9 +244,10 @@ class MemoryMonitor:
     def boundary(self, stage: str, handle: Any) -> None:
         if handle is None or not callable(getattr(handle, "get_memory_stats", None)):
             return
-        readings = self._probe(handle, log_stage=stage)
+        readings = self._probe(handle, log_stage=stage if self.log_boundaries else None)
         self._fold(readings)
-        self._log_line(stage, readings)
+        if self.log_boundaries:
+            self._log_line(stage, readings)
 
 
 def install_memory_monitoring(trainer: Any) -> Optional[MemoryMonitor]:

--- a/unirl/utils/memory_utils.py
+++ b/unirl/utils/memory_utils.py
@@ -1,0 +1,268 @@
+"""GPU memory observation utilities (verl-parity toolkit).
+
+Four tools, semantics aligned with verl's ``verl/utils/memory_utils.py`` so
+their monitoring playbook (wandb ``perf/max_memory_*`` curves, stage-tagged
+``[mem]`` log lines, allocator snapshots) applies to UniRL unchanged:
+
+* :func:`get_memory_info`      — one dict of allocator + device-level readings.
+* :func:`log_memory_usage`     — the readings as a single stage-tagged log line.
+* :func:`aggressive_empty_cache` — looped ``gc.collect + empty_cache`` until a
+  round frees less than ``min_freed_gb``.
+* :class:`MemorySnapshotSampler` — ``torch.cuda.memory._record_memory_history``
+  recorder + ``_dump_snapshot`` dumper (open dumps with
+  https://pytorch.org/memory_viz).
+
+Everything here reads the CURRENT process only. UniRL trainers run on a
+CUDA-less Ray driver, so these functions are useful on workers — the driver
+reaches them through ``Remote.get_memory_stats`` (a BROADCAST RPC probe).
+Orchestration (when to probe, per-step aggregation, wandb keys) lives in
+``unirl/utils/memory_monitor.py``.
+
+``misc.clear_memory()`` remains the one-shot cleanup helper; use
+:func:`aggressive_empty_cache` when you want the verl-style "loop until dry"
+behaviour with freed-bytes accounting.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_GB = float(2**30)  # matches train/stack/base.py's cuda_alloc_gb convention
+
+
+def _truthy(value: Optional[str], *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("memory: %s=%r is not an int; using default %d", name, raw, default)
+        return default
+
+
+def _rank_enabled(rank: int, spec_env: str = "UNIRL_MEMSNAP_RANKS") -> bool:
+    spec = os.environ.get(spec_env, "0").strip().lower()
+    if spec in ("all", "*"):
+        return True
+    try:
+        return rank in {int(p) for p in spec.split(",") if p.strip()}
+    except ValueError:
+        logger.warning("memory: %s=%r unparseable; defaulting to rank 0 only", spec_env, spec)
+        return rank == 0
+
+
+def _cpu_rss_gb() -> Optional[float]:
+    try:
+        import psutil
+
+        return psutil.Process().memory_info().rss / _GB
+    except Exception:  # psutil missing or /proc unreadable — omit rather than fail
+        return None
+
+
+def get_memory_info(device: Optional[int] = None) -> Dict[str, float]:
+    """Current-process memory readings in GB. Empty dict without CUDA.
+
+    Allocator-level (this process only): ``allocated_gb`` / ``reserved_gb`` /
+    ``cached_gb`` (= reserved - allocated) / ``max_allocated_gb`` /
+    ``max_reserved_gb`` (peaks since the last ``reset_peak_memory_stats``).
+
+    Device-level (every process on the GPU, e.g. a colocated SGLang server this
+    process's allocator cannot see): ``total_gb`` / ``device_used_gb`` from
+    ``torch.cuda.mem_get_info``.
+
+    Plus ``cpu_rss_gb`` for this process when psutil is available.
+    """
+    if not torch.cuda.is_available():
+        return {}
+    dev = torch.cuda.current_device() if device is None else device
+    allocated = torch.cuda.memory_allocated(dev) / _GB
+    reserved = torch.cuda.memory_reserved(dev) / _GB
+    info: Dict[str, float] = {
+        "allocated_gb": allocated,
+        "reserved_gb": reserved,
+        "cached_gb": reserved - allocated,
+        "max_allocated_gb": torch.cuda.max_memory_allocated(dev) / _GB,
+        "max_reserved_gb": torch.cuda.max_memory_reserved(dev) / _GB,
+    }
+    try:
+        free_b, total_b = torch.cuda.mem_get_info(dev)
+        info["total_gb"] = total_b / _GB
+        info["device_used_gb"] = (total_b - free_b) / _GB
+    except Exception:  # some backends lack mem_get_info — allocator stats still stand
+        pass
+    rss = _cpu_rss_gb()
+    if rss is not None:
+        info["cpu_rss_gb"] = rss
+    return info
+
+
+def log_memory_usage(
+    stage: str,
+    logger_: Optional[logging.Logger] = None,
+    level: int = logging.INFO,
+) -> Dict[str, float]:
+    """Log :func:`get_memory_info` as one ``[mem] stage=...`` line; return the info."""
+    info = get_memory_info()
+    log = logger_ or logger
+    if not info:
+        log.log(level, "[mem] stage=%s (no CUDA in this process)", stage)
+        return info
+    log.log(
+        level,
+        "[mem] stage=%s alloc=%.2f reserved=%.2f peak_alloc=%.2f peak_reserved=%.2f "
+        "device_used=%.1f/%.1f cpu_rss=%.1f (GB)",
+        stage,
+        info.get("allocated_gb", 0.0),
+        info.get("reserved_gb", 0.0),
+        info.get("max_allocated_gb", 0.0),
+        info.get("max_reserved_gb", 0.0),
+        info.get("device_used_gb", 0.0),
+        info.get("total_gb", 0.0),
+        info.get("cpu_rss_gb", 0.0),
+    )
+    return info
+
+
+def aggressive_empty_cache(
+    force_sync: bool = False,
+    max_rounds: int = 10,
+    min_freed_gb: float = 1.0,
+) -> Dict[str, float]:
+    """Loop ``gc.collect + torch.cuda.empty_cache`` until a round frees < ``min_freed_gb``.
+
+    verl semantics: the first round returns the allocator's big cached blocks,
+    later rounds catch tensors that only die once reference cycles are
+    collected. Stops early when a round stops paying. Never called by the
+    monitoring path by default — behaviour-neutral unless explicitly invoked
+    (e.g. via ``logging.memory.empty_cache_at``).
+
+    Returns ``{"freed_reserved_gb", "freed_allocated_gb", "rounds"}``.
+    """
+    if not torch.cuda.is_available():
+        return {"freed_reserved_gb": 0.0, "freed_allocated_gb": 0.0, "rounds": 0.0}
+    start_reserved = torch.cuda.memory_reserved() / _GB
+    start_allocated = torch.cuda.memory_allocated() / _GB
+    rounds = 0
+    for attempt in range(max_rounds):
+        before_reserved = torch.cuda.memory_reserved() / _GB
+        gc.collect()
+        torch.cuda.empty_cache()
+        if force_sync:
+            torch.cuda.synchronize()
+        rounds = attempt + 1
+        freed = before_reserved - torch.cuda.memory_reserved() / _GB
+        logger.debug("memory: cleanup round %d freed %.2f GB reserved", rounds, freed)
+        if freed < min_freed_gb:
+            break
+    return {
+        "freed_reserved_gb": start_reserved - torch.cuda.memory_reserved() / _GB,
+        "freed_allocated_gb": start_allocated - torch.cuda.memory_allocated() / _GB,
+        "rounds": float(rounds),
+    }
+
+
+class MemorySnapshotSampler:
+    """Record per-allocation history and dump it as memory_viz-openable pickles.
+
+    Must live in the process whose allocations you want to see (a Ray worker,
+    not the driver). Recording hooks every allocation — measurable overhead and
+    dumps of up to hundreds of MB — so it is env-gated off by default and
+    normally limited to rank 0.
+    """
+
+    def __init__(self, out_dir: str, max_entries: int = 100_000, rank: int = 0) -> None:
+        self.out_dir = Path(out_dir)
+        self.max_entries = max_entries
+        self.rank = rank
+        self._recording = False
+
+    def start(self) -> None:
+        if self._recording or not torch.cuda.is_available():
+            return
+        try:
+            torch.cuda.memory._record_memory_history(max_entries=self.max_entries)
+            self._recording = True
+            logger.info("memory: snapshot recording started (max_entries=%d)", self.max_entries)
+        except Exception:
+            logger.warning("memory: failed to start snapshot recording", exc_info=True)
+
+    def dump(self, tag: str) -> Optional[str]:
+        """Dump the history to ``<out_dir>/memsnap_<tag>_rank<r>.pickle``; None on failure."""
+        if not self._recording:
+            return None
+        try:
+            self.out_dir.mkdir(parents=True, exist_ok=True)
+            path = self.out_dir / f"memsnap_{tag}_rank{self.rank}.pickle"
+            torch.cuda.memory._dump_snapshot(str(path))
+            logger.info("memory: snapshot dumped to %s", path)
+            return str(path)
+        except Exception:  # never let diagnostics kill training
+            logger.warning("memory: snapshot dump failed for tag=%s", tag, exc_info=True)
+            return None
+
+    def stop(self) -> None:
+        if not self._recording:
+            return
+        try:
+            torch.cuda.memory._record_memory_history(enabled=None)
+        except Exception:
+            pass
+        self._recording = False
+
+    @classmethod
+    def maybe_from_env(cls, rank: int = 0) -> Optional["MemorySnapshotSampler"]:
+        """Build + start a sampler when ``UNIRL_MEMSNAP`` is truthy for this rank.
+
+        Env knobs (same family as ``UNIRL_PROFILE_*``): ``UNIRL_MEMSNAP``,
+        ``UNIRL_MEMSNAP_DIR`` (default ``outputs/memsnap``),
+        ``UNIRL_MEMSNAP_MAX_ENTRIES``, ``UNIRL_MEMSNAP_RANKS`` (default ``0``).
+        """
+        if not _truthy(os.environ.get("UNIRL_MEMSNAP")):
+            return None
+        if not _rank_enabled(rank):
+            return None
+        sampler = cls(
+            out_dir=os.environ.get("UNIRL_MEMSNAP_DIR", "outputs/memsnap"),
+            max_entries=_int_env("UNIRL_MEMSNAP_MAX_ENTRIES", 100_000),
+            rank=rank,
+        )
+        sampler.start()
+        return sampler
+
+
+# ── Process-level sampler registry ─────────────────────────────────────────
+#
+# The sampler must record inside the worker process, but the dump trigger
+# arrives via ``Remote.get_memory_stats`` (defined on a base class with no
+# Worker back-reference). A module-level slot is the simplest bridge: Worker
+# installs at startup, the probe fetches at dump time.
+
+_PROCESS_SAMPLER: Optional[MemorySnapshotSampler] = None
+
+
+def init_process_snapshot_sampler(rank: int = 0) -> Optional[MemorySnapshotSampler]:
+    """Install this process's sampler from env (idempotent). Called by Worker.__init__."""
+    global _PROCESS_SAMPLER
+    if _PROCESS_SAMPLER is None:
+        _PROCESS_SAMPLER = MemorySnapshotSampler.maybe_from_env(rank=rank)
+    return _PROCESS_SAMPLER
+
+
+def get_process_snapshot_sampler() -> Optional[MemorySnapshotSampler]:
+    return _PROCESS_SAMPLER

--- a/unirl/utils/memory_utils.py
+++ b/unirl/utils/memory_utils.py
@@ -274,12 +274,12 @@ class MemorySnapshotSampler:
             logger.warning("memory: failed to start snapshot recording", exc_info=True)
 
     def dump(self, tag: str) -> Optional[str]:
-        """Dump history to ``<out_dir>/memsnap_<tag>_rank<r>.pickle`` and log a
-        ranked :func:`summarize_snapshot` report inline; None on failure.
+        """Dump history to ``<out_dir>/memsnap_<tag>_rank<r>.pickle``; return the
+        ranked :func:`summarize_snapshot` report string (None on failure).
 
-        The report (top call sites holding live memory) lands in the training log
-        automatically — no separate file, no manual step. Re-analyse the pickle
-        later with :func:`summarize_snapshot` or the memory_viz GUI if needed.
+        Runs on the worker; the report is RETURNED (not logged here) so the driver
+        can surface it inline — a worker-side ``logging`` call would only reach the
+        Ray worker log files, not the training console.
         """
         if not self._recording:
             return None
@@ -287,13 +287,12 @@ class MemorySnapshotSampler:
             self.out_dir.mkdir(parents=True, exist_ok=True)
             path = self.out_dir / f"memsnap_{tag}_rank{self.rank}.pickle"
             torch.cuda.memory._dump_snapshot(str(path))
+            logger.info("memory: snapshot dumped to %s", path)
             try:
-                report = summarize_snapshot(torch.cuda.memory._snapshot())
-                logger.info("memory: snapshot %s (rank %d)\n%s", tag, self.rank, report)
+                return summarize_snapshot(torch.cuda.memory._snapshot())
             except Exception:  # analysis is a bonus; a failure must not lose the pickle
                 logger.warning("memory: snapshot analysis failed for tag=%s", tag, exc_info=True)
-            logger.info("memory: snapshot dumped to %s", path)
-            return str(path)
+                return None
         except Exception:  # never let diagnostics kill training
             logger.warning("memory: snapshot dump failed for tag=%s", tag, exc_info=True)
             return None

--- a/unirl/utils/memory_utils.py
+++ b/unirl/utils/memory_utils.py
@@ -177,6 +177,69 @@ def aggressive_empty_cache(
     }
 
 
+def _top_frame(frames: Optional[list]) -> str:
+    """The innermost non-torch-internal call frame as ``file:line:func``.
+
+    Attributes an allocation to the user code that requested it, skipping
+    torch's own allocator frames (which are the same for every allocation).
+    """
+    if not frames:
+        return "<no stack captured>"
+    for fr in frames:
+        fn = (fr.get("filename") or "").replace("\\", "/")
+        if fn and "/torch/" not in fn:
+            return f"{fn}:{fr.get('line', '?')}:{fr.get('name', '?')}"
+    fr = frames[0]
+    return f"{fr.get('filename', '?')}:{fr.get('line', '?')}:{fr.get('name', '?')}"
+
+
+def summarize_snapshot(snapshot, top: int = 15) -> str:
+    """Rank the call sites holding live GPU memory — a text report, no GUI.
+
+    ``snapshot`` is either a loaded torch snapshot dict
+    (``torch.cuda.memory._snapshot()``) or a path to a ``.pickle`` dump. The
+    pickle is plain dicts/lists, so this reads it **without torch or CUDA** —
+    an agent can analyse a dump on any machine.
+
+    Groups every still-live block (``state == "active_allocated"``) by its
+    allocating ``file:line`` and sorts by total bytes. For a leak, diff two
+    dumps (e.g. ``memsnap_step2`` vs ``memsnap_step8``): the site whose GB grew
+    is the leak. A single dump already shows the biggest holders.
+    """
+    if isinstance(snapshot, (str, Path)):
+        import pickle
+
+        with open(snapshot, "rb") as f:
+            snapshot = pickle.load(f)
+
+    from collections import defaultdict
+
+    by_site: Dict[str, list] = defaultdict(lambda: [0, 0])  # site -> [bytes, count]
+    total_live = 0
+    total_blocks = 0
+    for seg in snapshot.get("segments", []):
+        for blk in seg.get("blocks", []):
+            if blk.get("state") != "active_allocated":
+                continue
+            size = blk.get("requested_size") or blk.get("size", 0)
+            site = _top_frame(blk.get("frames"))
+            by_site[site][0] += size
+            by_site[site][1] += 1
+            total_live += size
+            total_blocks += 1
+
+    ranked = sorted(by_site.items(), key=lambda kv: kv[1][0], reverse=True)[:top]
+    lines = [
+        f"live GPU allocations: {total_live / _GB:.2f} GB across {total_blocks} blocks",
+        f"top {len(ranked)} call sites by live bytes:",
+    ]
+    for site, (nbytes, count) in ranked:
+        lines.append(f"  {nbytes / _GB:6.2f} GB  x{count:<5d}  {site}")
+    if not ranked:
+        lines.append("  (no live allocations with captured stacks)")
+    return "\n".join(lines)
+
+
 class MemorySnapshotSampler:
     """Record per-allocation history and dump it as memory_viz-openable pickles.
 
@@ -196,20 +259,39 @@ class MemorySnapshotSampler:
         if self._recording or not torch.cuda.is_available():
             return
         try:
-            torch.cuda.memory._record_memory_history(max_entries=self.max_entries)
+            # Capture PYTHON allocation stacks so summarize_snapshot can attribute
+            # live memory to a file:line. stacks="all" gives C++ unwind frames
+            # (useless here — everything collapses to torch::unwind); "python" is
+            # what yields real .py:line sites. Fall back to the minimal call on
+            # older torch that lacks the context/stacks keywords.
+            try:
+                torch.cuda.memory._record_memory_history(max_entries=self.max_entries, context="all", stacks="python")
+            except TypeError:
+                torch.cuda.memory._record_memory_history(max_entries=self.max_entries)
             self._recording = True
             logger.info("memory: snapshot recording started (max_entries=%d)", self.max_entries)
         except Exception:
             logger.warning("memory: failed to start snapshot recording", exc_info=True)
 
     def dump(self, tag: str) -> Optional[str]:
-        """Dump the history to ``<out_dir>/memsnap_<tag>_rank<r>.pickle``; None on failure."""
+        """Dump history to ``<out_dir>/memsnap_<tag>_rank<r>.pickle`` and log a
+        ranked :func:`summarize_snapshot` report inline; None on failure.
+
+        The report (top call sites holding live memory) lands in the training log
+        automatically — no separate file, no manual step. Re-analyse the pickle
+        later with :func:`summarize_snapshot` or the memory_viz GUI if needed.
+        """
         if not self._recording:
             return None
         try:
             self.out_dir.mkdir(parents=True, exist_ok=True)
             path = self.out_dir / f"memsnap_{tag}_rank{self.rank}.pickle"
             torch.cuda.memory._dump_snapshot(str(path))
+            try:
+                report = summarize_snapshot(torch.cuda.memory._snapshot())
+                logger.info("memory: snapshot %s (rank %d)\n%s", tag, self.rank, report)
+            except Exception:  # analysis is a bonus; a failure must not lose the pickle
+                logger.warning("memory: snapshot analysis failed for tag=%s", tag, exc_info=True)
             logger.info("memory: snapshot dumped to %s", path)
             return str(path)
         except Exception:  # never let diagnostics kill training

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -665,11 +665,7 @@ class UniRLWandBLogger:
         # which should depend on wandb being enabled. Its wandb keys are folded
         # into perf on the enabled path below. Covers async_ar (no train_step to
         # wrap), and this is the step window boundary for the peak counters.
-        mem_summary = (
-            self.memory_monitor.step_summary(step=rollout_id + 1)
-            if self.memory_monitor is not None
-            else None
-        )
+        mem_summary = self.memory_monitor.step_summary(step=rollout_id + 1) if self.memory_monitor is not None else None
         if not self.enabled or not self._initialized:
             return
         # Lazy import keeps wandb_logger importable without the training stack.

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -660,6 +660,16 @@ class UniRLWandBLogger:
         previews via :meth:`log_generated_media` at this same step value and
         frees them before dispatch.
         """
+        # Memory step boundary runs BEFORE the wandb early-out: the closing probe
+        # re-arms peak counters and fires snapshot dumps (Level 2), neither of
+        # which should depend on wandb being enabled. Its wandb keys are folded
+        # into perf on the enabled path below. Covers async_ar (no train_step to
+        # wrap), and this is the step window boundary for the peak counters.
+        mem_summary = (
+            self.memory_monitor.step_summary(step=rollout_id + 1)
+            if self.memory_monitor is not None
+            else None
+        )
         if not self.enabled or not self._initialized:
             return
         # Lazy import keeps wandb_logger importable without the training stack.
@@ -678,13 +688,8 @@ class UniRLWandBLogger:
             perf["rollout_time_s"] = float(step_time_s)
         if phase_times:
             perf.update({f"{name}_time_s": float(v) for name, v in phase_times.items()})
-        # Memory summary last, and only past the enabled/_initialized early-out
-        # above: no probe RPCs are spent when wandb is off. This is also the
-        # step boundary — the closing probe re-arms peak counters for the next
-        # step ("last log to this log" is the step window; covers async_ar,
-        # which has no train_step to wrap).
-        if self.memory_monitor is not None:
-            perf.update(self.memory_monitor.step_summary(step=step))
+        if mem_summary:
+            perf.update(mem_summary)
         if perf:
             self.log_perf(step, perf)
 

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -242,6 +242,9 @@ class UniRLWandBLogger:
         # Optimizer-step counter for the ``train/`` panel (moved here from
         # BaseTrainer so all step-axis bookkeeping lives in the logger).
         self._optimizer_step = int(optimizer_step)
+        # Set by MemoryMonitor.install(); when present, log_rollout_step folds
+        # its per-step summary (perf/max_memory_* etc.) into the perf dict.
+        self.memory_monitor = None
 
         # Only enable on rank 0
         self.enabled = enabled and rank == 0
@@ -675,6 +678,13 @@ class UniRLWandBLogger:
             perf["rollout_time_s"] = float(step_time_s)
         if phase_times:
             perf.update({f"{name}_time_s": float(v) for name, v in phase_times.items()})
+        # Memory summary last, and only past the enabled/_initialized early-out
+        # above: no probe RPCs are spent when wandb is off. This is also the
+        # step boundary — the closing probe re-arms peak counters for the next
+        # step ("last log to this log" is the step window; covers async_ar,
+        # which has no train_step to wrap).
+        if self.memory_monitor is not None:
+            perf.update(self.memory_monitor.step_summary(step=step))
         if perf:
             self.log_perf(step, perf)
 


### PR DESCRIPTION
## Summary

Ports verl's GPU-memory observability to UniRL. Today we only have two *current* readings (`train/cuda_alloc_gb|cuda_reserved_gb`): no peaks, no CPU RSS, no whole-device view, no per-stage logs — so when a run OOMs or creeps you can't tell which hand-off (wake-up / generate / weight-sync / train / ckpt-save) drove the peak, or how much a colocated SGLang server (invisible to the workers' allocator) is holding on the same card.

**Additive and off by default** — nothing is wrapped, logged, or spent unless enabled. Three new modules + light wiring (6 files, +620 / -0):

- **`utils/memory_utils.py`** — current-process readings: allocator level (allocated / reserved / peaks) + whole-device (`mem_get_info`, sees every process on the card) + CPU RSS; plus a `[mem]` logger, `aggressive_empty_cache`, and memory-snapshot record/dump (opens in pytorch.org/memory_viz).
- **`utils/memory_monitor.py`** — driver-side orchestration. Reuses the `install_phase_timing` monkey-patch pattern: wraps each trainer's phase methods once at startup, adding probes at the train/rollout hand-offs **with no trainer changes**, and folds a per-step summary into wandb's `perf`.
- **`Remote.get_memory_stats` (BROADCAST)** — the CUDA-less driver's channel for reading worker memory; reads happen before any reset so peaks survive, and log-line / empty_cache / peak-reset / snapshot-dump are bundled into one RPC.

Wiring: `BaseTrainer` builds the monitor (`None` when off), `_init_wandb` installs it, `Worker` starts the snapshot sampler, `log_rollout_step` folds the summary in.

Per-step wandb keys (verl's trio + one): `perf/max_memory_allocated_gb`, `perf/max_memory_reserved_gb`, `perf/cpu_memory_used_gb`, plus `perf/device_memory_used_gb` (whole-card, includes the colocated SGLang server). With `log_boundaries` on, each phase also logs a `[mem] stage=...` line and a pair brackets ckpt-save. Enable via `logging.memory.enabled=true` (+ `log_boundaries`, `empty_cache_at`), or env `UNIRL_MEM_MONITOR=0/1`; `UNIRL_MEMSNAP=1` force-enables snapshots (rank 0 only).

## Related Issue

N/A

## Test Plan

**Lint** — all hooks green on the changed files (only `ruff-format` normalized one ternary, since committed):
```
pre-commit run --files unirl/distributed/group/remote.py unirl/distributed/group/worker.py \
  unirl/trainer/base.py unirl/utils/memory_monitor.py unirl/utils/memory_utils.py \
  unirl/utils/wandb_logger.py unirl/utils/README.md
```

**Training smoke test** — SD3.5-medium FlowGRPO (DanceGRPO) + PickScore, 1×8 H20, `num_rollouts=3`:
```
UNIRL_MEM_MONITOR=1 REPORT_TO_WANDB=true WANDB_MODE=offline \
PRETRAINED_MODEL=<sd3.5-medium> PICKSCORE_MODEL_ID=<pickscore_v1> \
bash examples/run_experiment_single_node.sh diffusion/sd3/sd3_dancegrpo \
  num_rollouts=3 +logging.memory.enabled=true +logging.memory.log_boundaries=true
```
- Per-phase peaks are sensible and re-arm every step:
  ```
  wake_up 15.48 → generate 28.32 → sleep 20.33 → reward 20.46 → train 78.48  (step 1, GB)
  wake_up 15.48 → generate 28.32 → sleep 20.33 → reward 20.46 → train 78.48  (step 2)
  ```
  `train` is highest (FSDP grads + optimizer); step 2's `wake_up` returns exactly to step 1's value → the closing probe reset the peak between steps.
- All four wandb keys logged with the expected ordering **device_used(83.06) > reserved(79.93) > allocated(78.48) GB**; cpu(4.66) is the CUDA-less driver's RSS.
- Coexists cleanly with the timing stats (`perf/*_time_s` logged alongside). Training curves match baseline (reward ≈ 0.76, gn = 0, ratio = 1.0) — enabling it doesn't perturb training.

## Compatibility / Risk

- No config-schema / checkpoint / data-format / public-API changes. Purely additive; when off (`logging.memory.enabled=false` / `UNIRL_MEM_MONITOR=0`) nothing is wrapped, no probe RPCs, output byte-identical to the original.
- Overhead when on: two blocking BROADCAST probes per wrapped phase (millisecond-scale on multi-second steps); `empty_cache_at` empty by default so cleanup never triggers on its own.
- Diagnostics never break training: every probe/dump is try/except'd; a failure just warns.
- Running the SD3 recipe needs `diffusers>=0.38`.

## Reviewer Notes

- **Peak protocol**: torch keeps one high-water mark per process. Each phase wrapper resets on entry, reads on exit; phases run serially and never interleave, so each phase's peak is its own; the closing probe re-arms for the next step (also covers `async_ar`, which has no `train_step` to wrap). Folding uses `max` (idempotent), so the reading spanning a gap between phases is attributed correctly, never double-counted — worth a close look.
- **Installed outside `install_phase_timing`**: collaborator wrapping is deferred until after the first step so memory probes stay out of `perf/<phase>_time_s`.
- AI assistance (Claude) was used for the review and this write-up; the design and validation numbers are from a real 8×H20 run.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
