### PR TITLE
feat(trainer): add periodic eval to PE / ReFL / UnifiedModel

### DIFF
--- a/unirl/train/refl/policy.py
+++ b/unirl/train/refl/policy.py
@@ -143,7 +143,7 @@ class ReFLPolicy(Remote):
         )
 
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
-    def eval_sample(self, *, prompts: Texts, rollout_id: int = 0) -> Images:
+    def eval_sample(self, *, prompts: Texts, rollout_id: int = 0, guidance_scale: Optional[float] = None) -> Images:
         """Eval sampling: ``model.eval()`` + ``no_grad`` DRaFT-K, no autograd graph.
 
         The eval sibling of :meth:`sample_and_decode`. Reused outside the driver's
@@ -153,6 +153,10 @@ class ReFLPolicy(Remote):
         mode + ``torch.no_grad()`` so the returned ``Images`` carry no grad_fn and
         no graph is retained. The next ``train_step`` re-asserts ``model.train()``
         via ``sample_and_decode``, so no explicit mode restore is needed.
+
+        ``guidance_scale`` overrides the training CFG strength for eval (the
+        trainer passes ``eval_cfg_text_scale``; recipes train at 1.0 = no CFG);
+        ``None`` falls back to the training value.
 
         The seed is offset from ``sample_and_decode``'s so eval does not reuse the
         exact training-step params at the same ``rollout_id``. NOTE: the init latent
@@ -164,7 +168,7 @@ class ReFLPolicy(Remote):
         dp_rank = int(self.rank_info.dp_rank) if self.rank_info is not None else 0
         params = DiffusionSamplingParams(
             num_inference_steps=self.num_inference_steps,
-            guidance_scale=self.guidance_scale,
+            guidance_scale=self.guidance_scale if guidance_scale is None else float(guidance_scale),
             height=self.height,
             width=self.width,
             eta=0.0,  # deterministic ODE eval

--- a/unirl/train/refl/policy.py
+++ b/unirl/train/refl/policy.py
@@ -143,6 +143,46 @@ class ReFLPolicy(Remote):
         )
 
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
+    def eval_sample(self, *, prompts: Texts, rollout_id: int = 0) -> Images:
+        """Eval sampling: ``model.eval()`` + ``no_grad`` DRaFT-K, no autograd graph.
+
+        The eval sibling of :meth:`sample_and_decode`. Reused outside the driver's
+        ``enable_grad()`` context, ``sample_and_decode`` would still run in
+        ``train()`` mode and build the DRaFT-K activation graph (``draft_generate``
+        has no ``no_grad`` guard) only to discard it. This method fixes both: eval
+        mode + ``torch.no_grad()`` so the returned ``Images`` carry no grad_fn and
+        no graph is retained. The next ``train_step`` re-asserts ``model.train()``
+        via ``sample_and_decode``, so no explicit mode restore is needed.
+
+        The seed is offset from ``sample_and_decode``'s so eval does not reuse the
+        exact training-step params at the same ``rollout_id``. NOTE: the init latent
+        is currently drawn unseeded (``generate_latents`` ignores the seed for
+        ``init_same_noise=False`` with no ``noise_group_ids``), so eval is NOT
+        bit-exact reproducible — it agrees within sampling noise (~σ). Follow-up to
+        make it exact: thread ``noise_group_ids`` into the DRaFT noise path."""
+        self.backend.model.eval()
+        dp_rank = int(self.rank_info.dp_rank) if self.rank_info is not None else 0
+        params = DiffusionSamplingParams(
+            num_inference_steps=self.num_inference_steps,
+            guidance_scale=self.guidance_scale,
+            height=self.height,
+            width=self.width,
+            eta=0.0,  # deterministic ODE eval
+            samples_per_prompt=1,
+            seed=self.base_seed + 500_000 + 1000 * int(rollout_id) + dp_rank,
+            init_same_noise=False,
+        )
+        with torch.no_grad():
+            return draft_generate(
+                self.pipeline,
+                model_config=self._model_config,
+                texts=prompts,
+                params=params,
+                draft_num_steps=self.draft_num_steps,
+                activation_checkpoint=False,
+            )
+
+    @distributed(dispatch_mode=Dispatch.DP_SCATTER)
     def loss_backward(self, *, rewards: torch.Tensor) -> None:
         """``-reward.mean()`` seed node: local backward populates ``rewards.grad``;
         the empty return makes this an always-run backward node so GradContext

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -46,6 +46,7 @@ def main(cfg: DictConfig) -> None:
         eval_chunk_prompts=cfg.get("eval_chunk_prompts", 16),
         eval_cfg_text_scale=cfg.get("eval_cfg_text_scale", 4.0),
         eval_eta=cfg.get("eval_eta", 0.0),
+        eval_rewards_cfg=cfg.get("eval_rewards"),
         stage_config=cfg.get("stage_config"),
     )
     trainer.train(

--- a/unirl/train_pe.py
+++ b/unirl/train_pe.py
@@ -34,10 +34,17 @@ def main(cfg: DictConfig) -> None:
         pe_cfg=cfg.get("pe"),
         freeze_llm=cfg.get("freeze_llm", False),
         diffusion_group_scope=cfg.get("diffusion_group_scope", "rewrite"),
+        eval_interval=int(cfg.get("eval_interval", 0)),
+        eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
+        eval_eta=float(cfg.get("eval_eta", 0.0)),
     )
     trainer.train(
         num_rollouts=int(cfg.get("num_rollouts", 100)),
         weight_sync_interval=int(cfg.get("weight_sync_interval", 1)),
+        save_interval=int(cfg.get("save_interval", 0)),
+        save_dir=cfg.get("save_dir"),
+        load_dir=cfg.get("load_dir"),
+        save_mode=str(cfg.get("save_mode", "auto")),
     )
 
 

--- a/unirl/train_pe.py
+++ b/unirl/train_pe.py
@@ -36,6 +36,7 @@ def main(cfg: DictConfig) -> None:
         diffusion_group_scope=cfg.get("diffusion_group_scope", "rewrite"),
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
+        eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
         eval_eta=float(cfg.get("eval_eta", 0.0)),
     )
     trainer.train(

--- a/unirl/train_pe.py
+++ b/unirl/train_pe.py
@@ -38,6 +38,7 @@ def main(cfg: DictConfig) -> None:
         eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
         eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
         eval_eta=float(cfg.get("eval_eta", 0.0)),
+        eval_rewards_cfg=cfg.get("eval_rewards"),
     )
     trainer.train(
         num_rollouts=int(cfg.get("num_rollouts", 100)),

--- a/unirl/train_refl.py
+++ b/unirl/train_refl.py
@@ -28,6 +28,7 @@ def main(cfg: DictConfig) -> None:
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
         eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
+        eval_rewards_cfg=cfg.get("eval_rewards"),
         logging_cfg=cfg.get("logging"),
     )
     trainer.train(

--- a/unirl/train_refl.py
+++ b/unirl/train_refl.py
@@ -27,6 +27,7 @@ def main(cfg: DictConfig) -> None:
         reward_fraction=float(cfg.get("reward_fraction", 0.25)),
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
+        eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
         logging_cfg=cfg.get("logging"),
     )
     trainer.train(

--- a/unirl/train_refl.py
+++ b/unirl/train_refl.py
@@ -25,6 +25,8 @@ def main(cfg: DictConfig) -> None:
         data_source_cfg=cfg.data_source,
         max_grad_norm=float(cfg.get("max_grad_norm", 1.0)),
         reward_fraction=float(cfg.get("reward_fraction", 0.25)),
+        eval_interval=int(cfg.get("eval_interval", 0)),
+        eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
         logging_cfg=cfg.get("logging"),
     )
     trainer.train(

--- a/unirl/train_unified_model.py
+++ b/unirl/train_unified_model.py
@@ -44,6 +44,7 @@ def main(cfg: DictConfig) -> None:
         eval_num_prompts=cfg.get("eval_num_prompts", cfg.batch_size),
         eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
         eval_eta=float(cfg.get("eval_eta", 0.0)),
+        eval_rewards_cfg=cfg.get("eval_rewards"),
     )
     trainer.train(
         num_rollouts=cfg.get("num_rollouts", 100),

--- a/unirl/train_unified_model.py
+++ b/unirl/train_unified_model.py
@@ -42,6 +42,7 @@ def main(cfg: DictConfig) -> None:
         enable_fsdp_offload=cfg.get("enable_fsdp_offload", True),
         eval_interval=cfg.get("eval_interval", 0),
         eval_num_prompts=cfg.get("eval_num_prompts", cfg.batch_size),
+        eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
         eval_eta=float(cfg.get("eval_eta", 0.0)),
     )
     trainer.train(

--- a/unirl/train_unified_model.py
+++ b/unirl/train_unified_model.py
@@ -40,6 +40,9 @@ def main(cfg: DictConfig) -> None:
         dump_dir=cfg.get("dump_dir"),
         logging_cfg=cfg.get("logging"),
         enable_fsdp_offload=cfg.get("enable_fsdp_offload", True),
+        eval_interval=cfg.get("eval_interval", 0),
+        eval_num_prompts=cfg.get("eval_num_prompts", cfg.batch_size),
+        eval_eta=float(cfg.get("eval_eta", 0.0)),
     )
     trainer.train(
         num_rollouts=cfg.get("num_rollouts", 100),

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -199,8 +199,10 @@ class ARTrainer(BaseTrainer):
         advantage/backward: iterate up to ``eval_num_prompts`` prompts from
         ``run.eval_data_path`` in ``eval_batch_size``-sized batches, expand
         each prompt to ``eval_samples_per_prompt`` siblings, generate at
-        ``eval_temperature``, score, and log the mean reward (= avg@k accuracy
-        since reward is 0/1) under ``eval/*``. Returns it.
+        ``eval_temperature``, score, and log the mean reward under both
+        ``eval/acc`` (= avg@k accuracy, since the MC reward is 0/1) and
+        ``eval/reward`` (shares the eval axis with the other trainers).
+        Returns it.
 
         ``eval_num_prompts=-1`` (default) evaluates the full eval set;
         ``eval_num_prompts=0`` yields no batches (explicit skip). See the
@@ -258,7 +260,9 @@ class ARTrainer(BaseTrainer):
             self.eval_batch_size,
             acc,
         )
-        self.wandb_logger.log_eval(rollout_id + 1, {"acc": acc})
+        # MC reward is 0/1 so mean reward == accuracy; also emit it as `reward`
+        # so this run shares the eval/reward axis with the other trainers.
+        self.wandb_logger.log_eval(rollout_id + 1, {"acc": acc, "reward": acc})
         return acc
 
     def _dump_rollout_samples(self, req, resp, rollout_id: int) -> None:

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import os
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from hydra.utils import get_class, get_object, instantiate
@@ -13,6 +13,7 @@ from unirl.distributed.group.placement import placement, remote
 from unirl.distributed.tensor import hydrate
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict
+from unirl.trainer.eval_suites import EvalRewardSuite, build_eval_suites
 from unirl.types.prompts import RolloutInputs
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.sampling import BaseSamplingParams, total_samples_per_prompt
@@ -56,6 +57,7 @@ class DiffusionTrainer(BaseTrainer):
         eval_chunk_prompts: int = 16,
         eval_cfg_text_scale: float = 4.0,
         eval_eta: float = 0.0,
+        eval_rewards_cfg: Optional[Any] = None,
         stage_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -84,6 +86,11 @@ class DiffusionTrainer(BaseTrainer):
         self.eval_chunk_prompts = int(eval_chunk_prompts)
         self.eval_cfg_text_scale = float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
+        # eval_rewards: extra eval-only reward suites (multi-reward eval for
+        # checkpoint selection), built next to the training reward in
+        # _wire_eval_suites so they share its placement — see unirl.trainer.eval_suites.
+        self._eval_rewards_cfg = eval_rewards_cfg
+        self._eval_suites: List[EvalRewardSuite] = []
         # Per-request routing metadata pinned by the recipe (e.g. {"task": "it2i"}),
         # forwarded onto every RolloutReq. Pinning the task makes a dataset that is
         # MISSING source images fail loudly in the pipeline (it2i requires an input
@@ -98,8 +105,10 @@ class DiffusionTrainer(BaseTrainer):
         # so its hot path is untouched.
         self._uses_ema = False
 
-        # Driver-side data iterator (not a Remote).
+        # Driver-side data iterator (not a Remote). The raw cfg is kept so
+        # eval_rewards suites can clone it with their own prompt paths.
         self.data_source = instantiate(data_source_cfg)
+        self._data_source_cfg = data_source_cfg
 
         self.sampling_params: Dict[str, BaseSamplingParams] = build_sampling_dict(sampling_cfg)
 
@@ -193,6 +202,7 @@ class DiffusionTrainer(BaseTrainer):
         if reward_separate:
             with placement(self.pool, fraction=reward_fraction, shared_workers=True):
                 self.reward = remote_hydra(reward_cfg)
+                self._wire_eval_suites()
 
         # Pre-flight for the reward_fraction footgun: when reward takes its own
         # slab the policy/rollout DP is the REDUCED card count, and the per-rollout
@@ -208,6 +218,18 @@ class DiffusionTrainer(BaseTrainer):
                 f"leaving the policy/rollout on {self.rollout.dp_size} GPU(s) — pick batch_size * "
                 f"samples_per_prompt divisible by both."
             )
+
+    def _wire_eval_suites(self) -> None:
+        """Build the ``eval_rewards`` suites in the CALLER's placement scope.
+
+        Called exactly where the training reward was just created (train-side
+        sibling in ``_build_train_side``, or the separate ``reward_fraction``
+        slab in ``__init__``), so every suite reward shares the training
+        reward's placement. See :mod:`unirl.trainer.eval_suites`.
+        """
+        self._eval_suites = build_eval_suites(
+            self._eval_rewards_cfg, data_source_cfg=self._data_source_cfg, enabled=self.eval_interval > 0
+        )
 
     def _build_train_side(
         self,
@@ -233,6 +255,7 @@ class DiffusionTrainer(BaseTrainer):
         self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
         if reward_cfg is not None:
             self.reward = remote_hydra(reward_cfg)
+            self._wire_eval_suites()
         # DiffusionNFT resolves its frozen reference adapter off ``backend.ema`` (the
         # FSDPBackend owns the dual-adapter EMA), and FlowGRPO / FlowDPPO reach the
         # trainable model directly (LoRA disabled = the ``beta`` KL reference policy),
@@ -486,10 +509,12 @@ class DiffusionTrainer(BaseTrainer):
         Mirrors :meth:`train_step`'s rollout+reward path but skips advantage/backward.
         Generates at the deterministic best-quality setting (``cfg_text_scale=
         eval_cfg_text_scale``, ``eta=eval_eta``; ``eval_samples_per_prompt`` x_T per
-        prompt) over ``eval_num_prompts`` eval prompts (``run.eval_data_path``),
-        scores, logs the mean reward under ``eval/*``, and returns it. The eval
-        prompts are CHUNKED (``eval_chunk_prompts``) so one generate never holds N x
-        the KV/decoded on the driver.
+        prompt) and scores. The training reward plus every shared-set
+        ``eval_rewards`` suite scores the SAME generated images over the default
+        eval set (``run.eval_data_path``, ``eval_num_prompts`` prompts); each
+        own-set suite then gets its own generation pass over its own prompts.
+        All means land in one ``eval/*`` row (``eval/reward`` + ``eval/<suite>``);
+        returns ``eval/reward``.
         """
         # Override only the "diffusion" entry of the modality-keyed sampling dict
         # (mirrors the AR trainer's evaluate()). ``cfg_text_scale`` only exists
@@ -507,39 +532,62 @@ class DiffusionTrainer(BaseTrainer):
             replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
         eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
-        all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
-        n_prompts = len(all_inputs.sample_ids)
-        chunk = max(1, self.eval_chunk_prompts)
-        reward_sum, reward_n = 0.0, 0
         self.rollout.wake_up()
         if self.weight_sync is not None:
             self.weight_sync.sync()
+        # Default pass: training reward + shared-set suites score the SAME images.
+        scorers = [("reward", self.reward)] + [(s.name, s.reward) for s in self._eval_suites if s.data_source is None]
+        metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step)
+        for suite in self._eval_suites:
+            if suite.data_source is not None:
+                n = suite.num_prompts or self.eval_num_prompts
+                metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], eval_sp, step))
+        self.rollout.sleep()
+        logger.info(
+            "EVAL step %d  (%d samples/prompt, cfg=%.1f eta=%.1f)  %s",
+            step,
+            self.eval_samples_per_prompt,
+            self.eval_cfg_text_scale,
+            self.eval_eta,
+            "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
+        )
+        self.wandb_logger.log_eval(step, metrics)
+        return metrics["reward"]
+
+    def _eval_pass(
+        self,
+        data_source: Any,
+        num_prompts: int,
+        scorers: List[Tuple[str, Any]],
+        eval_sp: Dict[str, BaseSamplingParams],
+        step: int,
+    ) -> Dict[str, float]:
+        """One generate→score sweep over one eval set; returns each scorer's mean.
+
+        The eval prompts are CHUNKED (``eval_chunk_prompts``) so one generate
+        never holds N x the KV/decoded on the driver (the it2i memory
+        bottleneck). Scores the single scorable (segment-carrying) track with
+        every scorer — single-track for now; revisit if multi-track lands.
+        """
+        all_inputs = data_source.get_eval_samples(num_prompts)
+        n_prompts = len(all_inputs.sample_ids)
+        chunk = max(1, self.eval_chunk_prompts)
+        sums = {name: 0.0 for name, _ in scorers}
+        counts = {name: 0 for name, _ in scorers}
         for start in range(0, n_prompts, chunk):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             req = self._build_req(sub, step, base_sampling=eval_sp)
             resp = self.rollout.generate(req)
-            for name, track in list(resp.tracks.items()):
-                if track.segment is not None:
-                    resp.tracks[name] = self.reward.score_and_attach(req=req, track=track)
-            for track in resp.tracks.values():
-                if track.rewards is not None:
-                    rewards = hydrate(track.rewards).to(torch.float32)
-                    reward_sum += float(rewards.sum().item())
-                    reward_n += int(rewards.numel())
-                    break  # single-track for now; revisit if multi-track lands
-        self.rollout.sleep()
-        mean_reward = reward_sum / max(1, reward_n)
-        logger.info(
-            "EVAL step %d  eval_reward(%d prompts x %d samples, cfg=%.1f eta=%.1f)=%.4f",
-            step,
-            self.eval_num_prompts,
-            self.eval_samples_per_prompt,
-            self.eval_cfg_text_scale,
-            self.eval_eta,
-            mean_reward,
-        )
-        self.wandb_logger.log_eval(step, {"reward": mean_reward})
-        return mean_reward
+            track = next((t for t in resp.tracks.values() if t.segment is not None), None)
+            if track is None:
+                continue
+            for name, reward in scorers:
+                scored = reward.score_and_attach(req=req, track=track)
+                if scored.rewards is not None:
+                    r = hydrate(scored.rewards).to(torch.float32)
+                    sums[name] += float(r.sum().item())
+                    counts[name] += int(r.numel())
+        return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     def train(
         self,

--- a/unirl/trainer/eval_suites.py
+++ b/unirl/trainer/eval_suites.py
@@ -1,0 +1,125 @@
+"""Multi-reward eval suites — extra reward models scored during periodic eval.
+
+The ``eval_rewards`` recipe list declares EXTRA reward models to score during
+``evaluate()`` — beyond the training reward's ``eval/reward`` — so checkpoints
+can be selected on independent metrics (reward hacking shows up as the training
+reward climbing while the others stall)::
+
+    eval_rewards:
+      - name: hpsv2                 # unique, != "reward"; logged as eval/hpsv2
+        reward:                     # full reward cfg — same schema as the
+          _target_: unirl.reward.service.RewardService   # top-level `reward:`
+          backend: {...}
+      - name: geneval
+        reward: {...}
+        eval_data_path: datasets/geneval/eval.jsonl  # OPTIONAL: own prompt set
+        num_prompts: 64                              # OPTIONAL: own-pass size
+
+An entry WITHOUT ``eval_data_path`` scores the same images the default eval
+pass already generated (zero extra generation — the cheapest way to compare
+checkpoints on several metrics over one prompt set). An entry WITH it gets its
+own generation pass over its own prompts (e.g. a GenEval manifest or an OCR
+prompt set), sized by ``num_prompts`` (default: the trainer's
+``eval_num_prompts``).
+
+Placement: :func:`build_eval_suites` must be called inside the SAME placement
+context that created the trainer's training reward — each suite reward becomes
+a sibling remote there, so where the trainer has a ``reward_fraction`` slab
+(DiffusionTrainer, ReFL) ALL eval rewards share that dedicated-GPU slab, and
+elsewhere (PE, UnifiedModel) they colocate with the training reward.
+
+Data: an own-set suite instantiates its own driver-side data source — the
+trainer's ``data_source_cfg`` with ``args.run.data_path`` /
+``args.run.eval_data_path`` both pointed at the suite file — so every prompt
+format the trainer's data source reads (txt / JSONL / JSON manifests with
+metadata) works per suite.
+
+Scoring uses the trainer's own reward interface: composed/rollout trainers call
+``suite.reward.score_and_attach``, ReFL calls ``score_differentiable`` — a
+suite's backend must support whichever its trainer uses (the same contract as
+the training reward).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from unirl.utils.hydra import remote_hydra
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EvalRewardSuite:
+    """One extra eval reward: a sibling reward remote + (optionally) its own eval set."""
+
+    name: str  # wandb key: eval/<name>
+    reward: Any  # reward remote, placed next to the training reward
+    data_source: Optional[Any] = None  # None → scores the default eval pass
+    num_prompts: Optional[int] = None  # own-pass size; None → eval_num_prompts
+
+
+def build_eval_suites(
+    eval_rewards_cfg: Optional[Any],
+    *,
+    data_source_cfg: DictConfig,
+    enabled: bool = True,
+) -> List[EvalRewardSuite]:
+    """Instantiate the ``eval_rewards`` recipe list into :class:`EvalRewardSuite`\\ s.
+
+    MUST be called inside the placement context that owns the training reward
+    (suite rewards become sibling remotes there). Returns ``[]`` when the list
+    is unset/empty — the trainer then runs its single-reward eval unchanged —
+    or when ``enabled`` is False (eval off), in which case a non-empty list
+    only logs a warning instead of loading reward models that would never run.
+    """
+    if not eval_rewards_cfg:
+        return []
+    if not enabled:
+        logger.warning("eval_rewards is set but eval is disabled (eval_interval=0) — no suite rewards are built.")
+        return []
+    suites: List[EvalRewardSuite] = []
+    seen = set()
+    for entry in eval_rewards_cfg:
+        name = str(entry.get("name", "")).strip()
+        if not name or name == "reward":
+            raise ValueError(f"eval_rewards entries need a unique name (!= 'reward'); got {name!r}.")
+        if name in seen:
+            raise ValueError(f"duplicate eval_rewards name {name!r}.")
+        seen.add(name)
+        reward_cfg = entry.get("reward")
+        if reward_cfg is None:
+            raise ValueError(f"eval_rewards[{name}] is missing its `reward:` block.")
+        eval_path = entry.get("eval_data_path")
+        if entry.get("num_prompts") is not None and not eval_path:
+            raise ValueError(
+                f"eval_rewards[{name}] sets num_prompts without eval_data_path — a shared-set suite "
+                "scores whatever the default pass generated (eval_num_prompts prompts)."
+            )
+        suite_source = None
+        if eval_path:
+            # Own prompt set: clone the trainer's data-source cfg with both paths
+            # pointed at the suite file (a suite source only ever serves eval
+            # batches; data_path merely backs the class's load-time existence check).
+            ds_cfg = OmegaConf.create(OmegaConf.to_container(data_source_cfg, resolve=True))
+            ds_cfg.args.run.data_path = str(eval_path)
+            ds_cfg.args.run.eval_data_path = str(eval_path)
+            suite_source = instantiate(ds_cfg)
+        suites.append(
+            EvalRewardSuite(
+                name=name,
+                reward=remote_hydra(reward_cfg),
+                data_source=suite_source,
+                num_prompts=None if entry.get("num_prompts") is None else int(entry.get("num_prompts")),
+            )
+        )
+    logger.info(
+        "Eval reward suites: %s",
+        ", ".join(f"{s.name}({'own set' if s.data_source is not None else 'default set'})" for s in suites),
+    )
+    return suites

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -27,7 +27,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from hydra.utils import instantiate
@@ -38,6 +38,7 @@ from unirl.distributed.tensor import hydrate
 from unirl.models.pe.pipeline import PEPipeline
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict
+from unirl.trainer.eval_suites import build_eval_suites
 from unirl.types.prompts import RolloutInputs
 from unirl.types.rollout_req import RolloutReq
 from unirl.types.sampling import BaseSamplingParams
@@ -106,6 +107,7 @@ class PETrainer(BaseTrainer):
         eval_num_prompts: int = 8,
         eval_cfg_text_scale: float = 4.0,
         eval_eta: float = 0.0,
+        eval_rewards_cfg: Optional[Any] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -204,6 +206,11 @@ class PETrainer(BaseTrainer):
                 self.rollout = remote(**rollout_parsed)
 
             self.reward = remote_hydra(reward_cfg)
+            # Extra eval-only rewards (eval_rewards) — siblings of the training
+            # reward on this slab; see unirl.trainer.eval_suites.
+            self._eval_suites = build_eval_suites(
+                eval_rewards_cfg, data_source_cfg=data_source_cfg, enabled=self.eval_interval > 0
+            )
 
             # Non-trainside: one bridge per track, each routed to its child of
             # the composed engine by ``track_prefix`` (set in the sync block).
@@ -384,14 +391,12 @@ class PETrainer(BaseTrainer):
         credit-assign/advantage/backward: pull ``eval_num_prompts`` eval prompts
         (``run.eval_data_path``), generate the composed ``P→P*N*M`` fan-out with
         the diffusion sub-block forced onto the deterministic best-quality setting
-        (CFG at ``eval_cfg_text_scale``, ``eta=eval_eta``), score ONLY the image
-        ("diffusion") track (PickScore), and log the mean under ``eval/reward``.
-        Returns it.
-
-        Chunked by ``self.batch_size`` — the rollout DP-splits the un-expanded
-        P-prompt req, so the chunk must be divisible by the engine dp; ``batch_size``
-        is what training already runs, so it is divisible. A ragged tail
-        (``eval_num_prompts`` not a multiple of ``batch_size``) is floored off.
+        (CFG at ``eval_cfg_text_scale``, ``eta=eval_eta``), and score ONLY the
+        image ("diffusion") track. The training reward plus every shared-set
+        ``eval_rewards`` suite scores the SAME generated images; each own-set
+        suite then gets its own generation pass over its own prompts. All means
+        land in one ``eval/*`` row (``eval/reward`` + ``eval/<suite>``); returns
+        ``eval/reward``.
         """
         # Override only the "diffusion" entry of the modality-keyed sampling dict.
         # CFG strength lives in ``cfg_text_scale`` on Bagel-style sampling params
@@ -405,16 +410,50 @@ class PETrainer(BaseTrainer):
             replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
         eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
-        all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
-        n_prompts = len(all_inputs.sample_ids)
-        chunk = max(1, self.batch_size)
-        usable = n_prompts - n_prompts % chunk or n_prompts
-        reward_sum, reward_n = 0.0, 0
         self.rollout.wake_up()
         if self.diffusion_sync is not None:  # no-op trainside (bridges are None)
             self.diffusion_sync.sync()
             if self.ar_sync is not None:
                 self.ar_sync.sync()
+        # Default pass: training reward + shared-set suites score the SAME images.
+        scorers = [("reward", self.reward)] + [(s.name, s.reward) for s in self._eval_suites if s.data_source is None]
+        metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step)
+        for suite in self._eval_suites:
+            if suite.data_source is not None:
+                n = suite.num_prompts or self.eval_num_prompts
+                metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], eval_sp, step))
+        self.rollout.sleep()
+        logger.info(
+            "EVAL step %d  (cfg=%.1f eta=%.1f)  %s",
+            step,
+            self.eval_cfg_text_scale,
+            self.eval_eta,
+            "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
+        )
+        self.wandb_logger.log_eval(step, metrics)
+        return metrics["reward"]
+
+    def _eval_pass(
+        self,
+        data_source: Any,
+        num_prompts: int,
+        scorers: List[Tuple[str, Any]],
+        eval_sp: Dict[str, BaseSamplingParams],
+        step: int,
+    ) -> Dict[str, float]:
+        """One generate→score sweep over one eval set; returns each scorer's mean.
+
+        Chunked by ``self.batch_size`` — the rollout DP-splits the un-expanded
+        P-prompt req, so the chunk must be divisible by the engine dp; ``batch_size``
+        is what training already runs, so it is divisible. A ragged tail
+        (``num_prompts`` not a multiple of ``batch_size``) is floored off.
+        """
+        all_inputs = data_source.get_eval_samples(num_prompts)
+        n_prompts = len(all_inputs.sample_ids)
+        chunk = max(1, self.batch_size)
+        usable = n_prompts - n_prompts % chunk or n_prompts
+        sums = {name: 0.0 for name, _ in scorers}
+        counts = {name: 0 for name, _ in scorers}
         for start in range(0, usable, chunk):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             req = self._build_req(sub, step, base_sampling=eval_sp)
@@ -425,23 +464,13 @@ class PETrainer(BaseTrainer):
             diff_track = resp.tracks["diffusion"]
             n_track, p = len(diff_track.sample_ids), max(1, req.batch_size)
             reward_req = req.repeat_interleave(n_track // p) if n_track > p and n_track % p == 0 else req
-            scored = self.reward.score_and_attach(req=reward_req, track=diff_track)
-            if scored.rewards is not None:
-                r = hydrate(scored.rewards).to(torch.float32)
-                reward_sum += float(r.sum().item())
-                reward_n += int(r.numel())
-        self.rollout.sleep()
-        mean_reward = reward_sum / max(1, reward_n)
-        logger.info(
-            "EVAL step %d  eval_reward(%d prompts, cfg=%.1f eta=%.1f)=%.4f",
-            step,
-            self.eval_num_prompts,
-            self.eval_cfg_text_scale,
-            self.eval_eta,
-            mean_reward,
-        )
-        self.wandb_logger.log_eval(step, {"reward": mean_reward})
-        return mean_reward
+            for name, reward in scorers:
+                scored = reward.score_and_attach(req=reward_req, track=diff_track)
+                if scored.rewards is not None:
+                    r = hydrate(scored.rewards).to(torch.float32)
+                    sums[name] += float(r.sum().item())
+                    counts[name] += int(r.numel())
+        return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     # ---- checkpointing (PE trains two sides → one subdir per trained side) --
 

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -139,16 +139,13 @@ class PETrainer(BaseTrainer):
                 f"PETrainer.diffusion_group_scope must be 'rewrite' or 'prompt'; got {diffusion_group_scope!r}."
             )
 
-        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
-        # eval_interval=0 disables it. Scores only the image ("diffusion") track
-        # (PickScore) like train_step, mean logged as eval/reward. Eval generates
-        # at the deterministic best-quality setting, mirroring DiffusionTrainer:
-        # eval_cfg_text_scale sets the CFG strength (recipes train at
-        # guidance_scale=1.0 = no CFG; set it to the train value to eval in the
-        # training regime instead) and eval_eta forces the diffusion sub-block
-        # onto a deterministic ODE (recipe trains at eta>0 for exploration). No
-        # eval_samples_per_prompt knob: PE fans out P->P*N*M two levels, so a
-        # single per-prompt count is ambiguous (N*M is already a dense eval).
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*;
+        # eval_interval=0 disables it. Scores only the image ("diffusion") track,
+        # generated at the deterministic best-quality setting (CFG=
+        # eval_cfg_text_scale, eta=eval_eta) — same knobs/semantics as
+        # DiffusionTrainer; extra eval-only rewards: unirl.trainer.eval_suites.
+        # No eval_samples_per_prompt knob: the P->P*N*M two-level fan-out makes
+        # a single per-prompt count ambiguous (N*M is already a dense eval).
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
         self.eval_cfg_text_scale = float(eval_cfg_text_scale)

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import json
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
@@ -100,6 +102,9 @@ class PETrainer(BaseTrainer):
         pe_cfg: Optional[DictConfig] = None,
         freeze_llm: bool = False,
         diffusion_group_scope: str = "rewrite",
+        eval_interval: int = 0,
+        eval_num_prompts: int = 8,
+        eval_eta: float = 0.0,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -130,6 +135,17 @@ class PETrainer(BaseTrainer):
             raise ValueError(
                 f"PETrainer.diffusion_group_scope must be 'rewrite' or 'prompt'; got {diffusion_group_scope!r}."
             )
+
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
+        # eval_interval=0 disables it. Scores only the image ("diffusion") track
+        # (PickScore) like train_step, mean logged as eval/reward. eval_eta forces
+        # the diffusion sub-block onto a deterministic ODE for eval (recipe trains
+        # at eta>0 for exploration). No eval_samples_per_prompt knob: PE fans out
+        # P->P*N*M two levels, so a single per-prompt count is ambiguous (N*M is
+        # already a dense eval).
+        self.eval_interval = int(eval_interval)
+        self.eval_num_prompts = int(eval_num_prompts)
+        self.eval_eta = float(eval_eta)
 
         # PE prompt-rewrite knobs forwarded to the composed PEPipeline (trainside
         # only — they shape the LLM rewrite + the text the diffusion child sees,
@@ -224,7 +240,9 @@ class PETrainer(BaseTrainer):
         pipeline = remote_hydra(cfg.pipeline, bundle=bundle)
         return _Side(bundle=bundle, pipeline=pipeline)
 
-    def _build_req(self, inputs: RolloutInputs, rollout_id: int) -> RolloutReq:
+    def _build_req(
+        self, inputs: RolloutInputs, rollout_id: int, *, base_sampling: Optional[Dict[str, BaseSamplingParams]] = None
+    ) -> RolloutReq:
         """Turn a data-source batch of ``P`` prompts into a typed ``RolloutReq``.
 
         No pre-expansion: ``PEPipeline`` fans out ``P → P*N → P*N*M`` internally
@@ -238,11 +256,15 @@ class PETrainer(BaseTrainer):
         concrete ``sde_indices`` ride to the engine (mirrors
         :meth:`DiffusionTrainer._build_req` / :meth:`UnifiedModelTrainer._build_req`).
         The AR sub-block has no SDE machinery and is left untouched.
+
+        ``base_sampling`` overrides the modality-keyed sampling dict (``evaluate``
+        passes its own deterministic params); ``None`` uses ``self.sampling_params``.
         """
-        diff_params = self.sampling_params.get("diffusion")
+        base = base_sampling if base_sampling is not None else self.sampling_params
+        diff_params = base.get("diffusion")
         sde_indices = diff_params.resolve_sde_indices(rollout_id)
         diffusion = dataclasses.replace(diff_params, sde_indices=sde_indices, scheduler=None)
-        sampling_params = {**self.sampling_params, "diffusion": diffusion}
+        sampling_params = {**base, "diffusion": diffusion}
         return RolloutReq(
             sample_ids=list(inputs.sample_ids),
             group_ids=list(inputs.group_ids),
@@ -350,21 +372,182 @@ class PETrainer(BaseTrainer):
         self.wandb_logger.log_rollout_step(rollout_id, results, resp, step_time_s=time.perf_counter() - t0)
         return results, mean_reward
 
-    def train(self, *, num_rollouts: int, weight_sync_interval: int = 1) -> None:
+    def evaluate(self, step: int) -> float:
+        """Periodic eval on the eval set (no training); returns the mean image reward.
+
+        Mirrors :meth:`train_step`'s rollout+reward path but skips
+        credit-assign/advantage/backward: pull ``eval_num_prompts`` eval prompts
+        (``run.eval_data_path``), generate the composed ``P→P*N*M`` fan-out with
+        the diffusion sub-block forced onto a deterministic ODE (``eta=eval_eta``),
+        score ONLY the image ("diffusion") track (PickScore), and log the mean
+        under ``eval/reward``. Returns it.
+
+        Chunked by ``self.batch_size`` — the rollout DP-splits the un-expanded
+        P-prompt req, so the chunk must be divisible by the engine dp; ``batch_size``
+        is what training already runs, so it is divisible. A ragged tail
+        (``eval_num_prompts`` not a multiple of ``batch_size``) is floored off.
+        """
+        base_diffusion = self.sampling_params.get("diffusion")
+        eval_diffusion = dataclasses.replace(base_diffusion, eta=self.eval_eta)
+        eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
+        all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
+        n_prompts = len(all_inputs.sample_ids)
+        chunk = max(1, self.batch_size)
+        usable = n_prompts - n_prompts % chunk or n_prompts
+        reward_sum, reward_n = 0.0, 0
+        self.rollout.wake_up()
+        if self.diffusion_sync is not None:  # no-op trainside (bridges are None)
+            self.diffusion_sync.sync()
+            if self.ar_sync is not None:
+                self.ar_sync.sync()
+        for start in range(0, usable, chunk):
+            sub = all_inputs.slice(start, min(start + chunk, n_prompts))
+            req = self._build_req(sub, step, base_sampling=eval_sp)
+            resp = self.rollout.generate(req)
+            # Score the image track only; align the P-prompt req to the P*N*M
+            # image track so req and track shard identically across DP workers
+            # (same expansion as train_step).
+            diff_track = resp.tracks["diffusion"]
+            n_track, p = len(diff_track.sample_ids), max(1, req.batch_size)
+            reward_req = req.repeat_interleave(n_track // p) if n_track > p and n_track % p == 0 else req
+            scored = self.reward.score_and_attach(req=reward_req, track=diff_track)
+            if scored.rewards is not None:
+                r = hydrate(scored.rewards).to(torch.float32)
+                reward_sum += float(r.sum().item())
+                reward_n += int(r.numel())
+        self.rollout.sleep()
+        mean_reward = reward_sum / max(1, reward_n)
+        logger.info(
+            "EVAL step %d  eval_reward(%d prompts, eta=%.1f)=%.4f",
+            step,
+            self.eval_num_prompts,
+            self.eval_eta,
+            mean_reward,
+        )
+        self.wandb_logger.log_eval(step, {"reward": mean_reward})
+        return mean_reward
+
+    # ---- checkpointing (PE trains two sides → one subdir per trained side) --
+
+    def _ckpt_sides(self):
+        """The trained sides to checkpoint: diffusion always; ar only when it trains.
+
+        A frozen LLM (``freeze_llm=True``) has no AR backend and never trains, so
+        only the diffusion adapter is persisted. Otherwise BOTH LoRA adapters are
+        saved — eval reward depends on the AR rewriter AND the diffusion renderer,
+        so a resumed checkpoint must restore both for the A/B consistency check.
+        """
+        sides = [("diffusion", self.diffusion)]
+        if not self._freeze_llm and self.ar.backend is not None:
+            sides.append(("ar", self.ar))
+        return sides
+
+    def maybe_save_checkpoint(
+        self,
+        rollout_id: int,
+        num_rollouts: int,
+        *,
+        save_interval: int,
+        save_dir: Optional[str],
+        save_mode: str = "auto",
+    ) -> None:
+        """Save every ``save_interval`` rollouts (and on the last one), one subdir
+        per trained side. ``save_interval <= 0`` disables saving.
+
+        PE has no single ``self.backend`` (it owns ``self.diffusion.backend`` +
+        ``self.ar.backend``), so this overrides the BaseTrainer single-backend
+        version: each side writes ``<save_dir>/checkpoint-<step>/<side>/`` and the
+        driver-owned ``trainer_state.json`` (wandb run id + step axis) sits beside
+        them, mirroring the base method's semantics.
+        """
+        if save_interval <= 0:
+            return
+        step = rollout_id + 1
+        if step % save_interval != 0 and step < num_rollouts:
+            return
+        base_dir = os.path.abspath(save_dir) if save_dir else os.path.join(os.getcwd(), "checkpoints")
+        path = os.path.join(base_dir, f"checkpoint-{step}")
+        logger.info("Saving checkpoint at rollout %d/%d -> %s", step, num_rollouts, path)
+        for name, side in self._ckpt_sides():
+            side.backend.save(os.path.join(path, name), step=step, mode=save_mode)
+        with open(os.path.join(path, "trainer_state.json"), "w") as f:
+            json.dump({"wandb_run_id": self.wandb_logger.run_id, "optimizer_step": self.wandb_logger.optimizer_step}, f)
+
+    def maybe_load_checkpoint(self, load_dir: Optional[str], *, num_rollouts: Optional[int] = None) -> int:
+        """Restore both trained sides from ``load_dir``; return the resume step.
+
+        Returns 0 for a fresh run (``load_dir`` empty). Each trained side loads
+        from its subdir; both advance in lockstep so either side's returned step
+        is the resume point. Restores the driver-side ``_resume_state`` (wandb run
+        id / step axis) so a resume appends to the same wandb run.
+        """
+        if not load_dir:
+            return 0
+        load_dir = os.path.abspath(load_dir)
+        logger.info("Loading checkpoint from %s", load_dir)
+        start = 0
+        for name, side in self._ckpt_sides():
+            result = side.backend.load(os.path.join(load_dir, name))
+            if isinstance(result, list):  # BROADCAST dispatch collects one result per worker
+                result = result[0]
+            start = int(result or 0)
+        state_path = os.path.join(load_dir, "trainer_state.json")
+        if os.path.exists(state_path):
+            with open(state_path) as f:
+                self._resume_state = json.load(f)
+        logger.info("Checkpoint restored; resuming at rollout %d", start)
+        if num_rollouts is not None and start >= num_rollouts:
+            logger.warning(
+                "Checkpoint step %d >= num_rollouts %d — nothing left to train (num_rollouts is the TOTAL budget).",
+                start,
+                num_rollouts,
+            )
+        return start
+
+    def train(
+        self,
+        *,
+        num_rollouts: int,
+        weight_sync_interval: int = 1,
+        save_interval: int = 0,
+        save_dir: Optional[str] = None,
+        load_dir: Optional[str] = None,
+        save_mode: str = "auto",
+    ) -> None:
         """Minimal training loop: ``num_rollouts`` iterations of ``train_step``.
 
         ``weight_sync_interval``: push each track's adapter into the engine
         every N rollouts (fused into ``train_step``'s generate; no-op trainside).
+
+        ``save_interval``: write a checkpoint every N rollouts (and on the last
+        one), one subdir per trained side; ``0`` disables it. ``save_dir`` is the
+        output folder (defaults to ``./checkpoints``); ``save_mode="auto"`` writes
+        LoRA-only checkpoints when LoRA is active. ``load_dir``: restore from a
+        checkpoint directory and RESUME from its saved step — ``num_rollouts`` is
+        the TOTAL budget.
         """
         interval = max(1, weight_sync_interval)
+        start_rollout = self.maybe_load_checkpoint(load_dir, num_rollouts=num_rollouts)
+        resumed = bool(load_dir)
+        # Fast-forward the data stream to the resume point — exact when
+        # run.seed is set (deterministic shuffle); with seed=null the stream
+        # is non-reproducible anyway.
+        for _ in range(start_rollout):
+            self.data_source.get_samples(self.batch_size)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
-            for rollout_id in range(num_rollouts):
+            if self.eval_interval > 0:
+                self.evaluate(start_rollout)  # baseline eval before any training
+            for rollout_id in range(start_rollout, num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 inputs = self.data_source.get_samples(self.batch_size)
                 req = self._build_req(inputs, rollout_id)
-                # Sync before generate; skip step 0 (nothing trained yet).
-                sync_weights = rollout_id > 0 and rollout_id % interval == 0
+                # Sync before generate; skip step 0 (nothing trained yet). On
+                # resume, force the first sync — the engine booted with fresh
+                # weights and needs the restored adapter before generate.
+                sync_weights = (rollout_id > 0 and rollout_id % interval == 0) or (
+                    resumed and rollout_id == start_rollout
+                )
                 results, mean_reward = self.train_step(
                     req,
                     training_progress=training_progress,
@@ -372,5 +555,12 @@ class PETrainer(BaseTrainer):
                     rollout_id=rollout_id,
                 )
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, results, mean_reward, logger=logger)
+                # eval(k) BEFORE save(checkpoint-k) at the same step, so a
+                # resumed checkpoint re-runs the same eval (A/B consistency).
+                if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
+                    self.evaluate(rollout_id + 1)
+                self.maybe_save_checkpoint(
+                    rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir, save_mode=save_mode
+                )
         finally:
             self._finish_wandb()

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -104,6 +104,7 @@ class PETrainer(BaseTrainer):
         diffusion_group_scope: str = "rewrite",
         eval_interval: int = 0,
         eval_num_prompts: int = 8,
+        eval_cfg_text_scale: float = 4.0,
         eval_eta: float = 0.0,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -138,13 +139,17 @@ class PETrainer(BaseTrainer):
 
         # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
         # eval_interval=0 disables it. Scores only the image ("diffusion") track
-        # (PickScore) like train_step, mean logged as eval/reward. eval_eta forces
-        # the diffusion sub-block onto a deterministic ODE for eval (recipe trains
-        # at eta>0 for exploration). No eval_samples_per_prompt knob: PE fans out
-        # P->P*N*M two levels, so a single per-prompt count is ambiguous (N*M is
-        # already a dense eval).
+        # (PickScore) like train_step, mean logged as eval/reward. Eval generates
+        # at the deterministic best-quality setting, mirroring DiffusionTrainer:
+        # eval_cfg_text_scale sets the CFG strength (recipes train at
+        # guidance_scale=1.0 = no CFG; set it to the train value to eval in the
+        # training regime instead) and eval_eta forces the diffusion sub-block
+        # onto a deterministic ODE (recipe trains at eta>0 for exploration). No
+        # eval_samples_per_prompt knob: PE fans out P->P*N*M two levels, so a
+        # single per-prompt count is ambiguous (N*M is already a dense eval).
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
+        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
 
         # PE prompt-rewrite knobs forwarded to the composed PEPipeline (trainside
@@ -378,17 +383,27 @@ class PETrainer(BaseTrainer):
         Mirrors :meth:`train_step`'s rollout+reward path but skips
         credit-assign/advantage/backward: pull ``eval_num_prompts`` eval prompts
         (``run.eval_data_path``), generate the composed ``P→P*N*M`` fan-out with
-        the diffusion sub-block forced onto a deterministic ODE (``eta=eval_eta``),
-        score ONLY the image ("diffusion") track (PickScore), and log the mean
-        under ``eval/reward``. Returns it.
+        the diffusion sub-block forced onto the deterministic best-quality setting
+        (CFG at ``eval_cfg_text_scale``, ``eta=eval_eta``), score ONLY the image
+        ("diffusion") track (PickScore), and log the mean under ``eval/reward``.
+        Returns it.
 
         Chunked by ``self.batch_size`` — the rollout DP-splits the un-expanded
         P-prompt req, so the chunk must be divisible by the engine dp; ``batch_size``
         is what training already runs, so it is divisible. A ragged tail
         (``eval_num_prompts`` not a multiple of ``batch_size``) is floored off.
         """
+        # Override only the "diffusion" entry of the modality-keyed sampling dict.
+        # CFG strength lives in ``cfg_text_scale`` on Bagel-style sampling params
+        # and in ``guidance_scale`` on the standard DiffusionSamplingParams (SD3,
+        # ...) — same fallback as :meth:`DiffusionTrainer.evaluate`.
         base_diffusion = self.sampling_params.get("diffusion")
-        eval_diffusion = dataclasses.replace(base_diffusion, eta=self.eval_eta)
+        replace_kwargs = dict(eta=self.eval_eta)
+        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
+            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
+        else:
+            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
+        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
         all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
         n_prompts = len(all_inputs.sample_ids)
@@ -418,9 +433,10 @@ class PETrainer(BaseTrainer):
         self.rollout.sleep()
         mean_reward = reward_sum / max(1, reward_n)
         logger.info(
-            "EVAL step %d  eval_reward(%d prompts, eta=%.1f)=%.4f",
+            "EVAL step %d  eval_reward(%d prompts, cfg=%.1f eta=%.1f)=%.4f",
             step,
             self.eval_num_prompts,
+            self.eval_cfg_text_scale,
             self.eval_eta,
             mean_reward,
         )

--- a/unirl/trainer/refl.py
+++ b/unirl/trainer/refl.py
@@ -57,14 +57,12 @@ class RewardBackpropTrainer(BaseTrainer):
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = int(batch_size)
         self.max_grad_norm = float(max_grad_norm)
-        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*;
         # eval_interval=0 disables it. ReFL has no rollout engine / tracks: eval
-        # samples via ReFLPolicy.eval_sample (deterministic ODE, no grad) and scores
-        # with the same differentiable reward, mean logged as eval/reward.
-        # eval_cfg_text_scale sets the eval CFG strength (maps onto the SD3-family
-        # guidance_scale; recipes train at guidance_scale=1.0 = no CFG; set it to
-        # the train value to eval in the training regime instead) — mirrors
-        # DiffusionTrainer's knob of the same name.
+        # samples via ReFLPolicy.eval_sample (deterministic ODE, no grad, CFG=
+        # eval_cfg_text_scale — same knob/semantics as DiffusionTrainer, mapped
+        # onto the SD3-family guidance_scale) and scores with the differentiable
+        # reward. Extra eval-only rewards: unirl.trainer.eval_suites.
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
         self.eval_cfg_text_scale = float(eval_cfg_text_scale)

--- a/unirl/trainer/refl.py
+++ b/unirl/trainer/refl.py
@@ -47,11 +47,19 @@ class RewardBackpropTrainer(BaseTrainer):
         data_source_cfg: DictConfig,
         max_grad_norm: float = 1.0,
         reward_fraction: float = 0.25,
+        eval_interval: int = 0,
+        eval_num_prompts: int = 12,
         logging_cfg: Optional[DictConfig] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = int(batch_size)
         self.max_grad_norm = float(max_grad_norm)
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
+        # eval_interval=0 disables it. ReFL has no rollout engine / tracks: eval
+        # samples via ReFLPolicy.eval_sample (deterministic ODE, no grad) and scores
+        # with the same differentiable reward, mean logged as eval/reward.
+        self.eval_interval = int(eval_interval)
+        self.eval_num_prompts = int(eval_num_prompts)
         self.data_source = instantiate(data_source_cfg)
 
         # Unified reward placement — SAME knob/semantics as DiffusionTrainer's
@@ -104,6 +112,48 @@ class RewardBackpropTrainer(BaseTrainer):
         self.policy.zero_grad()
         return mean_reward, float(grad_norm or 0.0), time.perf_counter() - t0
 
+    def evaluate(self, step: int) -> float:
+        """Periodic eval — mean reward over the eval prompt set (no training).
+
+        ReFL has no rollout engine or tracks, so this mirrors :meth:`train_step`'s
+        sample→score path (minus ``enable_grad``/backward): pull
+        ``eval_num_prompts`` eval prompts (``run.eval_data_path``), sample images
+        with :meth:`ReFLPolicy.eval_sample` (deterministic ODE, ``model.eval()`` +
+        ``no_grad``), score with the differentiable reward, and log the mean under
+        ``eval/reward``. Returns it.
+
+        ``step`` keys the wandb log axis (and ``eval_sample``'s seed), mirroring
+        :meth:`DiffusionTrainer.evaluate` — so re-running a checkpoint via
+        ``num_rollouts=0 load_dir=checkpoint-k`` (→ baseline ``evaluate(k)``) evals
+        the restored weights at the same step. NOTE: eval is NOT bit-exact — the
+        init latent is drawn unseeded (see ``eval_sample``), so A vs B agree only
+        within sampling noise (~σ), not byte-identically.
+
+        Chunked by ``self.batch_size`` — both ``eval_sample`` and
+        ``score_differentiable`` are DP_SCATTER, and ``batch_size`` is validated
+        divisible by both the policy and reward dp sizes in ``__init__``; a ragged
+        tail (``eval_num_prompts`` not a multiple of ``batch_size``) is floored off.
+        """
+        eval_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
+        prompts = eval_inputs.primitives["text"]
+        if not isinstance(prompts, Texts):
+            prompts = Texts(texts=list(prompts))
+        texts = list(prompts.texts)
+        chunk = max(1, self.batch_size)
+        usable = len(texts) - len(texts) % chunk or len(texts)
+        reward_sum, reward_n = 0.0, 0
+        for start in range(0, usable, chunk):
+            sub = Texts(texts=texts[start : start + chunk])
+            images = self.policy.eval_sample(prompts=sub, rollout_id=step)
+            rewards = self.reward.score_differentiable(images=images, prompts=sub)
+            r = hydrate(rewards).float()
+            reward_sum += float(r.sum().item())
+            reward_n += int(r.numel())
+        mean_reward = reward_sum / max(1, reward_n)
+        logger.info("EVAL step %d  eval_reward(%d prompts)=%.4f", step, self.eval_num_prompts, mean_reward)
+        self.wandb_logger.log_eval(step, {"reward": mean_reward})
+        return mean_reward
+
     def train(
         self,
         *,
@@ -116,6 +166,8 @@ class RewardBackpropTrainer(BaseTrainer):
         start = self.maybe_load_checkpoint(load_dir, num_rollouts=num_rollouts)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
+            if self.eval_interval > 0:
+                self.evaluate(start)  # baseline eval before any training
             for rollout_id in range(start, num_rollouts):
                 inputs = self.data_source.get_samples(self.batch_size)
                 prompts = inputs.primitives["text"]
@@ -140,6 +192,10 @@ class RewardBackpropTrainer(BaseTrainer):
                     },
                     prefix="",
                 )
+                # eval(k) BEFORE save(checkpoint-k) at the same step, so a
+                # resumed checkpoint re-runs the same eval (A/B consistency).
+                if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
+                    self.evaluate(rollout_id + 1)
                 self.maybe_save_checkpoint(
                     rollout_id,
                     num_rollouts,

--- a/unirl/trainer/refl.py
+++ b/unirl/trainer/refl.py
@@ -49,6 +49,7 @@ class RewardBackpropTrainer(BaseTrainer):
         reward_fraction: float = 0.25,
         eval_interval: int = 0,
         eval_num_prompts: int = 12,
+        eval_cfg_text_scale: float = 4.0,
         logging_cfg: Optional[DictConfig] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -58,8 +59,13 @@ class RewardBackpropTrainer(BaseTrainer):
         # eval_interval=0 disables it. ReFL has no rollout engine / tracks: eval
         # samples via ReFLPolicy.eval_sample (deterministic ODE, no grad) and scores
         # with the same differentiable reward, mean logged as eval/reward.
+        # eval_cfg_text_scale sets the eval CFG strength (maps onto the SD3-family
+        # guidance_scale; recipes train at guidance_scale=1.0 = no CFG; set it to
+        # the train value to eval in the training regime instead) — mirrors
+        # DiffusionTrainer's knob of the same name.
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
+        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
         self.data_source = instantiate(data_source_cfg)
 
         # Unified reward placement — SAME knob/semantics as DiffusionTrainer's
@@ -119,8 +125,8 @@ class RewardBackpropTrainer(BaseTrainer):
         sample→score path (minus ``enable_grad``/backward): pull
         ``eval_num_prompts`` eval prompts (``run.eval_data_path``), sample images
         with :meth:`ReFLPolicy.eval_sample` (deterministic ODE, ``model.eval()`` +
-        ``no_grad``), score with the differentiable reward, and log the mean under
-        ``eval/reward``. Returns it.
+        ``no_grad``, CFG at ``eval_cfg_text_scale``), score with the differentiable
+        reward, and log the mean under ``eval/reward``. Returns it.
 
         ``step`` keys the wandb log axis (and ``eval_sample``'s seed), mirroring
         :meth:`DiffusionTrainer.evaluate` — so re-running a checkpoint via
@@ -144,13 +150,19 @@ class RewardBackpropTrainer(BaseTrainer):
         reward_sum, reward_n = 0.0, 0
         for start in range(0, usable, chunk):
             sub = Texts(texts=texts[start : start + chunk])
-            images = self.policy.eval_sample(prompts=sub, rollout_id=step)
+            images = self.policy.eval_sample(prompts=sub, rollout_id=step, guidance_scale=self.eval_cfg_text_scale)
             rewards = self.reward.score_differentiable(images=images, prompts=sub)
             r = hydrate(rewards).float()
             reward_sum += float(r.sum().item())
             reward_n += int(r.numel())
         mean_reward = reward_sum / max(1, reward_n)
-        logger.info("EVAL step %d  eval_reward(%d prompts)=%.4f", step, self.eval_num_prompts, mean_reward)
+        logger.info(
+            "EVAL step %d  eval_reward(%d prompts, cfg=%.1f)=%.4f",
+            step,
+            self.eval_num_prompts,
+            self.eval_cfg_text_scale,
+            mean_reward,
+        )
         self.wandb_logger.log_eval(step, {"reward": mean_reward})
         return mean_reward
 

--- a/unirl/trainer/refl.py
+++ b/unirl/trainer/refl.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from hydra.utils import instantiate
 from omegaconf import DictConfig
@@ -28,6 +28,7 @@ from unirl.distributed.group.placement import placement
 from unirl.distributed.tensor.grad_context import enable_grad
 from unirl.distributed.tensor.ref import hydrate
 from unirl.trainer.base import BaseTrainer
+from unirl.trainer.eval_suites import build_eval_suites
 from unirl.types.primitives import Texts
 from unirl.utils.hydra import remote_hydra
 
@@ -50,6 +51,7 @@ class RewardBackpropTrainer(BaseTrainer):
         eval_interval: int = 0,
         eval_num_prompts: int = 12,
         eval_cfg_text_scale: float = 4.0,
+        eval_rewards_cfg: Optional[Any] = None,
         logging_cfg: Optional[DictConfig] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -82,10 +84,19 @@ class RewardBackpropTrainer(BaseTrainer):
                 self.policy = remote_hydra(policy_cfg)
             with placement(self.pool, fraction=reward_frac, shared_workers=True):
                 self.reward = remote_hydra(reward_cfg)
+                # Extra eval-only rewards (eval_rewards) ride the reward slab —
+                # see unirl.trainer.eval_suites. Their backends must be
+                # differentiable-capable like the training reward.
+                self._eval_suites = build_eval_suites(
+                    eval_rewards_cfg, data_source_cfg=data_source_cfg, enabled=self.eval_interval > 0
+                )
         else:
             with placement(self.pool, fraction=1.0, shared_workers=True):
                 self.policy = remote_hydra(policy_cfg)
                 self.reward = remote_hydra(reward_cfg)
+                self._eval_suites = build_eval_suites(
+                    eval_rewards_cfg, data_source_cfg=data_source_cfg, enabled=self.eval_interval > 0
+                )
 
         self.policy.initialize()
         # BaseTrainer.maybe_save/load_checkpoint operate on ``self.backend``.
@@ -119,14 +130,17 @@ class RewardBackpropTrainer(BaseTrainer):
         return mean_reward, float(grad_norm or 0.0), time.perf_counter() - t0
 
     def evaluate(self, step: int) -> float:
-        """Periodic eval — mean reward over the eval prompt set (no training).
+        """Periodic eval — mean reward(s) over the eval prompt set (no training).
 
         ReFL has no rollout engine or tracks, so this mirrors :meth:`train_step`'s
-        sample→score path (minus ``enable_grad``/backward): pull
-        ``eval_num_prompts`` eval prompts (``run.eval_data_path``), sample images
-        with :meth:`ReFLPolicy.eval_sample` (deterministic ODE, ``model.eval()`` +
-        ``no_grad``, CFG at ``eval_cfg_text_scale``), score with the differentiable
-        reward, and log the mean under ``eval/reward``. Returns it.
+        sample→score path (minus ``enable_grad``/backward): sample images with
+        :meth:`ReFLPolicy.eval_sample` (deterministic ODE, ``model.eval()`` +
+        ``no_grad``, CFG at ``eval_cfg_text_scale``) and score. The training
+        reward plus every shared-set ``eval_rewards`` suite scores the SAME
+        images from the default eval set (``run.eval_data_path``,
+        ``eval_num_prompts`` prompts); each own-set suite then runs its own
+        sample→score pass over its own prompts. All means land in one ``eval/*``
+        row (``eval/reward`` + ``eval/<suite>``); returns ``eval/reward``.
 
         ``step`` keys the wandb log axis (and ``eval_sample``'s seed), mirroring
         :meth:`DiffusionTrainer.evaluate` — so re-running a checkpoint via
@@ -134,37 +148,50 @@ class RewardBackpropTrainer(BaseTrainer):
         the restored weights at the same step. NOTE: eval is NOT bit-exact — the
         init latent is drawn unseeded (see ``eval_sample``), so A vs B agree only
         within sampling noise (~σ), not byte-identically.
+        """
+        # Default pass: training reward + shared-set suites score the SAME images.
+        scorers = [("reward", self.reward)] + [(s.name, s.reward) for s in self._eval_suites if s.data_source is None]
+        metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, step)
+        for suite in self._eval_suites:
+            if suite.data_source is not None:
+                n = suite.num_prompts or self.eval_num_prompts
+                metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], step))
+        logger.info(
+            "EVAL step %d  (cfg=%.1f)  %s",
+            step,
+            self.eval_cfg_text_scale,
+            "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
+        )
+        self.wandb_logger.log_eval(step, metrics)
+        return metrics["reward"]
+
+    def _eval_pass(
+        self, data_source: Any, num_prompts: int, scorers: List[Tuple[str, Any]], step: int
+    ) -> Dict[str, float]:
+        """One sample→score sweep over one eval set; returns each scorer's mean.
 
         Chunked by ``self.batch_size`` — both ``eval_sample`` and
         ``score_differentiable`` are DP_SCATTER, and ``batch_size`` is validated
         divisible by both the policy and reward dp sizes in ``__init__``; a ragged
-        tail (``eval_num_prompts`` not a multiple of ``batch_size``) is floored off.
+        tail (``num_prompts`` not a multiple of ``batch_size``) is floored off.
         """
-        eval_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
+        eval_inputs = data_source.get_eval_samples(num_prompts)
         prompts = eval_inputs.primitives["text"]
         if not isinstance(prompts, Texts):
             prompts = Texts(texts=list(prompts))
         texts = list(prompts.texts)
         chunk = max(1, self.batch_size)
         usable = len(texts) - len(texts) % chunk or len(texts)
-        reward_sum, reward_n = 0.0, 0
+        sums = {name: 0.0 for name, _ in scorers}
+        counts = {name: 0 for name, _ in scorers}
         for start in range(0, usable, chunk):
             sub = Texts(texts=texts[start : start + chunk])
             images = self.policy.eval_sample(prompts=sub, rollout_id=step, guidance_scale=self.eval_cfg_text_scale)
-            rewards = self.reward.score_differentiable(images=images, prompts=sub)
-            r = hydrate(rewards).float()
-            reward_sum += float(r.sum().item())
-            reward_n += int(r.numel())
-        mean_reward = reward_sum / max(1, reward_n)
-        logger.info(
-            "EVAL step %d  eval_reward(%d prompts, cfg=%.1f)=%.4f",
-            step,
-            self.eval_num_prompts,
-            self.eval_cfg_text_scale,
-            mean_reward,
-        )
-        self.wandb_logger.log_eval(step, {"reward": mean_reward})
-        return mean_reward
+            for name, reward in scorers:
+                r = hydrate(reward.score_differentiable(images=images, prompts=sub)).float()
+                sums[name] += float(r.sum().item())
+                counts[name] += int(r.numel())
+        return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     def train(
         self,

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -57,7 +57,7 @@ import json
 import logging
 import os
 import time
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from hydra.utils import instantiate
@@ -68,6 +68,7 @@ from unirl.distributed.tensor import TensorRef, hydrate
 from unirl.distributed.tensor.batch import Batch
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict
+from unirl.trainer.eval_suites import build_eval_suites
 from unirl.types.primitives import Texts
 from unirl.types.prompts import RolloutInputs
 from unirl.types.rollout_req import RolloutReq
@@ -156,6 +157,7 @@ class UnifiedModelTrainer(BaseTrainer):
         eval_num_prompts: int = 32,
         eval_cfg_text_scale: float = 4.0,
         eval_eta: float = 0.0,
+        eval_rewards_cfg: Optional[Any] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -207,6 +209,11 @@ class UnifiedModelTrainer(BaseTrainer):
             self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
             self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
             self.reward = remote_hydra(reward_cfg)
+            # Extra eval-only rewards (eval_rewards) — siblings of the training
+            # reward on this slab; see unirl.trainer.eval_suites.
+            self._eval_suites = build_eval_suites(
+                eval_rewards_cfg, data_source_cfg=data_source_cfg, enabled=self.eval_interval > 0
+            )
 
             # Two algorithms over the SAME shared pipeline (each resolves its
             # own stage via ``stage_attr``: ar→pipeline.ar, image→pipeline.diffusion).
@@ -774,21 +781,24 @@ class UnifiedModelTrainer(BaseTrainer):
         :meth:`run_rollout` (so both the single-engine trainside path and the
         two-engine HI3 path work), with the diffusion sub-block forced onto the
         deterministic best-quality setting (CFG at ``eval_cfg_text_scale``,
-        ``eta=eval_eta``), score ONLY the image track (PickScore), and log the
-        mean under ``eval/reward``. Returns it.
+        ``eta=eval_eta``), and score ONLY the image track. The training reward
+        plus every shared-set ``eval_rewards`` suite scores the SAME generated
+        images; each own-set suite then gets its own generation pass over its
+        own prompts. All means land in one ``eval/*`` row (``eval/reward`` +
+        ``eval/<suite>``); returns ``eval/reward``.
 
         The two-engine path syncs the live adapter into the engines once per
-        eval (EXTRACT with the base onloaded → wake → PUSH, mirroring
-        :meth:`train_step`) — train_step syncs BEFORE its generate, so without
-        this the engines would eval weights one update stale, and a
+        eval (EXTRACT with the base onloaded → wake → PUSH → sleep, mirroring
+        :meth:`train_step`'s ordering) — train_step syncs BEFORE its generate,
+        so without this the engines would eval weights one update stale, and a
         restored-checkpoint baseline eval would see fresh (unloaded) engine
-        weights. Unlike train_step it never onloads the base afterwards: eval
-        has no backward, so the FSDP state stays offloaded (the steady state)
-        throughout. The single-engine trainside path needs none of it (the
-        rollout shares the live FSDP modules; ``_enable_fsdp_offload`` is
-        forced False). Chunked by ``self.batch_size`` (the un-expanded P-prompt
-        req DP-splits, so the chunk must be dp-divisible; ``batch_size`` is
-        what training runs). A ragged tail is floored off.
+        weights. Pushed weights persist across engine sleep/wake cycles (as
+        train_step relies on), so the passes below just wake/sleep around each
+        chunk's rollout. Unlike train_step, eval never onloads the base after
+        the extract: there is no backward, so the FSDP state stays offloaded
+        (the steady state) throughout. The single-engine trainside path needs
+        none of it (the rollout shares the live FSDP modules;
+        ``_enable_fsdp_offload`` is forced False).
         """
         # Override only the "diffusion" entry of the modality-keyed sampling dict.
         # CFG strength lives in ``cfg_text_scale`` on Bagel-style sampling params
@@ -802,21 +812,57 @@ class UnifiedModelTrainer(BaseTrainer):
             replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
         eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
-        all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
-        n_prompts = len(all_inputs.sample_ids)
-        chunk = max(1, self.batch_size)
-        usable = n_prompts - n_prompts % chunk or n_prompts
-        reward_sum, reward_n = 0.0, 0
-        # Two-engine: extract the CURRENT adapter once for the whole eval (PUSH
-        # rides the first chunk's wake below — it needs awake engines; pushed
-        # weights persist across engine sleep/wake cycles, as train_step relies on).
-        eval_sync = not self._single_engine and self.weight_sync is not None
-        if eval_sync:
+        # Two-engine: sync the CURRENT adapter once for the whole eval (PUSH
+        # needs awake engines, so it rides one short wake/sleep cycle here).
+        if not self._single_engine and self.weight_sync is not None:
             if self._enable_fsdp_offload:
                 self.backend.onload()
             self.weight_sync.extract()
             if self._enable_fsdp_offload:
                 self.backend.offload()
+            for eng in self.ar_rollouts + self.dit_rollouts:
+                eng.wake_up()
+            self.weight_sync.push()
+            for eng in self.ar_rollouts + self.dit_rollouts:
+                eng.sleep()
+        # Default pass: training reward + shared-set suites score the SAME images.
+        scorers = [("reward", self.reward)] + [(s.name, s.reward) for s in self._eval_suites if s.data_source is None]
+        metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step)
+        for suite in self._eval_suites:
+            if suite.data_source is not None:
+                n = suite.num_prompts or self.eval_num_prompts
+                metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], eval_sp, step))
+        logger.info(
+            "EVAL step %d  (cfg=%.1f eta=%.1f)  %s",
+            step,
+            self.eval_cfg_text_scale,
+            self.eval_eta,
+            "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
+        )
+        self.wandb_logger.log_eval(step, metrics)
+        return metrics["reward"]
+
+    def _eval_pass(
+        self,
+        data_source: Any,
+        num_prompts: int,
+        scorers: List[Tuple[str, Any]],
+        eval_sp: Dict[str, BaseSamplingParams],
+        step: int,
+    ) -> Dict[str, float]:
+        """One generate→score sweep over one eval set; returns each scorer's mean.
+
+        Chunked by ``self.batch_size`` (the un-expanded P-prompt req DP-splits,
+        so the chunk must be dp-divisible; ``batch_size`` is what training
+        runs). A ragged tail (``num_prompts`` not a multiple of ``batch_size``)
+        is floored off.
+        """
+        all_inputs = data_source.get_eval_samples(num_prompts)
+        n_prompts = len(all_inputs.sample_ids)
+        chunk = max(1, self.batch_size)
+        usable = n_prompts - n_prompts % chunk or n_prompts
+        sums = {name: 0.0 for name, _ in scorers}
+        counts = {name: 0 for name, _ in scorers}
         for start in range(0, usable, chunk):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             req = self._build_req(sub, step, base_sampling=eval_sp)
@@ -825,9 +871,6 @@ class UnifiedModelTrainer(BaseTrainer):
             else:
                 for eng in self.ar_rollouts + self.dit_rollouts:
                     eng.wake_up()
-                if eval_sync:
-                    self.weight_sync.push()
-                    eval_sync = False
                 resp = self.run_rollout(req)
                 for eng in self.ar_rollouts + self.dit_rollouts:
                     eng.sleep()
@@ -854,22 +897,13 @@ class UnifiedModelTrainer(BaseTrainer):
                 sampling_params=req.sampling_params,
                 metadata=reward_metadata,
             )
-            scored = self.reward.score_and_attach(req=reward_req, track=img_track)
-            if scored.rewards is not None:
-                r = hydrate(scored.rewards).to(torch.float32)
-                reward_sum += float(r.sum().item())
-                reward_n += int(r.numel())
-        mean_reward = reward_sum / max(1, reward_n)
-        logger.info(
-            "EVAL step %d  eval_reward(%d prompts, cfg=%.1f eta=%.1f)=%.4f",
-            step,
-            self.eval_num_prompts,
-            self.eval_cfg_text_scale,
-            self.eval_eta,
-            mean_reward,
-        )
-        self.wandb_logger.log_eval(step, {"reward": mean_reward})
-        return mean_reward
+            for name, reward in scorers:
+                scored = reward.score_and_attach(req=reward_req, track=img_track)
+                if scored.rewards is not None:
+                    r = hydrate(scored.rewards).to(torch.float32)
+                    sums[name] += float(r.sum().item())
+                    counts[name] += int(r.numel())
+        return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     def train(
         self,

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -154,6 +154,7 @@ class UnifiedModelTrainer(BaseTrainer):
         enable_fsdp_offload: bool = True,
         eval_interval: int = 0,
         eval_num_prompts: int = 32,
+        eval_cfg_text_scale: float = 4.0,
         eval_eta: float = 0.0,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -165,12 +166,17 @@ class UnifiedModelTrainer(BaseTrainer):
 
         # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
         # eval_interval=0 disables it. Scores only the image track (PickScore) like
-        # train_step, mean logged as eval/reward. eval_eta forces the diffusion
-        # sub-block onto a deterministic ODE for eval (recipe trains at eta>0). No
+        # train_step, mean logged as eval/reward. Eval generates at the
+        # deterministic best-quality setting, mirroring DiffusionTrainer:
+        # eval_cfg_text_scale sets the CFG strength (UniGRPO recipes train at
+        # cfg_text_scale=1.0 = no CFG; set it to the train value to eval in the
+        # training regime instead) and eval_eta forces the diffusion sub-block
+        # onto a deterministic ODE (recipe trains at eta>0). No
         # eval_samples_per_prompt knob: the 2-track fan-out makes a single count
         # ambiguous (bagel is M=1, image shares the AR advantage).
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
+        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
 
         # W&B logging (logging_cfg, wandb_logger, optimizer-step counter) is owned
@@ -766,9 +772,10 @@ class UnifiedModelTrainer(BaseTrainer):
         credit-assign/advantage/backward: pull ``eval_num_prompts`` eval prompts
         (``run.eval_data_path``), run the ``P→P*N→P*N*M`` fan-out through
         :meth:`run_rollout` (so both the single-engine trainside path and the
-        two-engine HI3 path work), with the diffusion sub-block forced onto a
-        deterministic ODE (``eta=eval_eta``), score ONLY the image track
-        (PickScore), and log the mean under ``eval/reward``. Returns it.
+        two-engine HI3 path work), with the diffusion sub-block forced onto the
+        deterministic best-quality setting (CFG at ``eval_cfg_text_scale``,
+        ``eta=eval_eta``), score ONLY the image track (PickScore), and log the
+        mean under ``eval/reward``. Returns it.
 
         The two-engine path replicates ``train_step``'s colocate memory dance
         (wake engines → rollout → sleep → onload base → re-offload to steady
@@ -778,8 +785,17 @@ class UnifiedModelTrainer(BaseTrainer):
         must be dp-divisible; ``batch_size`` is what training runs). A ragged tail
         is floored off.
         """
+        # Override only the "diffusion" entry of the modality-keyed sampling dict.
+        # CFG strength lives in ``cfg_text_scale`` on Bagel-style sampling params
+        # and in ``guidance_scale`` on the standard DiffusionSamplingParams (HI3,
+        # ...) — same fallback as :meth:`DiffusionTrainer.evaluate`.
         base_diffusion = self.sampling_params.get("diffusion")
-        eval_diffusion = dataclasses.replace(base_diffusion, eta=self.eval_eta)
+        replace_kwargs = dict(eta=self.eval_eta)
+        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
+            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
+        else:
+            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
+        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
         all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
         n_prompts = len(all_inputs.sample_ids)
@@ -832,9 +848,10 @@ class UnifiedModelTrainer(BaseTrainer):
                 self.backend.offload()
         mean_reward = reward_sum / max(1, reward_n)
         logger.info(
-            "EVAL step %d  eval_reward(%d prompts, eta=%.1f)=%.4f",
+            "EVAL step %d  eval_reward(%d prompts, cfg=%.1f eta=%.1f)=%.4f",
             step,
             self.eval_num_prompts,
+            self.eval_cfg_text_scale,
             self.eval_eta,
             mean_reward,
         )

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -777,13 +777,18 @@ class UnifiedModelTrainer(BaseTrainer):
         ``eta=eval_eta``), score ONLY the image track (PickScore), and log the
         mean under ``eval/reward``. Returns it.
 
-        The two-engine path replicates ``train_step``'s colocate memory dance
-        (wake engines → rollout → sleep → onload base → re-offload to steady
-        state); the single-engine trainside path needs none of it
-        (``_enable_fsdp_offload`` is forced False, no engines to wake). Chunked by
-        ``self.batch_size`` (the un-expanded P-prompt req DP-splits, so the chunk
-        must be dp-divisible; ``batch_size`` is what training runs). A ragged tail
-        is floored off.
+        The two-engine path syncs the live adapter into the engines once per
+        eval (EXTRACT with the base onloaded → wake → PUSH, mirroring
+        :meth:`train_step`) — train_step syncs BEFORE its generate, so without
+        this the engines would eval weights one update stale, and a
+        restored-checkpoint baseline eval would see fresh (unloaded) engine
+        weights. Unlike train_step it never onloads the base afterwards: eval
+        has no backward, so the FSDP state stays offloaded (the steady state)
+        throughout. The single-engine trainside path needs none of it (the
+        rollout shares the live FSDP modules; ``_enable_fsdp_offload`` is
+        forced False). Chunked by ``self.batch_size`` (the un-expanded P-prompt
+        req DP-splits, so the chunk must be dp-divisible; ``batch_size`` is
+        what training runs). A ragged tail is floored off.
         """
         # Override only the "diffusion" entry of the modality-keyed sampling dict.
         # CFG strength lives in ``cfg_text_scale`` on Bagel-style sampling params
@@ -802,6 +807,16 @@ class UnifiedModelTrainer(BaseTrainer):
         chunk = max(1, self.batch_size)
         usable = n_prompts - n_prompts % chunk or n_prompts
         reward_sum, reward_n = 0.0, 0
+        # Two-engine: extract the CURRENT adapter once for the whole eval (PUSH
+        # rides the first chunk's wake below — it needs awake engines; pushed
+        # weights persist across engine sleep/wake cycles, as train_step relies on).
+        eval_sync = not self._single_engine and self.weight_sync is not None
+        if eval_sync:
+            if self._enable_fsdp_offload:
+                self.backend.onload()
+            self.weight_sync.extract()
+            if self._enable_fsdp_offload:
+                self.backend.offload()
         for start in range(0, usable, chunk):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             req = self._build_req(sub, step, base_sampling=eval_sp)
@@ -810,11 +825,12 @@ class UnifiedModelTrainer(BaseTrainer):
             else:
                 for eng in self.ar_rollouts + self.dit_rollouts:
                     eng.wake_up()
+                if eval_sync:
+                    self.weight_sync.push()
+                    eval_sync = False
                 resp = self.run_rollout(req)
                 for eng in self.ar_rollouts + self.dit_rollouts:
                     eng.sleep()
-                if self._enable_fsdp_offload:
-                    self.backend.onload()
             # Score the image track only; build a reward req aligned 1:1 with the
             # image track (each image's ORIGINAL prompt) so req and track shard
             # together across DP ranks (mirrors train_step).
@@ -843,9 +859,6 @@ class UnifiedModelTrainer(BaseTrainer):
                 r = hydrate(scored.rewards).to(torch.float32)
                 reward_sum += float(r.sum().item())
                 reward_n += int(r.numel())
-            # Back to steady state (base on CPU) so the next chunk's engines have room.
-            if self._enable_fsdp_offload and not self._single_engine:
-                self.backend.offload()
         mean_reward = reward_sum / max(1, reward_n)
         logger.info(
             "EVAL step %d  eval_reward(%d prompts, cfg=%.1f eta=%.1f)=%.4f",

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -152,6 +152,9 @@ class UnifiedModelTrainer(BaseTrainer):
         dump_dir: Optional[str] = None,
         logging_cfg: Optional[DictConfig] = None,
         enable_fsdp_offload: bool = True,
+        eval_interval: int = 0,
+        eval_num_prompts: int = 32,
+        eval_eta: float = 0.0,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -159,6 +162,16 @@ class UnifiedModelTrainer(BaseTrainer):
         # optimizer) to CPU during rollout so the awake engines fit, onload
         # before the train backward. HI3's ~150GB base needs this → default True.
         self._enable_fsdp_offload = bool(enable_fsdp_offload)
+
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
+        # eval_interval=0 disables it. Scores only the image track (PickScore) like
+        # train_step, mean logged as eval/reward. eval_eta forces the diffusion
+        # sub-block onto a deterministic ODE for eval (recipe trains at eta>0). No
+        # eval_samples_per_prompt knob: the 2-track fan-out makes a single count
+        # ambiguous (bagel is M=1, image shares the AR advantage).
+        self.eval_interval = int(eval_interval)
+        self.eval_num_prompts = int(eval_num_prompts)
+        self.eval_eta = float(eval_eta)
 
         # W&B logging (logging_cfg, wandb_logger, optimizer-step counter) is owned
         # by BaseTrainer + UniRLWandBLogger now — see super().__init__ above.
@@ -335,7 +348,9 @@ class UnifiedModelTrainer(BaseTrainer):
         role_cls = parsed.pop("role_cls")
         return self.pool.create_remote(role_cls, device_ids=[anchor_device], init_kwargs=parsed)
 
-    def _build_req(self, inputs: RolloutInputs, rollout_id: int) -> RolloutReq:
+    def _build_req(
+        self, inputs: RolloutInputs, rollout_id: int, *, base_sampling: Optional[Dict[str, BaseSamplingParams]] = None
+    ) -> RolloutReq:
         """Turn a data-source batch of ``P`` prompts into a typed ``RolloutReq``.
 
         Like :meth:`PETrainer._build_req`, NO pre-expansion: ``train_step`` fans
@@ -346,11 +361,15 @@ class UnifiedModelTrainer(BaseTrainer):
         ``samples_per_prompt`` to validate the expansion factor); the SDE step
         schedule is resolved off the diffusion sub-block per rollout and stamped
         back onto a per-request copy.
+
+        ``base_sampling`` overrides the modality-keyed sampling dict (``evaluate``
+        passes its own deterministic params); ``None`` uses ``self.sampling_params``.
         """
-        diff_params = self.sampling_params.get("diffusion")
+        base = base_sampling if base_sampling is not None else self.sampling_params
+        diff_params = base.get("diffusion")
         sde_indices = diff_params.resolve_sde_indices(rollout_id)
         diffusion = dataclasses.replace(diff_params, sde_indices=sde_indices, scheduler=None)
-        sampling_params = {**self.sampling_params, "diffusion": diffusion}
+        sampling_params = {**base, "diffusion": diffusion}
         return RolloutReq(
             sample_ids=list(inputs.sample_ids),
             group_ids=list(inputs.group_ids),
@@ -740,6 +759,88 @@ class UnifiedModelTrainer(BaseTrainer):
         except Exception as exc:  # noqa: BLE001 — dump must never break training
             logger.warning("[HI3-DUMP] rollout %d dump failed (non-fatal): %s", rollout_id, exc)
 
+    def evaluate(self, step: int) -> float:
+        """Periodic eval on the eval set (no training); returns the mean image reward.
+
+        Mirrors :meth:`train_step`'s rollout+reward path but skips
+        credit-assign/advantage/backward: pull ``eval_num_prompts`` eval prompts
+        (``run.eval_data_path``), run the ``P→P*N→P*N*M`` fan-out through
+        :meth:`run_rollout` (so both the single-engine trainside path and the
+        two-engine HI3 path work), with the diffusion sub-block forced onto a
+        deterministic ODE (``eta=eval_eta``), score ONLY the image track
+        (PickScore), and log the mean under ``eval/reward``. Returns it.
+
+        The two-engine path replicates ``train_step``'s colocate memory dance
+        (wake engines → rollout → sleep → onload base → re-offload to steady
+        state); the single-engine trainside path needs none of it
+        (``_enable_fsdp_offload`` is forced False, no engines to wake). Chunked by
+        ``self.batch_size`` (the un-expanded P-prompt req DP-splits, so the chunk
+        must be dp-divisible; ``batch_size`` is what training runs). A ragged tail
+        is floored off.
+        """
+        base_diffusion = self.sampling_params.get("diffusion")
+        eval_diffusion = dataclasses.replace(base_diffusion, eta=self.eval_eta)
+        eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
+        all_inputs = self.data_source.get_eval_samples(self.eval_num_prompts)
+        n_prompts = len(all_inputs.sample_ids)
+        chunk = max(1, self.batch_size)
+        usable = n_prompts - n_prompts % chunk or n_prompts
+        reward_sum, reward_n = 0.0, 0
+        for start in range(0, usable, chunk):
+            sub = all_inputs.slice(start, min(start + chunk, n_prompts))
+            req = self._build_req(sub, step, base_sampling=eval_sp)
+            if self._single_engine:
+                resp = self.run_rollout(req)
+            else:
+                for eng in self.ar_rollouts + self.dit_rollouts:
+                    eng.wake_up()
+                resp = self.run_rollout(req)
+                for eng in self.ar_rollouts + self.dit_rollouts:
+                    eng.sleep()
+                if self._enable_fsdp_offload:
+                    self.backend.onload()
+            # Score the image track only; build a reward req aligned 1:1 with the
+            # image track (each image's ORIGINAL prompt) so req and track shard
+            # together across DP ranks (mirrors train_step).
+            img_track = resp.tracks[IMAGE_TRACK]
+            ar_params = req.sampling_params.get("ar")
+            diff_params = req.sampling_params.get("diffusion")
+            n_rec = int(ar_params.samples_per_prompt) if ar_params is not None else 1
+            n_img = int(diff_params.samples_per_prompt)
+            orig_texts = req.primitives.get("text")
+            reward_texts = Texts(
+                texts=[orig_texts.texts[i // (n_rec * n_img)] for i in range(len(img_track.sample_ids))]
+            )
+            reward_metadata = (
+                [req.metadata[i // (n_rec * n_img)] for i in range(len(img_track.sample_ids))] if req.metadata else []
+            )
+            reward_req = RolloutReq(
+                sample_ids=list(img_track.sample_ids),
+                group_ids=list(img_track.parent_ids) if img_track.parent_ids else list(img_track.sample_ids),
+                primitives={"text": reward_texts},
+                request_conditions={},
+                sampling_params=req.sampling_params,
+                metadata=reward_metadata,
+            )
+            scored = self.reward.score_and_attach(req=reward_req, track=img_track)
+            if scored.rewards is not None:
+                r = hydrate(scored.rewards).to(torch.float32)
+                reward_sum += float(r.sum().item())
+                reward_n += int(r.numel())
+            # Back to steady state (base on CPU) so the next chunk's engines have room.
+            if self._enable_fsdp_offload and not self._single_engine:
+                self.backend.offload()
+        mean_reward = reward_sum / max(1, reward_n)
+        logger.info(
+            "EVAL step %d  eval_reward(%d prompts, eta=%.1f)=%.4f",
+            step,
+            self.eval_num_prompts,
+            self.eval_eta,
+            mean_reward,
+        )
+        self.wandb_logger.log_eval(step, {"reward": mean_reward})
+        return mean_reward
+
     def train(
         self,
         *,
@@ -769,6 +870,8 @@ class UnifiedModelTrainer(BaseTrainer):
             self.data_source.get_samples(self.batch_size)
         self._init_wandb(num_rollouts=num_rollouts)
         try:
+            if self.eval_interval > 0:
+                self.evaluate(start_rollout)  # baseline eval before any training
             for rollout_id in range(start_rollout, num_rollouts):
                 training_progress = rollout_id / max(1, num_rollouts - 1)
                 self._dump_rollout_id = rollout_id  # picked up by train_step's dump
@@ -797,6 +900,10 @@ class UnifiedModelTrainer(BaseTrainer):
                 # logp convention (temperature / top-k-p filtering / full-vs-renorm
                 # softmax) doesn't match vLLM's sampler.
                 self.wandb_logger.log_progress(rollout_id, num_rollouts, results, mean_reward, logger=logger)
+                # eval(k) BEFORE save(checkpoint-k) at the same step, so a
+                # resumed checkpoint re-runs the same eval (A/B consistency).
+                if self.eval_interval > 0 and (rollout_id + 1) % self.eval_interval == 0:
+                    self.evaluate(rollout_id + 1)
                 self.maybe_save_checkpoint(
                     rollout_id, num_rollouts, save_interval=save_interval, save_dir=save_dir, save_mode=save_mode
                 )

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -166,16 +166,12 @@ class UnifiedModelTrainer(BaseTrainer):
         # before the train backward. HI3's ~150GB base needs this → default True.
         self._enable_fsdp_offload = bool(enable_fsdp_offload)
 
-        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
-        # eval_interval=0 disables it. Scores only the image track (PickScore) like
-        # train_step, mean logged as eval/reward. Eval generates at the
-        # deterministic best-quality setting, mirroring DiffusionTrainer:
-        # eval_cfg_text_scale sets the CFG strength (UniGRPO recipes train at
-        # cfg_text_scale=1.0 = no CFG; set it to the train value to eval in the
-        # training regime instead) and eval_eta forces the diffusion sub-block
-        # onto a deterministic ODE (recipe trains at eta>0). No
-        # eval_samples_per_prompt knob: the 2-track fan-out makes a single count
-        # ambiguous (bagel is M=1, image shares the AR advantage).
+        # Periodic eval on the eval set (run.eval_data_path), logged under eval/*;
+        # eval_interval=0 disables it. Scores only the image track, generated at
+        # the deterministic best-quality setting (CFG=eval_cfg_text_scale,
+        # eta=eval_eta) — same knobs/semantics as DiffusionTrainer; extra
+        # eval-only rewards: unirl.trainer.eval_suites. No eval_samples_per_prompt
+        # knob: the 2-track fan-out makes a single count ambiguous (bagel is M=1).
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
         self.eval_cfg_text_scale = float(eval_cfg_text_scale)
@@ -776,29 +772,26 @@ class UnifiedModelTrainer(BaseTrainer):
         """Periodic eval on the eval set (no training); returns the mean image reward.
 
         Mirrors :meth:`train_step`'s rollout+reward path but skips
-        credit-assign/advantage/backward: pull ``eval_num_prompts`` eval prompts
-        (``run.eval_data_path``), run the ``P→P*N→P*N*M`` fan-out through
-        :meth:`run_rollout` (so both the single-engine trainside path and the
-        two-engine HI3 path work), with the diffusion sub-block forced onto the
-        deterministic best-quality setting (CFG at ``eval_cfg_text_scale``,
-        ``eta=eval_eta``), and score ONLY the image track. The training reward
-        plus every shared-set ``eval_rewards`` suite scores the SAME generated
-        images; each own-set suite then gets its own generation pass over its
-        own prompts. All means land in one ``eval/*`` row (``eval/reward`` +
-        ``eval/<suite>``); returns ``eval/reward``.
+        credit-assign/advantage/backward: run the ``P→P*N→P*N*M`` fan-out through
+        :meth:`run_rollout` (works on both the single-engine trainside and the
+        two-engine HI3 path) at the deterministic best-quality setting (CFG at
+        ``eval_cfg_text_scale``, ``eta=eval_eta``) and score ONLY the image
+        track — the training reward plus the ``eval_rewards`` suites (see
+        :mod:`unirl.trainer.eval_suites`). Logs one ``eval/*`` row; returns
+        ``eval/reward``.
 
         The two-engine path syncs the live adapter into the engines once per
         eval (EXTRACT with the base onloaded → wake → PUSH → sleep, mirroring
         :meth:`train_step`'s ordering) — train_step syncs BEFORE its generate,
-        so without this the engines would eval weights one update stale, and a
-        restored-checkpoint baseline eval would see fresh (unloaded) engine
-        weights. Pushed weights persist across engine sleep/wake cycles (as
-        train_step relies on), so the passes below just wake/sleep around each
-        chunk's rollout. Unlike train_step, eval never onloads the base after
-        the extract: there is no backward, so the FSDP state stays offloaded
-        (the steady state) throughout. The single-engine trainside path needs
-        none of it (the rollout shares the live FSDP modules;
-        ``_enable_fsdp_offload`` is forced False).
+        so without this the engines would eval one update stale, and a
+        restored-checkpoint baseline eval would see fresh engine weights.
+        Pushed weights persist across sleep/wake cycles (as train_step relies
+        on), so the passes below just wake/sleep around each chunk's rollout.
+        Unlike train_step, eval never onloads the base after the extract: there
+        is no backward, so the FSDP state stays offloaded (the steady state)
+        throughout. The single-engine trainside path needs none of it (the
+        rollout shares the live FSDP modules; ``_enable_fsdp_offload`` is
+        forced False).
         """
         # Override only the "diffusion" entry of the modality-keyed sampling dict.
         # CFG strength lives in ``cfg_text_scale`` on Bagel-style sampling params


### PR DESCRIPTION
## Summary

Make in-training **eval** work — and be verifiable — across **all** trainers.
Eval (`evaluate()` + scheduling in the `train()` loop, logged under `eval/*`)
previously existed only in `DiffusionTrainer` and `ARTrainer`. `PETrainer`,
`RewardBackpropTrainer` (ReFL), and `UnifiedModelTrainer` had **no eval path at
all** (0 references — passing `eval_interval` was silently ignored). This PR adds
eval to those three, mirroring `DiffusionTrainer`:

- pull `eval_num_prompts` eval prompts (`run.eval_data_path`), force the diffusion
  sub-block onto a deterministic ODE (`eval_eta`, default 0), score the image track
  with the configured reward (PickScore) → `eval/reward`, and run `evaluate(k)`
  **before** `save(checkpoint-k)` at the same step so a resumed checkpoint
  reproduces the same eval (the basis of the A/B consistency check below).
- entry scripts (`train_pe` / `train_refl` / `train_unified_model`) read `eval_*`
  via `cfg.get`.
- **PE** additionally gains two-side checkpointing (it had none) so its
  consistency run can resume; **ReFL** gains `ReFLPolicy.eval_sample` (an
  eval-mode `no_grad` DRaFT-K sampler, no autograd graph).

It also aligns `ARTrainer`'s eval metric with the others: AR now reports
`eval/reward` alongside its existing `eval/acc` (the MC reward is 0/1, so the two
are numerically equal). This gives every trainer an `eval/reward` key, so AR eval
runs share that axis with the diffusion / PE / ReFL / UnifiedModel curves.

Additive by design: all eval is gated on `eval_interval > 0`, so the default
(`0`) leaves every trainer's training path byte-for-byte unchanged.

## Follow-up commits on this branch (maintainer, post-review)

Four commits added during review (haonan3 + agent), same additive-by-default discipline:

- `6813c29f` **eval CFG knob**: `eval_cfg_text_scale` (default 4.0) now reaches PE / ReFL / UnifiedModel eval, mirroring `DiffusionTrainer` (Bagel-style params take `cfg_text_scale`, standard `DiffusionSamplingParams` fall back to `guidance_scale`). Recipes train at cfg=1.0; eval no longer silently inherits that — set the knob to the train value to eval in the training regime instead.
- `b4f85dfa` **UnifiedModel two-engine eval sync**: `evaluate()` now EXTRACT -> wake -> PUSH-es the live adapter once per eval (mirroring `train_step`); previously the engines eval'd one update stale and a restored-checkpoint baseline eval saw fresh weights. Also drops the per-chunk base onload/offload round trip (eval has no backward).
- `1fd6f29c` **`eval_rewards` multi-reward eval suites** (`unirl/trainer/eval_suites.py`): extra eval-only reward models for checkpoint selection, logged as `eval/<name>` next to `eval/reward`. Entries without `eval_data_path` score the images the default eval pass already generated; entries with it get their own generation pass over their own prompt set. Suite rewards are built in the training reward's placement scope (`reward_fraction` => dedicated slab). Unset => byte-identical behavior. Wired into Diffusion / PE / ReFL / UnifiedModel; AR is out of scope (text MC acc).
- `6a16dfff` comment-prose dedupe (docs-only).

## Related Issue

N/A.

## Test Plan

**Static:** `pre-commit run ruff-check / ruff-format` on the changed files — pass;
`python -m py_compile` — OK.

**eval + ckpt consistency.** For each of the **5 trainers**, a representative
recipe was run at reduced scale (single-GPU, ~50 rollouts, `eval_interval ==
save_interval == 5` → eval at step 0,5,…,50 + 10 checkpoints). Each `checkpoint-k`
was then reloaded (`num_rollouts=0 +eval_interval=1 +load_dir=checkpoint-k`) and
re-evaluated to build curve **B**, overlaid on the training-time curve **A** in
wandb project `unirl-eval`:

| Trainer | recipe | metric | A vs B consistency |
|---|---|---|---|
| DiffusionTrainer (already had eval) | `sd3_flowdppo` | `eval/reward` | **bit-exact A==B** (eta=0 deterministic) |
| ARTrainer (already had eval) | `bagel_grpo_arxivqa_mc_2x8_lora` | `eval/acc` | A≈B within σ (temp=1.0 sampling); greedy `eval_temperature=0` → A==B exact |
| **PETrainer** (eval ADDED) | `pe_trainside_pickscore` | `eval/reward` | A≈B, mean\|Δ\|≈0.003 (within σ) |
| **ReFL** (eval ADDED) | `refl_sd3` | `eval/reward` | A≈B, mean\|Δ\|≈0.006 (within σ) |
| **UnifiedModel** (eval ADDED) | `bagel_trainside_unigrpo` (full-FT BAGEL-7B) | `eval/reward` | A≈B, mean\|Δ\|≈0.007, max 0.014 (within σ) |

Outcome: the eval switch (on/off) behaves as expected, eval uses the current live
weights, and **reloaded-checkpoint eval matches training-time eval at every step** —
exactly for the deterministic paths, and within sampling-noise σ for the stochastic
ones. Both curves (A + B) are on wandb per trainer:
`sd3_flowdppo-trainEval/-ckptReplay`, `bagel_arxivqa-trainEval50/-ckptReplay50`,
`pe_pickscore-trainEval/-ckptReplay`, `refl_sd3-trainEval/-ckptReplay`,
`bagel_unigrpo-trainEval50/-ckptReplay50`.

**5 wandb eval curves attached below (one per trainer).**

<img width="1195" height="757" alt="Clipboard_Screenshot_1783839772" src="https://github.com/user-attachments/assets/93bed306-c96e-4594-b996-a687213a67c8" />

<img width="1228" height="764" alt="Clipboard_Screenshot_1783839815" src="https://github.com/user-attachments/assets/f1ecc41f-e99a-4e8e-87d8-ba2f8545479b" />

<img width="1228" height="785" alt="Clipboard_Screenshot_1783839834" src="https://github.com/user-attachments/assets/16c840b9-9248-44f6-a791-2a79da7b65cd" />

<img width="1232" height="773" alt="Clipboard_Screenshot_1783839849" src="https://github.com/user-attachments/assets/87903555-b6a5-41da-9a3b-59bdd53501be" />

<img width="1223" height="777" alt="Clipboard_Screenshot_1783839869" src="https://github.com/user-attachments/assets/f2b9b225-00d6-4e03-8214-ed1770fd6aae" />


**Follow-up verification (maintainer):**
- CPU logic tests for `eval_suites` parsing / validation / per-suite data-source cloning — pass.
- GPU component smoke (1xH20, live DevicePool): 3 `RewardService` remotes as placement siblings; the own-set suite serves its own prompts; a shared-set suite scores identical images bit-identically to the training reward — pass.
- End-to-end litmus (1xH20): SD3.5-medium + FlowGRPO trainside, train `guidance_scale=1.0` (no CFG) / eval `cfg=4.0`, `eval_rewards` = clip + image_reward + hpsv2 each on its own prompt file; 4 rollouts, eval@0/2/4 all emit the 4 reward curves (e.g. step0: `reward=0.8499 clip=1.0384 image_reward=0.7822 hpsv2=0.2844`); exit 0.
- Still static-only: UnifiedModel two-engine (HI3) and the sglang-engine eval paths (env limits, as originally disclosed above).

## Compatibility / Risk

- **No-op by default / training untouched**: eval is gated on `eval_interval > 0`;
  unset (default 0) → no eval runs and every training path is unchanged. No training
  sampler/step was modified (ReFL's `sample_and_decode` is untouched; `_build_req`
  gained an optional `base_sampling=None` that defaults to prior behavior).
- **PE gains checkpointing** — a new capability (two-side LoRA save/load), opt-in via
  `save_interval > 0`; PE had none before.
- ReFL `__init__` reflects current `main`'s `reward_fraction` (#151) — merged cleanly.
- No checkpoint / data-format / API changes.

## Reviewer Notes

- The three added `evaluate()`s mirror `DiffusionTrainer.evaluate` (eval-before-save
  ordering, image-track scoring, deterministic-ODE eval, `eval/reward` metric).
- **Eval reproducibility**: Diffusion is bit-exact because `eval_eta=0` zeroes the SDE
  noise. AR / PE / ReFL / UnifiedModel eval is **value-consistent within σ, not
  bit-exact** — their initial latent / thinking-chain sampling is drawn unseeded
  (`generate_latents` ignores the seed for `init_same_noise=False` with no
  `noise_group_ids`; AR `multinomial` has no generator). A/B agreeing within σ (and AR
  greedy → exact) confirms the checkpoint-load path is correct; threading
  `noise_group_ids` / seeding the multinomial to make them bit-exact is a follow-up.
- **Static-only (env limits, not run dynamically here)**: `AsyncARTrainer` (inherits
  AR's `evaluate` + `_drain_all()`; only sglang recipes exist) and `DiffusionTrainer`'s
  separate-engine (vllm/sglang) eval path (`weight_sync.sync()` before generate) —
  both need a torch-stack swap that breaks the diffusion env used for these runs.
- Surfaced during BAGEL eval testing but **fixed in a separate PR** (not here): the
  vendored BAGEL ViT `ImageTransform` stride (7) ≠ SigLIP patch size (14), which
  crashes `patchify` on non-square image inputs.
- AI-assisted. Duplicate-work checked: no existing/open PR adds eval to these trainers.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.

