### PR TITLE
fix(perf): rename misleading perf/rollout_time_s to perf/step_time_s

### DIFF
--- a/examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml
@@ -41,7 +41,8 @@ adv_normalization_scope: global
 
 # Online wandb reporting (driver/rank-0 only). Absent this block wandb is a
 # no-op. Per-rollout: rollout/reward_mean + train/{loss,grad_norm,lr,ratio_*,
-# clip_fraction,approx_kl} + perf/rollout_time_s. WANDB_API_KEY from launcher env.
+# clip_fraction,approx_kl} + perf/step_time_s + perf/<phase>_time_s.
+# WANDB_API_KEY from launcher env.
 logging:
   report_to_wandb: true
   project_name: unirl-flowgrpo-newstac

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -201,7 +201,7 @@ def install_phase_timing(trainer: Any) -> None:
     If a collaborator ever becomes async-submit (returns before the work
     finishes), its phase collapses to submission time and the wait leaks into
     the residual — a sudden near-zero phase plus a large
-    ``rollout_time_s - sum(phases)`` residual is the tell.
+    ``step_time_s - sum(phases)`` residual is the tell.
     """
     inner = getattr(trainer, "train_step", None)
     if not callable(inner):
@@ -755,7 +755,7 @@ class UniRLWandBLogger:
           any ``extra_metrics`` (e.g. ``sync_weights``) merged in.
         - ``train/*``: optimizer scalars + algorithm metrics, per-update aware
           (see :meth:`_log_train`).
-        - ``perf/rollout_time_s``: optional wall-clock for the step.
+        - ``perf/step_time_s``: optional total wall-clock for the step.
         - ``perf/<phase>_time_s``: optional per-phase wall-clocks from
           ``phase_times`` (e.g. ``generate``/``weight_sync``/``reward``/
           ``train``), so the step total can be attributed without log
@@ -788,7 +788,7 @@ class UniRLWandBLogger:
 
         perf: Dict[str, float] = {}
         if step_time_s is not None:
-            perf["rollout_time_s"] = float(step_time_s)
+            perf["step_time_s"] = float(step_time_s)
         if phase_times:
             perf.update({f"{name}_time_s": float(v) for name, v in phase_times.items()})
         if mem_summary:


### PR DESCRIPTION
## Summary

`perf/rollout_time_s` actually measures the entire `train_step` wall-clock (rollout + reward + train), not just the rollout phase. This is confusing because `perf/generate_time_s` (from `install_phase_timing`) already reports the true rollout generation time.

Rename the key to `perf/step_time_s` to accurately reflect what it measures.

Changes:
- `unirl/utils/wandb_logger.py`: rename the key from `rollout_time_s` to `step_time_s` in `log_rollout_step`, update docstring and comment
- `examples/ar/qwen_vl_grpo_geo3k_mc_4x8.yaml`: update comment to match new key name

Note: this is a breaking change for existing wandb dashboards that reference `perf/rollout_time_s` — panels using that key will need updating to `perf/step_time_s`.

## Test Plan

Not run; reason: pure key rename with no logic change — the value logged is identical, only the wandb metric name changes. Existing `install_phase_timing` tests (if any) and integration runs will validate.