### PR TITLE
ci: auto-sync PR status labels (wip / need review / changes requested / approved)

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -1,0 +1,67 @@
+name: PR Status Labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-status-labels-${{ github.event.pull_request.number }}
+
+jobs:
+  sync-label:
+    name: Sync PR status label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute and apply status label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          event="$GITHUB_EVENT_PATH"
+          number=$(jq -r '.pull_request.number' "$event")
+          draft=$(jq -r '.pull_request.draft' "$event")
+
+          has_label() {
+            jq -e --arg name "$1" '.pull_request.labels | any(.name == $name)' "$event" >/dev/null
+          }
+
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
+            [ "$draft" = "true" ] && exit 0
+            if [ "$(jq -r '.action' "$event")" = "dismissed" ]; then
+              target="need review"
+            else
+              case "$(jq -r '.review.state' "$event")" in
+                approved) target="approved" ;;
+                changes_requested) target="changes requested" ;;
+                *) exit 0 ;;
+              esac
+            fi
+          else
+            [ "$(jq -r '.pull_request.state' "$event")" = "open" ] || exit 0
+            if [ "$draft" = "true" ]; then
+              target="wip"
+            elif [ "$(jq -r '.action' "$event")" = "synchronize" ]; then
+              # New commits only move the status back to review after changes were requested.
+              has_label "changes requested" || exit 0
+              target="need review"
+            else
+              target="need review"
+            fi
+          fi
+
+          for label in "wip" "need review" "changes requested" "approved"; do
+            [ "$label" = "$target" ] && continue
+            if has_label "$label"; then
+              gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/issues/$number/labels/$(jq -rn --arg l "$label" '$l | @uri')" \
+                >/dev/null || true
+            fi
+          done
+          if ! has_label "$target"; then
+            gh api "repos/$GITHUB_REPOSITORY/issues/$number/labels" -f "labels[]=$target" >/dev/null
+          fi


### PR DESCRIPTION
## Summary

Adds a `PR Status Labels` workflow that keeps exactly one lifecycle status label on every open PR, so PR state is visible at a glance in the PR list (and filterable, e.g. `label:"need review"`):

- `wip` — draft PR
- `need review` — open non-draft, waiting for review
- `changes requested` — a reviewer requested changes
- `approved` — approved by a reviewer

Transitions handled: open/reopen/draft↔ready set `wip`/`need review`; submitted reviews set `approved`/`changes requested` (plain comments are ignored); a dismissed review resets to `need review`; pushing new commits after `changes requested` flips back to `need review` (pushes in other states are no-ops). Labels are mutually exclusive — the workflow removes the other three before applying the target.

The four labels themselves were created repo-side via `gh label create` (not part of this diff). Existing open PRs were backfilled to their current state.

## Related Issue

N/A

## Test Plan

- YAML parsed with PyYAML; the extracted `run` script was exercised locally (jq 1.7.1 + stubbed `gh`) against 10 event fixtures: draft opened, ready_for_review, approved, changes_requested, synchronize after changes-requested, synchronize otherwise (no-op), comment-only review (no-op), review dismissed, converted_to_draft, review on draft (no-op). All produced the expected add/remove label API calls, including URL-encoding of multi-word label names.
- End-to-end on live PR events: not run; reason: `pull_request_target` workflows execute from the base branch, so this only activates after merge. Will verify on the first PR event after merging.

## Compatibility / Risk

- Uses `pull_request_target` (same trigger as the existing `pr-body.yml` / `semantic-pull-request.yml`) for a write-capable token; the job never checks out or executes PR code — it only calls the labels API — so there is no untrusted-code-execution surface.
- For PRs from forks, `pull_request_review` events get a read-only token, so review-state labels only sync for same-repo branches (the team's normal flow); the draft/ready transitions still work for forks via `pull_request_target`.
- No effect on merges or required checks; the job exits 0 on all no-op paths.

## Reviewer Notes

AI-assisted (Claude Code), full diff reviewed by haonan3. Checked open PRs for overlapping `.github/workflows` work — none. Label colors/descriptions can be tweaked in the repo label settings without touching this workflow; the four label names are the only coupling.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
