### PR TITLE
feat(cosmos3): SFT training domain + Cosmos3 omnimodal task adapters (videopred + action BC)

### DIFF
--- a/examples/sft/README.md
+++ b/examples/sft/README.md
@@ -54,6 +54,22 @@ checkpoint (`save_interval`) → periodic samples (`eval_interval`, written to
   the joint objective Cosmos3-Nano-Policy-DROID was post-trained with
   (`action_loss_weight=10`, `flow_shift=5.0` per the upstream action recipes).
 
+## Verified runs (2026-07-06, 1×8 H20, nvidia/Cosmos3-Nano, droid_100 512 train / 16 eval windows)
+
+- `cosmos3_droid100_videopred` (6-step smoke): loss 0.345 → 0.230, grad_norm
+  1.6–14.6, ~1 s/step after load; eval samples at steps 3/6; `checkpoint-6`
+  written and resumable.
+- `cosmos3_droid100_action_bc` (150 steps ≈ 2.3 epochs, batch 8): total loss
+  (vision + 10× action) mean 12.89 (first 25 steps) → 9.95 (last 25), min 4.12
+  — per-step values are noisy by construction (logitnormal σ). Eval samples at
+  steps 50/100/150 each contain the generated video `[17,3,192,320]` and the
+  predicted action chunk `[16,10]`; final `checkpoint-150` (55 GB torch format;
+  prefer `checkpoint_format: dcp` or LoRA for long runs).
+
+Note: ~half of droid_100's episodes carry no language annotation (the dataset
+has 47 task strings over 100 episodes); those windows fall back to the generic
+"perform the task" instruction.
+
 ## Known debug-scale simplifications
 
 - **droid_100 actions are LeRobot's collapsed 7-D `action` field** (≈ 6-D

--- a/examples/sft/README.md
+++ b/examples/sft/README.md
@@ -1,0 +1,69 @@
+# SFT / Behavior-Cloning Recipes (Cosmos3)
+
+Supervised flow-matching finetuning for **NVIDIA Cosmos3-Nano** (16B omnimodal
+MoT world model), including robot **action-trajectory behavior cloning** in the
+style of Cosmos3-Nano-Policy-DROID.
+
+## Module split
+
+| Layer | Code | Role |
+|---|---|---|
+| Generic training framework | `unirl/trainer/sft.py`, `unirl/train_sft.py`, `unirl/train/sft/{policy,data}.py` | Model-agnostic loop: manifest records → task loss → `FSDPBackend` optimizer step → checkpoint → periodic samples. Mirrors the ReFL domain (`unirl/trainer/refl.py`). |
+| Cosmos3 wrapper | `unirl/models/cosmos3/{config,bundle,packing}.py` | Weights + freeze policy (und/AR tower frozen, gen tower trainable), joint-sequence packing that reuses `diffusers.Cosmos3OmniPipeline`'s own helpers, flow-matching sigma/noise/velocity math. |
+| Task adapters | `unirl/models/cosmos3/sft_task.py` | `Cosmos3VideoSFTTask` (t2i / t2v / video prediction) and `Cosmos3ActionBCTask` (policy-mode BC: obs + instruction → action chunk + co-denoised future video). |
+| Data prep | `unirl/utils/prepare_droid100.py` | LeRobot-v3 → self-contained debug samples (uint8 clips + z-normalized action chunks + JSONL manifests). |
+
+## Requirements
+
+- `diffusers>=0.39` (first release with `Cosmos3OmniTransformer` / `Cosmos3OmniPipeline`).
+- The trainer venv only — no inference engine (sglang / vllm-omni) is involved.
+- Checkpoint: `nvidia/Cosmos3-Nano` (diffusers layout; ~33 GB for
+  `transformer/ vae/ text_tokenizer/ scheduler/`).
+
+## Quickstart
+
+```bash
+# 1. Data: droid_100 (0.93 GB, 100 episodes, LeRobot v3) -> debug windows
+python -m unirl.utils.prepare_droid100 --root datasets/droid100_debug
+
+# 2. First milestone — video prediction (obs frame + instruction -> 16 frames)
+export PRETRAINED_MODEL=/path/to/Cosmos3-Nano
+ray start --head
+RAY_ADDRESS=auto python -m unirl.train_sft --config-name sft/cosmos3_droid100_videopred
+
+# 3. Action BC (policy mode, the Cosmos3-Nano-Policy-DROID objective)
+RAY_ADDRESS=auto python -m unirl.train_sft --config-name sft/cosmos3_droid100_action_bc
+```
+
+Each step covers the full chain: dataset → collate (worker-side) → packed MoT
+forward → masked velocity MSE → backward → clip + AdamW step → periodic
+checkpoint (`save_interval`) → periodic samples (`eval_interval`, written to
+`<save_dir>/samples/step_N.pt` as `{"video": [T,C,H,W], "action": [T,D]}`).
+
+## How training matches inference
+
+- Packing calls the *pipeline's own* `tokenize_prompt` / `_prepare_*_segment`
+  helpers, so prompts (chat template + metadata sentences + `<|vision_start|>`),
+  mRoPE ids, and sequence layout are bit-identical to `Cosmos3OmniPipeline.__call__`.
+- VAE encoding uses `_encode_video` (argmax mode + per-channel mean/std, amp off).
+- Velocity target is `v = eps - x0` (the UniPC `flow_prediction` convention:
+  `x0_pred = sample - sigma * v`); sigma is logitnormal, warped by the same
+  `flow_shift` map `set_timesteps` uses.
+- Policy-mode BC: latent frame 0 clean (no timestep embedding, excluded from
+  loss), future frames + the whole action chunk noised with one shared sigma —
+  the joint objective Cosmos3-Nano-Policy-DROID was post-trained with
+  (`action_loss_weight=10`, `flow_shift=5.0` per the upstream action recipes).
+
+## Known debug-scale simplifications
+
+- **droid_100 actions are LeRobot's collapsed 7-D `action` field** (≈ 6-D
+  cartesian velocity + gripper), not the 10-D EE-pose layout the
+  `droid_lerobot` domain head (id 8) was pretrained on, and not the 8-D
+  absolute joint positions Policy-DROID uses. Fine for a debug BC run — the
+  head is being finetuned — but for faithful Policy-DROID reproduction, prep
+  `nvidia/Cosmos3-DROID` (success split) with `action.joint_position` +
+  `gripper_position` instead.
+- No proprioceptive-state stream (the released inference stacks don't consume
+  one either); NVIDIA's internal recipe additionally conditions on state.
+- Full finetune of the gen stream only; `lora_cfg` is wired through
+  `FSDPBackend` if adapter training is preferred.

--- a/examples/sft/cosmos3_droid100_action_bc.yaml
+++ b/examples/sft/cosmos3_droid100_action_bc.yaml
@@ -1,0 +1,78 @@
+# @package _global_
+# Cosmos3-Nano action behavior cloning (policy mode) on droid_100 — 1x8.
+#
+# Mirrors Cosmos3-Nano-Policy-DROID's pretraining objective at debug scale:
+# latent frame 0 = clean observation, future video frames + the whole action
+# chunk are noised and jointly denoised; loss = vision MSE + 10x action MSE
+# (upstream action_loss_weight), sigma ~ logitnormal with flow_shift=5.0
+# (upstream action-recipe schedule).
+#
+# NB droid_100 carries LeRobot's collapsed 7-D `action` field, not the 10-D
+# EE-pose layout the droid_lerobot domain head was pretrained on — fine for a
+# debug BC run (the head is being finetuned), documented in examples/sft/README.md.
+
+num_devices: 8
+batch_size: 8
+num_rollouts: 300
+max_grad_norm: 1.0
+save_interval: 100
+save_mode: auto
+eval_interval: 100
+eval_num_samples: 1
+save_dir: ${oc.env:SAVE_DIR,outputs/cosmos3_droid100_action_bc}
+
+policy:
+  _target_: unirl.train.sft.policy.SFTPolicy
+  task_target: unirl.models.cosmos3.sft_task.Cosmos3ActionBCTask
+  seed: 42
+  model_config:
+    _target_: unirl.models.cosmos3.config.Cosmos3SFTConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,nvidia/Cosmos3-Nano}
+    model_precision: bf16
+    vae_precision: fp32
+    freeze_understanding: true
+    flow_shift: 5.0
+    time_dist: logitnormal
+    fps: 15.0
+    condition_on_first_frame: true
+    action_domain_name: droid_lerobot
+    action_chunk_size: 16
+    raw_action_dim: 7
+    action_loss_weight: 10.0
+    action_view_point: third_person_view
+    sample_num_inference_steps: 30
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 10
+    total_steps: ${num_rollouts}
+  lora_cfg: null
+
+data_source:
+  _target_: unirl.train.sft.data.JsonlSFTDataSource
+  manifest_path: ${oc.env:DATA_PATH,datasets/droid100_debug/manifest.jsonl}
+  eval_manifest_path: ${oc.env:EVAL_DATA_PATH,datasets/droid100_debug/eval_manifest.jsonl}
+  seed: 42
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,false}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-sft}
+  run_name: ${oc.env:WANDB_RUN_NAME,cosmos3_droid100_action_bc}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["cosmos3", "sft", "action-bc", "policy-mode", "droid100"]
+  log_media: false

--- a/examples/sft/cosmos3_droid100_videopred.yaml
+++ b/examples/sft/cosmos3_droid100_videopred.yaml
@@ -1,0 +1,71 @@
+# @package _global_
+# Cosmos3-Nano video-prediction SFT on the droid_100 debug set — 1x8, gen-stream
+# full finetune (und/AR tower frozen), flow-matching velocity MSE.
+#
+# The first-milestone recipe: obs frame 0 (clean) + instruction -> predict the
+# next 16 frames. Data comes from `python -m unirl.utils.prepare_droid100`
+# (self-contained uint8 clips; no video decoding in the training loop).
+#
+# Launch (single node): ray start --head; RAY_ADDRESS=auto python -m unirl.train_sft \
+#   --config-name sft/cosmos3_droid100_videopred
+
+num_devices: 8
+batch_size: 8                # one packed sample per rank per step
+num_rollouts: 200            # optimizer steps
+max_grad_norm: 1.0
+save_interval: 100
+save_mode: auto
+eval_interval: 50
+eval_num_samples: 1
+save_dir: ${oc.env:SAVE_DIR,outputs/cosmos3_droid100_videopred}
+
+policy:
+  _target_: unirl.train.sft.policy.SFTPolicy
+  task_target: unirl.models.cosmos3.sft_task.Cosmos3VideoSFTTask
+  seed: 42
+  model_config:
+    _target_: unirl.models.cosmos3.config.Cosmos3SFTConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,nvidia/Cosmos3-Nano}
+    model_precision: bf16
+    vae_precision: fp32
+    freeze_understanding: true
+    time_dist: logitnormal
+    fps: 15.0
+    condition_on_first_frame: true
+    sample_num_inference_steps: 20
+    sample_guidance_scale: 6.0
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 10
+    total_steps: ${num_rollouts}
+  lora_cfg: null               # full finetune of the (unfrozen) gen stream
+
+data_source:
+  _target_: unirl.train.sft.data.JsonlSFTDataSource
+  manifest_path: ${oc.env:DATA_PATH,datasets/droid100_debug/manifest.jsonl}
+  eval_manifest_path: ${oc.env:EVAL_DATA_PATH,datasets/droid100_debug/eval_manifest.jsonl}
+  seed: 42
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,false}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-sft}
+  run_name: ${oc.env:WANDB_RUN_NAME,cosmos3_droid100_videopred}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["cosmos3", "sft", "videopred", "droid100"]
+  log_media: false

--- a/tests/models/test_cosmos3_packing.py
+++ b/tests/models/test_cosmos3_packing.py
@@ -1,0 +1,163 @@
+"""CPU tests for Cosmos3 SFT packing + flow math (no checkpoints, no GPU)."""
+
+import types
+
+import pytest
+import torch
+
+from unirl.models.cosmos3.bundle import is_understanding_param
+from unirl.models.cosmos3.packing import (
+    noise_action_latents,
+    noise_vision_latents,
+    pack_joint_sequence,
+    pad_action_chunk,
+    sample_train_sigma,
+)
+
+
+def test_sample_train_sigma_bounds_and_shift_identity():
+    gen = torch.Generator().manual_seed(0)
+    for dist in ("uniform", "logitnormal"):
+        for _ in range(50):
+            s = sample_train_sigma(
+                time_dist=dist,
+                logitnormal_mean=0.0,
+                logitnormal_std=1.0,
+                shift=5.0,
+                generator=gen,
+                device=torch.device("cpu"),
+            )
+            assert 0.0 < float(s) < 1.0
+    # shift=1 is the identity warp: sigma' = 1*s / (1 + 0*s) = s.
+    gen_a = torch.Generator().manual_seed(7)
+    gen_b = torch.Generator().manual_seed(7)
+    s1 = sample_train_sigma(
+        time_dist="uniform", logitnormal_mean=0.0, logitnormal_std=1.0, shift=1.0, generator=gen_a, device=torch.device("cpu")
+    )
+    base = torch.rand((), generator=gen_b)
+    assert torch.allclose(s1, base.clamp(1e-4, 1 - 1e-4))
+
+
+def test_noise_vision_latents_conditioning_and_velocity_relation():
+    gen = torch.Generator().manual_seed(0)
+    x0 = torch.randn(1, 4, 3, 6, 8)
+    sigma = torch.tensor(0.7)
+    x_t, v = noise_vision_latents(x0, sigma, condition_frame_indexes=[0], generator=gen)
+    assert torch.equal(x_t[:, :, 0], x0[:, :, 0])  # clean conditioning frame
+    # Flow relation on noisy frames: x_t = x0 + sigma * v  (since v = eps - x0).
+    assert torch.allclose(x_t[:, :, 1:], x0[:, :, 1:] + sigma * v[:, :, 1:], atol=1e-5)
+
+
+def test_action_padding_and_noising():
+    actions = torch.randn(16, 7)
+    padded = pad_action_chunk(actions, 64)
+    assert padded.shape == (16, 64)
+    assert torch.equal(padded[:, :7], actions)
+    assert padded[:, 7:].abs().sum() == 0
+    with pytest.raises(ValueError):
+        pad_action_chunk(torch.randn(16, 65), 64)
+
+    gen = torch.Generator().manual_seed(0)
+    x_t, v = noise_action_latents(padded, torch.tensor(0.5), raw_action_dim=7, generator=gen)
+    assert x_t[:, 7:].abs().sum() == 0
+    assert v[:, 7:].abs().sum() == 0
+    assert torch.allclose(x_t[:, :7], padded[:, :7] + 0.5 * v[:, :7], atol=1e-5)
+
+
+def test_understanding_param_patterns():
+    frozen = [
+        "embed_tokens.weight",
+        "lm_head.weight",
+        "norm.weight",
+        "layers.0.self_attn.to_q.weight",
+        "layers.12.self_attn.to_out.weight",
+        "layers.3.self_attn.norm_k.weight",
+        "layers.7.mlp.gate_proj.weight",
+        "layers.7.input_layernorm.weight",
+        "layers.7.post_attention_layernorm.weight",
+    ]
+    trainable = [
+        "norm_moe_gen.weight",
+        "layers.0.self_attn.add_q_proj.weight",
+        "layers.12.self_attn.to_add_out.weight",
+        "layers.3.self_attn.norm_added_k.weight",
+        "layers.7.mlp_moe_gen.gate_proj.weight",
+        "layers.7.input_layernorm_moe_gen.weight",
+        "proj_in.weight",
+        "proj_out.bias",
+        "time_embedder.linear_1.weight",
+        "action_proj_in.fc.weight",
+        "action_modality_embed",
+    ]
+    for name in frozen:
+        assert is_understanding_param(name), name
+    for name in trainable:
+        assert not is_understanding_param(name), name
+
+
+def _duck_pipe():
+    """Duck-typed pipeline exposing the real diffusers segment helpers."""
+    diffusers = pytest.importorskip("diffusers", minversion="0.39.0")
+    del diffusers
+    from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import Cosmos3OmniPipeline
+
+    duck = types.SimpleNamespace()
+    duck.transformer = types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            enable_fps_modulation=True,
+            unified_3d_mrope_temporal_modality_margin=15000,
+            unified_3d_mrope_reset_spatial_ids=True,
+            latent_patch_size=2,
+            base_fps=24,
+        ),
+        dtype=torch.float32,
+    )
+    duck.vae = types.SimpleNamespace(config=types.SimpleNamespace(scale_factor_temporal=4))
+    for name in ("_prepare_text_segment", "_prepare_vision_segment", "_prepare_action_segment"):
+        setattr(duck, name, types.MethodType(getattr(Cosmos3OmniPipeline, name), duck))
+    return duck
+
+
+def test_pack_joint_sequence_layout():
+    pipe = _duck_pipe()
+    device = torch.device("cpu")
+    latent_t, latent_h, latent_w = 3, 6, 8  # patch grid 3 x 3 x 4
+    vision = torch.randn(1, 4, latent_t, latent_h, latent_w)
+    input_ids = list(range(11))
+    kwargs, meta = pack_joint_sequence(
+        pipe,
+        input_ids=input_ids,
+        vision_tokens=vision,
+        condition_frame_indexes=[0],
+        vision_fps=15.0,
+        device=device,
+    )
+    und = len(input_ids)
+    tokens_per_frame = 3 * 4
+    num_vision = latent_t * tokens_per_frame
+    assert kwargs["und_len"] == und
+    assert kwargs["sequence_length"] == und + num_vision
+    assert kwargs["position_ids"].shape == (3, und + num_vision)
+    assert kwargs["vision_sequence_indexes"].tolist() == list(range(und, und + num_vision))
+    # Conditioned latent frame 0 is excluded from the loss token set.
+    assert meta["num_noisy_vision_tokens"] == (latent_t - 1) * tokens_per_frame
+    assert kwargs["vision_mse_loss_indexes"].min().item() == und + tokens_per_frame
+    assert meta["vision_noisy_frames"].tolist() == [1, 2]
+
+    # With an action chunk appended, its tokens land after the vision tokens.
+    actions = torch.randn(5, 64)
+    kwargs, meta = pack_joint_sequence(
+        pipe,
+        input_ids=input_ids,
+        vision_tokens=vision,
+        condition_frame_indexes=[0],
+        vision_fps=15.0,
+        device=device,
+        action_tokens=actions,
+        action_domain_id=torch.tensor([8]),
+        action_fps=15.0,
+    )
+    assert kwargs["sequence_length"] == und + num_vision + 5
+    assert kwargs["action_sequence_indexes"].tolist() == list(range(und + num_vision, und + num_vision + 5))
+    assert meta["num_noisy_action_tokens"] == 5
+    assert kwargs["action_domain_ids"][0].item() == 8

--- a/tests/train/test_sft_data.py
+++ b/tests/train/test_sft_data.py
@@ -1,0 +1,47 @@
+"""CPU tests for the generic SFT JSONL data source."""
+
+import json
+
+from unirl.train.sft.data import JsonlSFTDataSource
+
+
+def _write_manifest(path, n):
+    with open(path, "w") as fh:
+        for i in range(n):
+            fh.write(json.dumps({"sample_id": f"s{i}", "instruction": "t", "frames_path": f"frames/s{i}.pt"}) + "\n")
+
+
+def test_epoch_cycling_and_root_injection(tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, 5)
+    src = JsonlSFTDataSource(str(manifest), seed=0, shuffle=True)
+
+    batch = src.get_samples(3)
+    assert len(batch) == 3
+    assert all(record["_root"] == str(tmp_path) for record in batch)
+
+    # 5 records, batches of 3: the second batch crosses the epoch boundary.
+    seen = {record["sample_id"] for record in batch}
+    seen |= {record["sample_id"] for record in src.get_samples(3)}
+    assert seen == {f"s{i}" for i in range(5)}
+
+
+def test_shuffle_determinism(tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, 8)
+    a = JsonlSFTDataSource(str(manifest), seed=1)
+    b = JsonlSFTDataSource(str(manifest), seed=1)
+    ids = lambda source: [record["sample_id"] for record in source.get_samples(8)]  # noqa: E731
+    assert ids(a) == ids(b)
+
+
+def test_eval_samples_fallback(tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    _write_manifest(manifest, 4)
+    src = JsonlSFTDataSource(str(manifest), seed=0)
+    assert len(src.eval_samples(2)) == 2  # falls back to train records
+
+    eval_manifest = tmp_path / "eval.jsonl"
+    _write_manifest(eval_manifest, 2)
+    src = JsonlSFTDataSource(str(manifest), eval_manifest_path=str(eval_manifest), seed=0)
+    assert [r["sample_id"] for r in src.eval_samples(2)] == ["s0", "s1"]

--- a/unirl/models/cosmos3/__init__.py
+++ b/unirl/models/cosmos3/__init__.py
@@ -1,0 +1,9 @@
+"""Cosmos3 (NVIDIA omnimodal world model) SFT support.
+
+CPU-importable package top: the diffusers>=0.39 runtime imports live inside
+``bundle.py``/``sft_task.py`` bodies.
+"""
+
+from unirl.models.cosmos3.config import Cosmos3SFTConfig
+
+__all__ = ["Cosmos3SFTConfig"]

--- a/unirl/models/cosmos3/bundle.py
+++ b/unirl/models/cosmos3/bundle.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Optional
 
 import torch
 

--- a/unirl/models/cosmos3/bundle.py
+++ b/unirl/models/cosmos3/bundle.py
@@ -1,0 +1,144 @@
+"""Cosmos3Bundle — plain weight holder for Cosmos3 SFT.
+
+Loads the diffusers-layout checkpoint (``transformer/``, ``vae/``,
+``text_tokenizer/``, ``scheduler/``) and applies the freeze policy. FSDP
+wrapping, optimizer, and checkpointing are owned by the backend
+(:class:`unirl.train.backend.fsdp.FSDPBackend` over ``trainable_attr="transformer"``).
+
+Requires diffusers >= 0.39 (first release with ``Cosmos3OmniTransformer`` /
+``Cosmos3OmniPipeline``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+import torch
+
+from unirl.models.cosmos3.config import Cosmos3SFTConfig
+from unirl.utils.dtypes import parse_torch_dtype
+
+logger = logging.getLogger(__name__)
+
+# Full-name patterns of the understanding (AR/text) parameter set inside
+# Cosmos3OmniTransformer. Everything else — add_{q,k,v}_proj / to_add_out,
+# mlp_moe_gen.*, *_moe_gen norms, proj_in/proj_out, time_embedder, and the
+# action/audio modality heads — is the generation stream and stays trainable.
+# NB ``to_out`` must not swallow ``to_add_out`` and ``norm.`` must not swallow
+# ``norm_moe_gen.`` — hence the trailing ``\.`` anchors.
+_UND_PARAM_PATTERNS = (
+    r"^embed_tokens\.",
+    r"^lm_head\.",
+    r"^norm\.",
+    r"^layers\.\d+\.self_attn\.(to_q|to_k|to_v|to_out|norm_q|norm_k)\.",
+    r"^layers\.\d+\.mlp\.",
+    r"^layers\.\d+\.(input_layernorm|post_attention_layernorm)\.",
+)
+_UND_PARAM_RE = re.compile("|".join(f"(?:{p})" for p in _UND_PARAM_PATTERNS))
+
+
+def is_understanding_param(name: str) -> bool:
+    """True if ``name`` (a ``named_parameters`` key of Cosmos3OmniTransformer)
+    belongs to the frozen-by-default understanding stream."""
+    return _UND_PARAM_RE.match(name) is not None
+
+
+def _import_diffusers_classes():
+    try:
+        from diffusers import AutoencoderKLWan, Cosmos3OmniTransformer, UniPCMultistepScheduler
+        from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import Cosmos3OmniPipeline
+    except ImportError as exc:  # pragma: no cover - version guard
+        raise ImportError(
+            "Cosmos3 support requires diffusers>=0.39 (Cosmos3OmniTransformer/"
+            "Cosmos3OmniPipeline first shipped in 0.39.0)."
+        ) from exc
+    return Cosmos3OmniTransformer, AutoencoderKLWan, UniPCMultistepScheduler, Cosmos3OmniPipeline
+
+
+class Cosmos3Bundle:
+    """Weights for Cosmos3 SFT: MoT transformer (trainable), WanVAE + tokenizer
+    + scheduler (frozen helpers)."""
+
+    def __init__(self, *, transformer, vae, text_tokenizer, scheduler, config: Cosmos3SFTConfig) -> None:
+        self.transformer = transformer
+        self.vae = vae
+        self.text_tokenizer = text_tokenizer
+        self.scheduler = scheduler
+        self.config = config
+        self._pipeline = None
+
+    @classmethod
+    def from_config(cls, config: Cosmos3SFTConfig) -> "Cosmos3Bundle":
+        Cosmos3OmniTransformer, AutoencoderKLWan, UniPCMultistepScheduler, _ = _import_diffusers_classes()
+        path = config.pretrained_model_ckpt_path
+        device = torch.device(config.device)
+        model_dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
+        vae_dtype = parse_torch_dtype(config.vae_precision, field_name="vae_precision")
+
+        transformer = Cosmos3OmniTransformer.from_pretrained(
+            path, subfolder="transformer", torch_dtype=model_dtype
+        ).to(device)
+        vae = AutoencoderKLWan.from_pretrained(path, subfolder="vae", torch_dtype=vae_dtype).to(device)
+        vae.requires_grad_(False)
+        vae.eval()
+
+        from transformers import AutoTokenizer
+
+        text_tokenizer = AutoTokenizer.from_pretrained(path, subfolder="text_tokenizer")
+        scheduler = UniPCMultistepScheduler.from_pretrained(path, subfolder="scheduler")
+
+        if config.freeze_understanding:
+            frozen = trainable = 0
+            for name, param in transformer.named_parameters():
+                if is_understanding_param(name):
+                    param.requires_grad_(False)
+                    frozen += param.numel()
+                else:
+                    trainable += param.numel()
+            logger.info(
+                "Cosmos3Bundle: froze und stream (%.2fB params); gen stream trainable (%.2fB params)",
+                frozen / 1e9,
+                trainable / 1e9,
+            )
+
+        return cls(
+            transformer=transformer,
+            vae=vae,
+            text_tokenizer=text_tokenizer,
+            scheduler=scheduler,
+            config=config,
+        )
+
+    @property
+    def flow_shift(self) -> float:
+        """Effective flow shift: config override, else the checkpoint scheduler's."""
+        if self.config.flow_shift is not None:
+            return float(self.config.flow_shift)
+        return float(getattr(self.scheduler.config, "flow_shift", 5.0))
+
+    def build_pipeline(self):
+        """The real ``Cosmos3OmniPipeline`` over this bundle's components.
+
+        Used both for its packing helpers (tokenize_prompt / _prepare_*_segment /
+        _encode_video — training mirrors inference bit-for-bit through them) and
+        for eval sampling. Safety checker disabled: SFT prompts come from local
+        datasets, and the guardrail model download/latency has no place in the
+        training loop.
+        """
+        if self._pipeline is None:
+            *_, Cosmos3OmniPipeline = _import_diffusers_classes()
+            self._pipeline = Cosmos3OmniPipeline(
+                transformer=self.transformer,
+                text_tokenizer=self.text_tokenizer,
+                vae=self.vae,
+                scheduler=self.scheduler,
+                sound_tokenizer=None,
+                safety_checker=None,
+                enable_safety_checker=False,
+            )
+        return self._pipeline
+
+
+__all__ = ["Cosmos3Bundle", "is_understanding_param"]

--- a/unirl/models/cosmos3/bundle.py
+++ b/unirl/models/cosmos3/bundle.py
@@ -56,6 +56,25 @@ def _import_diffusers_classes():
     return Cosmos3OmniTransformer, AutoencoderKLWan, UniPCMultistepScheduler, Cosmos3OmniPipeline
 
 
+class _CastOutput(torch.nn.Module):
+    """Parameter-free wrapper casting a module's output dtype.
+
+    Cosmos3's ``forward`` feeds ``time_proj`` sinusoids (always fp32 — diffusers'
+    ``get_timestep_embedding`` calls ``.float()`` internally) straight into
+    ``time_embedder`` and relies on that embedder staying fp32. With the
+    transformer uniformly cast for FSDP2 the embedder is bf16, so restore the
+    standard diffusers convention (cast the projection before the linear).
+    """
+
+    def __init__(self, inner: torch.nn.Module, dtype: torch.dtype) -> None:
+        super().__init__()
+        self.inner = inner
+        self._dtype = dtype
+
+    def forward(self, *args, **kwargs):
+        return self.inner(*args, **kwargs).to(self._dtype)
+
+
 class Cosmos3Bundle:
     """Weights for Cosmos3 SFT: MoT transformer (trainable), WanVAE + tokenizer
     + scheduler (frozen helpers)."""
@@ -82,6 +101,7 @@ class Cosmos3Bundle:
         # matching the other UniRL bundles that run transformers fully in
         # model_precision.
         transformer = transformer.to(device=device, dtype=model_dtype)
+        transformer.time_proj = _CastOutput(transformer.time_proj, model_dtype)
         vae = AutoencoderKLWan.from_pretrained(path, subfolder="vae", torch_dtype=vae_dtype).to(device)
         vae.requires_grad_(False)
         vae.eval()

--- a/unirl/models/cosmos3/bundle.py
+++ b/unirl/models/cosmos3/bundle.py
@@ -76,9 +76,12 @@ class Cosmos3Bundle:
         model_dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
         vae_dtype = parse_torch_dtype(config.vae_precision, field_name="vae_precision")
 
-        transformer = Cosmos3OmniTransformer.from_pretrained(
-            path, subfolder="transformer", torch_dtype=model_dtype
-        ).to(device)
+        transformer = Cosmos3OmniTransformer.from_pretrained(path, subfolder="transformer", torch_dtype=model_dtype)
+        # diffusers pins `time_embedder` to fp32 (_keep_in_fp32_modules), but FSDP2
+        # requires a uniform original dtype per param group — cast the whole module,
+        # matching the other UniRL bundles that run transformers fully in
+        # model_precision.
+        transformer = transformer.to(device=device, dtype=model_dtype)
         vae = AutoencoderKLWan.from_pretrained(path, subfolder="vae", torch_dtype=vae_dtype).to(device)
         vae.requires_grad_(False)
         vae.eval()

--- a/unirl/models/cosmos3/config.py
+++ b/unirl/models/cosmos3/config.py
@@ -1,0 +1,79 @@
+"""Cosmos3 SFT configuration.
+
+One plain dataclass consumed by :class:`~unirl.models.cosmos3.bundle.Cosmos3Bundle`
+and the SFT task adapters (``sft_task.py``). Recipes reference it by
+``_target_: unirl.models.cosmos3.config.Cosmos3SFTConfig`` — no registration.
+
+Cosmos3-Nano is a 16B Mixture-of-Transformers: a causal "understanding" (und)
+text stream and a bidirectional "generation" (gen) stream share each
+``Cosmos3VLTextMoTDecoderLayer`` with disjoint parameter sets. SFT here trains
+the gen stream (velocity prediction) and freezes the und stream by default.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Cosmos3SFTConfig:
+    """Weights + flow-matching-SFT knobs for the Cosmos3 family."""
+
+    pretrained_model_ckpt_path: str
+
+    # -- precision / placement -------------------------------------------------
+    model_precision: str = "bf16"
+    # WanVAE was trained with amp off; encode/decode run in the VAE's own dtype.
+    vae_precision: str = "fp32"
+    device: str = "cuda"
+
+    # -- trainability ----------------------------------------------------------
+    # Freeze the und (AR/text) parameter set: embed_tokens, lm_head, und
+    # attention/MLP/norms. The gen stream (add_*_proj / mlp_moe_gen /
+    # *_moe_gen norms / proj_in / proj_out / time_embedder / modality heads)
+    # stays trainable.
+    freeze_understanding: bool = True
+
+    # -- flow-matching training schedule ----------------------------------------
+    # None -> read ``flow_shift`` from the checkpoint's scheduler config. The
+    # upstream action recipes run flow_shift=5.0; t2v checkpoints ship their own.
+    flow_shift: Optional[float] = None
+    # Training-time sigma distribution before the shift warp:
+    # "logitnormal" (sigmoid of N(mean, std), the upstream action-SFT choice)
+    # or "uniform".
+    time_dist: str = "logitnormal"
+    logitnormal_mean: float = 0.0
+    logitnormal_std: float = 1.0
+
+    # -- prompting (must mirror inference so tokenize_prompt output matches) ----
+    use_system_prompt: bool = True
+    add_resolution_template: bool = True
+    add_duration_template: bool = True
+
+    # -- vision task -------------------------------------------------------------
+    fps: float = 15.0
+    # Video prediction / i2v-style SFT: latent frame 0 is clean conditioning
+    # (the observation), later frames are noised. False -> pure t2v/t2i SFT.
+    condition_on_first_frame: bool = True
+    vision_loss_weight: float = 1.0
+
+    # -- action BC (policy-mode) -------------------------------------------------
+    # Embodiment domain for the DomainAwareLinear action heads. DROID/Franka
+    # single-arm = "droid_lerobot" (domain id 8). The canonical Cosmos3 width
+    # for that domain is 10 (9D EE pose + 1D gripper); debug datasets that only
+    # carry another action layout (e.g. droid_100's 7-D flattened action) may
+    # override ``raw_action_dim`` — fine for finetuning, but then the head no
+    # longer matches the base checkpoint's pretrained action semantics.
+    action_domain_name: str = "droid_lerobot"
+    action_chunk_size: int = 16
+    raw_action_dim: int = 7
+    action_loss_weight: float = 10.0
+    action_view_point: str = "concat_view"
+
+    # -- eval sampling -----------------------------------------------------------
+    sample_num_inference_steps: int = 20
+    sample_guidance_scale: float = 6.0
+
+
+__all__ = ["Cosmos3SFTConfig"]

--- a/unirl/models/cosmos3/packing.py
+++ b/unirl/models/cosmos3/packing.py
@@ -1,0 +1,191 @@
+"""Joint-sequence packing + flow-matching noising for Cosmos3 SFT.
+
+Training mirrors ``Cosmos3OmniPipeline.__call__`` steps 2-5 bit-for-bit by
+calling the pipeline's own helpers (``tokenize_prompt``,
+``_prepare_text_segment``, ``_prepare_vision_segment``,
+``_prepare_action_segment``, ``_encode_video``), then replaces the denoising
+loop with a single noised forward:
+
+    sigma ~ p(t), flow-shift-warped exactly like ``set_timesteps``
+    x_t   = (1 - sigma) * x0 + sigma * eps      # noisy frames only; condition
+                                                # frames stay clean x0 and get
+                                                # no timestep embedding
+    v*    = eps - x0                            # UniPC ``flow_prediction``
+                                                # convention: x0_pred =
+                                                # sample - sigma * v
+    loss  = MSE over noisy tokens
+
+The transformer consumes ONE packed sequence per call (no batch dim); a
+training micro-batch is one sample, with gradient accumulation across samples.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+import torch
+
+
+def sample_train_sigma(
+    *,
+    time_dist: str,
+    logitnormal_mean: float,
+    logitnormal_std: float,
+    shift: float,
+    generator: Optional[torch.Generator],
+    device: torch.device,
+) -> torch.Tensor:
+    """Draw one training sigma in (0, 1), then apply the same shift warp
+    ``set_timesteps`` uses: ``sigma' = shift*s / (1 + (shift-1)*s)``."""
+    if time_dist == "uniform":
+        base = torch.rand((), generator=generator, device=device, dtype=torch.float32)
+    elif time_dist == "logitnormal":
+        z = torch.randn((), generator=generator, device=device, dtype=torch.float32)
+        base = torch.sigmoid(z * logitnormal_std + logitnormal_mean)
+    else:
+        raise ValueError(f"Unknown time_dist={time_dist!r}; expected 'logitnormal' or 'uniform'.")
+    sigma = shift * base / (1.0 + (shift - 1.0) * base)
+    return sigma.clamp(1e-4, 1.0 - 1e-4)
+
+
+def noise_vision_latents(
+    x0: torch.Tensor,
+    sigma: torch.Tensor,
+    condition_frame_indexes: Sequence[int],
+    generator: Optional[torch.Generator],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Flow-matching interpolation for vision latents ``[1, C, T_lat, H, W]``.
+
+    Returns ``(x_t, velocity_target)``; conditioned latent frames carry clean
+    ``x0`` in ``x_t`` (their velocity-target slots are never read by the loss).
+    """
+    noise = torch.randn(x0.shape, generator=generator, device=x0.device, dtype=x0.dtype)
+    x_t = (1.0 - sigma) * x0 + sigma * noise
+    for frame_idx in condition_frame_indexes:
+        x_t[:, :, frame_idx] = x0[:, :, frame_idx]
+    return x_t, noise - x0
+
+
+def pad_action_chunk(actions: torch.Tensor, action_dim: int) -> torch.Tensor:
+    """Zero-pad a raw action chunk ``[T, D_raw]`` up to the model's
+    ``action_dim`` (the checkpoint convention: padded dims are exactly zero)."""
+    if actions.ndim != 2:
+        raise ValueError(f"action chunk must be [T, D], got {tuple(actions.shape)}")
+    if actions.shape[1] > action_dim:
+        raise ValueError(f"action width {actions.shape[1]} exceeds model action_dim={action_dim}")
+    if actions.shape[1] == action_dim:
+        return actions
+    pad = torch.zeros(actions.shape[0], action_dim - actions.shape[1], dtype=actions.dtype, device=actions.device)
+    return torch.cat([actions, pad], dim=-1)
+
+
+def noise_action_latents(
+    x0_padded: torch.Tensor,
+    sigma: torch.Tensor,
+    raw_action_dim: int,
+    generator: Optional[torch.Generator],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Flow-matching interpolation for a fully-noisy action chunk ``[T, action_dim]``
+    (policy-mode BC: no clean action conditioning). Channels >= ``raw_action_dim``
+    are pinned to zero in both the sample and the target, matching inference."""
+    noise = torch.randn(x0_padded.shape, generator=generator, device=x0_padded.device, dtype=x0_padded.dtype)
+    noise[:, raw_action_dim:] = 0
+    x_t = (1.0 - sigma) * x0_padded + sigma * noise
+    x_t[:, raw_action_dim:] = 0
+    return x_t, noise - x0_padded
+
+
+def pack_joint_sequence(
+    pipe: Any,
+    *,
+    input_ids: Sequence[int],
+    vision_tokens: torch.Tensor,
+    condition_frame_indexes: Sequence[int],
+    vision_fps: float,
+    device: torch.device,
+    action_tokens: Optional[torch.Tensor] = None,
+    action_condition_frame_indexes: Sequence[int] = (),
+    action_domain_id: Optional[torch.Tensor] = None,
+    action_fps: Optional[float] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Assemble ``Cosmos3OmniTransformer.forward`` kwargs for ONE sample.
+
+    Mirrors the conditional-pass assembly in ``Cosmos3OmniPipeline.__call__``
+    (text segment -> vision segment -> optional action segment -> position_ids
+    concat). ``pipe`` only needs the pipeline's segment helpers plus
+    ``transformer.config`` / ``vae.config`` — a duck-typed stand-in works in
+    tests.
+
+    Returns ``(kwargs, meta)``: ``kwargs`` lacks only the per-call
+    ``vision_timesteps`` / ``action_timesteps`` tensors (sized via ``meta``).
+    """
+    text_seg = pipe._prepare_text_segment(list(input_ids), device=device)
+    vision_seg = pipe._prepare_vision_segment(
+        input_vision_tokens=vision_tokens,
+        has_image_condition=bool(condition_frame_indexes),
+        mrope_offset=text_seg["vision_start_temporal_offset"],
+        vision_fps=vision_fps,
+        curr=text_seg["und_len"],
+        device=device,
+        condition_frame_indexes=list(condition_frame_indexes),
+    )
+    mrope_segments = [text_seg["text_mrope_ids"], vision_seg["vision_mrope_ids"]]
+    sequence_length = text_seg["und_len"] + vision_seg["num_vision_tokens"]
+
+    action_seg: Dict[str, Any] = {}
+    if action_tokens is not None:
+        if action_domain_id is None:
+            raise ValueError("action_tokens require an action_domain_id")
+        action_seg = pipe._prepare_action_segment(
+            input_action_tokens=action_tokens,
+            condition_frame_indexes=list(action_condition_frame_indexes),
+            mrope_offset=text_seg["vision_start_temporal_offset"],
+            action_fps=action_fps if action_fps is not None else vision_fps,
+            curr=sequence_length,
+            device=device,
+        )
+        mrope_segments.append(action_seg["action_mrope_ids"])
+        sequence_length += action_seg["action_len"]
+
+    model_dtype = pipe.transformer.dtype
+    kwargs: Dict[str, Any] = {
+        "input_ids": text_seg["input_ids"],
+        "text_indexes": text_seg["text_indexes"],
+        "position_ids": torch.cat(mrope_segments, dim=1),
+        "und_len": text_seg["und_len"],
+        "sequence_length": sequence_length,
+        "vision_tokens": [vision_tokens.to(dtype=model_dtype)],
+        "vision_token_shapes": vision_seg["vision_token_shapes"],
+        "vision_sequence_indexes": vision_seg["vision_sequence_indexes"],
+        "vision_mse_loss_indexes": vision_seg["vision_mse_loss_indexes"],
+        "vision_noisy_frame_indexes": vision_seg["vision_noisy_frame_indexes"],
+    }
+    if action_seg:
+        kwargs.update(
+            {
+                "action_tokens": [action_tokens.to(dtype=model_dtype)],
+                "action_token_shapes": action_seg["action_token_shapes"],
+                "action_sequence_indexes": action_seg["action_sequence_indexes"],
+                "action_mse_loss_indexes": action_seg["action_mse_loss_indexes"],
+                "action_timesteps": None,  # filled by the caller
+                "action_noisy_frame_indexes": action_seg["action_noisy_frame_indexes"],
+                "action_domain_ids": [action_domain_id],
+            }
+        )
+
+    meta = {
+        "num_noisy_vision_tokens": vision_seg["num_noisy_vision_tokens"],
+        "vision_noisy_frames": vision_seg["vision_noisy_frame_indexes"][0],
+        "num_noisy_action_tokens": action_seg.get("num_noisy_action_tokens", 0),
+        "action_noisy_frames": (action_seg["action_noisy_frame_indexes"][0] if action_seg else None),
+    }
+    return kwargs, meta
+
+
+__all__ = [
+    "noise_action_latents",
+    "noise_vision_latents",
+    "pack_joint_sequence",
+    "pad_action_chunk",
+    "sample_train_sigma",
+]

--- a/unirl/models/cosmos3/sft_task.py
+++ b/unirl/models/cosmos3/sft_task.py
@@ -1,0 +1,269 @@
+"""Cosmos3 SFT task adapters.
+
+Two tasks over one packed-forward core:
+
+- :class:`Cosmos3VideoSFTTask` — text(+first-frame)-conditioned video/image
+  flow-matching SFT (t2i via 1-frame clips, t2v, video prediction).
+- :class:`Cosmos3ActionBCTask` — policy-mode behavior cloning: latent frame 0
+  = clean observation, future video frames + the whole action chunk are
+  noised and jointly denoised (the pretraining objective of
+  Cosmos3-Nano-Policy-DROID).
+
+A task owns the Cosmos3-specific pieces (bundle, tokenization, packing, loss);
+the generic SFT loop (:mod:`unirl.train.sft`) only calls
+``from_config`` / ``load_record`` / ``compute_loss`` / ``sample``.
+
+Dataset records (one JSONL row each, see ``unirl/utils/prepare_droid100.py``)::
+
+    {"sample_id": ..., "instruction": str, "frames_path": "frames/x.pt",
+     "actions_path": "actions/x.pt" | null, "fps": float}
+
+``frames_path`` -> uint8 ``[T, 3, H, W]``; ``actions_path`` -> float32
+``[chunk, D_raw]`` (already normalized by the prep script). H/W should be an
+exact Cosmos3 resolution bin so training and tier-based action inference see
+the same canvas (the prep script guarantees this).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from unirl.models.cosmos3.bundle import Cosmos3Bundle
+from unirl.models.cosmos3.config import Cosmos3SFTConfig
+from unirl.models.cosmos3.packing import (
+    noise_action_latents,
+    noise_vision_latents,
+    pack_joint_sequence,
+    pad_action_chunk,
+    sample_train_sigma,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Cosmos3SFTTaskBase:
+    """Shared packed-forward core; subclasses fix the task mode."""
+
+    block_class_names: Tuple[str, ...] = ("Cosmos3VLTextMoTDecoderLayer",)
+    train_action: bool = False
+    action_mode: Optional[str] = None  # tokenize_prompt template selector
+
+    def __init__(self, *, bundle: Cosmos3Bundle, config: Cosmos3SFTConfig) -> None:
+        self.bundle = bundle
+        self.config = config
+        self.pipe = bundle.build_pipeline()
+        self._token_cache: Dict[Any, list] = {}
+
+    @classmethod
+    def from_config(cls, config: Cosmos3SFTConfig) -> "Cosmos3SFTTaskBase":
+        return cls(bundle=Cosmos3Bundle.from_config(config), config=config)
+
+    # ------------------------------------------------------------------
+    # Data loading (worker-side; records carry paths, tensors load here)
+    # ------------------------------------------------------------------
+
+    def load_record(self, record: Dict[str, Any]) -> Dict[str, Any]:
+        root = record.get("_root", "")
+        loaded = dict(record)
+        frames = torch.load(os.path.join(root, record["frames_path"]), weights_only=True)
+        if frames.ndim != 4 or frames.shape[1] != 3:
+            raise ValueError(f"frames must be [T, 3, H, W], got {tuple(frames.shape)}")
+        loaded["frames"] = frames
+        if self.train_action:
+            if not record.get("actions_path"):
+                raise ValueError(f"record {record.get('sample_id')} lacks actions_path for action BC")
+            actions = torch.load(os.path.join(root, record["actions_path"]), weights_only=True)
+            chunk = self.config.action_chunk_size
+            if actions.shape != (chunk, self.config.raw_action_dim):
+                raise ValueError(
+                    f"actions must be [{chunk}, {self.config.raw_action_dim}], got {tuple(actions.shape)}"
+                )
+            if frames.shape[0] != chunk + 1:
+                raise ValueError(
+                    f"policy BC pairs {chunk} actions with {chunk + 1} frames, got {frames.shape[0]} frames"
+                )
+            loaded["actions"] = actions
+        return loaded
+
+    # ------------------------------------------------------------------
+    # Loss
+    # ------------------------------------------------------------------
+
+    def _tokenize(self, prompt: str, *, num_frames: int, height: int, width: int, fps: float) -> list:
+        key = (prompt, num_frames, height, width, round(float(fps), 3))
+        ids = self._token_cache.get(key)
+        if ids is None:
+            ids, _ = self.pipe.tokenize_prompt(
+                prompt,
+                None,
+                num_frames=num_frames,
+                height=height,
+                width=width,
+                fps=fps,
+                use_system_prompt=self.config.use_system_prompt,
+                add_resolution_template=self.config.add_resolution_template,
+                add_duration_template=self.config.add_duration_template,
+                action_mode=self.action_mode,
+                action_view_point=self.config.action_view_point if self.action_mode else None,
+            )
+            self._token_cache[key] = ids
+        return ids
+
+    def compute_loss(
+        self, record: Dict[str, Any], *, generator: Optional[torch.Generator] = None
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        """One packed forward + masked flow-matching MSE for ONE sample."""
+        cfg = self.config
+        device = torch.device(cfg.device)
+        frames = record["frames"]
+        num_frames, _, height, width = frames.shape
+        fps = float(record.get("fps", cfg.fps))
+
+        pixels = frames.to(device=device, dtype=torch.float32).div(127.5).sub(1.0)
+        pixels = pixels.permute(1, 0, 2, 3).unsqueeze(0)  # [1, 3, T, H, W]
+        with torch.no_grad():
+            x0 = self.pipe._encode_video(pixels)  # [1, C, T_lat, H_lat, W_lat], float32
+
+        condition_frames = [0] if (cfg.condition_on_first_frame and x0.shape[2] > 1) else []
+        sigma = sample_train_sigma(
+            time_dist=cfg.time_dist,
+            logitnormal_mean=cfg.logitnormal_mean,
+            logitnormal_std=cfg.logitnormal_std,
+            shift=self.bundle.flow_shift,
+            generator=generator,
+            device=device,
+        )
+        x_t, v_target = noise_vision_latents(x0, sigma, condition_frames, generator)
+
+        action_kwargs: Dict[str, Any] = {}
+        v_target_action: Optional[torch.Tensor] = None
+        if self.train_action:
+            from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import _EMBODIMENT_TO_DOMAIN_ID
+
+            x0_action = pad_action_chunk(
+                record["actions"].to(device=device, dtype=torch.float32),
+                int(self.bundle.transformer.config.action_dim),
+            )
+            x_t_action, v_target_action = noise_action_latents(
+                x0_action, sigma, cfg.raw_action_dim, generator
+            )
+            action_kwargs = {
+                "action_tokens": x_t_action,
+                "action_condition_frame_indexes": (),  # policy BC: fully noisy chunk
+                "action_domain_id": torch.tensor(
+                    [_EMBODIMENT_TO_DOMAIN_ID[cfg.action_domain_name]], dtype=torch.long, device=device
+                ),
+                "action_fps": fps,
+            }
+
+        input_ids = self._tokenize(record["instruction"], num_frames=num_frames, height=height, width=width, fps=fps)
+        kwargs, meta = pack_joint_sequence(
+            self.pipe,
+            input_ids=input_ids,
+            vision_tokens=x_t,
+            condition_frame_indexes=condition_frames,
+            vision_fps=fps,
+            device=device,
+            **action_kwargs,
+        )
+        timestep = float(sigma.item()) * float(self.pipe.scheduler.config.num_train_timesteps)
+        kwargs["vision_timesteps"] = torch.full((meta["num_noisy_vision_tokens"],), timestep, device=device)
+        if self.train_action:
+            kwargs["action_timesteps"] = torch.full((meta["num_noisy_action_tokens"],), timestep, device=device)
+
+        preds_vision, _preds_sound, preds_action = self.bundle.transformer(**kwargs)
+
+        pred_v = preds_vision[0]
+        if pred_v.dim() == 4:  # [C, T_lat, H, W] -> [1, C, T_lat, H, W]
+            pred_v = pred_v.unsqueeze(0)
+        noisy_frames = meta["vision_noisy_frames"]
+        vision_loss = F.mse_loss(pred_v[:, :, noisy_frames].float(), v_target[:, :, noisy_frames])
+        loss = cfg.vision_loss_weight * vision_loss
+        metrics = {
+            "loss/vision": float(vision_loss.detach().item()),
+            "train/sigma": float(sigma.item()),
+        }
+
+        if self.train_action:
+            pred_a = preds_action[0]
+            if pred_a.dim() == 3:  # [1, T, D] -> [T, D]
+                pred_a = pred_a.squeeze(0)
+            raw = cfg.raw_action_dim
+            action_loss = F.mse_loss(pred_a[:, :raw].float(), v_target_action[:, :raw])
+            loss = loss + cfg.action_loss_weight * action_loss
+            metrics["loss/action"] = float(action_loss.detach().item())
+
+        metrics["loss/total"] = float(loss.detach().item())
+        return loss, metrics
+
+    # ------------------------------------------------------------------
+    # Eval sampling (all FSDP ranks must enter together — collective weights)
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def sample(self, record: Dict[str, Any], *, generator: Optional[torch.Generator] = None) -> Dict[str, Any]:
+        from PIL import Image as PILImage
+
+        cfg = self.config
+        frames = record["frames"]
+        num_frames, _, height, width = frames.shape
+        first_frame = PILImage.fromarray(frames[0].permute(1, 2, 0).numpy())
+        common = {
+            "num_inference_steps": cfg.sample_num_inference_steps,
+            "output_type": "pt",
+            "generator": generator,
+            "enable_safety_check": False,
+            "use_system_prompt": cfg.use_system_prompt,
+        }
+        if self.train_action:
+            from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import CosmosActionCondition
+
+            # NB: CosmosActionCondition resolves the canonical embodiment width
+            # (droid_lerobot -> 10); when the BC data uses a narrower layout the
+            # extra predicted columns are just the model's zero-padding.
+            condition = CosmosActionCondition(
+                mode="policy",
+                chunk_size=cfg.action_chunk_size,
+                domain_name=cfg.action_domain_name,
+                image=first_frame,
+                view_point=cfg.action_view_point,
+            )
+            out = self.pipe(
+                prompt=record["instruction"], action=condition, guidance_scale=1.0, fps=record.get("fps", cfg.fps), **common
+            )
+            action = out.action[0] if out.action else None
+            return {"video": out.video.cpu(), "action": action}
+        out = self.pipe(
+            prompt=record["instruction"],
+            image=first_frame if cfg.condition_on_first_frame else None,
+            num_frames=num_frames,
+            height=height,
+            width=width,
+            fps=record.get("fps", cfg.fps),
+            guidance_scale=cfg.sample_guidance_scale,
+            **common,
+        )
+        return {"video": out.video.cpu()}
+
+
+class Cosmos3VideoSFTTask(Cosmos3SFTTaskBase):
+    """Text(+first-frame)-conditioned video/image flow-matching SFT."""
+
+    train_action = False
+    action_mode = None
+
+
+class Cosmos3ActionBCTask(Cosmos3SFTTaskBase):
+    """Policy-mode behavior cloning: obs frame 0 + instruction -> action chunk
+    (+ co-denoised future video, the pretraining objective)."""
+
+    train_action = True
+    action_mode = "policy"
+
+
+__all__ = ["Cosmos3ActionBCTask", "Cosmos3SFTTaskBase", "Cosmos3VideoSFTTask"]

--- a/unirl/train/sft/__init__.py
+++ b/unirl/train/sft/__init__.py
@@ -1,0 +1,6 @@
+"""Generic supervised-finetuning (SFT / behavior-cloning) training domain."""
+
+from unirl.train.sft.data import JsonlSFTDataSource
+from unirl.train.sft.policy import SFTPolicy
+
+__all__ = ["JsonlSFTDataSource", "SFTPolicy"]

--- a/unirl/train/sft/data.py
+++ b/unirl/train/sft/data.py
@@ -1,0 +1,76 @@
+"""JSONL manifest data source for supervised training.
+
+Model-agnostic: rows are opaque record dicts handed to the task adapter's
+``load_record`` on the worker (tensors load worker-side from paths, so nothing
+heavy crosses the driver/Ray boundary). ``_root`` (the manifest's directory)
+is injected into every record so relative paths stay portable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+from typing import Any, Dict, List, Optional
+
+
+class JsonlSFTDataSource:
+    """Epoch-cycling shuffled reader over a JSONL manifest (+ optional eval manifest)."""
+
+    def __init__(
+        self,
+        manifest_path: str,
+        *,
+        eval_manifest_path: Optional[str] = None,
+        seed: int = 42,
+        shuffle: bool = True,
+    ) -> None:
+        self.records = self._load(manifest_path)
+        if not self.records:
+            raise ValueError(f"empty SFT manifest: {manifest_path}")
+        self.eval_records_all = self._load(eval_manifest_path) if eval_manifest_path else []
+        self.seed = int(seed)
+        self.shuffle = bool(shuffle)
+        self._epoch = 0
+        self._pos = 0
+        self._order = self._make_order()
+
+    @staticmethod
+    def _load(path: Optional[str]) -> List[Dict[str, Any]]:
+        if path is None:
+            return []
+        root = os.path.dirname(os.path.abspath(path))
+        records = []
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                record["_root"] = root
+                records.append(record)
+        return records
+
+    def _make_order(self) -> List[int]:
+        order = list(range(len(self.records)))
+        if self.shuffle:
+            random.Random(self.seed + self._epoch).shuffle(order)
+        return order
+
+    def get_samples(self, batch_size: int) -> List[Dict[str, Any]]:
+        batch: List[Dict[str, Any]] = []
+        while len(batch) < batch_size:
+            if self._pos >= len(self._order):
+                self._epoch += 1
+                self._pos = 0
+                self._order = self._make_order()
+            batch.append(self.records[self._order[self._pos]])
+            self._pos += 1
+        return batch
+
+    def eval_samples(self, k: int) -> List[Dict[str, Any]]:
+        pool = self.eval_records_all or self.records
+        return pool[: max(1, int(k))]
+
+
+__all__ = ["JsonlSFTDataSource"]

--- a/unirl/train/sft/policy.py
+++ b/unirl/train/sft/policy.py
@@ -1,0 +1,156 @@
+"""SFTPolicy — task-agnostic supervised-training Remote.
+
+Mirrors :class:`unirl.train.refl.policy.ReFLPolicy` structurally: a
+config-chosen **task adapter** (which owns the model bundle, data unpacking,
+and the loss — e.g. ``unirl.models.cosmos3.sft_task.Cosmos3ActionBCTask``) is
+FSDP-wrapped through :class:`FSDPBackend`, and the per-batch gradient work runs
+worker-side. The driver only ships record dicts (paths + metadata) and reads
+back scalar metrics.
+
+Batch semantics: ``train_batch`` receives the FULL global batch on every worker
+(BROADCAST) and takes the ``records[dp_rank::dp_size]`` shard locally — the
+trainer enforces ``batch_size % dp_size == 0`` so every rank runs the same
+number of backward passes (FSDP collectives stay aligned). Per-sample losses
+are scaled by ``1/len(shard)``; FSDP's mean gradient reduction then yields the
+global batch mean.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from hydra.utils import get_class
+
+from unirl.distributed.group.dispatch import Dispatch, Execute, distributed
+from unirl.distributed.group.remote import Remote
+from unirl.train.backend.base import LrSchedulerConfig, OptimizerConfig
+from unirl.train.backend.fsdp import FSDPBackend
+from unirl.train.configs import FSDPConfig, LoraConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SFTPolicy(Remote):
+    """Config-chosen SFT task adapter + FSDPBackend + worker-side loss/backward."""
+
+    def __init__(
+        self,
+        *,
+        task_target: str,
+        model_config: Any,
+        fsdp_cfg: FSDPConfig,
+        optimizer_cfg: OptimizerConfig,
+        scheduler_cfg: LrSchedulerConfig,
+        lora_cfg: Optional[LoraConfig] = None,
+        block_class_names: Optional[Tuple[str, ...]] = None,
+        seed: int = 42,
+    ) -> None:
+        super().__init__()
+        self._task_target = str(task_target)
+        self._model_config = model_config
+        self._fsdp_cfg = fsdp_cfg
+        self._optimizer_cfg = optimizer_cfg
+        self._scheduler_cfg = scheduler_cfg
+        self._lora_cfg = lora_cfg
+        self._block_class_names = tuple(block_class_names) if block_class_names else None
+        self.base_seed = int(seed)
+
+    def initialize(self) -> None:
+        torch.cuda.set_device(self.device)
+        if self.rank_info is not None and int(self.rank_info.world_size) > 1 and not dist.is_initialized():
+            dist.init_process_group(backend="nccl")
+
+        try:
+            self._model_config.device = self.device  # runtime device injection
+        except Exception:
+            pass
+
+        task_cls = get_class(self._task_target)
+        self.task = task_cls.from_config(self._model_config)
+
+        self.backend = FSDPBackend(
+            bundle=self.task.bundle,
+            block_class_names=self._block_class_names or tuple(self.task.block_class_names),
+            trainable_attr="transformer",
+            fsdp_cfg=self._fsdp_cfg,
+            optimizer_cfg=self._optimizer_cfg,
+            scheduler_cfg=self._scheduler_cfg,
+            device=self.device,
+            rank=int(self.rank_info.rank) if self.rank_info is not None else 0,
+            lora_cfg=self._lora_cfg,
+        )
+        logger.info("SFTPolicy initialized: task=%s", self._task_target)
+
+    def _dp_rank(self) -> int:
+        if self.rank_info is None:
+            return 0
+        return int(getattr(self.rank_info, "dp_rank", self.rank_info.rank))
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST, execute_mode=Execute.ALL)
+    def train_batch(self, *, records: List[Dict[str, Any]], step: int, dp_size: int) -> Dict[str, float]:
+        """Backward over this rank's shard of the global batch; returns rank-mean metrics."""
+        shard = records[self._dp_rank() :: max(1, int(dp_size))]
+        if not shard:
+            raise ValueError(f"empty shard: batch={len(records)} dp_size={dp_size} dp_rank={self._dp_rank()}")
+        self.backend.model.train()
+        generator = torch.Generator(device=self.device)
+        generator.manual_seed(self.base_seed + 100_003 * int(step) + self._dp_rank())
+
+        totals: Dict[str, float] = {}
+        for record in shard:
+            loaded = self.task.load_record(record)
+            loss, metrics = self.task.compute_loss(loaded, generator=generator)
+            (loss / len(shard)).backward()
+            for key, value in metrics.items():
+                totals[key] = totals.get(key, 0.0) + float(value) / len(shard)
+        return totals
+
+    # ------------------------------------------------------------------
+    # Eval sampling — every FSDP rank must participate (weight all-gathers),
+    # but only dp rank 0 returns the media.
+    # ------------------------------------------------------------------
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST, execute_mode=Execute.ALL)
+    def sample_media(self, *, records: List[Dict[str, Any]], step: int) -> Optional[List[Dict[str, Any]]]:
+        self.backend.model.eval()
+        generator = torch.Generator(device=self.device)
+        generator.manual_seed(self.base_seed)  # fixed noise -> comparable evals
+        outputs = []
+        for record in records:
+            loaded = self.task.load_record(record)
+            out = self.task.sample(loaded, generator=generator)
+            out["sample_id"] = record.get("sample_id")
+            out["instruction"] = record.get("instruction")
+            outputs.append(out)
+        self.backend.model.train()
+        return outputs if self._dp_rank() == 0 else None
+
+    # ------------------------------------------------------------------
+    # Optimizer / checkpoint (delegate to the composed FSDPBackend)
+    # ------------------------------------------------------------------
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST, execute_mode=Execute.ALL)
+    def optimizer_step(self, *, max_grad_norm: float) -> float:
+        return self.backend.optimizer_step(max_grad_norm=max_grad_norm)
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST, execute_mode=Execute.ALL)
+    def zero_grad(self) -> None:
+        self.backend.zero_grad()
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST, execute_mode=Execute.ALL)
+    def save(self, path: str, step: Optional[int] = None, mode: str = "auto") -> None:
+        self.backend.save(path, step=step, mode=mode)
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST, execute_mode=Execute.ALL)
+    def load(self, path: str) -> int:
+        return self.backend.load(path)
+
+
+__all__ = ["SFTPolicy"]

--- a/unirl/train_sft.py
+++ b/unirl/train_sft.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""UniRL SFT / behavior-cloning training entry point (Hydra-native).
+
+Thin wrapper around :class:`unirl.trainer.sft.SFTTrainer` — supervised
+flow-matching finetuning driven by a task adapter (first family: Cosmos3,
+``examples/sft/cosmos3_*.yaml``). Like ``train_refl``, the Ray cluster is
+started by the launcher (``ray start --head`` + ``RAY_ADDRESS=auto``).
+"""
+
+from __future__ import annotations
+
+import hydra
+from omegaconf import DictConfig
+
+from unirl.trainer.sft import SFTTrainer
+
+
+@hydra.main(version_base=None, config_path="../examples", config_name="sft/cosmos3_droid100_videopred")
+def main(cfg: DictConfig) -> None:
+    trainer = SFTTrainer(
+        cfg=cfg,
+        batch_size=cfg.batch_size,
+        policy_cfg=cfg.policy,
+        data_source_cfg=cfg.data_source,
+        max_grad_norm=float(cfg.get("max_grad_norm", 1.0)),
+        eval_interval=int(cfg.get("eval_interval", 0)),
+        eval_num_samples=int(cfg.get("eval_num_samples", 1)),
+        logging_cfg=cfg.get("logging"),
+    )
+    trainer.train(
+        num_rollouts=int(cfg.get("num_rollouts", 100)),
+        save_interval=int(cfg.get("save_interval", 0)),
+        save_dir=cfg.get("save_dir"),
+        load_dir=cfg.get("load_dir"),
+        save_mode=str(cfg.get("save_mode", "auto")),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/unirl/trainer/sft.py
+++ b/unirl/trainer/sft.py
@@ -25,6 +25,7 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement
+from unirl.distributed.tensor.ref import hydrate
 from unirl.trainer.base import BaseTrainer
 from unirl.utils.hydra import remote_hydra
 
@@ -86,6 +87,7 @@ class SFTTrainer(BaseTrainer):
             outputs = next((o for o in outputs if o is not None), None)
         if outputs is None:
             return
+        outputs = hydrate(outputs)  # materialize worker-side TensorRef proxies
         out_dir = os.path.join(save_dir or ".", "samples")
         os.makedirs(out_dir, exist_ok=True)
         path = os.path.join(out_dir, f"step_{step}.pt")

--- a/unirl/trainer/sft.py
+++ b/unirl/trainer/sft.py
@@ -1,0 +1,136 @@
+"""SFTTrainer — driver orchestrator for supervised finetuning / behavior cloning.
+
+One role: an :class:`~unirl.train.sft.policy.SFTPolicy` (config-chosen task
+adapter + FSDP + optimizer) on the whole device pool. Each step::
+
+    records = data_source.get_samples(batch_size)     # driver-side manifest rows
+    policy.train_batch(records, step, dp_size)        # worker-side load->loss->backward
+    policy.optimizer_step(max_grad_norm); policy.zero_grad()
+
+No rollout engine / reward / advantages / weight sync — mirrors the ReFL
+domain's shape (``unirl/trainer/refl.py``), the codified template for
+non-GRPO domains. Success signal: the flow-matching loss falls and periodic
+samples improve.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+
+from unirl.distributed.group.placement import placement
+from unirl.trainer.base import BaseTrainer
+from unirl.utils.hydra import remote_hydra
+
+logger = logging.getLogger(__name__)
+
+
+class SFTTrainer(BaseTrainer):
+    """Supervised trainer: manifest records -> task loss -> optimizer step."""
+
+    def __init__(
+        self,
+        *,
+        cfg: DictConfig,
+        batch_size: int,
+        policy_cfg: DictConfig,
+        data_source_cfg: DictConfig,
+        max_grad_norm: float = 1.0,
+        eval_interval: int = 0,
+        eval_num_samples: int = 1,
+        logging_cfg: Optional[DictConfig] = None,
+    ) -> None:
+        super().__init__(cfg=cfg, logging_cfg=logging_cfg)
+        self.batch_size = int(batch_size)
+        self.max_grad_norm = float(max_grad_norm)
+        self.eval_interval = int(eval_interval)
+        self.eval_num_samples = int(eval_num_samples)
+        self.data_source = instantiate(data_source_cfg)
+
+        with placement(self.pool, fraction=1.0, shared_workers=True):
+            self.policy = remote_hydra(policy_cfg)
+        self.policy.initialize()
+        # BaseTrainer.maybe_save/load_checkpoint operate on ``self.backend``.
+        self.backend = self.policy
+
+        self.dp_size = int(self.policy.dp_size)
+        if self.batch_size % self.dp_size:
+            raise ValueError(f"batch_size={self.batch_size} must be divisible by policy dp={self.dp_size}")
+        logger.info("SFTTrainer ready: dp=%d batch=%d max_grad_norm=%.2f", self.dp_size, self.batch_size, self.max_grad_norm)
+
+    def train_step(self, records: List[Dict[str, Any]], *, step: int) -> Tuple[Dict[str, float], float, float]:
+        t0 = time.perf_counter()
+        per_worker = self.policy.train_batch(records=records, step=step, dp_size=self.dp_size)
+        grad_norm = self.policy.optimizer_step(max_grad_norm=self.max_grad_norm)
+        if isinstance(grad_norm, list):  # BROADCAST -> one result per worker
+            grad_norm = grad_norm[0]
+        self.policy.zero_grad()
+
+        metrics: Dict[str, float] = {}
+        worker_metrics = per_worker if isinstance(per_worker, list) else [per_worker]
+        for worker in worker_metrics:
+            for key, value in worker.items():
+                metrics[key] = metrics.get(key, 0.0) + float(value) / len(worker_metrics)
+        return metrics, float(grad_norm or 0.0), time.perf_counter() - t0
+
+    def _run_eval(self, step: int, save_dir: Optional[str]) -> None:
+        records = self.data_source.eval_samples(self.eval_num_samples)
+        outputs = self.policy.sample_media(records=records, step=step)
+        if isinstance(outputs, list):  # one entry per worker; dp rank 0 carries media
+            outputs = next((o for o in outputs if o is not None), None)
+        if outputs is None:
+            return
+        out_dir = os.path.join(save_dir or ".", "samples")
+        os.makedirs(out_dir, exist_ok=True)
+        path = os.path.join(out_dir, f"step_{step}.pt")
+        torch.save(outputs, path)
+        logger.info("eval samples @ step %d -> %s", step, path)
+
+    def train(
+        self,
+        *,
+        num_rollouts: int,
+        save_interval: int = 0,
+        save_dir: Optional[str] = None,
+        load_dir: Optional[str] = None,
+        save_mode: str = "auto",
+    ) -> None:
+        start = self.maybe_load_checkpoint(load_dir, num_rollouts=num_rollouts)
+        self._init_wandb(num_rollouts=num_rollouts)
+        try:
+            for step in range(start, num_rollouts):
+                records = self.data_source.get_samples(self.batch_size)
+                metrics, grad_norm, dt = self.train_step(records, step=step)
+                logger.info(
+                    "step %d/%d  loss=%.5f grad_norm=%.4f  %.1fs",
+                    step + 1,
+                    num_rollouts,
+                    metrics.get("loss/total", float("nan")),
+                    grad_norm,
+                    dt,
+                )
+                self.wandb_logger.log_step(
+                    step + 1,
+                    {"train/loss": metrics.get("loss/total", 0.0), "train/grad_norm": grad_norm, "perf/step_time_s": dt, **metrics},
+                    prefix="",
+                )
+                if self.eval_interval and (step + 1) % self.eval_interval == 0:
+                    self._run_eval(step + 1, save_dir)
+                self.maybe_save_checkpoint(
+                    step,
+                    num_rollouts,
+                    save_interval=save_interval,
+                    save_dir=save_dir,
+                    save_mode=save_mode,
+                )
+        finally:
+            self._finish_wandb()
+
+
+__all__ = ["SFTTrainer"]

--- a/unirl/trainer/sft.py
+++ b/unirl/trainer/sft.py
@@ -25,7 +25,7 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement
-from unirl.distributed.tensor.ref import hydrate
+from unirl.distributed.tensor.ref import hydrate, map_tree
 from unirl.trainer.base import BaseTrainer
 from unirl.utils.hydra import remote_hydra
 
@@ -87,7 +87,7 @@ class SFTTrainer(BaseTrainer):
             outputs = next((o for o in outputs if o is not None), None)
         if outputs is None:
             return
-        outputs = hydrate(outputs)  # materialize worker-side TensorRef proxies
+        outputs = map_tree(outputs, hydrate)  # materialize worker-side TensorRef proxies
         out_dir = os.path.join(save_dir or ".", "samples")
         os.makedirs(out_dir, exist_ok=True)
         path = os.path.join(out_dir, f"step_{step}.pt")

--- a/unirl/utils/prepare_droid100.py
+++ b/unirl/utils/prepare_droid100.py
@@ -44,7 +44,7 @@ def download_dataset(repo: str, local_dir: Optional[str]) -> str:
     return snapshot_download(repo, repo_type="dataset", local_dir=local_dir)
 
 
-def load_meta(root: str) -> Tuple[dict, Dict[int, str], "pandas.DataFrame"]:
+def load_meta(root: str) -> Tuple[dict, Dict[int, str], "object"]:
     pd = _require("pandas")
     with open(os.path.join(root, "meta", "info.json")) as fh:
         info = json.load(fh)
@@ -139,10 +139,10 @@ def resize_clip(clip: np.ndarray, height: int, width: int) -> torch.Tensor:
     return x.round().clamp(0, 255).to(torch.uint8)
 
 
-def iter_episode_rows(dataset_root: str, info: dict, episodes) -> Iterator[Tuple[int, dict, "pandas.DataFrame"]]:
+def iter_episode_rows(dataset_root: str, info: dict, episodes) -> Iterator[Tuple[int, dict, "object"]]:
     """Yield (episode_index, episode_meta_row_dict, per-step dataframe)."""
     pd = _require("pandas")
-    data_files: Dict[Tuple[int, int], "pandas.DataFrame"] = {}
+    data_files: Dict[Tuple[int, int], object] = {}
     template = info.get("data_path", "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
     for _, row in episodes.iterrows():
         row = row.to_dict()

--- a/unirl/utils/prepare_droid100.py
+++ b/unirl/utils/prepare_droid100.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+"""Prepare a small LeRobot-v3 robot dataset (default ``lerobot/droid_100``) into
+self-contained Cosmos3 SFT debug samples.
+
+Emits, under ``--root``::
+
+    frames/<sample_id>.pt    uint8 [T, 3, H, W]      (decoded once here; training
+                                                      never touches AV1/mp4)
+    actions/<sample_id>.pt   float32 [T-1, D_raw]    (z-normalized action chunk)
+    manifest.jsonl           one record per training window
+    eval_manifest.jsonl      held-out episodes
+    stats.json               action mean/std used for normalization
+
+Window convention matches Cosmos3 policy mode: a chunk of ``T-1`` action
+transitions pairs with ``T`` frames. The default output canvas (H=192, W=320)
+is exactly the Cosmos3 action resolution-tier-256 bin with ratio 5:3, so
+training-time encoding and tier-based action inference see the same canvas.
+
+Only stdlib + torch + pandas/pyarrow + huggingface_hub + av are required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from fractions import Fraction
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+
+def _require(module: str):
+    try:
+        return __import__(module)
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(f"prepare_droid100 needs `{module}` (pip install {module})") from exc
+
+
+def download_dataset(repo: str, local_dir: Optional[str]) -> str:
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(repo, repo_type="dataset", local_dir=local_dir)
+
+
+def load_meta(root: str) -> Tuple[dict, Dict[int, str], "pandas.DataFrame"]:
+    pd = _require("pandas")
+    with open(os.path.join(root, "meta", "info.json")) as fh:
+        info = json.load(fh)
+
+    tasks_path = os.path.join(root, "meta", "tasks.parquet")
+    tasks_df = pd.read_parquet(tasks_path)
+    # LeRobot v3 stores the task string either as a column or as the index.
+    if "task" in tasks_df.columns:
+        task_strings = tasks_df["task"].tolist()
+    else:
+        task_strings = tasks_df.index.tolist()
+    if "task_index" in tasks_df.columns:
+        tasks = {int(i): str(t) for i, t in zip(tasks_df["task_index"], task_strings)}
+    else:
+        tasks = {i: str(t) for i, t in enumerate(task_strings)}
+
+    episodes_dir = os.path.join(root, "meta", "episodes")
+    frames_meta = []
+    for dirpath, _dirnames, filenames in os.walk(episodes_dir):
+        for name in sorted(filenames):
+            if name.endswith(".parquet"):
+                frames_meta.append(pd.read_parquet(os.path.join(dirpath, name)))
+    if not frames_meta:
+        raise SystemExit(f"no episode metadata parquet under {episodes_dir}")
+    episodes = pd.concat(frames_meta, ignore_index=True)
+    return info, tasks, episodes
+
+
+def _episode_video_source(episode_row, camera: str) -> Tuple[int, int, float, float]:
+    """(chunk_index, file_index, from_ts, to_ts) for one episode's camera stream."""
+    prefix = f"videos/{camera}/"
+    row = episode_row
+
+    def _get(*names, default=None):
+        for name in names:
+            if name in row and row[name] is not None:
+                return row[name]
+        return default
+
+    chunk = _get(prefix + "chunk_index", "video_chunk_index", default=0)
+    file = _get(prefix + "file_index", "video_file_index", default=0)
+    from_ts = _get(prefix + "from_timestamp", "from_timestamp", default=0.0)
+    to_ts = _get(prefix + "to_timestamp", "to_timestamp", default=None)
+    return int(chunk), int(file), float(from_ts), (float(to_ts) if to_ts is not None else None)
+
+
+def decode_episode_frames(
+    dataset_root: str,
+    info: dict,
+    camera: str,
+    episode_row,
+    num_frames_needed: int,
+) -> np.ndarray:
+    """Decode one episode's frames for ``camera`` -> uint8 [L, H, W, 3].
+
+    LeRobot v3 concatenates episodes into per-chunk mp4 files; the episode's
+    span is ``[from_timestamp, to_timestamp)`` within that file.
+    """
+    av = _require("av")
+    chunk, file, from_ts, to_ts = _episode_video_source(episode_row, camera)
+    template = info.get("video_path", "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4")
+    rel = template.format(video_key=camera, chunk_index=chunk, file_index=file, episode_chunk=chunk, episode_index=file)
+    path = os.path.join(dataset_root, rel)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"video file not found: {path} (template={template!r})")
+
+    frames: List[np.ndarray] = []
+    with av.open(path) as container:
+        stream = container.streams.video[0]
+        # Seek slightly before the episode start, then decode forward.
+        seek_ts = max(from_ts - 0.5, 0.0)
+        container.seek(int(seek_ts / float(stream.time_base or Fraction(1, 90000))), stream=stream, any_frame=False)
+        eps = 1e-4
+        for frame in container.decode(stream):
+            t = float(frame.pts * (stream.time_base or Fraction(1, 90000))) if frame.pts is not None else None
+            if t is not None and t < from_ts - eps:
+                continue
+            if to_ts is not None and t is not None and t >= to_ts - eps:
+                break
+            frames.append(frame.to_ndarray(format="rgb24"))
+            if len(frames) >= num_frames_needed:
+                break
+    if not frames:
+        raise RuntimeError(f"decoded 0 frames for episode at {path} [{from_ts}, {to_ts})")
+    return np.stack(frames)
+
+
+def resize_clip(clip: np.ndarray, height: int, width: int) -> torch.Tensor:
+    """uint8 [T, H0, W0, 3] -> uint8 [T, 3, H, W] (bilinear, antialiased)."""
+    x = torch.from_numpy(clip).permute(0, 3, 1, 2).float()
+    x = torch.nn.functional.interpolate(x, size=(height, width), mode="bilinear", align_corners=False, antialias=True)
+    return x.round().clamp(0, 255).to(torch.uint8)
+
+
+def iter_episode_rows(dataset_root: str, info: dict, episodes) -> Iterator[Tuple[int, dict, "pandas.DataFrame"]]:
+    """Yield (episode_index, episode_meta_row_dict, per-step dataframe)."""
+    pd = _require("pandas")
+    data_files: Dict[Tuple[int, int], "pandas.DataFrame"] = {}
+    template = info.get("data_path", "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet")
+    for _, row in episodes.iterrows():
+        row = row.to_dict()
+        ep_idx = int(row["episode_index"])
+        chunk = int(row.get("data/chunk_index", row.get("chunk_index", 0)) or 0)
+        file = int(row.get("data/file_index", row.get("file_index", 0)) or 0)
+        key = (chunk, file)
+        if key not in data_files:
+            rel = template.format(chunk_index=chunk, file_index=file, episode_chunk=chunk, episode_index=file)
+            data_files[key] = pd.read_parquet(os.path.join(dataset_root, rel))
+        df = data_files[key]
+        yield ep_idx, row, df[df["episode_index"] == ep_idx].sort_values("frame_index")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default="lerobot/droid_100")
+    parser.add_argument("--hf-local-dir", default=None, help="reuse an existing snapshot dir")
+    parser.add_argument("--root", default="datasets/droid100_debug")
+    parser.add_argument("--camera", default="observation.images.exterior_image_1_left")
+    parser.add_argument("--num-frames", type=int, default=17, help="frames per window (chunk = num-frames - 1)")
+    parser.add_argument("--stride", type=int, default=8)
+    parser.add_argument("--height", type=int, default=192)
+    parser.add_argument("--width", type=int, default=320)
+    parser.add_argument("--max-windows", type=int, default=512)
+    parser.add_argument("--max-eval-windows", type=int, default=16)
+    parser.add_argument("--eval-episodes", type=int, default=5, help="last N episodes held out")
+    parser.add_argument("--action-key", default="action")
+    args = parser.parse_args()
+
+    dataset_root = download_dataset(args.repo, args.hf_local_dir)
+    info, tasks, episodes = load_meta(dataset_root)
+    fps = float(info.get("fps", 15.0))
+    print(f"dataset={args.repo} fps={fps} episodes={len(episodes)} camera={args.camera}")
+
+    episode_indexes = sorted(int(i) for i in episodes["episode_index"].tolist())
+    eval_set = set(episode_indexes[-args.eval_episodes :]) if args.eval_episodes else set()
+
+    os.makedirs(os.path.join(args.root, "frames"), exist_ok=True)
+    os.makedirs(os.path.join(args.root, "actions"), exist_ok=True)
+
+    # Pass 1: action normalization stats over train episodes.
+    sums = sq_sums = None
+    count = 0
+    for ep_idx, _row, steps in iter_episode_rows(dataset_root, info, episodes):
+        if ep_idx in eval_set:
+            continue
+        actions = np.stack(steps[args.action_key].to_numpy()).astype(np.float64)
+        sums = actions.sum(0) if sums is None else sums + actions.sum(0)
+        sq_sums = (actions**2).sum(0) if sq_sums is None else sq_sums + (actions**2).sum(0)
+        count += actions.shape[0]
+    mean = sums / count
+    std = np.sqrt(np.maximum(sq_sums / count - mean**2, 1e-8))
+    stats = {"mean": mean.tolist(), "std": std.tolist(), "count": int(count), "source": args.repo, "action_key": args.action_key}
+    with open(os.path.join(args.root, "stats.json"), "w") as fh:
+        json.dump(stats, fh, indent=1)
+    print(f"action stats over {count} steps: dim={len(mean)}")
+
+    # Pass 2: window extraction.
+    manifests = {"train": [], "eval": []}
+    for ep_idx, row, steps in iter_episode_rows(dataset_root, info, episodes):
+        split = "eval" if ep_idx in eval_set else "train"
+        budget = args.max_eval_windows if split == "eval" else args.max_windows
+        if len(manifests[split]) >= budget:
+            continue
+        length = len(steps)
+        if length < args.num_frames:
+            continue
+        task_idx = int(steps["task_index"].iloc[0]) if "task_index" in steps else 0
+        instruction = tasks.get(task_idx, "").strip() or "perform the task"
+        actions = np.stack(steps[args.action_key].to_numpy()).astype(np.float32)
+        actions = (actions - mean.astype(np.float32)) / std.astype(np.float32)
+
+        last_start = length - args.num_frames
+        starts = list(range(0, last_start + 1, args.stride))
+        max_frame = max(starts) + args.num_frames
+        try:
+            clip_all = decode_episode_frames(dataset_root, info, args.camera, row, max_frame)
+        except Exception as exc:
+            print(f"[skip] episode {ep_idx}: {exc}")
+            continue
+        for start in starts:
+            if len(manifests[split]) >= budget:
+                break
+            if start + args.num_frames > len(clip_all):
+                break
+            sample_id = f"ep{ep_idx:04d}_f{start:05d}"
+            frames = resize_clip(clip_all[start : start + args.num_frames], args.height, args.width)
+            chunk = torch.from_numpy(actions[start : start + args.num_frames - 1])
+            torch.save(frames, os.path.join(args.root, "frames", f"{sample_id}.pt"))
+            torch.save(chunk, os.path.join(args.root, "actions", f"{sample_id}.pt"))
+            manifests[split].append(
+                {
+                    "sample_id": sample_id,
+                    "instruction": instruction,
+                    "frames_path": f"frames/{sample_id}.pt",
+                    "actions_path": f"actions/{sample_id}.pt",
+                    "fps": fps,
+                    "episode_index": ep_idx,
+                }
+            )
+        print(f"episode {ep_idx} [{split}]: total {len(manifests[split])} windows")
+        if len(manifests["train"]) >= args.max_windows and len(manifests["eval"]) >= args.max_eval_windows:
+            break
+
+    for split, name in (("train", "manifest.jsonl"), ("eval", "eval_manifest.jsonl")):
+        with open(os.path.join(args.root, name), "w") as fh:
+            for record in manifests[split]:
+                fh.write(json.dumps(record) + "\n")
+        print(f"{name}: {len(manifests[split])} records")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds **supervised training support for NVIDIA Cosmos3-Nano** (16B omnimodal MoT world model) — the first supervised/BC domain in UniRL — treating Cosmos3 as an omnimodal model (text/image/video/action; audio deferred):

- **Generic SFT domain** (`unirl/trainer/sft.py`, `unirl/train_sft.py`, `unirl/train/sft/`): manifest records → worker-side task loss → FSDPBackend optimizer step → checkpoint → periodic samples. Mirrors the ReFL domain shape (BaseTrainer + FSDPBackend; no rollout/reward/advantages), per the codified trainer-README extension pattern.
- **Cosmos3 wrapper** (`unirl/models/cosmos3/`): bundle on diffusers>=0.39 (`Cosmos3OmniTransformer` + `AutoencoderKLWan` + Qwen2 tokenizer), understanding-stream freezing (train the gen tower only), joint-sequence packing that calls `Cosmos3OmniPipeline`'s own `tokenize_prompt`/`_prepare_*_segment`/`_encode_video` helpers so training conditioning is bit-identical to inference, flow-matching math (logitnormal σ + flow-shift warp, velocity target `v = ε − x0` per the UniPC `flow_prediction` convention).
- **Task adapters**: `Cosmos3VideoSFTTask` (t2i/t2v/video prediction) and `Cosmos3ActionBCTask` (policy-mode behavior cloning: clean obs latent frame 0 + instruction → noised action chunk + co-denoised future video — the Cosmos3-Nano-Policy-DROID objective, `action_loss_weight=10`, `flow_shift=5.0` per upstream action recipes).
- **Data prep** (`unirl/utils/prepare_droid100.py`): LeRobot-v3 `lerobot/droid_100` (0.93 GB) → self-contained uint8 clips + z-normalized action chunks + JSONL manifests (no AV1 decoding in the training loop).
- Recipes `examples/sft/cosmos3_droid100_{videopred,action_bc}.yaml` + `examples/sft/README.md` (module split, quickstart, verified runs, known debug-scale simplifications).

## Related Issue

N/A

## Test Plan

- `pytest tests/models/test_cosmos3_packing.py tests/train/test_sft_data.py` — **8 passed** (CPU; packing layout validated against the real diffusers 0.39 segment helpers via a duck-typed pipeline).
- `python3 -m ruff check` over all new files — clean.
- **GPU e2e, 1×8 H20 (Taiji box, `diffusionrl:unirl-v1d` + diffusers 0.39.0), `nvidia/Cosmos3-Nano`, droid_100 debug set (512 train / 16 eval windows via `python -m unirl.utils.prepare_droid100`):**
  - `python -m unirl.train_sft --config-name sft/cosmos3_droid100_videopred num_rollouts=6 eval_interval=3 save_interval=6` — loss 0.345→0.230, grad_norm 1.6–14.6, ~1 s/step; eval samples at steps 3/6; `checkpoint-6` written.
  - `python -m unirl.train_sft --config-name sft/cosmos3_droid100_action_bc num_rollouts=150 eval_interval=50 save_interval=150` — total loss (vision + 10×action) mean 12.89 (first 25) → 9.95 (last 25), min 4.12, no NaN; eval samples at 50/100/150 each contain generated video `[17,3,192,320]` and predicted action chunk `[16,10]`; final `checkpoint-150` (55 GB torch format) written with `trainer_state.json`.

## Compatibility / Risk

- Purely additive (16 new files, zero edits to existing modules). Existing GRPO/ReFL/rollout paths untouched.
- Requires **diffusers>=0.39** at runtime for the Cosmos3 classes; the import is guarded with a clear error and the base `diffusers>=0.38` floor is NOT bumped by this PR (fresh installs already resolve to 0.39; a coordinated floor bump can follow separately). Note: the Tencent PyPI mirror had not yet synced 0.39.0 as of 2026-07-06; install from the official index or a local wheel.
- Two Cosmos3 dtype quirks are handled in the bundle (uniform bf16 cast for FSDP2's uniform-dtype requirement + a parameter-free `time_proj` output cast restoring the standard diffusers convention).
- droid_100 debug actions are LeRobot's 7-D collapsed field, not the pretrained droid_lerobot 10-D EE-pose layout — documented in the README as a debug-scale simplification (for faithful Policy-DROID reproduction, prep `nvidia/Cosmos3-DROID` with `action.joint_position` + `gripper_position`).

## Reviewer Notes

- AI-assisted implementation; duplicate-work check done (no existing SFT/BC domain or Cosmos3 code in-tree; design doc + env audit on the Feishu board task card).
- Review order suggestion: `packing.py` (flow math + layout) → `sft_task.py` (loss/masking) → `policy.py`/`trainer/sft.py` (domain plumbing).
- For long runs prefer `checkpoint_format: dcp` or LoRA (`lora_cfg`) — the full torch-format checkpoint of the 16B model is 55 GB.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
