### PR TITLE
feat(boogu_image): Boogu-Image-0.1-Base T2I bundle + trainside FlowGRPO recipe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,11 @@ default_stages: [pre-commit, pre-push, manual]
 #   - unirl/models/bagel/vendor/ : pristine official ByteDance-Seed/Bagel modeling
 #     (see VENDOR_COMMIT.txt); kept byte-identical to upstream, so the whitespace/format
 #     hooks must not rewrite it either.
+#   - unirl/models/boogu_image/vendor/ : pristine boogu-project/Boogu-Image model code
+#     (see VENDOR_COMMIT.txt); same re-vendor rationale as bagel/vendor/.
 #   - benchmarks/*/*/data/ : vendored upstream benchmark prompt sets (GenEval,
 #     PartiPrompts, VBench, ...); kept byte-identical so upstream checksums verify.
-exclude: ^(unirl-reward-service/|unirl/models/bagel/vendor/|benchmarks/[^/]+/[^/]+/data/)
+exclude: ^(unirl-reward-service/|unirl/models/bagel/vendor/|unirl/models/boogu_image/vendor/|benchmarks/[^/]+/[^/]+/data/)
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/examples/diffusion/boogu_image/boogu_image_trainside.yaml
+++ b/examples/diffusion/boogu_image/boogu_image_trainside.yaml
@@ -1,0 +1,215 @@
+# @package _global_
+# Boogu-Image-0.1-Base + trainside (FSDP) colocate, v2 trainer, FlowGRPO.
+#
+# Trainside = rollout runs in-process on the FSDP-wrapped training pipeline
+# (no separate rollout actor, no weight sync). Strongest colocate form.
+#
+# This recipe targets Boogu/Boogu-Image-0.1-Base: a 10.29B vendored
+# single/double-stream DiT (Lumina-2 lineage) + frozen Qwen3-VL-8B mllm
+# instruction encoder + FLUX.1 16-channel AutoencoderKL. The released Base
+# scheduler is a STATIC v1 time shift (seq_len=4096) whose sigma-space form is
+# the standard static shift with s = e^{1.15} = 3.158192909689768 — pinned via
+# BooguImagePipeline.build_schedule_policy (Boogu's scheduler_config.json uses
+# custom field names the generic JSON loader would silently ignore).
+#
+# CFG is intentionally OFF here (guidance_scale=1.0 — Boogu's off value; the
+# combine is pred + (g-1)*(pred - pred_neg)). Same rationale as z_image: CFG
+# sharpens the per-prompt distribution (less in-group diversity -> weaker GRPO
+# advantage) AND doubles the per-step forward cost. To re-enable: set
+# sampling.guidance_scale to 2.0-4.0 (reference inference uses 4.0); the
+# pipeline then auto-adds ""-negatives, which the embed stage routes to the
+# DROP system prompt (dataset logic).
+#
+# Resolution note: Boogu's native band is 1K/1.5K/2K; 512^2 is off-band but
+# the sigma schedule is resolution-invariant (config-pinned static shift), and
+# 512^2 keeps the smoke cheap. If early rollout/generated_media look too
+# degenerate for PickScore to rank, fall back to 1024^2:
+#   sampling.height=1024 sampling.width=1024 rollout.forward_batch_size=1 \
+#   stack.micro_batch_size=1 batch_size=16 sampling.samples_per_prompt=8
+#
+# Scale is set by the launcher (num_devices = cluster GPU count). For a quick
+# wiring smoke, shrink via CLI overrides, e.g.:
+#   batch_size=8 sampling.samples_per_prompt=4 num_rollouts=2
+
+num_devices: 8
+batch_size: 48                # prompts_per_rollout (divisible by 8)
+adv_use_global_std: true      # advantage: divide by ONE batch-wide std, not per-group
+num_rollouts: 10000
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,false}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-boogu-image}
+  run_name: ${oc.env:WANDB_RUN_NAME,boogu_image_trainside}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: null
+
+bundle:
+  _target_: unirl.models.boogu_image.bundle.BooguImageBundle.from_config
+  config:
+    _target_: unirl.models.boogu_image.config.BooguImagePipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:BOOGU_IMAGE_PATH,Boogu/Boogu-Image-0.1-Base}
+    model_precision: bf16
+    # Reference __call__ default; the Qwen3-VL processor pads to the batch
+    # longest under this cap (pickscore prompts are far shorter — this is a
+    # cap, not a padded length).
+    max_sequence_length: 1280
+    # e^{lin(4096)} = e^{1.15}: the released static-v1 shift. Read by
+    # build_schedule_policy (static posture pinned from config).
+    shift: 3.158192909689768
+
+# Pipeline relies on the optional-stages constructor (mirrors z_image): the
+# trainer auto-injects `bundle=self.bundle`; text_embed/diffusion/vae_decode
+# are built from the bundle here using the precision policy below.
+pipeline:
+  _target_: unirl.models.boogu_image.pipeline.BooguImagePipeline
+  shift: 3.158192909689768
+  autocast_precision: bf16
+  trajectory_precision: bf16
+  logprob_precision: fp32
+  max_sequence_length: 1280
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  # FSDP matches by EXACT concrete class name (train/backend/fsdp/wrap.py):
+  # the bare BooguImageTransformerBlock base is never instantiated — the DiT
+  # builds 4 pass-subclasses plus BooguImageDoubleStreamTransformerBlock,
+  # which is a separate class (NOT a subclass) and must be listed or the 8
+  # double-stream layers stay unsharded/un-checkpointed. RefImgRefiner blocks
+  # exist and hold weights even in T2I.
+  block_class_names:
+    - BooguImageNoiseRefinerTransformerBlock
+    - BooguImageRefImgRefinerTransformerBlock
+    - BooguImageContextRefinerTransformerBlock
+    - BooguImageSingleStreamTransformerBlock
+    - BooguImageDoubleStreamTransformerBlock
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    # 10.29B DiT + frozen Qwen3-VL-8B under full-graph replay: keep AC on.
+    activation_checkpointing: true
+    use_torch_compile: false
+    # fp32 LoRA master + Adam states (bagel's reward-collapse fix): a bf16
+    # master rounds away ~1e-4-scale GRPO updates on a bf16-loaded base.
+    master_dtype: fp32
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    # Boogu attention projections. peft suffix-matching is dot-boundary, so
+    # the double-stream joint-attention projections — which live INSIDE the
+    # attn processor module (img_instruct_attn's own to_q/to_k/to_v are
+    # deleted at ctor) — must be listed explicitly; `to_q` does NOT match
+    # `img_to_q`. Covers: 32 single-stream + 6 refiner blocks + img_self_attn
+    # (standard diffusers Attention: to_q/to_k/to_v/to_out.0) and the 8
+    # double-stream joint attentions (processor img/instruct projections).
+    # No bare FFN linear_N targets: those suffixes also match norm_out and
+    # the timestep embedder.
+    target_modules:
+      - to_k
+      - to_out.0
+      - to_q
+      - to_v
+      - img_to_q
+      - img_to_k
+      - img_to_v
+      - instruct_to_q
+      - instruct_to_k
+      - instruct_to_v
+      - img_out
+      - instruct_out
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  # 10.29B DiT + 8.8B frozen encoder: chunk generate() so the rollout/decode
+  # peak stays bounded. Start at 4 (z_image 6B uses 8; qwen 20B uses 1);
+  # bump to 8 after an HBM check, halve if CFG is enabled (2x forwards).
+  forward_batch_size: 4
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.pickscore.PickScoreRewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.pickscore.PickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  # Recompute pi_old at the exact train micro-geometry so the on-policy ratio
+  # is exactly 1. REQUIRED here (not just prudence): forward_batch_size (4)
+  # != micro_batch_size (2) and bf16 forwards are batch-shape sensitive.
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.boogu_image.conditions.BooguImageConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  # Per-GPU mini-batch is batch_size*spp/num_devices/num_updates_per_batch =
+  # 48*16/8/2 = 48 -> mbs 2 = 24 accum steps. Resident frozen weights
+  # dominate HBM at 10.29B+8.8B; try mbs 4 if headroom allows.
+  micro_batch_size: 2
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2      # PPO mini-batches per rollout (pi_old frozen once)
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 12       # RL-reduced from the native 25-50 (matches
+                                # z_image/qwen recipes)
+  guidance_scale: 1.0           # CFG OFF in Boogu's convention (1.0 == off;
+                                # reference inference uses 4.0). Set 2.0-4.0
+                                # to re-enable (auto-""-negatives + DROP
+                                # system prompt; ~2x rollout+replay cost).
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 3
+    # SDE-step window: confine SDE noise to the early high-sigma steps.
+    timestep_fraction: [0, 0.5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
   # Match the engine stacks' 5.6.x baseline; BAGEL vendor smoke passed on 5.6.0.
   "transformers>=5.6,<5.7",
   "huggingface-hub>=0.34",
+  # Vendored Boogu-Image DiT (unirl/models/boogu_image/vendor/) imports einops
+  # in transformer_boogu.py / attention_processor.py / rope.py. Pure-python,
+  # engine-agnostic.
+  "einops>=0.7",
   "peft>=0.14.0",  # exclude_modules support used by LoRA/NFT adapter injection
   "safetensors>=0.4",
   "Pillow>=10",

--- a/unirl/models/boogu_image/__init__.py
+++ b/unirl/models/boogu_image/__init__.py
@@ -1,0 +1,34 @@
+"""Boogu-Image model package — Base (T2I) RL support.
+
+Recipes wire the classes by ``_target_`` dotpath:
+
+- ``unirl.models.boogu_image.BooguImageBundle.from_config`` (+ nested
+  ``unirl.models.boogu_image.BooguImagePipelineConfig``)
+- ``unirl.models.boogu_image.BooguImagePipeline``
+- ``unirl.models.boogu_image.conditions.BooguImageConditions``
+  (``algorithm.conditions_cls``)
+
+The DiT architecture is vendored under ``vendor/`` (pinned upstream commit —
+see ``vendor/VENDOR_COMMIT.txt``); the Edit (TI2I) and Turbo (DMD few-step)
+variants are follow-ups.
+"""
+
+from .bundle import BooguImageBundle
+from .conditions import BooguImageConditions
+from .config import BOOGU_IMAGE_BASE_STATIC_SHIFT, BooguImagePipelineConfig
+from .diffusion import BooguImageDiffusionStage, BooguImageDiffusionStep
+from .pipeline import BooguImagePipeline
+from .text_embed import BooguImageTextEmbedStage
+from .vae import BooguImageVAEDecodeStage
+
+__all__ = [
+    "BOOGU_IMAGE_BASE_STATIC_SHIFT",
+    "BooguImageBundle",
+    "BooguImageConditions",
+    "BooguImagePipelineConfig",
+    "BooguImagePipeline",
+    "BooguImageDiffusionStage",
+    "BooguImageDiffusionStep",
+    "BooguImageTextEmbedStage",
+    "BooguImageVAEDecodeStage",
+]

--- a/unirl/models/boogu_image/bundle.py
+++ b/unirl/models/boogu_image/bundle.py
@@ -39,7 +39,7 @@ import torch
 import torch.nn as nn
 
 from unirl.models.types.bundle import Bundle
-from unirl.models.types.meta_init import finalize_meta_init
+from unirl.models.types.meta_init import build_meta_init_transformer
 from unirl.utils.dtypes import parse_torch_dtype
 
 from .config import BooguImagePipelineConfig
@@ -92,7 +92,7 @@ class BooguImageBundle(Bundle):
         self,
         *,
         transformer: nn.Module,
-        vae: nn.Module,
+        vae: Optional[nn.Module],
         text_encoder: Optional[nn.Module],
         processor: Any,
         dtype: torch.dtype,
@@ -156,19 +156,19 @@ class BooguImageBundle(Bundle):
         te_raw = config.text_encoder_dtype if config.text_encoder_dtype is not None else config.model_precision
         te_dtype = parse_torch_dtype(te_raw, field_name="text_encoder_dtype")
 
+        meta_init_state = None
         if config.meta_init_transformer:
             # Architecture only, on the meta device; the backend materializes
             # per-rank shards after wrapping and loads weights from the
             # stashed path. Boogu's vendored tree has zero registered buffers
             # and zero init-computed plain-tensor attrs (rope freqs_cis is a
-            # per-call input), so this is the trivial finalize_meta_init case
-            # — its non-persistent-buffer warning must come out EMPTY; if it
-            # ever fires after a re-vendor, that is the signal to add a
-            # stamp_init_state_restore quirk fix.
+            # per-call input), so the captured init state must come out EMPTY;
+            # if it ever grows after a re-vendor, that is the signal a quirk
+            # restore became load-bearing.
             transformer_config = BooguImageTransformer2DModel.load_config(path, subfolder="transformer")
-            with torch.device("meta"):
-                transformer = BooguImageTransformer2DModel.from_config(transformer_config)
-            transformer = finalize_meta_init(transformer, dtype=dtype)
+            transformer, meta_init_state = build_meta_init_transformer(
+                lambda: BooguImageTransformer2DModel.from_config(transformer_config), dtype=dtype
+            )
         else:
             transformer = BooguImageTransformer2DModel.from_pretrained(
                 path, subfolder="transformer", torch_dtype=dtype
@@ -185,8 +185,10 @@ class BooguImageBundle(Bundle):
             swapped = _swap_attention_processors_to_flash(transformer)
             logger.info("attention_backend=flash2_varlen: swapped %d processor(s)", swapped)
 
-        vae = AutoencoderKL.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(device).eval()
-        vae.requires_grad_(False)
+        vae = None
+        if config.load_vae:
+            vae = AutoencoderKL.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(device).eval()
+            vae.requires_grad_(False)
 
         # Separate-engine recipes can skip the frozen encoder copy on actors
         # that never embed text (qwen_image precedent).
@@ -219,6 +221,7 @@ class BooguImageBundle(Bundle):
         if config.meta_init_transformer:
             # Consumed by the backends' post-wrap sharded weight load.
             bundle._transformer_weights_path = os.path.join(path, "transformer")
+            bundle._meta_init_state = meta_init_state
         return bundle
 
 

--- a/unirl/models/boogu_image/bundle.py
+++ b/unirl/models/boogu_image/bundle.py
@@ -1,0 +1,225 @@
+"""BooguImageBundle — concrete weights+params holder for Boogu-Image.
+
+Implements the empty :class:`Bundle` Protocol. Pure container of the modules
+Boogu-Image-0.1 ships with: 1× vendored ``BooguImageTransformer2DModel`` (the
+10.29B Lumina-2-lineage single/double-stream DiT), 1× ``AutoencoderKL`` (the
+16-channel FLUX.1 VAE), 1× Qwen3-VL instruction encoder (the checkpoint's
+``mllm/`` subfolder) + its ``Qwen3VLProcessor`` (``processor/`` subfolder).
+
+Diverges from :class:`unirl.models.z_image.ZImageBundle` /
+:class:`unirl.models.qwen_image.QwenImageBundle` in three ways:
+
+- **Non-standard checkpoint subfolders**: the encoder lives under ``mllm/``
+  (not ``text_encoder/``) and the tokenizer side is a full processor under
+  ``processor/`` (not ``tokenizer/``). There is no ``tokenizer`` attribute —
+  the processor owns tokenization + chat templating.
+- **lm_head strip**: the reference pipeline reuses the encoder checkpoint as
+  an optional prompt rewriter, so ``mllm/`` may hold a full
+  ``Qwen3VLForConditionalGeneration``. Mirroring ``pipeline_boogu.py:194-198``,
+  the bundle keeps only the inner ``.model`` (``Qwen3VLModel``) when an
+  ``lm_head`` is present — conditioning uses hidden states only.
+- **No scheduler object**: the upstream time-shifting scheduler class is not
+  vendored; its released static-v1 schedule is expressed through
+  ``BooguImagePipeline.build_schedule_policy()`` (bagel precedent — the σ
+  math lives in the policy, not a diffusers scheduler instance).
+
+No LoRA injection, FSDP wrap, adapter switching, autocast helpers, or
+weight-sync logic — those are lifecycle concerns owned outside the bundle.
+
+Use :meth:`BooguImageBundle.from_config` to load a checkpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+
+from unirl.models.types.bundle import Bundle
+from unirl.models.types.meta_init import finalize_meta_init
+from unirl.utils.dtypes import parse_torch_dtype
+
+from .config import BooguImagePipelineConfig
+from .vendor import BooguImageTransformer2DModel
+
+logger = logging.getLogger(__name__)
+
+
+def _swap_attention_processors_to_flash(transformer: nn.Module) -> int:
+    """Swap the pinned SDPA attention processors for their Flash2Varlen
+    twins (identical parameter names, so ``load_state_dict`` transfers the
+    double-stream QKV weights losslessly). Returns the swap count.
+
+    Meta-built modules are swapped structurally with no state transfer —
+    the post-shard checkpoint load fills the fresh processors.
+    """
+    from .vendor.attention_processor import (
+        BooguImageAttnProcessor,
+        BooguImageAttnProcessorFlash2Varlen,
+        BooguImageDoubleStreamSelfAttnProcessor,
+        BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen,
+    )
+
+    count = 0
+    for module in transformer.modules():
+        processor = getattr(module, "processor", None)
+        if isinstance(processor, BooguImageDoubleStreamSelfAttnProcessor):
+            fresh = BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen(
+                head_dim=processor.head_dim,
+                num_attention_heads=processor.num_attention_heads,
+                num_kv_heads=processor.num_kv_heads,
+                qkv_bias=False,
+            )
+            params = list(processor.parameters())
+            if params and not params[0].is_meta:
+                fresh.load_state_dict(processor.state_dict())
+                fresh = fresh.to(device=params[0].device, dtype=params[0].dtype)
+            module.set_processor(fresh)
+            count += 1
+        elif isinstance(processor, BooguImageAttnProcessor):
+            module.set_processor(BooguImageAttnProcessorFlash2Varlen())
+            count += 1
+    return count
+
+
+class BooguImageBundle(Bundle):
+    """Boogu-Image bundle: vendored DiT + FLUX VAE + Qwen3-VL encoder + processor."""
+
+    def __init__(
+        self,
+        *,
+        transformer: nn.Module,
+        vae: nn.Module,
+        text_encoder: Optional[nn.Module],
+        processor: Any,
+        dtype: torch.dtype,
+        device: torch.device,
+        pretrained_path: str,
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.vae = vae
+        self.text_encoder = text_encoder
+        self.processor = processor
+        self.dtype = dtype
+        self.device = device
+        self.pretrained_path = pretrained_path
+
+    @classmethod
+    def from_config(cls, config: BooguImagePipelineConfig) -> "BooguImageBundle":
+        """Load all Boogu-Image components from a HuggingFace-layout checkpoint.
+
+        Honors per-component path overrides (``vae_ckpt_path`` /
+        ``text_encoder_ckpt_path``); both default to
+        ``pretrained_model_ckpt_path``.
+        """
+
+        import fcntl
+
+        # Node-local load serialization (qwen_image precedent): 8 colocated
+        # ranks each stage ~20 GiB (10.29B DiT) + ~17 GiB (Qwen3-VL-8B)
+        # while materializing; the simultaneous burst can blow the pod memcg.
+        # DIFFRL_MODEL_LOAD_SERIALIZE=0 opts out (single-rank runs).
+        serialize = os.environ.get("DIFFRL_MODEL_LOAD_SERIALIZE", "1") != "0"
+        lock_file = open("/tmp/diffrl_model_load.lock", "a+") if serialize else None
+        if lock_file is not None:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            return cls._from_config_locked(config)
+        finally:
+            if lock_file is not None:
+                import gc
+
+                gc.collect()
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+                lock_file.close()
+
+    @classmethod
+    def _from_config_locked(cls, config: BooguImagePipelineConfig) -> "BooguImageBundle":
+        from diffusers import AutoencoderKL
+        from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
+
+        path = config.pretrained_model_ckpt_path
+        vae_path = config.vae_ckpt_path or path
+        text_encoder_path = config.text_encoder_ckpt_path or path
+
+        device = config.device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if isinstance(device, str):
+            device = torch.device(device)
+
+        dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
+        vae_raw = config.vae_dtype if config.vae_dtype is not None else config.model_precision
+        vae_dtype = parse_torch_dtype(vae_raw, field_name="vae_dtype")
+        te_raw = config.text_encoder_dtype if config.text_encoder_dtype is not None else config.model_precision
+        te_dtype = parse_torch_dtype(te_raw, field_name="text_encoder_dtype")
+
+        if config.meta_init_transformer:
+            # Architecture only, on the meta device; the backend materializes
+            # per-rank shards after wrapping and loads weights from the
+            # stashed path. Boogu's vendored tree has zero registered buffers
+            # and zero init-computed plain-tensor attrs (rope freqs_cis is a
+            # per-call input), so this is the trivial finalize_meta_init case
+            # — its non-persistent-buffer warning must come out EMPTY; if it
+            # ever fires after a re-vendor, that is the signal to add a
+            # stamp_init_state_restore quirk fix.
+            transformer_config = BooguImageTransformer2DModel.load_config(path, subfolder="transformer")
+            with torch.device("meta"):
+                transformer = BooguImageTransformer2DModel.from_config(transformer_config)
+            transformer = finalize_meta_init(transformer, dtype=dtype)
+        else:
+            transformer = BooguImageTransformer2DModel.from_pretrained(
+                path, subfolder="transformer", torch_dtype=dtype
+            ).to(device)
+
+        if bool(getattr(transformer, "enable_teacache", False)) or bool(
+            getattr(transformer, "enable_taylorseer", False)
+        ):
+            raise RuntimeError(
+                "BooguImageBundle: transformer loaded with TeaCache/TaylorSeer "
+                "enabled — RL rollout/replay must be cache-free."
+            )
+        if config.attention_backend == "flash2_varlen":
+            swapped = _swap_attention_processors_to_flash(transformer)
+            logger.info("attention_backend=flash2_varlen: swapped %d processor(s)", swapped)
+
+        vae = AutoencoderKL.from_pretrained(vae_path, subfolder="vae", torch_dtype=vae_dtype).to(device).eval()
+        vae.requires_grad_(False)
+
+        # Separate-engine recipes can skip the frozen encoder copy on actors
+        # that never embed text (qwen_image precedent).
+        text_encoder = None
+        processor = None
+        if config.load_text_encoder:
+            # ``mllm/`` may ship the full CausalLM wrapper (reused upstream as
+            # a prompt rewriter). Conditioning uses hidden states only, so
+            # keep the inner ``Qwen3VLModel`` and free the wrapper/lm_head
+            # (mirrors pipeline_boogu.py:194-198).
+            wrapper = Qwen3VLForConditionalGeneration.from_pretrained(
+                text_encoder_path, subfolder="mllm", torch_dtype=te_dtype
+            )
+            text_encoder = wrapper.model if hasattr(wrapper, "lm_head") else wrapper
+            del wrapper
+            text_encoder = text_encoder.to(device).eval()
+            text_encoder.requires_grad_(False)
+
+            processor = AutoProcessor.from_pretrained(text_encoder_path, subfolder="processor")
+
+        bundle = cls(
+            transformer=transformer,
+            vae=vae,
+            text_encoder=text_encoder,
+            processor=processor,
+            dtype=dtype,
+            device=device,
+            pretrained_path=path,
+        )
+        if config.meta_init_transformer:
+            # Consumed by the backends' post-wrap sharded weight load.
+            bundle._transformer_weights_path = os.path.join(path, "transformer")
+        return bundle
+
+
+__all__ = ["BooguImageBundle"]

--- a/unirl/models/boogu_image/conditions.py
+++ b/unirl/models/boogu_image/conditions.py
@@ -10,8 +10,8 @@ consumes directly (no unpad/repack — see ``BooguImageTextEmbedStage``).
 
 The CFG negative branch is a sibling ``negative_text`` field so the schema
 is honest about which slots travel on the wire — a reader of
-``RolloutResp.tracks["image"].conditions`` sees ``"text"`` and
-``"negative_text"`` as two equal-status entries.
+``Part.conditions`` sees ``"text"`` and ``"negative_text"`` as two
+equal-status entries.
 """
 
 from __future__ import annotations
@@ -55,7 +55,7 @@ class BooguImageConditions(Batch):
 
     def to_dict(self) -> Dict[str, Condition]:
         """Convert back to the generic ``Conditions`` dict shape for
-        packing into ``RolloutResp.tracks["image"].conditions``.
+        packing into ``Part.conditions``.
 
         Emits ``"negative_text"`` only when ``negative_text is not None``
         so the dict shape stays minimal for CFG-off rollouts.

--- a/unirl/models/boogu_image/conditions.py
+++ b/unirl/models/boogu_image/conditions.py
@@ -1,0 +1,71 @@
+"""BooguImageConditions — typed conditions container for Boogu-Image diffusion.
+
+Concrete instantiation of the ``DiffusionStage[C]`` type parameter.
+Mirrors :class:`unirl.models.z_image.ZImageConditions`: text + optional
+negative_text, both as :class:`TextEmbedCondition` instances. Boogu-Image
+does not emit a ``pooled`` text vector, so ``TextEmbedCondition.pooled`` is
+always ``None``; the ``attn_mask`` field carries the right-padded
+chat-template token mask that the transformer's variable-length attention
+consumes directly (no unpad/repack — see ``BooguImageTextEmbedStage``).
+
+The CFG negative branch is a sibling ``negative_text`` field so the schema
+is honest about which slots travel on the wire — a reader of
+``RolloutResp.tracks["image"].conditions`` sees ``"text"`` and
+``"negative_text"`` as two equal-status entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from unirl.distributed.tensor.batch import Batch, FieldKind, field
+from unirl.types.conditions import Condition, TextEmbedCondition
+
+
+@dataclass
+class BooguImageConditions(Batch):
+    """Typed conditions container for Boogu-Image diffusion."""
+
+    text: Optional[TextEmbedCondition] = field(kind=FieldKind.CONCAT, default=None)
+    negative_text: Optional[TextEmbedCondition] = field(kind=FieldKind.CONCAT, default=None)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Condition]) -> "BooguImageConditions":
+        """Build from the generic ``Conditions`` dict shape.
+
+        Validates that the ``"text"`` slot is present and is a
+        ``TextEmbedCondition``. The ``"negative_text"`` slot is optional;
+        when absent the result has ``negative_text=None`` (CFG-off).
+        """
+        text = d.get("text")
+        if not isinstance(text, TextEmbedCondition):
+            raise TypeError(
+                f"BooguImageConditions.from_dict: expected d['text'] to be a "
+                f"TextEmbedCondition, got "
+                f"{type(text).__name__ if text is not None else 'None'}"
+            )
+        negative_text = d.get("negative_text")
+        if negative_text is not None and not isinstance(negative_text, TextEmbedCondition):
+            raise TypeError(
+                f"BooguImageConditions.from_dict: expected d['negative_text'] to be a "
+                f"TextEmbedCondition or absent, got {type(negative_text).__name__}"
+            )
+        return cls(text=text, negative_text=negative_text)
+
+    def to_dict(self) -> Dict[str, Condition]:
+        """Convert back to the generic ``Conditions`` dict shape for
+        packing into ``RolloutResp.tracks["image"].conditions``.
+
+        Emits ``"negative_text"`` only when ``negative_text is not None``
+        so the dict shape stays minimal for CFG-off rollouts.
+        """
+        if self.text is None:
+            raise ValueError("BooguImageConditions.to_dict: text field is None")
+        out: Dict[str, Condition] = {"text": self.text}
+        if self.negative_text is not None:
+            out["negative_text"] = self.negative_text
+        return out
+
+
+__all__ = ["BooguImageConditions"]

--- a/unirl/models/boogu_image/config.py
+++ b/unirl/models/boogu_image/config.py
@@ -81,6 +81,9 @@ class BooguImagePipelineConfig:
     # on actors that never embed text (qwen_image precedent).
     load_text_encoder: bool = True
 
+    # Trainer-side VAE. False for separate-engine recipes (engine owns decode).
+    load_vae: bool = True
+
     # Build the 10.29B DiT on the meta device and materialize per-rank
     # shards after FSDP wrapping (avoids the per-rank full-model load
     # spike). Boogu's transformer has no registered buffers or

--- a/unirl/models/boogu_image/config.py
+++ b/unirl/models/boogu_image/config.py
@@ -1,0 +1,105 @@
+"""Construction config for the typed Boogu-Image pipeline.
+
+Sibling of :class:`unirl.models.z_image.ZImagePipelineConfig` and
+:class:`unirl.models.qwen_image.QwenImagePipelineConfig`. Carries
+weights+precision knobs only; LoRA injection, FSDP wrapping, gradient
+checkpointing, and offload control all live in the training backend config —
+the bundle is weights+params only.
+
+``shift`` lives here so the hosting engine can build the
+:class:`FlowMatchSchedulePolicy` at startup. The released
+``Boogu-Image-0.1-Base`` scheduler config is a **static** v1 time shift
+(``do_shift: true, dynamic_time_shift: false, time_shift_version: "v1",
+seq_len: 4096``). Boogu's v1 logistic time shift over ``t`` is algebraically
+identical to the standard static sigma shift
+``σ' = s·σ / (1 + (s−1)·σ)`` with ``s = e^μ`` and
+``μ = lin(seq_len)`` where ``lin`` maps 256→0.5, 4096→1.15 — so the released
+checkpoint's schedule is exactly UniRL's static shift with
+``s = e^1.15 = 3.158192909689768`` (verified to 1 fp32 ulp against the
+reference scheduler). :meth:`BooguImagePipeline.build_schedule_policy` pins
+the static posture from this value.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from unirl.config.validation import validate_precision_type
+
+# e^{1.15}: the released Base checkpoint's static-v1 shift (seq_len=4096).
+BOOGU_IMAGE_BASE_STATIC_SHIFT = 3.158192909689768
+
+_ATTENTION_BACKENDS = ("sdpa", "flash2_varlen")
+
+
+@dataclass
+class BooguImagePipelineConfig:
+    """Construction args for ``BooguImagePipeline.from_config``.
+
+    ``device`` may be runtime-injected by the actor after compose; the
+    other fields are set at compose time and read once during pipeline
+    construction.
+    """
+
+    pretrained_model_ckpt_path: str
+    vae_ckpt_path: Optional[str] = None
+    # Covers BOTH the ``mllm/`` (Qwen3-VL encoder) and ``processor/``
+    # checkpoint subfolders; defaults to ``pretrained_model_ckpt_path``.
+    text_encoder_ckpt_path: Optional[str] = None
+    vae_dtype: Any = None
+    text_encoder_dtype: Any = None
+    model_precision: Any = "bf16"
+    device: Any = None
+
+    # Stage-level precision / numerical policy. Lives here (not on
+    # DiffusionSamplingParams) because these are operator/runtime knobs,
+    # not per-request shape.
+    autocast_precision: str = "bf16"
+    trajectory_precision: str = "fp16"
+    logprob_precision: str = "fp32"
+
+    # Static FlowMatch shift. See the module docstring for the e^{1.15}
+    # derivation from the released static-v1 scheduler config.
+    shift: float = BOOGU_IMAGE_BASE_STATIC_SHIFT
+
+    # Trainer-side policy wraps the bare DiT, while engines load it under
+    # the pipeline's ``transformer.*`` namespace.
+    weight_sync_param_name_prefix: str = "transformer."
+
+    # Token budget for the Qwen3-VL chat-template encoder. The reference
+    # ``__call__`` passes ``max_sequence_length=1280`` with truncation off;
+    # the processor pads to the batch-longest under this cap.
+    max_sequence_length: int = 1280
+
+    # LoRA hints for rollout-side engines. The trainer-side LoRA injection
+    # lives in the backend config.
+    use_lora: bool = False
+    lora_target_modules: Optional[List[str]] = None
+
+    # Separate-engine recipes can skip loading the frozen Qwen3-VL encoder
+    # on actors that never embed text (qwen_image precedent).
+    load_text_encoder: bool = True
+
+    # Build the 10.29B DiT on the meta device and materialize per-rank
+    # shards after FSDP wrapping (avoids the per-rank full-model load
+    # spike). Boogu's transformer has no registered buffers or
+    # init-computed plain tensors, so this is the trivial
+    # ``finalize_meta_init`` case.
+    meta_init_transformer: bool = False
+
+    # Vendored attention processors are pinned to SDPA; "flash2_varlen"
+    # requests a post-load processor swap (identical parameter names, so
+    # checkpoints/LoRA are backend-independent).
+    attention_backend: str = "sdpa"
+
+    def __post_init__(self) -> None:
+        validate_precision_type(self.model_precision, field="BooguImagePipelineConfig.model_precision")
+        if self.attention_backend not in _ATTENTION_BACKENDS:
+            raise ValueError(
+                f"BooguImagePipelineConfig.attention_backend must be one of "
+                f"{_ATTENTION_BACKENDS}, got {self.attention_backend!r}"
+            )
+
+
+__all__ = ["BooguImagePipelineConfig", "BOOGU_IMAGE_BASE_STATIC_SHIFT"]

--- a/unirl/models/boogu_image/diffusion.py
+++ b/unirl/models/boogu_image/diffusion.py
@@ -368,8 +368,8 @@ class BooguImageDiffusionStage(DiffusionStage[BooguImageConditions]):
     ) -> LatentSegment:
         """Run full Boogu-Image sampling. Returns a ``LatentSegment``.
 
-        ``initial_latents`` (optional) — driver-shipped x_T per
-        ``req.request_conditions['initial_latents']``.
+        ``initial_latents`` (optional) — x_T resolved from the request
+        ``Sample``'s diffusion generation Part.
         """
         from unirl.sde.noise import generate_latents
 

--- a/unirl/models/boogu_image/diffusion.py
+++ b/unirl/models/boogu_image/diffusion.py
@@ -150,9 +150,7 @@ class BooguImageDiffusionStep(DiffusionStep[BooguImageBundle, BooguImageConditio
         if use_cfg:
             neg = conditions.negative_text
             if neg.embeds is None or neg.attn_mask is None:
-                raise ValueError(
-                    "BooguImageDiffusionStep.predict_noise: negative_text embeds/attn_mask is None"
-                )
+                raise ValueError("BooguImageDiffusionStep.predict_noise: negative_text embeds/attn_mask is None")
             neg_out = model.transformer(
                 sample,
                 timestep,
@@ -341,9 +339,7 @@ class BooguImageDiffusionStage(DiffusionStage[BooguImageConditions]):
         return self._freqs_cis
 
     @staticmethod
-    def _effective_guidance_scale(
-        step_index: int, num_steps: int, params: DiffusionSamplingParams
-    ) -> float:
+    def _effective_guidance_scale(step_index: int, num_steps: int, params: DiffusionSamplingParams) -> float:
         """Collapse the reference's ``cfg_range`` step-fraction gate into a
         per-step scale (pipeline_boogu.py:3367-3381, inclusive bounds; the
         out-of-range value is 1.0 == CFG off in Boogu's convention).
@@ -384,9 +380,7 @@ class BooguImageDiffusionStage(DiffusionStage[BooguImageConditions]):
         batch_size = int(prompt_embeds.shape[0])
         T = int(params.num_inference_steps)
         if int(schedule.shape[0]) != T + 1:
-            raise ValueError(
-                f"BooguImageDiffusionStage.diffuse: schedule length {schedule.shape[0]} != T+1={T + 1}"
-            )
+            raise ValueError(f"BooguImageDiffusionStage.diffuse: schedule length {schedule.shape[0]} != T+1={T + 1}")
         schedule = schedule.to(device)
         self.strategy.init_schedule(schedule)
 
@@ -517,8 +511,7 @@ class BooguImageDiffusionStage(DiffusionStage[BooguImageConditions]):
         bad = [i for i in target if i not in sde_set]
         if bad:
             raise ValueError(
-                f"BooguImageDiffusionStage.replay: step_indices {bad} not in "
-                f"segment.sde_indices={sorted(sde_set)}"
+                f"BooguImageDiffusionStage.replay: step_indices {bad} not in segment.sde_indices={sorted(sde_set)}"
             )
 
         device = torch.device(self.model.device)

--- a/unirl/models/boogu_image/diffusion.py
+++ b/unirl/models/boogu_image/diffusion.py
@@ -1,0 +1,612 @@
+"""Boogu-Image diffusion: per-step kernel + rollout-level stage.
+
+Two classes mirror :mod:`unirl.models.z_image.diffusion`:
+
+- :class:`BooguImageDiffusionStep` — stateless per-step kernel. Wraps
+  :meth:`predict_noise` (which adapts the vendored
+  ``BooguImageTransformer2DModel`` forward to the framework's batched
+  ``[B, C, H, W]`` SDE math) around ``StepStrategy.denoise``. The
+  protocol-matching ``forward`` / ``step`` / ``step_with_logp`` ride on top.
+- :class:`BooguImageDiffusionStage` — implements
+  ``DiffusionStage[BooguImageConditions]``. Owns the SDE strategy, the loop
+  bookkeeping, and the cached rotary tables; segment latents stay in spatial
+  ``[B, C, H, W]`` so :class:`BooguImageVAEDecodeStage` reads them directly.
+
+Transformer adapter
+-------------------
+The vendored DiT consumes batched 4D latents directly (it lifts to a
+per-sample list internally for variable-length packing). :meth:`predict_noise`:
+
+1. passes ``t = 1 - sigma`` as the timestep in **model dtype** (the reference
+   ``predict`` does ``t.expand(B).to(latents.dtype)``; the transformer scales
+   by ``timestep_scale=1000`` internally);
+2. forwards positionally per the reference
+   (``transformer(latents, timestep, instruction_embeds, freqs_cis,
+   instruction_attention_mask, ref_image_hidden_states=None)``) — the
+   default ``return_dict=False`` returns a **bare tensor**, not a tuple
+   (indexing ``[0]`` would take sample 0 of the batch);
+3. applies CFG with Boogu's convention — gate ``guidance_scale > 1.0``
+   (1.0 == off), a **second sequential forward** on the negative branch
+   (the reference runs branches sequentially; positive/negative embeds are
+   padded to different lengths), plain linear combine
+   ``out + (g - 1) * (out - neg_out)`` with no norm correction;
+4. **negates** the result: Boogu integrates ``x += (t_next - t)·v`` in the
+   t-convention (t = 1 - σ, toward data), so the σ-convention FlowMatch
+   velocity ``FlowSDEStrategy`` expects is ``-v`` (z_image precedent).
+
+Rotary tables (``freqs_cis``) are the reference pipeline's per-call input:
+built once from ``(axes_dim_rope, axes_lens, theta=10000)`` — resolution
+independent — and cached per device on the stage.
+
+CFG range
+---------
+The reference gates guidance by step fraction (``cfg_range``,
+pipeline_boogu.py:3367-3381; default ``(0, 1)`` == always on). The stage
+collapses that into a per-step *effective* guidance scale
+(:meth:`BooguImageDiffusionStage._effective_guidance_scale`); scale 1.0 makes
+the kernel skip the negative forward exactly like the reference's skipped
+branch. ``cfg_range`` rides in ``DiffusionSamplingParams.sampler_kwargs``.
+
+Math mirrors the reference ``BooguImagePipeline.processing`` T2I denoising
+loop (pipeline_boogu.py:3243-3688).
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import ClassVar, List, Optional, Set, Tuple
+
+import torch
+
+from unirl.models.types.diffusion import DiffusionStage, DiffusionStep
+from unirl.models.types.replay_result import ReplayResult
+from unirl.sde.kernels import StepStrategy
+from unirl.types.sampling import DiffusionSamplingParams, compute_trajectory_positions
+from unirl.types.segments.latent import LatentSegment
+from unirl.utils.dtypes import parse_torch_dtype
+
+from .bundle import BooguImageBundle
+from .conditions import BooguImageConditions
+from .vendor.rope import BooguImageRotaryPosEmbed
+
+
+def build_freqs_cis(transformer_config, device: torch.device) -> List[torch.Tensor]:
+    """Build the reference pipeline's rotary tables for the vendored DiT.
+
+    Depends only on ``(axes_dim_rope, axes_lens, theta)`` — resolution
+    independent; the per-(H, W) position gather happens inside the
+    transformer's ``rope_embedder``. Mirrors the reference ``__call__``
+    (pipeline_boogu.py:2896-2900).
+    """
+    tables = BooguImageRotaryPosEmbed.get_freqs_cis(
+        list(transformer_config.axes_dim_rope),
+        list(transformer_config.axes_lens),
+        theta=10000,
+    )
+    return [t.to(device) for t in tables]
+
+
+class BooguImageDiffusionStep(DiffusionStep[BooguImageBundle, BooguImageConditions]):
+    """Per-step Boogu-Image denoising kernel — stateless."""
+
+    def predict_noise(
+        self,
+        model: BooguImageBundle,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        conditions: BooguImageConditions,
+        *,
+        guidance_scale: float,
+        freqs_cis: Optional[List[torch.Tensor]] = None,
+    ) -> torch.Tensor:
+        """Run the vendored DiT and return the FlowMatch velocity
+        ``[B, C, H, W]`` (negated model output, with Boogu's text CFG applied
+        when ``guidance_scale > 1.0``)."""
+        if conditions.text is None or conditions.text.embeds is None:
+            raise ValueError("BooguImageDiffusionStep.predict_noise: conditions.text is None")
+
+        dev = model.device
+        try:
+            model_dtype = next(model.transformer.parameters()).dtype
+        except StopIteration:
+            model_dtype = sample.dtype
+        sample = sample.to(device=dev, dtype=model_dtype)
+        sigma = sigma.to(dev)
+
+        batch_size = int(sample.shape[0])
+        # Boogu timestep input: t = 1 - sigma, in MODEL dtype (the reference
+        # predict() does t.expand(B).to(latents.dtype); timestep_scale=1000
+        # is applied inside the transformer).
+        if sigma.dim() == 0 or sigma.shape[0] != batch_size:
+            timestep = (1.0 - sigma).expand(batch_size)
+        else:
+            timestep = 1.0 - sigma
+        timestep = timestep.to(device=dev, dtype=model_dtype)
+
+        if freqs_cis is None:
+            freqs_cis = build_freqs_cis(model.transformer.config, dev)
+
+        embeds = conditions.text.embeds.to(device=dev, dtype=model_dtype)
+        mask = conditions.text.attn_mask
+        if mask is None:
+            raise ValueError("BooguImageDiffusionStep.predict_noise: conditions.text.attn_mask is None")
+        mask = mask.to(dev)
+
+        # Bare-tensor return: the vendored forward defaults return_dict=False
+        # and returns [B, C, H, W] directly — no `[0]` indexing.
+        out = model.transformer(
+            sample,
+            timestep,
+            embeds,
+            freqs_cis,
+            mask,
+            ref_image_hidden_states=None,
+        )
+
+        # Boogu CFG gate: 1.0 == off (unlike z_image's 0.0). Sequential
+        # negative forward — positive/negative embeds are padded to
+        # different lengths, and the reference runs branches sequentially.
+        use_cfg = guidance_scale > 1.0 and conditions.negative_text is not None
+        if use_cfg:
+            neg = conditions.negative_text
+            if neg.embeds is None or neg.attn_mask is None:
+                raise ValueError(
+                    "BooguImageDiffusionStep.predict_noise: negative_text embeds/attn_mask is None"
+                )
+            neg_out = model.transformer(
+                sample,
+                timestep,
+                neg.embeds.to(device=dev, dtype=model_dtype),
+                freqs_cis,
+                neg.attn_mask.to(dev),
+                ref_image_hidden_states=None,
+            )
+            # Reference combine (pipeline_boogu.py:3646-3649), plain linear:
+            # model_pred + (g - 1) * (model_pred - model_pred_drop_all).
+            out = out + (guidance_scale - 1.0) * (out - neg_out)
+        elif guidance_scale > 1.0:
+            raise ValueError(
+                "BooguImageDiffusionStep.predict_noise: guidance_scale > 1.0 "
+                "but conditions.negative_text is None — the pipeline should "
+                "have built ''-negatives"
+            )
+
+        # t-convention velocity -> sigma-convention FlowMatch velocity.
+        return -out
+
+    # ---- Protocol surface ---------------------------------------------------
+
+    def forward(
+        self,
+        *,
+        strategy: StepStrategy,
+        noise_pred: torch.Tensor,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        prev_sample: Optional[torch.Tensor] = None,
+        sigma_max: float = 0.99,
+        eta: float = 1.0,
+        step_index: int = 0,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Run one SDE transition given a precomputed ``noise_pred``."""
+        return strategy.denoise(
+            noise_pred=noise_pred,
+            sample=sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            eta=eta,
+            prev_sample=prev_sample,
+            sigma_max=sigma_max,
+            step_index=step_index,
+        )
+
+    def step(
+        self,
+        model: BooguImageBundle,
+        conditions: BooguImageConditions,
+        *,
+        strategy: StepStrategy,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        guidance_scale: float,
+        prev_sample: Optional[torch.Tensor] = None,
+        sigma_max: float = 0.99,
+        eta: float = 1.0,
+        step_index: int = 0,
+        freqs_cis: Optional[List[torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Run model forward + SDE transition. End-to-end one diffusion step."""
+        noise_pred = self.predict_noise(
+            model,
+            sample,
+            sigma,
+            conditions,
+            guidance_scale=guidance_scale,
+            freqs_cis=freqs_cis,
+        )
+        return self.forward(
+            strategy=strategy,
+            noise_pred=noise_pred,
+            sample=sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            prev_sample=prev_sample,
+            sigma_max=sigma_max,
+            eta=eta,
+            step_index=step_index,
+        )
+
+    def step_with_logp(
+        self,
+        model: BooguImageBundle,
+        conditions: BooguImageConditions,
+        *,
+        strategy: StepStrategy,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        sigma_next: torch.Tensor,
+        guidance_scale: float,
+        prev_sample: Optional[torch.Tensor] = None,
+        sigma_max: float = 0.99,
+        eta: float = 1.0,
+        step_index: int = 0,
+        freqs_cis: Optional[List[torch.Tensor]] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Run model forward + SDE transition.
+
+        Returns ``(prev_sample, log_prob, prev_sample_mean)``. ``log_prob``
+        and ``prev_sample_mean`` are ``None`` for deterministic strategies.
+        """
+        return self.step(
+            model,
+            conditions,
+            strategy=strategy,
+            sample=sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            guidance_scale=guidance_scale,
+            prev_sample=prev_sample,
+            sigma_max=sigma_max,
+            eta=eta,
+            step_index=step_index,
+            freqs_cis=freqs_cis,
+        )
+
+
+class BooguImageDiffusionStage(DiffusionStage[BooguImageConditions]):
+    """Boogu-Image rollout-level diffusion stage.
+
+    Owns the SDE ``strategy``, the bundle, the stateless kernel, the
+    precision policy, and the per-device rotary-table cache.
+
+    Segment latents stay in spatial ``[B, C, H, W]`` (standard 2D FLUX
+    ``AutoencoderKL``), so :class:`BooguImageVAEDecodeStage` reads
+    ``segment.latents[:, -1]`` without per-shape handling.
+
+    ``_no_split_modules`` is the model-side fallback used by FSDPPolicy when
+    HF auto-discovery yields nothing. NOTE: FSDP wrap matching is by exact
+    concrete class name — recipes must list the five INSTANTIATED block
+    classes (the bare ``BooguImageTransformerBlock`` is never instantiated,
+    and ``BooguImageDoubleStreamTransformerBlock`` is a separate class, not
+    a subclass).
+    """
+
+    _no_split_modules: ClassVar[Tuple[str, ...]] = (
+        "BooguImageTransformerBlock",
+        "BooguImageNoiseRefinerTransformerBlock",
+        "BooguImageRefImgRefinerTransformerBlock",
+        "BooguImageContextRefinerTransformerBlock",
+        "BooguImageSingleStreamTransformerBlock",
+        "BooguImageDoubleStreamTransformerBlock",
+    )
+
+    def __init__(
+        self,
+        *,
+        model: BooguImageBundle,
+        step: BooguImageDiffusionStep,
+        strategy: StepStrategy,
+        autocast_precision: str = "bf16",
+        trajectory_precision: str = "fp16",
+        logprob_precision: str = "fp32",
+        vae_scale_factor: int = 8,
+        latent_channels: Optional[int] = None,
+    ) -> None:
+        self.model = model
+        self.step = step
+        self.strategy = strategy
+        self.autocast_dtype = parse_torch_dtype(autocast_precision, field_name="autocast_precision")
+        self.trajectory_dtype = parse_torch_dtype(trajectory_precision, field_name="trajectory_precision")
+        self.logprob_dtype = parse_torch_dtype(logprob_precision, field_name="logprob_precision")
+        self.vae_scale_factor = vae_scale_factor
+        if latent_channels is None:
+            tx_cfg = getattr(model.transformer, "config", None)
+            in_channels = getattr(tx_cfg, "in_channels", 16) if tx_cfg is not None else 16
+            latent_channels = int(in_channels)
+        self.latent_channels = int(latent_channels)
+        self._freqs_cis: Optional[List[torch.Tensor]] = None
+        self._freqs_cis_device: Optional[torch.device] = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_freqs_cis(self, device: torch.device) -> List[torch.Tensor]:
+        """Per-device cache of the resolution-independent rotary tables."""
+        if self._freqs_cis is None or self._freqs_cis_device != device:
+            self._freqs_cis = build_freqs_cis(self.model.transformer.config, device)
+            self._freqs_cis_device = device
+        return self._freqs_cis
+
+    @staticmethod
+    def _effective_guidance_scale(
+        step_index: int, num_steps: int, params: DiffusionSamplingParams
+    ) -> float:
+        """Collapse the reference's ``cfg_range`` step-fraction gate into a
+        per-step scale (pipeline_boogu.py:3367-3381, inclusive bounds; the
+        out-of-range value is 1.0 == CFG off in Boogu's convention).
+
+        ``cfg_range`` rides in ``params.sampler_kwargs``; the default
+        ``(0.0, 1.0)`` keeps guidance on at every step. Deterministic in
+        ``(step_index, num_steps)``, so replay reproduces rollout exactly.
+        """
+        lo, hi = params.sampler_kwargs.get("cfg_range", (0.0, 1.0))
+        fraction = step_index / num_steps if num_steps > 0 else 0.0
+        if float(lo) <= fraction <= float(hi):
+            return float(params.guidance_scale)
+        return 1.0
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+
+    def diffuse(
+        self,
+        conditions: BooguImageConditions,
+        *,
+        schedule: torch.Tensor,
+        params: DiffusionSamplingParams,
+        initial_latents: Optional[torch.Tensor] = None,
+    ) -> LatentSegment:
+        """Run full Boogu-Image sampling. Returns a ``LatentSegment``.
+
+        ``initial_latents`` (optional) — driver-shipped x_T per
+        ``req.request_conditions['initial_latents']``.
+        """
+        from unirl.sde.noise import generate_latents
+
+        if conditions.text is None or conditions.text.embeds is None:
+            raise ValueError("BooguImageDiffusionStage.diffuse: conditions.text.embeds is None")
+        prompt_embeds = conditions.text.embeds
+        device = prompt_embeds.device
+        batch_size = int(prompt_embeds.shape[0])
+        T = int(params.num_inference_steps)
+        if int(schedule.shape[0]) != T + 1:
+            raise ValueError(
+                f"BooguImageDiffusionStage.diffuse: schedule length {schedule.shape[0]} != T+1={T + 1}"
+            )
+        schedule = schedule.to(device)
+        self.strategy.init_schedule(schedule)
+
+        # Latent grid: 2 * (H // (vae_scale_factor * 2)) — equals the
+        # reference's H // 8 after its ×16 pixel-size floor
+        # (pipeline_boogu.py:2994-2997, 863-867) and guarantees the patch-2
+        # divisibility flat_and_pad_to_seq needs.
+        vsf = int(self.vae_scale_factor)
+        latent_h = 2 * (int(params.height) // (vsf * 2))
+        latent_w = 2 * (int(params.width) // (vsf * 2))
+        expected_latent_shape = (int(self.latent_channels), latent_h, latent_w)
+        if initial_latents is not None:
+            if int(initial_latents.shape[0]) != batch_size:
+                raise ValueError(
+                    f"BooguImageDiffusionStage.diffuse: initial_latents.shape[0]="
+                    f"{int(initial_latents.shape[0])} != batch_size={batch_size}."
+                )
+            if tuple(initial_latents.shape[1:]) != expected_latent_shape:
+                raise ValueError(
+                    f"BooguImageDiffusionStage.diffuse: initial_latents.shape[1:]="
+                    f"{tuple(initial_latents.shape[1:])} != expected {expected_latent_shape} "
+                    f"for height={int(params.height)}, width={int(params.width)}."
+                )
+            latents = initial_latents.to(device=device, dtype=self.trajectory_dtype)
+        else:
+            latents = generate_latents(
+                batch_size=batch_size,
+                latent_shape=expected_latent_shape,
+                device=device,
+                dtype=self.trajectory_dtype,
+                init_same_noise=bool(params.init_same_noise),
+                samples_per_prompt=int(params.samples_per_prompt),
+                noise_group_ids=params.noise_group_ids,
+                base_seed=int(params.seed),
+            )
+
+        sde_set: Set[int] = set(int(i) for i in (params.sde_indices or []))
+        sde_sorted: List[int] = sorted(sde_set)
+
+        needed: Set[int] = set(compute_trajectory_positions(sde_set, T))
+        needed.add(T)
+
+        stored_pairs: List[Tuple[int, torch.Tensor]] = []
+        if 0 in needed:
+            stored_pairs.append((0, latents.detach().clone()))
+        sde_logp_list: List[torch.Tensor] = []
+
+        autocast_ctx = (
+            torch.autocast("cuda", self.autocast_dtype)
+            if device.type == "cuda" and self.autocast_dtype in (torch.float16, torch.bfloat16)
+            else nullcontext()
+        )
+        sigma_max = schedule[1].float() if int(schedule.shape[0]) > 1 else torch.tensor(0.99)
+
+        freqs_cis = self._get_freqs_cis(device)
+
+        for i in range(T):
+            sigma = schedule[i].to(device)
+            sigma_next = schedule[i + 1].to(device)
+            step_eta = float(params.eta) if i in sde_set else 0.0
+
+            with torch.no_grad(), autocast_ctx:
+                new_latents, log_prob, _ = self.step.step_with_logp(
+                    self.model,
+                    conditions,
+                    strategy=self.strategy,
+                    sample=latents,
+                    sigma=sigma,
+                    sigma_next=sigma_next,
+                    guidance_scale=self._effective_guidance_scale(i, T, params),
+                    eta=step_eta,
+                    sigma_max=sigma_max,
+                    step_index=i,
+                    freqs_cis=freqs_cis,
+                )
+            latents = new_latents.to(dtype=self.trajectory_dtype)
+
+            if (i + 1) in needed:
+                stored_pairs.append((i + 1, latents.detach().clone()))
+
+            if log_prob is not None:
+                sde_logp_list.append(log_prob.to(dtype=self.logprob_dtype))
+
+        positions_collected = [p for p, _ in stored_pairs]
+        latents_stacked = torch.stack([t for _, t in stored_pairs], dim=1)  # [B, K, C, H, W]
+
+        sde_logp = torch.stack(sde_logp_list, dim=1) if sde_logp_list else None
+        sde_indices_tensor = torch.tensor(sde_sorted, dtype=torch.long, device=device) if sde_sorted else None
+
+        indices_tensor = torch.tensor(positions_collected, dtype=torch.long, device=device)
+
+        return LatentSegment(
+            latents=latents_stacked,
+            sigmas=schedule,
+            indices=indices_tensor,
+            sde_logp=sde_logp,
+            sde_indices=sde_indices_tensor,
+        )
+
+    # ------------------------------------------------------------------
+    # Replay
+    # ------------------------------------------------------------------
+
+    def replay(
+        self,
+        conditions: BooguImageConditions,
+        *,
+        segment: LatentSegment,
+        params: DiffusionSamplingParams,
+        step_indices: Optional[List[int]] = None,
+    ) -> ReplayResult:
+        """Segment-based log-prob replay over the rollout's SDE transitions.
+
+        Caller is responsible for ``.train()`` mode + grad scope; this method
+        only manages the autocast scope.
+        """
+        if segment.sde_indices is None or segment.latents is None:
+            raise ValueError("BooguImageDiffusionStage.replay: segment.sde_indices / latents missing")
+        if segment.sigmas is None:
+            raise ValueError("BooguImageDiffusionStage.replay: segment.sigmas missing")
+
+        sde_set = set(int(i) for i in segment.sde_indices.tolist())
+        target = (
+            [int(i) for i in step_indices]
+            if step_indices is not None
+            else [int(i) for i in segment.sde_indices.tolist()]
+        )
+        bad = [i for i in target if i not in sde_set]
+        if bad:
+            raise ValueError(
+                f"BooguImageDiffusionStage.replay: step_indices {bad} not in "
+                f"segment.sde_indices={sorted(sde_set)}"
+            )
+
+        device = torch.device(self.model.device)
+        sigmas = segment.sigmas.to(device)
+        # The cfg_range fraction denominator is the rollout's step count,
+        # recovered from the stored schedule (T + 1 sigmas).
+        num_steps = int(sigmas.shape[0]) - 1
+        sigma_max = sigmas[1].float() if int(sigmas.shape[0]) > 1 else torch.tensor(0.99)
+
+        autocast_ctx = (
+            torch.autocast("cuda", self.autocast_dtype)
+            if device.type == "cuda" and self.autocast_dtype in (torch.float16, torch.bfloat16)
+            else nullcontext()
+        )
+        freqs_cis = self._get_freqs_cis(device)
+        log_probs: List[torch.Tensor] = []
+        prev_sample_means: List[torch.Tensor] = []
+        with autocast_ctx:
+            for step_idx in target:
+                sigma = sigmas[step_idx].to(dtype=torch.float32)
+                sigma_next = sigmas[step_idx + 1].to(dtype=torch.float32)
+                sample = segment.latents_at(step_idx).to(device)
+                prev_sample = segment.latents_at(step_idx + 1).to(device)
+                _, log_prob, prev_mean = self.step.step_with_logp(
+                    self.model,
+                    conditions,
+                    strategy=self.strategy,
+                    sample=sample,
+                    prev_sample=prev_sample,
+                    sigma=sigma,
+                    sigma_next=sigma_next,
+                    guidance_scale=self._effective_guidance_scale(step_idx, num_steps, params),
+                    eta=float(params.eta),
+                    sigma_max=sigma_max,
+                    step_index=step_idx,
+                    freqs_cis=freqs_cis,
+                )
+                if log_prob is None:
+                    raise RuntimeError(
+                        f"BooguImageDiffusionStage.replay: strategy returned None log-prob "
+                        f"at step_index={step_idx} (deterministic mode); replay "
+                        f"requires a stochastic SDE strategy."
+                    )
+                log_probs.append(log_prob)
+                if prev_mean is not None:
+                    prev_sample_means.append(prev_mean)
+
+        log_probs_t = torch.stack(log_probs, dim=1).to(dtype=self.logprob_dtype)
+        means_t = torch.stack(prev_sample_means, dim=1).to(dtype=self.trajectory_dtype) if prev_sample_means else None
+        return ReplayResult(log_probs=log_probs_t, prev_sample_means=means_t)
+
+    # ------------------------------------------------------------------
+    # Single-step noise prediction (forward-process algorithms: DiffusionNFT et al.)
+    # ------------------------------------------------------------------
+
+    def predict_noise_at_step(
+        self,
+        conditions: BooguImageConditions,
+        *,
+        sample: torch.Tensor,
+        sigma: torch.Tensor,
+        params: DiffusionSamplingParams,
+    ) -> torch.Tensor:
+        """Single ``(xt, sigma)`` model forward — no scheduler iteration.
+
+        Delegates to ``BooguImageDiffusionStep.predict_noise`` so CFG and
+        guidance handling stay identical to the sampling path. Forward-process
+        algorithms carry no loop index, so the ``cfg_range`` fraction gate is
+        not applied here (the default ``(0, 1)`` makes this moot).
+        """
+        return self.step.predict_noise(
+            self.model,
+            sample,
+            sigma,
+            conditions,
+            guidance_scale=float(params.guidance_scale),
+            freqs_cis=self._get_freqs_cis(torch.device(self.model.device)),
+        )
+
+    # ------------------------------------------------------------------
+    # Trainable surface for FSDPPolicy
+    # ------------------------------------------------------------------
+
+    def trainable_module(self) -> "torch.nn.Module":
+        """Return the module the diffusion forward operates on — the
+        bundle's vendored ``BooguImageTransformer2DModel`` (the FSDP wrap
+        target)."""
+        return self.model.transformer
+
+
+__all__ = ["BooguImageDiffusionStage", "BooguImageDiffusionStep", "build_freqs_cis"]

--- a/unirl/models/boogu_image/pipeline.py
+++ b/unirl/models/boogu_image/pipeline.py
@@ -1,0 +1,259 @@
+"""BooguImagePipeline — RolloutReq → RolloutResp end-to-end for Boogu-Image.
+
+Implements the four-tier flow::
+
+    Texts ──text_embed──▶ BooguImageConditions ──diffuse──▶ LatentSegment
+                                                                │
+                                                                ▼
+                                                            vae_decode
+                                                                │
+                                                                ▼
+                                                              Images
+
+Hydra constructs a pipeline via
+``BooguImagePipeline.from_config(BooguImagePipelineConfig)`` (see
+``config.py``); ``from_config`` loads the :class:`BooguImageBundle` then
+constructs the stages with the precision policy from the config.
+
+σ schedule contract
+-------------------
+The hosting engine (``TrainsideRolloutEngine``) pins ``req.sigmas`` via
+:func:`unirl.sde.runtime.ensure_req_sigmas` BEFORE calling ``generate(req)``;
+this pipeline reads ``req.sigmas`` verbatim. The released
+``Boogu-Image-0.1-Base`` scheduler config is a **static v1 time shift**
+(``do_shift: true, dynamic_time_shift: false, time_shift_version: "v1",
+seq_len: 4096``) whose sigma-space form is exactly the standard static shift
+``σ' = s·σ / (1 + (s−1)·σ)`` with ``s = e^{lin(seq_len)} = e^{1.15}``
+(verified to 1 fp32 ulp against the reference scheduler at N ∈ {12, 50}).
+:meth:`build_schedule_policy` pins that static posture from ``self.shift``
+— Boogu's ``scheduler_config.json`` uses custom field names that the base
+``FlowMatchSchedulePolicy.from_pretrained`` would silently ignore, so the
+config-pinned ``static_only`` posture (z_image / bagel precedent) is the
+safe wiring.
+
+CFG convention
+--------------
+Boogu's guidance-off value is ``guidance_scale = 1.0`` (the combine is
+``pred + (g−1)·(pred − pred_neg)``), so :meth:`build_conditions` gates the
+auto-``""`` negative on ``guidance_scale > 1.0`` — a deliberate divergence
+from z_image's ``> 0.0`` gate. The empty negative ``""`` is re-encoded
+through the chat template, where it routes to the DROP system prompt (see
+``text_embed.py``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Optional
+
+from unirl.models.types.pipeline import Pipeline
+from unirl.sde.kernels import FlowSDEStrategy, StepStrategy
+from unirl.types.noise_recipe import NoiseRecipe
+from unirl.types.primitives import Texts
+from unirl.types.rollout_req import RolloutReq
+from unirl.types.rollout_resp import RolloutResp, RolloutTrack
+from unirl.types.sampling import DiffusionSamplingParams
+
+from .bundle import BooguImageBundle
+from .conditions import BooguImageConditions
+from .config import BOOGU_IMAGE_BASE_STATIC_SHIFT, BooguImagePipelineConfig
+from .diffusion import BooguImageDiffusionStage, BooguImageDiffusionStep
+from .text_embed import BooguImageTextEmbedStage
+from .vae import BooguImageVAEDecodeStage
+
+
+class BooguImagePipeline(Pipeline):
+    """Boogu-Image generate pipeline.
+
+    Reads from ``RolloutReq``:
+
+    - ``primitives["text"]: Texts`` — required prompts.
+    - ``primitives["negative_text"]: Texts`` — optional CFG negatives.
+    - ``sampling_params["diffusion"]`` — diffusion sampling params.
+    - ``sigmas: Tensor[T+1]`` — pinned by the engine adapter (required).
+
+    Writes to ``RolloutResp`` (single ``"image"`` track):
+
+    - ``conditions["text"]: TextEmbedCondition``; plus
+      ``conditions["negative_text"]`` when negatives were supplied/built.
+    - ``segment: LatentSegment``.
+    - ``decoded: Images``.
+    """
+
+    def __init__(
+        self,
+        *,
+        bundle: BooguImageBundle,
+        text_embed: Optional[BooguImageTextEmbedStage] = None,
+        diffusion: Optional[BooguImageDiffusionStage] = None,
+        vae_decode: Optional[BooguImageVAEDecodeStage] = None,
+        strategy: Optional[StepStrategy] = None,
+        shift: float = BOOGU_IMAGE_BASE_STATIC_SHIFT,
+        autocast_precision: str = "bf16",
+        trajectory_precision: str = "fp16",
+        logprob_precision: str = "fp32",
+        max_sequence_length: int = 1280,
+    ) -> None:
+        super().__init__()
+        self.bundle = bundle
+        self.text_embed = (
+            text_embed
+            if text_embed is not None
+            else BooguImageTextEmbedStage(bundle, max_sequence_length=max_sequence_length)
+        )
+        if diffusion is None:
+            diffusion = BooguImageDiffusionStage(
+                model=bundle,
+                step=BooguImageDiffusionStep(),
+                strategy=strategy if strategy is not None else FlowSDEStrategy(),
+                autocast_precision=autocast_precision,
+                trajectory_precision=trajectory_precision,
+                logprob_precision=logprob_precision,
+            )
+        self.diffusion = diffusion
+        self.vae_decode = vae_decode if vae_decode is not None else BooguImageVAEDecodeStage(bundle)
+        # Retained so the hosting engine can read it when constructing the
+        # FlowMatchSchedulePolicy at startup (static shift, e^{1.15}).
+        self.shift = shift
+
+    @classmethod
+    def latent_shape(cls, *, model_config: Any, sampling_spec: Any) -> tuple:
+        """Per-sample latent shape ``(C, H_lat, W_lat)`` for driver-side
+        noise pre-computation. Boogu-Image: 16-channel FLUX ``AutoencoderKL``,
+        8× spatial downsample with the patchify-2×2 rounding
+        (``latent_h = 2 * (H // 16)``)."""
+        height = int(sampling_spec.height)
+        width = int(sampling_spec.width)
+        vae_scale_factor = 8  # FLUX.1 AutoencoderKL with 4 block_out_channels
+        latent_h = 2 * (height // (vae_scale_factor * 2))
+        latent_w = 2 * (width // (vae_scale_factor * 2))
+        return (16, latent_h, latent_w)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: BooguImagePipelineConfig,
+        *,
+        strategy: Optional[StepStrategy] = None,
+    ) -> "BooguImagePipeline":
+        """Build the full pipeline from a config.
+
+        ``strategy`` is the SDE step strategy. Defaults to
+        :class:`FlowSDEStrategy`; callers running GRPO with a different SDE
+        family (Dance / CPS / DPM2) pass an explicit strategy.
+        """
+        bundle = BooguImageBundle.from_config(config)
+        text_embed = BooguImageTextEmbedStage(bundle, max_sequence_length=config.max_sequence_length)
+        step = BooguImageDiffusionStep()
+        diffusion = BooguImageDiffusionStage(
+            model=bundle,
+            step=step,
+            strategy=strategy if strategy is not None else FlowSDEStrategy(),
+            autocast_precision=config.autocast_precision,
+            trajectory_precision=config.trajectory_precision,
+            logprob_precision=config.logprob_precision,
+        )
+        vae_decode = BooguImageVAEDecodeStage(bundle)
+        return cls(
+            bundle=bundle,
+            text_embed=text_embed,
+            diffusion=diffusion,
+            vae_decode=vae_decode,
+            shift=float(config.shift),
+            max_sequence_length=config.max_sequence_length,
+        )
+
+    def build_schedule_policy(self):
+        """Static-shift FlowMatch σ policy for the released Boogu-Image-0.1.
+
+        Boogu's released Base scheduler is static v1 with ``seq_len: 4096``:
+        μ = lin(4096) = 1.15 (the reference hardcodes the 256→0.5 / 4096→1.15
+        linear map), and v1's logistic t-shift equals the standard static
+        sigma shift with ``s = e^μ = 3.158192909689768``. Returning an
+        explicit ``static_only`` policy built from ``self.shift`` pins that
+        posture regardless of whether ``pretrained_path`` is an HF repo id or
+        a local mount — Boogu's ``scheduler_config.json`` uses custom field
+        names (``do_shift`` / ``dynamic_time_shift`` / ``time_shift_version``
+        / ``seq_len``) that the base policy's JSON loader would silently
+        ignore, which would otherwise produce a wrong-shift schedule without
+        an error. Mirrors ``ZImagePipeline.build_schedule_policy``.
+        """
+        from unirl.sde.runtime import FlowMatchSchedulePolicy
+
+        return FlowMatchSchedulePolicy.static_only(float(self.shift))
+
+    def build_conditions(
+        self,
+        texts: Texts,
+        *,
+        negatives: Optional[Texts] = None,
+        guidance_scale: float = 1.0,
+    ) -> BooguImageConditions:
+        """Encode prompts (+ optional CFG negatives) into ``BooguImageConditions``.
+
+        CFG empty negative: the reference ``encode_instruction`` defaults the
+        negative instruction to ``""`` when CFG is active
+        (pipeline_boogu.py:2491-2494); inside the embed stage the empty
+        string routes to the DROP system prompt (dataset logic). Boogu gates
+        CFG on ``guidance_scale > 1.0`` — 1.0 is guidance-off (unlike
+        z_image's ``> 0.0`` gate).
+        """
+        text_cond = self.text_embed.embed(texts)
+        if negatives is None and float(guidance_scale) > 1.0:
+            negatives = Texts(texts=[""] * len(texts.texts))
+        negative_text_cond = self.text_embed.embed(negatives) if negatives is not None else None
+        return BooguImageConditions(text=text_cond, negative_text=negative_text_cond)
+
+    def generate(self, req: RolloutReq) -> RolloutResp:
+        """Run Boogu-Image t2i end-to-end. Requires ``req.sigmas`` to be
+        pinned by the hosting engine adapter."""
+        if req.sigmas is None:
+            raise ValueError(
+                "BooguImagePipeline.generate: req.sigmas is None. The hosting "
+                "engine must call unirl.sde.runtime.ensure_req_sigmas(req, "
+                "policy) before invoking pipeline.generate; see the σ "
+                "ownership note in unirl.models.types.pipeline."
+            )
+        texts = req.primitives.get("text")
+        if not isinstance(texts, Texts):
+            raise TypeError(
+                f"BooguImagePipeline.generate: req.primitives['text'] must be Texts, "
+                f"got {type(texts).__name__ if texts is not None else 'None'}"
+            )
+        negatives_raw = req.primitives.get("negative_text")
+        negatives = negatives_raw if isinstance(negatives_raw, Texts) else None
+        if negatives is not None and len(negatives.texts) != len(texts.texts):
+            raise ValueError(
+                f"BooguImagePipeline.generate: negative_text length "
+                f"{len(negatives.texts)} != text length {len(texts.texts)}"
+            )
+
+        params: DiffusionSamplingParams = req.sampling_params.get("diffusion")
+        if bool(params.init_same_noise) and not params.noise_group_ids:
+            params = dataclasses.replace(params, noise_group_ids=list(req.group_ids))
+
+        conds = self.build_conditions(texts, negatives=negatives, guidance_scale=float(params.guidance_scale))
+
+        schedule = req.sigmas.to(self.bundle.device)
+
+        # Driver-authoritative x_T via the model-aware recipe (NoiseRecipe); a
+        # pre-shipped initial_latents tensor still wins.
+        initial_latents = NoiseRecipe.from_rollout_req(req).resolve()
+
+        latent_seg = self.diffusion.diffuse(conds, schedule=schedule, params=params, initial_latents=initial_latents)
+        images = self.vae_decode.decode(latent_seg)
+
+        return RolloutResp(
+            tracks={
+                "image": RolloutTrack(
+                    sample_ids=list(req.sample_ids),
+                    parent_ids=list(req.group_ids),
+                    conditions=conds.to_dict(),
+                    segment=latent_seg,
+                    decoded=images,
+                ),
+            }
+        )
+
+
+__all__ = ["BooguImagePipeline"]

--- a/unirl/models/boogu_image/pipeline.py
+++ b/unirl/models/boogu_image/pipeline.py
@@ -1,4 +1,4 @@
-"""BooguImagePipeline — RolloutReq → RolloutResp end-to-end for Boogu-Image.
+"""BooguImagePipeline — ``Sample → Sample`` end-to-end for Boogu-Image.
 
 Implements the four-tier flow::
 
@@ -17,9 +17,9 @@ constructs the stages with the precision policy from the config.
 
 σ schedule contract
 -------------------
-The hosting engine (``TrainsideRolloutEngine``) pins ``req.sigmas`` via
-:func:`unirl.sde.runtime.ensure_req_sigmas` BEFORE calling ``generate(req)``;
-this pipeline reads ``req.sigmas`` verbatim. The released
+The hosting engine (``TrainsideRolloutEngine``) pins the σ schedule onto the
+gen Part's ``DiffusionSamplingParams.sigmas`` BEFORE calling
+``generate(sample)``; this pipeline reads ``params.sigmas`` verbatim. The released
 ``Boogu-Image-0.1-Base`` scheduler config is a **static v1 time shift**
 (``do_shift: true, dynamic_time_shift: false, time_shift_version: "v1",
 seq_len: 4096``) whose sigma-space form is exactly the standard static shift
@@ -50,8 +50,7 @@ from unirl.models.types.pipeline import Pipeline
 from unirl.sde.kernels import FlowSDEStrategy, StepStrategy
 from unirl.types.noise_recipe import NoiseRecipe
 from unirl.types.primitives import Texts
-from unirl.types.rollout_req import RolloutReq
-from unirl.types.rollout_resp import RolloutResp, RolloutTrack
+from unirl.types.sample import Sample
 from unirl.types.sampling import DiffusionSamplingParams
 
 from .bundle import BooguImageBundle
@@ -63,21 +62,20 @@ from .vae import BooguImageVAEDecodeStage
 
 
 class BooguImagePipeline(Pipeline):
-    """Boogu-Image generate pipeline.
+    """Boogu-Image generate pipeline: ``Sample → Sample``.
 
-    Reads from ``RolloutReq``:
+    Consumes a request ``Sample`` whose frontier Part is a pre-forked diffusion
+    gen shell carrying ``DiffusionSamplingParams`` (with ``sigmas`` pinned by
+    the hosting engine). Reads the prompt via ``sample.conditioning()`` and
+    fills the frontier Part:
 
-    - ``primitives["text"]: Texts`` — required prompts.
-    - ``primitives["negative_text"]: Texts`` — optional CFG negatives.
-    - ``sampling_params["diffusion"]`` — diffusion sampling params.
-    - ``sigmas: Tensor[T+1]`` — pinned by the engine adapter (required).
+    - ``segment: LatentSegment`` — the denoising trajectory.
+    - ``primitives["image"]: Images`` — the decoded images.
 
-    Writes to ``RolloutResp`` (single ``"image"`` track):
-
-    - ``conditions["text"]: TextEmbedCondition``; plus
-      ``conditions["negative_text"]`` when negatives were supplied/built.
-    - ``segment: LatentSegment``.
-    - ``decoded: Images``.
+    ``Part.conditions`` carries the encoded conditions for trainer-side replay
+    (the train stack re-types them via ``conditions_cls.from_dict``).
+    User-supplied negatives are deferred; CFG (``guidance_scale > 1.0``) uses a
+    synthesized empty negative routed to the DROP system prompt.
     """
 
     def __init__(
@@ -198,62 +196,63 @@ class BooguImagePipeline(Pipeline):
         CFG on ``guidance_scale > 1.0`` — 1.0 is guidance-off (unlike
         z_image's ``> 0.0`` gate).
         """
+        if negatives is not None and len(negatives.texts) != len(texts.texts):
+            raise ValueError(
+                f"BooguImagePipeline.build_conditions: negative_text length "
+                f"{len(negatives.texts)} != text length {len(texts.texts)}"
+            )
         text_cond = self.text_embed.embed(texts)
         if negatives is None and float(guidance_scale) > 1.0:
             negatives = Texts(texts=[""] * len(texts.texts))
         negative_text_cond = self.text_embed.embed(negatives) if negatives is not None else None
         return BooguImageConditions(text=text_cond, negative_text=negative_text_cond)
 
-    def generate(self, req: RolloutReq) -> RolloutResp:
-        """Run Boogu-Image t2i end-to-end. Requires ``req.sigmas`` to be
-        pinned by the hosting engine adapter."""
-        if req.sigmas is None:
-            raise ValueError(
-                "BooguImagePipeline.generate: req.sigmas is None. The hosting "
-                "engine must call unirl.sde.runtime.ensure_req_sigmas(req, "
-                "policy) before invoking pipeline.generate; see the σ "
-                "ownership note in unirl.models.types.pipeline."
+    def generate(self, sample: Sample) -> Sample:
+        """Run Boogu-Image t2i end-to-end, filling the frontier (pre-forked) gen Part.
+
+        Requires σ to be pinned onto the gen part's ``DiffusionSamplingParams.sigmas``
+        by the hosting engine before the call; see the σ ownership note in
+        ``unirl.models.types.pipeline``.
+        """
+        frontier = sample.parts[-1]
+        params = frontier.sampling_params
+        if not isinstance(params, DiffusionSamplingParams):
+            raise TypeError(
+                f"BooguImagePipeline.generate: frontier gen Part must carry DiffusionSamplingParams, "
+                f"got {type(params).__name__ if params is not None else 'None'}"
             )
-        texts = req.primitives.get("text")
+        if params.sigmas is None:
+            raise ValueError(
+                "BooguImagePipeline.generate: gen part sampling_params.sigmas is None. The hosting "
+                "engine must pin σ before invoking pipeline.generate; see the σ ownership note "
+                "in unirl.models.types.pipeline."
+            )
+
+        conditioning = sample.conditioning()
+        texts = conditioning[0] if conditioning else None
         if not isinstance(texts, Texts):
             raise TypeError(
-                f"BooguImagePipeline.generate: req.primitives['text'] must be Texts, "
+                f"BooguImagePipeline.generate: expected a Texts prompt from sample.conditioning()[0], "
                 f"got {type(texts).__name__ if texts is not None else 'None'}"
             )
-        negatives_raw = req.primitives.get("negative_text")
-        negatives = negatives_raw if isinstance(negatives_raw, Texts) else None
-        if negatives is not None and len(negatives.texts) != len(texts.texts):
-            raise ValueError(
-                f"BooguImagePipeline.generate: negative_text length "
-                f"{len(negatives.texts)} != text length {len(texts.texts)}"
-            )
 
-        params: DiffusionSamplingParams = req.sampling_params.get("diffusion")
         if bool(params.init_same_noise) and not params.noise_group_ids:
-            params = dataclasses.replace(params, noise_group_ids=list(req.group_ids))
+            params = dataclasses.replace(params, noise_group_ids=list(frontier.group_ids))
 
-        conds = self.build_conditions(texts, negatives=negatives, guidance_scale=float(params.guidance_scale))
-
-        schedule = req.sigmas.to(self.bundle.device)
+        conds = self.build_conditions(texts, guidance_scale=float(params.guidance_scale))
+        schedule = params.sigmas.to(self.bundle.device)
 
         # Driver-authoritative x_T via the model-aware recipe (NoiseRecipe); a
         # pre-shipped initial_latents tensor still wins.
-        initial_latents = NoiseRecipe.from_rollout_req(req).resolve()
+        initial_latents = NoiseRecipe.from_sample(sample).resolve()
 
         latent_seg = self.diffusion.diffuse(conds, schedule=schedule, params=params, initial_latents=initial_latents)
         images = self.vae_decode.decode(latent_seg)
 
-        return RolloutResp(
-            tracks={
-                "image": RolloutTrack(
-                    sample_ids=list(req.sample_ids),
-                    parent_ids=list(req.group_ids),
-                    conditions=conds.to_dict(),
-                    segment=latent_seg,
-                    decoded=images,
-                ),
-            }
-        )
+        # Fill the frontier shell, carrying the encoded conditions for trainer-side
+        # replay (FlowGRPO re-types Part.conditions via conditions_cls.from_dict).
+        filled = frontier.fill(segment=latent_seg, primitives={"image": images}, conditions=conds.to_dict())
+        return Sample(parts=[*sample.parts[:-1], filled], reward_compute_s=sample.reward_compute_s)
 
 
 __all__ = ["BooguImagePipeline"]

--- a/unirl/models/boogu_image/text_embed.py
+++ b/unirl/models/boogu_image/text_embed.py
@@ -1,0 +1,133 @@
+"""BooguImageTextEmbedStage — Qwen3-VL chat-template text → TextEmbedCondition.
+
+Implements ``EmbedStage[Texts, TextEmbedCondition]``. Mirrors the reference
+``BooguImagePipeline._get_instruction_feature_embeds`` /
+``_apply_chat_template`` (T2I path, no images) at the spec level:
+
+- **Single multimodal LLM encoder** (the lm_head-stripped ``Qwen3VLModel``
+  from the checkpoint's ``mllm/`` subfolder). Each prompt becomes a chat
+  message list ``[system, user(text)]`` and the paired ``Qwen3VLProcessor``
+  templates + tokenizes it in one ``apply_chat_template`` call
+  (``padding="longest"``, ``padding_side="right"``, truncation off — the
+  reference passes ``truncate_instruction_sequence=False``).
+- **Adaptive system prompt** (reference ``_apply_chat_template`` with its
+  ``system_prompt_follows_task_type=False`` default): a non-empty prompt
+  gets the fixed T2I system prompt; an **empty/whitespace prompt — which is
+  exactly what the CFG negative ``""`` is — gets the DROP system prompt**
+  ("dataset logic"). Reproducing this switch is required for CFG parity
+  with the reference pipeline.
+- **Last hidden layer, full sequence, no repacking** (unlike z_image's
+  pad-drop repack and qwen_image's fixed-prefix strip): the checkpoint's
+  ``instruction_feature_configs`` selects 1 layer with mean-reduce ==
+  identity, and the transformer consumes the right-padded embeds plus the
+  processor's attention mask directly (its ``rope_embedder`` /
+  context-refiner run variable-length attention off that mask).
+
+No ``pooled`` vector is produced — the DiT accepts token-level hidden
+states only. ``TextEmbedCondition.pooled`` is left as ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+
+from unirl.models.types.embedding import EmbedStage
+from unirl.types.conditions import TextEmbedCondition
+from unirl.types.primitives import Texts
+
+from .bundle import BooguImageBundle
+
+# Fixed system prompts — exact strings from the reference pipeline
+# (pipeline_boogu.py:231-232). SYSTEM_PROMPT_DROP is what empty/whitespace
+# instructions (the CFG negative "") are routed to.
+SYSTEM_PROMPT_T2I = (
+    "You are a helpful assistant that generates high-quality images based on "
+    "user instructions. The instructions are as follows."
+)
+SYSTEM_PROMPT_DROP = (
+    "Describe the key features of the input image (color, shape, size, "
+    "texture, objects, background), then explain how the user's text "
+    "instruction should alter or modify the image. Generate a new image that "
+    "meets the user's requirements while maintaining consistency with the "
+    "original input where appropriate."
+)
+
+
+class BooguImageTextEmbedStage(EmbedStage[Texts, TextEmbedCondition]):
+    """Qwen3-VL chat-template text → ``TextEmbedCondition`` stage."""
+
+    def __init__(
+        self,
+        bundle: BooguImageBundle,
+        *,
+        max_sequence_length: int = 1280,
+    ) -> None:
+        self.bundle = bundle
+        self.max_sequence_length = int(max_sequence_length)
+
+    def embed(self, p: Texts) -> TextEmbedCondition:
+        """Encode prompts into a ``TextEmbedCondition``."""
+        prompt_embeds, prompt_embeds_mask = self._encode(list(p.texts))
+        return TextEmbedCondition(
+            embeds=prompt_embeds,
+            attn_mask=prompt_embeds_mask,
+            pooled=None,
+        )
+
+    # ---- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _messages(prompt: str) -> List[dict]:
+        """Build the reference chat-message list for one T2I prompt.
+
+        Empty/whitespace prompts (the CFG negative ``""``) switch to the
+        DROP system prompt, mirroring the reference adaptive branch
+        (``_apply_chat_template``, pipeline_boogu.py:1594-1612).
+        """
+        system_prompt = SYSTEM_PROMPT_T2I if prompt and prompt.strip() else SYSTEM_PROMPT_DROP
+        return [
+            {"role": "system", "content": [{"type": "text", "text": system_prompt}]},
+            {"role": "user", "content": [{"type": "text", "text": prompt}]},
+        ]
+
+    def _encode(self, prompts: List[str]) -> Tuple[torch.Tensor, torch.Tensor]:
+        bundle = self.bundle
+        if bundle.text_encoder is None or bundle.processor is None:
+            raise ValueError(
+                "BooguImageTextEmbedStage._encode: bundle has no text encoder/processor "
+                "(load_text_encoder=False?)"
+            )
+        device = bundle.device
+        dtype = next(bundle.text_encoder.parameters()).dtype
+
+        message_lists = [self._messages(prompt) for prompt in prompts]
+        # Exact reference kwargs (pipeline_boogu.py:1299-1308 with the
+        # __call__ defaults max_sequence_length=1280, truncation off).
+        vlm_inputs = bundle.processor.apply_chat_template(
+            message_lists,
+            padding="longest",
+            max_length=self.max_sequence_length,
+            truncation=False,
+            padding_side="right",
+            return_tensors="pt",
+            tokenize=True,
+            return_dict=True,
+        )
+        input_ids = vlm_inputs["input_ids"].to(device)
+        attention_mask = vlm_inputs["attention_mask"].to(device)
+
+        with torch.no_grad():
+            encoder_out = bundle.text_encoder(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+            )
+        # instruction_feature_configs: 1 layer, mean-reduce == identity →
+        # the last hidden layer, full right-padded sequence, no repacking.
+        hidden_states = encoder_out.last_hidden_state
+
+        return hidden_states.to(device=device, dtype=dtype), attention_mask
+
+
+__all__ = ["BooguImageTextEmbedStage", "SYSTEM_PROMPT_T2I", "SYSTEM_PROMPT_DROP"]

--- a/unirl/models/boogu_image/text_embed.py
+++ b/unirl/models/boogu_image/text_embed.py
@@ -96,8 +96,7 @@ class BooguImageTextEmbedStage(EmbedStage[Texts, TextEmbedCondition]):
         bundle = self.bundle
         if bundle.text_encoder is None or bundle.processor is None:
             raise ValueError(
-                "BooguImageTextEmbedStage._encode: bundle has no text encoder/processor "
-                "(load_text_encoder=False?)"
+                "BooguImageTextEmbedStage._encode: bundle has no text encoder/processor (load_text_encoder=False?)"
             )
         device = bundle.device
         dtype = next(bundle.text_encoder.parameters()).dtype

--- a/unirl/models/boogu_image/vae.py
+++ b/unirl/models/boogu_image/vae.py
@@ -53,6 +53,13 @@ class BooguImageVAEDecodeStage(DecodeStage[LatentSegment, Images]):
         trainable params, so only ``clean``'s graph is extended. ``activation_checkpoint``
         (grad only) recomputes the decode in backward to trade compute for memory.
         """
+        if self.bundle.vae is None:
+            raise RuntimeError(
+                "BooguImageVAEDecodeStage.decode: no VAE loaded (load_vae=False). "
+                "The trainer-side pipeline cannot decode latents in this "
+                "configuration — separate-engine recipes decode in the "
+                "rollout engine; trainside rollout requires load_vae=True."
+            )
         if s.latents is None:
             raise ValueError("BooguImageVAEDecodeStage.decode: segment.latents is None")
         if s.latents.ndim < 5:

--- a/unirl/models/boogu_image/vae.py
+++ b/unirl/models/boogu_image/vae.py
@@ -57,8 +57,7 @@ class BooguImageVAEDecodeStage(DecodeStage[LatentSegment, Images]):
             raise ValueError("BooguImageVAEDecodeStage.decode: segment.latents is None")
         if s.latents.ndim < 5:
             raise ValueError(
-                f"BooguImageVAEDecodeStage.decode: expected latents shape [N, K, C, H, W], "
-                f"got {tuple(s.latents.shape)}"
+                f"BooguImageVAEDecodeStage.decode: expected latents shape [N, K, C, H, W], got {tuple(s.latents.shape)}"
             )
         clean = s.latents[:, -1]  # [B, C, H, W]
 

--- a/unirl/models/boogu_image/vae.py
+++ b/unirl/models/boogu_image/vae.py
@@ -1,0 +1,85 @@
+"""BooguImageVAEDecodeStage — LatentSegment → Images via VAE decode.
+
+Implements ``DecodeStage[LatentSegment, Images]``. Reads the final stored
+position from ``LatentSegment.latents[:, -1]`` (``BooguImageDiffusionStage``
+always stores position ``T``, the clean latent), runs the ``AutoencoderKL``
+decode in fp32, and normalizes the output from ``[-1, 1]`` to ``[0, 1]``
+before wrapping in ``Images``.
+
+Boogu-Image uses the FLUX.1 16-channel ``AutoencoderKL`` with both
+``scaling_factor`` (0.3611) and ``shift_factor`` (0.1159) — identical VAE
+family to z_image/SD3. The latent un-normalization mirrors the reference
+``processing`` tail (pipeline_boogu.py:3681-3686):
+``x = latent / scaling_factor + shift_factor``.
+
+Documented divergence from the reference: no bilinear resize of the decoded
+image back to the pre-floor request size (pipeline_boogu.py:2939) — recipes
+must use ``height``/``width`` ≡ 0 (mod 16), which makes the resize a no-op.
+
+No ``BooguImageVAEEncodeStage`` here — Base is text-to-image only; the
+encoder path lands with the Edit (TI2I) variant.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import torch
+
+from unirl.models.types.codec import DecodeStage
+from unirl.types.primitives import Images
+from unirl.types.segments import LatentSegment
+
+from .bundle import BooguImageBundle
+
+
+class BooguImageVAEDecodeStage(DecodeStage[LatentSegment, Images]):
+    """Boogu-Image VAE decode stage."""
+
+    def __init__(self, bundle: BooguImageBundle) -> None:
+        self.bundle = bundle
+
+    def decode(self, s: LatentSegment, *, grad: bool = False, activation_checkpoint: bool = False) -> Images:
+        """Decode the final-step latents in *s* into pixel images.
+
+        Reads ``s.latents[:, -1]`` (the final stored position, which is
+        ``T`` — the clean latent ``x_0`` in spatial shape ``[B, C, H, W]``).
+        VAE forward runs in fp32 (the FLUX.1 VAE declares ``force_upcast``);
+        output is clamped to ``[0, 1]`` before being wrapped in ``Images``.
+
+        ``grad=False`` (default) keeps the rollout path under ``torch.no_grad()``.
+        ``grad=True`` (ReFL direct-reward backprop) runs the decode WITH grad so it
+        flows from the reward through the frozen VAE into ``clean``; the VAE has no
+        trainable params, so only ``clean``'s graph is extended. ``activation_checkpoint``
+        (grad only) recomputes the decode in backward to trade compute for memory.
+        """
+        if s.latents is None:
+            raise ValueError("BooguImageVAEDecodeStage.decode: segment.latents is None")
+        if s.latents.ndim < 5:
+            raise ValueError(
+                f"BooguImageVAEDecodeStage.decode: expected latents shape [N, K, C, H, W], "
+                f"got {tuple(s.latents.shape)}"
+            )
+        clean = s.latents[:, -1]  # [B, C, H, W]
+
+        scaling_factor = self.bundle.vae.config.scaling_factor
+        shift_factor = getattr(self.bundle.vae.config, "shift_factor", None)
+
+        def _decode(lat: torch.Tensor) -> torch.Tensor:
+            latents_f32 = lat.to(dtype=torch.float32) / scaling_factor
+            if shift_factor is not None:
+                latents_f32 = latents_f32 + float(shift_factor)
+            return self.bundle.vae.to(torch.float32).decode(latents_f32).sample
+
+        with nullcontext() if grad else torch.no_grad():
+            if grad and activation_checkpoint and clean.requires_grad:
+                from torch.utils.checkpoint import checkpoint
+
+                decoded = checkpoint(_decode, clean, use_reentrant=False)
+            else:
+                decoded = _decode(clean)
+        pixels = ((decoded + 1.0) / 2.0).clamp(0.0, 1.0)
+        return Images(pixels=pixels)
+
+
+__all__ = ["BooguImageVAEDecodeStage"]

--- a/unirl/models/boogu_image/vendor/VENDOR_COMMIT.txt
+++ b/unirl/models/boogu_image/vendor/VENDOR_COMMIT.txt
@@ -1,0 +1,50 @@
+source     = boogu-project/Boogu-Image  (https://github.com/boogu-project/Boogu-Image)
+commit     = 434fb56d2a5f6ae6f30cce6a8b56e319e9cd1979
+short      = 434fb56
+commit_date= 2026-07 (main @ clone date)
+vendored   = 2026-07-17  (into unirl/models/boogu_image/vendor/, FLAT layout)
+target     = celve/unirl LIN-567/main (@ 80b24995)
+
+Files (upstream path -> vendor file):
+  boogu/models/transformers/transformer_boogu.py -> transformer_boogu.py
+  boogu/models/attention_processor.py            -> attention_processor.py
+  boogu/models/transformers/rope.py              -> rope.py           (pristine)
+  boogu/models/transformers/block_lumina2.py     -> block_lumina2.py
+  boogu/models/transformers/components.py        -> components.py     (pristine)
+  boogu/models/embeddings.py                     -> embeddings.py     (pristine)
+  boogu/utils/import_utils.py                    -> import_utils.py   (pristine)
+  boogu/utils/teacache_util.py                   -> teacache_util.py  (pristine)
+  (new) taylorseer_stubs.py — raising stubs replacing boogu.cache_functions /
+        boogu.taylorseer_utils imports (RL must be cache-free)
+
+NOT vendored (deliberate): boogu/pipelines/* (UniRL stages reimplement
+sampling), boogu/schedulers/* (static-v1 shift == FlowMatchSchedulePolicy
+static shift with shift = e^1.15 = 3.158192909689768; verified to 1 fp32 ulp),
+boogu/cache_functions + taylorseer_utils + ops/triton (inference accel only).
+
+Mechanical changes (see vendor/__init__.py docstring, marked inline):
+  1. import flattening to same-dir relatives (transformer_boogu.py,
+     attention_processor.py, block_lumina2.py)
+  2. triton-RMSNorm + flash-swiglu env conditionals -> torch.nn.RMSNorm +
+     pure-torch swiglu (upstream default-env branches)
+  3. the four os.getenv("device","cpu") attention-processor gates pinned to
+     SDPA processors (BooguImageTransformerBlock.__init__,
+     BooguImageDoubleStreamTransformerBlock.__init__); Flash2Varlen classes
+     kept for optional post-load swap (identical param names)
+  4. taylorseer/cache_functions imports -> taylorseer_stubs.py
+  5. orphaned `import os` / `import warnings` removed
+
+No functional edits to forward math. Zero registered buffers / plain-tensor
+attrs in the tree (verified) -> meta-init is the trivial finalize_meta_init
+case; the non-persistent-buffer warning must come out EMPTY (canary on
+re-vendor).
+
+To re-vendor a newer upstream:
+  1. git -C Boogu-Image fetch && git checkout <new_commit>
+  2. recopy the 8 files (flat) per the table above
+  3. re-apply mechanical changes 1-5
+  4. bump this file; re-run the parity gates (sigma grid, embeds,
+     teacher-forced per-step, free-running) AND the diffuse<->replay ratio==1
+     check PLUS a replay-backward smoke — the ratio test alone runs under
+     no_grad and won't catch grad-only regressions (see bagel's inplace-view
+     lesson).

--- a/unirl/models/boogu_image/vendor/__init__.py
+++ b/unirl/models/boogu_image/vendor/__init__.py
@@ -1,0 +1,47 @@
+"""Vendored Boogu-Image model code — official boogu-project/Boogu-Image, flattened.
+
+Copied from boogu-project/Boogu-Image (commit pinned in ``VENDOR_COMMIT.txt``).
+Unlike bagel's whole-subpackage copy, this vendor dir is FLAT: the 8 files are
+cherry-picked from three upstream dirs (``boogu/models/transformers/``,
+``boogu/models/``, ``boogu/utils/``). The pipeline, scheduler, LoRA-loader, and
+cache/acceleration packages are intentionally NOT vendored — UniRL reimplements
+sampling as stages, and the released static-v1 time shift is expressed through
+``FlowMatchSchedulePolicy.static_only(exp(1.15))`` (see
+``unirl/models/boogu_image/pipeline.py``).
+
+Intended deviations from upstream (all mechanical, marked inline with
+"UniRL vendor edit"):
+
+- import flattening: ``...utils.teacache_util`` / ``..attention_processor`` /
+  ``..embeddings`` / ``...utils.import_utils`` -> same-dir relative imports;
+- triton-RMSNorm conditionals (gated on ``is_triton_available()`` + a ``device``
+  env var) -> ``torch.nn.RMSNorm`` (the upstream default-env branch) in
+  ``transformer_boogu.py`` and ``block_lumina2.py``;
+- flash-swiglu conditional -> pure-torch ``components.swiglu`` (upstream
+  default-env branch) in ``block_lumina2.py``;
+- attention processors: the four ``os.getenv("device", "cpu")`` selection gates
+  in ``BooguImageTransformerBlock.__init__`` and
+  ``BooguImageDoubleStreamTransformerBlock.__init__`` are pinned to the SDPA
+  processors (``BooguImageAttnProcessor`` /
+  ``BooguImageDoubleStreamSelfAttnProcessor``). Training numerics must not
+  depend on process environment; the Flash2Varlen processor classes remain in
+  ``attention_processor.py`` (its guarded ``flash_attn`` import is pristine)
+  for an optional post-load swap via the bundle's ``attention_backend`` config
+  — SDPA and Flash2Varlen variants share identical parameter names, so
+  checkpoints and LoRA adapters are backend-independent;
+- TaylorSeer/TeaCache: ``boogu.cache_functions`` / ``boogu.taylorseer_utils``
+  imports -> ``taylorseer_stubs.py`` (raising stubs). Every call site is gated
+  on ``enable_taylorseer`` / ``enable_teacache`` flags that default False and
+  are asserted False by ``BooguImageBundle.from_config``; ``teacache_util.py``
+  is vendored verbatim because ``TeaCacheParams`` is instantiated
+  unconditionally in the transformer ``__init__``;
+- orphaned ``import os`` / ``import warnings`` removed where the rewrites made
+  them unused.
+
+Byte-pristine files: ``rope.py``, ``embeddings.py``, ``components.py``,
+``import_utils.py``, ``teacache_util.py``.
+"""
+
+from .transformer_boogu import BooguImageTransformer2DModel, PromptEmbedding
+
+__all__ = ["BooguImageTransformer2DModel", "PromptEmbedding"]

--- a/unirl/models/boogu_image/vendor/attention_processor.py
+++ b/unirl/models/boogu_image/vendor/attention_processor.py
@@ -1,0 +1,1275 @@
+import math
+import warnings
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import repeat
+
+from ..utils.import_utils import is_flash_attn_available
+
+if is_flash_attn_available():
+    from flash_attn import flash_attn_varlen_func
+    from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input
+else:
+    warnings.warn(
+        "Cannot import flash_attn, install flash_attn to use Flash2Varlen attention for better performance"
+    )
+
+
+from diffusers.models.attention_processor import Attention
+
+from .embeddings import apply_rotary_emb
+
+
+class BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen(nn.Module):
+    """
+    Double-stream self-attention processor with flash attention and variable length sequences.
+
+    This processor implements double-stream attention where:
+    - Instruction and image features are processed separately to generate QKV
+    - QKV are concatenated and processed together for cross-modal attention
+    - Uses flash attention for efficient computation
+    - Supports both standard and causal attention masks
+
+    Args:
+        head_dim: Dimension of each attention head
+        num_attention_heads: Number of attention heads for queries
+        num_kv_heads: Number of key-value heads
+        qkv_bias: Whether to use bias in QKV linear layers
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        num_attention_heads: int,
+        num_kv_heads: int,
+        qkv_bias: bool = False,
+    ) -> None:
+        """Initialize the double-stream attention processor."""
+        super().__init__()
+        if not is_flash_attn_available():
+            raise ImportError(
+                "BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen requires flash_attn. "
+                "Please install flash_attn."
+            )
+
+        # Calculate dimensions
+        self.head_dim = head_dim
+        self.num_attention_heads = num_attention_heads
+        self.num_kv_heads = num_kv_heads
+
+        query_dim = head_dim * num_attention_heads
+        kv_dim = head_dim * num_kv_heads
+
+        # Initialize separate Q, K, V linear layers for instruction and image
+        # Query uses num_attention_heads, Key/Value use num_kv_heads
+        self.img_to_q = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+        self.img_to_k = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+        self.img_to_v = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+
+        self.instruct_to_q = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+        self.instruct_to_k = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+        self.instruct_to_v = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+
+        # Additional output projection layers for instruction and image streams
+        self.instruct_out = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+        self.img_out = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+
+        # Initialize weights
+        self.initialize_weights()
+        # rank, world_size, worker, num_workers = pytorch_worker_info(None)
+
+    def initialize_weights(self) -> None:
+        """
+        Initialize the weights of the double-stream attention processor.
+
+        Uses Xavier uniform initialization for linear layers and zero initialization for biases.
+        """
+        # Initialize image stream QKV projection layers
+        nn.init.xavier_uniform_(self.img_to_q.weight)
+        nn.init.xavier_uniform_(self.img_to_k.weight)
+        nn.init.xavier_uniform_(self.img_to_v.weight)
+
+        # Initialize instruction stream QKV projection layers
+        nn.init.xavier_uniform_(self.instruct_to_q.weight)
+        nn.init.xavier_uniform_(self.instruct_to_k.weight)
+        nn.init.xavier_uniform_(self.instruct_to_v.weight)
+
+        # Initialize separate output projection layers
+        nn.init.xavier_uniform_(self.instruct_out.weight)
+        nn.init.xavier_uniform_(self.img_out.weight)
+
+        # Initialize biases if they exist
+        if self.img_to_q.bias is not None:
+            nn.init.zeros_(self.img_to_q.bias)
+            nn.init.zeros_(self.img_to_k.bias)
+            nn.init.zeros_(self.img_to_v.bias)
+            nn.init.zeros_(self.instruct_to_q.bias)
+            nn.init.zeros_(self.instruct_to_k.bias)
+            nn.init.zeros_(self.instruct_to_v.bias)
+            nn.init.zeros_(self.instruct_out.bias)
+            nn.init.zeros_(self.img_out.bias)
+
+    def _upad_input(
+        self,
+        query_layer: torch.Tensor,
+        key_layer: torch.Tensor,
+        value_layer: torch.Tensor,
+        attention_mask: torch.Tensor,
+        query_length: int,
+        num_heads: int,
+    ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        Tuple[torch.Tensor, torch.Tensor],
+        Tuple[int, int],
+    ]:
+        """
+        Unpad the input tensors for flash attention.
+        Same implementation as BooguImageAttnProcessorFlash2Varlen.
+        """
+
+        def _get_unpad_data(
+            attention_mask: torch.Tensor,
+        ) -> Tuple[torch.Tensor, torch.Tensor, int]:
+            """Helper function to get unpadding data from attention mask."""
+            seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
+            indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
+            max_seqlen_in_batch = seqlens_in_batch.max().item()
+            cu_seqlens = F.pad(
+                torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+            )
+            return indices, cu_seqlens, max_seqlen_in_batch
+
+        indices_k, cu_seqlens_k, max_seqlen_in_batch_k = _get_unpad_data(attention_mask)
+        batch_size, kv_seq_len, num_key_value_heads, head_dim = key_layer.shape
+
+        # Unpad key and value layers
+        key_layer = index_first_axis(
+            key_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
+            indices_k,
+        )
+        value_layer = index_first_axis(
+            value_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
+            indices_k,
+        )
+
+        # Handle different query length cases
+        if query_length == kv_seq_len:
+            query_layer = index_first_axis(
+                query_layer.reshape(batch_size * kv_seq_len, num_heads, head_dim),
+                indices_k,
+            )
+            cu_seqlens_q = cu_seqlens_k
+            max_seqlen_in_batch_q = max_seqlen_in_batch_k
+            indices_q = indices_k
+        elif query_length == 1:
+            max_seqlen_in_batch_q = 1
+            cu_seqlens_q = torch.arange(
+                batch_size + 1, dtype=torch.int32, device=query_layer.device
+            )
+            indices_q = cu_seqlens_q[:-1]
+            query_layer = query_layer.squeeze(1)
+        else:
+            attention_mask = attention_mask[:, -query_length:]
+            query_layer, indices_q, cu_seqlens_q, max_seqlen_in_batch_q = unpad_input(
+                query_layer, attention_mask
+            )
+
+        return (
+            query_layer,
+            key_layer,
+            value_layer,
+            indices_q,
+            (cu_seqlens_q, cu_seqlens_k),
+            (max_seqlen_in_batch_q, max_seqlen_in_batch_k),
+        )
+
+    def _concat_instruction_image_features(
+        self,
+        img_hidden_states_list: List[torch.Tensor],
+        instruct_hidden_states_list: List[torch.Tensor],
+        encoder_seq_lengths: List[int],
+        seq_lengths: List[int],
+    ) -> List[torch.Tensor]:
+        """
+        Concatenate instruction (text & image) and reference image features (instruction first, then image).
+
+        Args:
+            img_hidden_states_list: List of image tensors [img_query, img_key, img_value]
+            instruct_hidden_states_list: List of instruction tensors [instruct_query, instruct_key, instruct_value]
+            encoder_seq_lengths: Instruction sequence lengths for each sample [B]
+            seq_lengths: Total sequence lengths for each sample [B]
+
+        Returns:
+            List of concatenated tensors [query, key, value]
+        """
+        assert len(img_hidden_states_list) == len(instruct_hidden_states_list), (
+            f"Length mismatch: img_list={len(img_hidden_states_list)}, instruct_list={len(instruct_hidden_states_list)}"
+        )
+
+        batch_size = img_hidden_states_list[0].shape[0]
+        max_seq_len = max(seq_lengths)
+
+        concatenated_list = []
+
+        for img_tensor, instruct_tensor in zip(
+            img_hidden_states_list, instruct_hidden_states_list
+        ):
+            # Ensure tensors are on the same device
+            device = img_tensor.device
+            if instruct_tensor.device != device:
+                instruct_tensor = instruct_tensor.to(device)
+
+            # Create output tensor with proper shape [B, max_seq_len, feature_dim]
+            feature_dim = img_tensor.shape[-1]
+            concatenated = img_tensor.new_zeros(batch_size, max_seq_len, feature_dim)
+
+            # Concatenate instruction first, then image for each sample
+            for i, (encoder_seq_len, seq_len) in enumerate(
+                zip(encoder_seq_lengths, seq_lengths)
+            ):
+                # Place instruction tokens first
+                concatenated[i, :encoder_seq_len] = instruct_tensor[i, :encoder_seq_len]
+                # Place image tokens after instruction
+                concatenated[i, encoder_seq_len:seq_len] = img_tensor[
+                    i, : seq_len - encoder_seq_len
+                ]
+
+            concatenated_list.append(concatenated)
+
+        return concatenated_list
+
+    def _split_instruction_image_features(
+        self,
+        hidden_states_list: List[torch.Tensor],
+        encoder_seq_lengths: List[int],
+        seq_lengths: List[int],
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        Split concatenated features back to instruction and image features.
+        Inverse operation of _concat_instruction_image_features.
+
+        Args:
+            hidden_states_list: List of concatenated tensors (usually just one element)
+            encoder_seq_lengths: Instruction sequence lengths for each sample [B]
+            seq_lengths: Total sequence lengths for each sample [B]
+
+        Returns:
+            List of tuples, each containing (instruct_hidden_states, img_hidden_states)
+        """
+        result_list = []
+
+        for hidden_states in hidden_states_list:
+            batch_size = hidden_states.shape[0]
+            feature_dim = hidden_states.shape[-1]
+
+            # Get maximum lengths for instruction and image
+            max_instruct_len = max(encoder_seq_lengths)
+            max_img_len = max(
+                seq_len - encoder_seq_len
+                for seq_len, encoder_seq_len in zip(seq_lengths, encoder_seq_lengths)
+            )
+
+            # Create output tensors [B, max_len, feature_dim]
+            instruct_hidden_states = hidden_states.new_zeros(
+                batch_size, max_instruct_len, feature_dim
+            )
+            img_hidden_states = hidden_states.new_zeros(
+                batch_size, max_img_len, feature_dim
+            )
+
+            # Split each sample back to instruction and image
+            for i, (encoder_seq_len, seq_len) in enumerate(
+                zip(encoder_seq_lengths, seq_lengths)
+            ):
+                img_len = seq_len - encoder_seq_len
+
+                # Extract instruction portion
+                instruct_hidden_states[i, :encoder_seq_len] = hidden_states[
+                    i, :encoder_seq_len
+                ]
+                # Extract image portion
+                img_hidden_states[i, :img_len] = hidden_states[
+                    i, encoder_seq_len:seq_len
+                ]
+
+            result_list.append((instruct_hidden_states, img_hidden_states))
+
+        return result_list
+
+    def __call__(
+        self,
+        attn: Attention,
+        img_hidden_states: torch.Tensor,
+        instruct_hidden_states: torch.Tensor,
+        joint_attention_mask: Optional[torch.Tensor] = None,
+        rotary_emb: Optional[torch.Tensor] = None,
+        encoder_seq_lengths: List[
+            int
+        ] = None,  # [B] - Instruction sequence lengths for each sample
+        seq_lengths: List[int] = None,  # [B] - Total sequence lengths for each sample
+        base_sequence_length: Optional[int] = None,
+    ) -> torch.Tensor:
+        """
+        Process double-stream self-attention computation with flash attention.
+
+        Args:
+            attn: Attention module
+            img_hidden_states: Image hidden states tensor [B, L_img, D]
+            instruct_hidden_states: Instruction hidden states tensor [B, L_instruct, D]
+            joint_attention_mask: Combined attention mask [B, L_total]
+            rotary_emb: Rotary embeddings for the joint sequence
+            encoder_seq_lengths: Instruction sequence lengths for each sample [B]
+            seq_lengths: Total sequence lengths for each sample [B]
+            base_sequence_length: Optional base sequence length for proportional attention
+
+        Returns:
+            torch.Tensor: Processed hidden states after attention computation
+        """
+        batch_size = img_hidden_states.shape[0]
+        L_instruct = instruct_hidden_states.shape[1]
+        L_img = img_hidden_states.shape[1]
+
+        # Ensure Q, K, V linear layers are on the same device as input tensors
+        device = img_hidden_states.device
+        for layer in [
+            self.img_to_q,
+            self.img_to_k,
+            self.img_to_v,
+            self.instruct_to_q,
+            self.instruct_to_k,
+            self.instruct_to_v,
+            self.instruct_out,
+            self.img_out,
+        ]:
+            if (
+                (layer.weight.device != device)
+                and (str(layer.weight.device).lower() != "meta")
+                and (str(device).lower() not in {"meta", "auto"})
+            ):
+                layer = layer.to(device)
+
+        # Generate Q, K, V for image and instruction streams (NO head reshaping yet)
+        img_query = self.img_to_q(img_hidden_states)  # [B, L_img, query_dim]
+        img_key = self.img_to_k(img_hidden_states)  # [B, L_img, kv_dim]
+        img_value = self.img_to_v(img_hidden_states)  # [B, L_img, kv_dim]
+
+        instruct_query = self.instruct_to_q(
+            instruct_hidden_states
+        )  # [B, L_instruct, query_dim]
+        instruct_key = self.instruct_to_k(
+            instruct_hidden_states
+        )  # [B, L_instruct, kv_dim]
+        instruct_value = self.instruct_to_v(
+            instruct_hidden_states
+        )  # [B, L_instruct, kv_dim]
+
+        # Use helper function to concatenate QKV (instruction first, then image)
+        img_list = [img_query, img_key, img_value]  # [B, L_img, feature_dim] each
+        instruct_list = [
+            instruct_query,
+            instruct_key,
+            instruct_value,
+        ]  # [B, L_instruct, feature_dim] each
+        concatenated_list = self._concat_instruction_image_features(
+            img_list, instruct_list, encoder_seq_lengths, seq_lengths
+        )
+        query, key, value = concatenated_list  # [B, max_seq_len, feature_dim] each
+
+        # From here, follow exactly the same logic as BooguImageAttnProcessorFlash2Varlen
+        sequence_length = max(seq_lengths)
+
+        query_dim = query.shape[-1]
+        inner_dim = key.shape[-1]
+        head_dim = query_dim // attn.heads
+        dtype = query.dtype
+
+        # Get key-value heads
+        kv_heads = inner_dim // head_dim
+
+        # Reshape tensors for attention computation
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, kv_heads, head_dim)
+        value = value.view(batch_size, -1, kv_heads, head_dim)
+
+        # Apply Query-Key normalization
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        # Apply Rotary Position Embeddings
+        if rotary_emb is not None:
+            query = apply_rotary_emb(query, rotary_emb, use_real=False)
+            key = apply_rotary_emb(key, rotary_emb, use_real=False)
+
+        query, key = query.to(dtype), key.to(dtype)
+
+        # Calculate attention scale
+        if base_sequence_length is not None:
+            softmax_scale = (
+                math.sqrt(math.log(sequence_length, base_sequence_length)) * attn.scale
+            )
+        else:
+            softmax_scale = attn.scale
+
+        # Detect if we have a causal mask
+        is_causal = False
+        if joint_attention_mask is not None and joint_attention_mask.dim() == 3:
+            # Check if it's a lower triangular causal mask
+            # For efficiency, we only check the first sample
+            mask_sample = joint_attention_mask[0]  # [seq_len, seq_len]
+            is_causal = torch.allclose(
+                mask_sample, torch.tril(torch.ones_like(mask_sample))
+            )
+
+        # Unpad input for flash attention
+        (
+            query_states,
+            key_states,
+            value_states,
+            indices_q,
+            cu_seq_lens,
+            max_seq_lens,
+        ) = self._upad_input(
+            query, key, value, joint_attention_mask, sequence_length, attn.heads
+        )
+
+        cu_seqlens_q, cu_seqlens_k = cu_seq_lens
+        max_seqlen_in_batch_q, max_seqlen_in_batch_k = max_seq_lens
+
+        # Handle different number of heads
+        if kv_heads < attn.heads:
+            key_states = repeat(
+                key_states, "l h c -> l (h k) c", k=attn.heads // kv_heads
+            )
+            value_states = repeat(
+                value_states, "l h c -> l (h k) c", k=attn.heads // kv_heads
+            )
+
+        # Apply flash attention with causal parameter
+        attn_output_unpad = flash_attn_varlen_func(
+            query_states,
+            key_states,
+            value_states,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_in_batch_q,
+            max_seqlen_k=max_seqlen_in_batch_k,
+            dropout_p=0.0,
+            causal=is_causal,  # Use detected causal setting
+            softmax_scale=softmax_scale,
+        )
+
+        # Pad output and apply final transformations
+        hidden_states = pad_input(
+            attn_output_unpad, indices_q, batch_size, sequence_length
+        )
+        hidden_states = hidden_states.flatten(-2)
+        hidden_states = hidden_states.type_as(query)
+
+        # Split hidden_states back to instruction and image, apply separate output projections, then merge
+        split_results = self._split_instruction_image_features(
+            [hidden_states], encoder_seq_lengths, seq_lengths
+        )
+        instruct_hidden_states, img_hidden_states = split_results[
+            0
+        ]  # [B, max_instruct_len, feature_dim], [B, max_img_len, feature_dim]
+
+        # Apply separate output projections for instruction and image
+        instruct_projected = self.instruct_out(
+            instruct_hidden_states
+        )  # [B, max_instruct_len, feature_dim]
+        img_projected = self.img_out(img_hidden_states)  # [B, max_img_len, feature_dim]
+
+        # Merge back to joint representation
+        merged_list = self._concat_instruction_image_features(
+            [img_projected], [instruct_projected], encoder_seq_lengths, seq_lengths
+        )
+        hidden_states = merged_list[0]  # [B, max_seq_len, feature_dim]
+
+        # Apply final output projection
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+
+        # rank, world_size, worker, num_workers = pytorch_worker_info(None)
+
+        return hidden_states
+
+
+class BooguImageDoubleStreamSelfAttnProcessor(nn.Module):
+    """
+    Double-stream self-attention processor without flash attention.
+
+    This processor implements double-stream attention where:
+    - Instruction and image features are processed separately to generate QKV
+    - QKV are concatenated and processed together for cross-modal attention
+    - Uses PyTorch's scaled_dot_product_attention for computation
+    - Supports both standard and causal attention masks
+
+    Args:
+        head_dim: Dimension of each attention head
+        num_attention_heads: Number of attention heads for queries
+        num_kv_heads: Number of key-value heads
+        qkv_bias: Whether to use bias in QKV linear layers
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        num_attention_heads: int,
+        num_kv_heads: int,
+        qkv_bias: bool = False,
+    ) -> None:
+        """Initialize the double-stream attention processor."""
+        super().__init__()
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError(
+                "BooguImageDoubleStreamSelfAttnProcessor requires PyTorch 2.0. "
+                "Please upgrade PyTorch to version 2.0 or later."
+            )
+
+        # Calculate dimensions
+        self.head_dim = head_dim
+        self.num_attention_heads = num_attention_heads
+        self.num_kv_heads = num_kv_heads
+
+        query_dim = head_dim * num_attention_heads
+        kv_dim = head_dim * num_kv_heads
+
+        # Initialize separate Q, K, V linear layers for instruction and image
+        # Query uses num_attention_heads, Key/Value use num_kv_heads
+        self.img_to_q = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+        self.img_to_k = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+        self.img_to_v = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+
+        self.instruct_to_q = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+        self.instruct_to_k = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+        self.instruct_to_v = nn.Linear(query_dim, kv_dim, bias=qkv_bias)
+
+        # Additional output projection layers for instruction and image streams
+        self.instruct_out = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+        self.img_out = nn.Linear(query_dim, query_dim, bias=qkv_bias)
+
+        # Initialize weights
+        self.initialize_weights()
+
+    def initialize_weights(self) -> None:
+        """
+        Initialize the weights of the double-stream attention processor.
+
+        Uses Xavier uniform initialization for linear layers and zero initialization for biases.
+        """
+        # Initialize image stream QKV projection layers
+        nn.init.xavier_uniform_(self.img_to_q.weight)
+        nn.init.xavier_uniform_(self.img_to_k.weight)
+        nn.init.xavier_uniform_(self.img_to_v.weight)
+
+        # Initialize instruction stream QKV projection layers
+        nn.init.xavier_uniform_(self.instruct_to_q.weight)
+        nn.init.xavier_uniform_(self.instruct_to_k.weight)
+        nn.init.xavier_uniform_(self.instruct_to_v.weight)
+
+        # Initialize separate output projection layers
+        nn.init.xavier_uniform_(self.instruct_out.weight)
+        nn.init.xavier_uniform_(self.img_out.weight)
+
+        # Initialize biases if they exist
+        if self.img_to_q.bias is not None:
+            nn.init.zeros_(self.img_to_q.bias)
+            nn.init.zeros_(self.img_to_k.bias)
+            nn.init.zeros_(self.img_to_v.bias)
+            nn.init.zeros_(self.instruct_to_q.bias)
+            nn.init.zeros_(self.instruct_to_k.bias)
+            nn.init.zeros_(self.instruct_to_v.bias)
+            nn.init.zeros_(self.instruct_out.bias)
+            nn.init.zeros_(self.img_out.bias)
+
+    def _concat_instruction_image_features(
+        self,
+        img_hidden_states_list: List[torch.Tensor],
+        instruct_hidden_states_list: List[torch.Tensor],
+        encoder_seq_lengths: List[int],
+        seq_lengths: List[int],
+    ) -> List[torch.Tensor]:
+        """
+        Concatenate instruction (text & image) and reference image features (instruction first, then image).
+
+        Args:
+            img_hidden_states_list: List of image tensors [img_query, img_key, img_value]
+            instruct_hidden_states_list: List of instruction tensors [instruct_query, instruct_key, instruct_value]
+            encoder_seq_lengths: Instruction sequence lengths for each sample [B]
+            seq_lengths: Total sequence lengths for each sample [B]
+
+        Returns:
+            List of concatenated tensors [query, key, value]
+        """
+        assert len(img_hidden_states_list) == len(instruct_hidden_states_list), (
+            f"Length mismatch: img_list={len(img_hidden_states_list)}, instruct_list={len(instruct_hidden_states_list)}"
+        )
+
+        batch_size = img_hidden_states_list[0].shape[0]
+        max_seq_len = max(seq_lengths)
+
+        concatenated_list = []
+
+        for img_tensor, instruct_tensor in zip(
+            img_hidden_states_list, instruct_hidden_states_list
+        ):
+            # Ensure tensors are on the same device
+            device = img_tensor.device
+            if instruct_tensor.device != device:
+                instruct_tensor = instruct_tensor.to(device)
+
+            # Create output tensor with proper shape [B, max_seq_len, feature_dim]
+            feature_dim = img_tensor.shape[-1]
+            concatenated = img_tensor.new_zeros(batch_size, max_seq_len, feature_dim)
+
+            # Concatenate instruction first, then image for each sample
+            for i, (encoder_seq_len, seq_len) in enumerate(
+                zip(encoder_seq_lengths, seq_lengths)
+            ):
+                # Place instruction tokens first
+                concatenated[i, :encoder_seq_len] = instruct_tensor[i, :encoder_seq_len]
+                # Place image tokens after instruction
+                concatenated[i, encoder_seq_len:seq_len] = img_tensor[
+                    i, : seq_len - encoder_seq_len
+                ]
+
+            concatenated_list.append(concatenated)
+
+        return concatenated_list
+
+    def _split_instruction_image_features(
+        self,
+        hidden_states_list: List[torch.Tensor],
+        encoder_seq_lengths: List[int],
+        seq_lengths: List[int],
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """
+        Split concatenated features back to instruction and image features.
+        Inverse operation of _concat_instruction_image_features.
+
+        Args:
+            hidden_states_list: List of concatenated tensors (usually just one element)
+            encoder_seq_lengths: Instruction sequence lengths for each sample [B]
+            seq_lengths: Total sequence lengths for each sample [B]
+
+        Returns:
+            List of tuples, each containing (instruct_hidden_states, img_hidden_states)
+        """
+        result_list = []
+
+        for hidden_states in hidden_states_list:
+            batch_size = hidden_states.shape[0]
+            feature_dim = hidden_states.shape[-1]
+
+            # Get maximum lengths for instruction and image
+            max_instruct_len = max(encoder_seq_lengths)
+            max_img_len = max(
+                seq_len - encoder_seq_len
+                for seq_len, encoder_seq_len in zip(seq_lengths, encoder_seq_lengths)
+            )
+
+            # Create output tensors [B, max_len, feature_dim]
+            instruct_hidden_states = hidden_states.new_zeros(
+                batch_size, max_instruct_len, feature_dim
+            )
+            img_hidden_states = hidden_states.new_zeros(
+                batch_size, max_img_len, feature_dim
+            )
+
+            # Split each sample back to instruction and image
+            for i, (encoder_seq_len, seq_len) in enumerate(
+                zip(encoder_seq_lengths, seq_lengths)
+            ):
+                img_len = seq_len - encoder_seq_len
+
+                # Extract instruction portion
+                instruct_hidden_states[i, :encoder_seq_len] = hidden_states[
+                    i, :encoder_seq_len
+                ]
+                # Extract image portion
+                img_hidden_states[i, :img_len] = hidden_states[
+                    i, encoder_seq_len:seq_len
+                ]
+
+            result_list.append((instruct_hidden_states, img_hidden_states))
+
+        return result_list
+
+    def __call__(
+        self,
+        attn: Attention,
+        img_hidden_states: torch.Tensor,
+        instruct_hidden_states: torch.Tensor,
+        joint_attention_mask: Optional[torch.Tensor] = None,
+        rotary_emb: Optional[torch.Tensor] = None,
+        encoder_seq_lengths: List[
+            int
+        ] = None,  # [B] - Instruction sequence lengths for each sample
+        seq_lengths: List[int] = None,  # [B] - Total sequence lengths for each sample
+        base_sequence_length: Optional[int] = None,
+    ) -> torch.Tensor:
+        """
+        Process double-stream self-attention computation with PyTorch's scaled_dot_product_attention.
+
+        Args:
+            attn: Attention module
+            img_hidden_states: Image hidden states tensor [B, L_img, D]
+            instruct_hidden_states: Instruction hidden states tensor [B, L_instruct, D]
+            joint_attention_mask: Combined attention mask [B, L_total]
+            rotary_emb: Rotary embeddings for the joint sequence
+            encoder_seq_lengths: Instruction sequence lengths for each sample [B]
+            seq_lengths: Total sequence lengths for each sample [B]
+            base_sequence_length: Optional base sequence length for proportional attention
+
+        Returns:
+            torch.Tensor: Processed hidden states after attention computation
+        """
+        batch_size = img_hidden_states.shape[0]
+        L_instruct = instruct_hidden_states.shape[1]
+        L_img = img_hidden_states.shape[1]
+
+        # Ensure Q, K, V linear layers are on the same device as input tensors
+        device = img_hidden_states.device
+        for layer in [
+            self.img_to_q,
+            self.img_to_k,
+            self.img_to_v,
+            self.instruct_to_q,
+            self.instruct_to_k,
+            self.instruct_to_v,
+            self.instruct_out,
+            self.img_out,
+        ]:
+            if (
+                (layer.weight.device != device)
+                and (str(layer.weight.device).lower() != "meta")
+                and (str(device).lower() not in {"meta", "auto"})
+            ):
+                layer = layer.to(device)
+
+        # Generate Q, K, V for image and instruction streams (NO head reshaping yet)
+        img_query = self.img_to_q(img_hidden_states)  # [B, L_img, query_dim]
+        img_key = self.img_to_k(img_hidden_states)  # [B, L_img, kv_dim]
+        img_value = self.img_to_v(img_hidden_states)  # [B, L_img, kv_dim]
+
+        instruct_query = self.instruct_to_q(
+            instruct_hidden_states
+        )  # [B, L_instruct, query_dim]
+        instruct_key = self.instruct_to_k(
+            instruct_hidden_states
+        )  # [B, L_instruct, kv_dim]
+        instruct_value = self.instruct_to_v(
+            instruct_hidden_states
+        )  # [B, L_instruct, kv_dim]
+
+        # Use helper function to concatenate QKV (instruction first, then image)
+        img_list = [img_query, img_key, img_value]  # [B, L_img, feature_dim] each
+        instruct_list = [
+            instruct_query,
+            instruct_key,
+            instruct_value,
+        ]  # [B, L_instruct, feature_dim] each
+        concatenated_list = self._concat_instruction_image_features(
+            img_list, instruct_list, encoder_seq_lengths, seq_lengths
+        )
+        query, key, value = concatenated_list  # [B, max_seq_len, feature_dim] each
+
+        # From here, follow exactly the same logic as BooguImageAttnProcessor
+        sequence_length = max(seq_lengths)
+
+        query_dim = query.shape[-1]
+        inner_dim = key.shape[-1]
+        head_dim = query_dim // attn.heads
+        dtype = query.dtype
+
+        # Get key-value heads
+        kv_heads = inner_dim // head_dim
+
+        # Reshape tensors for attention computation
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, kv_heads, head_dim)
+        value = value.view(batch_size, -1, kv_heads, head_dim)
+
+        # Apply Query-Key normalization
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        # Apply Rotary Position Embeddings
+        if rotary_emb is not None:
+            query = apply_rotary_emb(query, rotary_emb, use_real=False)
+            key = apply_rotary_emb(key, rotary_emb, use_real=False)
+
+        query, key = query.to(dtype), key.to(dtype)
+
+        # Calculate attention scale
+        if base_sequence_length is not None:
+            softmax_scale = (
+                math.sqrt(math.log(sequence_length, base_sequence_length)) * attn.scale
+            )
+        else:
+            softmax_scale = attn.scale
+
+        # scaled_dot_product_attention expects attention_mask shape to be
+        # (batch, heads, source_length, target_length)
+        if joint_attention_mask is not None:
+            joint_attention_mask = joint_attention_mask.bool()
+            if joint_attention_mask.dim() == 2:
+                # Standard mask [B, seq_len] -> [B, 1, 1, seq_len]
+                joint_attention_mask = joint_attention_mask.view(batch_size, 1, 1, -1)
+            elif joint_attention_mask.dim() == 3:
+                # Causal mask [B, seq_len, seq_len] -> [B, 1, seq_len, seq_len]
+                joint_attention_mask = joint_attention_mask.unsqueeze(1)
+            else:
+                raise ValueError(
+                    f"Unsupported joint_attention_mask shape: {joint_attention_mask.shape}"
+                )
+
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+
+        # explicitly repeat key and value to match query length, otherwise using enable_gqa=True results in MATH backend of sdpa in our test of pytorch2.6
+        key = key.repeat_interleave(query.size(-3) // key.size(-3), -3)
+        value = value.repeat_interleave(query.size(-3) // value.size(-3), -3)
+
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=joint_attention_mask, scale=softmax_scale
+        )
+        hidden_states = hidden_states.transpose(1, 2).reshape(
+            batch_size, -1, attn.heads * head_dim
+        )
+        hidden_states = hidden_states.type_as(query)
+
+        # Split hidden_states back to instruction and image, apply separate output projections, then merge
+        split_results = self._split_instruction_image_features(
+            [hidden_states], encoder_seq_lengths, seq_lengths
+        )
+        instruct_hidden_states, img_hidden_states = split_results[
+            0
+        ]  # [B, max_instruct_len, feature_dim], [B, max_img_len, feature_dim]
+
+        # Apply separate output projections for instruction and image
+        instruct_projected = self.instruct_out(
+            instruct_hidden_states
+        )  # [B, max_instruct_len, feature_dim]
+        img_projected = self.img_out(img_hidden_states)  # [B, max_img_len, feature_dim]
+
+        # Merge back to joint representation
+        merged_list = self._concat_instruction_image_features(
+            [img_projected], [instruct_projected], encoder_seq_lengths, seq_lengths
+        )
+        hidden_states = merged_list[0]  # [B, max_seq_len, feature_dim]
+
+        # Apply final output projection
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+
+        return hidden_states
+
+
+class BooguImageAttnProcessorFlash2Varlen:
+    """
+    Processor for implementing scaled dot-product attention with flash attention and variable length sequences.
+
+    This processor implements:
+    - Flash attention with variable length sequences
+    - Rotary position embeddings (RoPE)
+    - Query-Key normalization
+    - Proportional attention scaling
+
+    Args:
+        None
+    """
+
+    def __init__(self) -> None:
+        """Initialize the attention processor."""
+        if not is_flash_attn_available():
+            raise ImportError(
+                "BooguImageAttnProcessorFlash2Varlen requires flash_attn. "
+                "Please install flash_attn."
+            )
+
+    def _upad_input(
+        self,
+        query_layer: torch.Tensor,
+        key_layer: torch.Tensor,
+        value_layer: torch.Tensor,
+        attention_mask: torch.Tensor,
+        query_length: int,
+        num_heads: int,
+    ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        Tuple[torch.Tensor, torch.Tensor],
+        Tuple[int, int],
+    ]:
+        """
+        Unpad the input tensors for flash attention.
+
+        Args:
+            query_layer: Query tensor of shape (batch_size, seq_len, num_heads, head_dim)
+            key_layer: Key tensor of shape (batch_size, seq_len, num_kv_heads, head_dim)
+            value_layer: Value tensor of shape (batch_size, seq_len, num_kv_heads, head_dim)
+            attention_mask: Attention mask tensor of shape (batch_size, seq_len) or (batch_size, seq_len, seq_len) for causal
+            query_length: Length of the query sequence
+            num_heads: Number of attention heads
+
+        Returns:
+            Tuple containing:
+                - Unpadded query tensor
+                - Unpadded key tensor
+                - Unpadded value tensor
+                - Query indices
+                - Tuple of cumulative sequence lengths for query and key
+                - Tuple of maximum sequence lengths for query and key
+        """
+
+        def _get_unpad_data(
+            mask_2d: torch.Tensor,
+        ) -> Tuple[torch.Tensor, torch.Tensor, int]:
+            """Helper function to get unpadding data from a 2D attention mask [B, L]."""
+            seqlens_in_batch = mask_2d.sum(dim=-1, dtype=torch.int32)
+            indices = torch.nonzero(mask_2d.flatten(), as_tuple=False).flatten()
+            max_seqlen_in_batch = seqlens_in_batch.max().item()
+            cu_seqlens = F.pad(
+                torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+            )
+            return indices, cu_seqlens, max_seqlen_in_batch
+
+        # Normalize attention mask: if a causal 3D mask is provided [B, L, L],
+        # convert it to a standard 2D padding mask [B, L] with True for valid tokens.
+        if attention_mask is not None and attention_mask.dim() == 3:
+            B, L, _ = attention_mask.shape
+            # For a proper lower-triangular causal mask, all first L positions are valid per sample.
+            # However, to be robust, infer per-sample effective lengths from the diagonal.
+            diag_valid = torch.diagonal(attention_mask, dim1=-2, dim2=-1)
+            lengths = diag_valid.sum(dim=-1, dtype=torch.int32)  # [B]
+            mask_2d = torch.zeros(B, L, dtype=torch.bool, device=attention_mask.device)
+            for i in range(B):
+                if lengths[i].item() > 0:
+                    mask_2d[i, : int(lengths[i].item())] = True
+        else:
+            mask_2d = attention_mask  # already [B, L]
+
+        indices_k, cu_seqlens_k, max_seqlen_in_batch_k = _get_unpad_data(mask_2d)
+        batch_size, kv_seq_len, num_key_value_heads, head_dim = key_layer.shape
+
+        # Unpad key and value layers (shared path for both standard and causal cases)
+        key_layer = index_first_axis(
+            key_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
+            indices_k,
+        )
+        value_layer = index_first_axis(
+            value_layer.reshape(batch_size * kv_seq_len, num_key_value_heads, head_dim),
+            indices_k,
+        )
+
+        # Handle different query length cases
+        if query_length == kv_seq_len:
+            query_layer = index_first_axis(
+                query_layer.reshape(batch_size * kv_seq_len, num_heads, head_dim),
+                indices_k,
+            )
+            cu_seqlens_q = cu_seqlens_k
+            max_seqlen_in_batch_q = max_seqlen_in_batch_k
+            indices_q = indices_k
+        elif query_length == 1:
+            max_seqlen_in_batch_q = 1
+            cu_seqlens_q = torch.arange(
+                batch_size + 1, dtype=torch.int32, device=query_layer.device
+            )
+            indices_q = cu_seqlens_q[:-1]
+            query_layer = query_layer.squeeze(1)
+        else:
+            # Use the last query_length positions of the 2D mask
+            q_mask = mask_2d[:, -query_length:]
+            query_layer, indices_q, cu_seqlens_q, max_seqlen_in_batch_q = unpad_input(
+                query_layer, q_mask
+            )
+
+        return (
+            query_layer,
+            key_layer,
+            value_layer,
+            indices_q,
+            (cu_seqlens_q, cu_seqlens_k),
+            (max_seqlen_in_batch_q, max_seqlen_in_batch_k),
+        )
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        image_rotary_emb: Optional[torch.Tensor] = None,
+        base_sequence_length: Optional[int] = None,
+    ) -> torch.Tensor:
+        """
+        Process attention computation with flash attention.
+
+        Args:
+            attn: Attention module
+            hidden_states: Hidden states tensor of shape (batch_size, seq_len, hidden_dim)
+            encoder_hidden_states: Encoder hidden states tensor
+            attention_mask: Optional attention mask tensor
+            image_rotary_emb: Optional rotary embeddings for image tokens
+            base_sequence_length: Optional base sequence length for proportional attention
+
+        Returns:
+            torch.Tensor: Processed hidden states after attention computation
+        """
+
+        batch_size, sequence_length, _ = hidden_states.shape
+
+        # Get Query-Key-Value Pair
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        query_dim = query.shape[-1]
+        inner_dim = key.shape[-1]
+        head_dim = query_dim // attn.heads
+        dtype = query.dtype
+
+        # Get key-value heads
+        kv_heads = inner_dim // head_dim
+
+        # Reshape tensors for attention computation
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, kv_heads, head_dim)
+        value = value.view(batch_size, -1, kv_heads, head_dim)
+
+        # Apply Query-Key normalization
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        # Apply Rotary Position Embeddings
+        if image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=False)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=False)
+
+        query, key = query.to(dtype), key.to(dtype)
+
+        # Calculate attention scale
+        if base_sequence_length is not None:
+            softmax_scale = (
+                math.sqrt(math.log(sequence_length, base_sequence_length)) * attn.scale
+            )
+        else:
+            softmax_scale = attn.scale
+
+        # Detect if we have a causal mask
+        is_causal = False
+        if attention_mask is not None and attention_mask.dim() == 3:
+            # Check if it's a lower triangular causal mask
+            # For efficiency, we only check the first sample
+            mask_sample = attention_mask[0]  # [seq_len, seq_len]
+            is_causal = torch.allclose(
+                mask_sample, torch.tril(torch.ones_like(mask_sample))
+            )
+
+        # Unpad input for flash attention
+        (
+            query_states,
+            key_states,
+            value_states,
+            indices_q,
+            cu_seq_lens,
+            max_seq_lens,
+        ) = self._upad_input(
+            query, key, value, attention_mask, sequence_length, attn.heads
+        )
+
+        cu_seqlens_q, cu_seqlens_k = cu_seq_lens
+        max_seqlen_in_batch_q, max_seqlen_in_batch_k = max_seq_lens
+
+        # Handle different number of heads
+        if kv_heads < attn.heads:
+            key_states = repeat(
+                key_states, "l h c -> l (h k) c", k=attn.heads // kv_heads
+            )
+            value_states = repeat(
+                value_states, "l h c -> l (h k) c", k=attn.heads // kv_heads
+            )
+
+        # Apply flash attention with causal parameter
+        attn_output_unpad = flash_attn_varlen_func(
+            query_states,
+            key_states,
+            value_states,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_in_batch_q,
+            max_seqlen_k=max_seqlen_in_batch_k,
+            dropout_p=0.0,
+            causal=is_causal,  # Use detected causal setting
+            softmax_scale=softmax_scale,
+        )
+
+        # Pad output and apply final transformations
+        hidden_states = pad_input(
+            attn_output_unpad, indices_q, batch_size, sequence_length
+        )
+        hidden_states = hidden_states.flatten(-2)
+        hidden_states = hidden_states.type_as(query)
+
+        # Apply output projection
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+
+        return hidden_states
+
+
+class BooguImageAttnProcessor:
+    """
+    Processor for implementing scaled dot-product attention with flash attention and variable length sequences.
+
+    This processor is optimized for PyTorch 2.0 and implements:
+    - Flash attention with variable length sequences
+    - Rotary position embeddings (RoPE)
+    - Query-Key normalization
+    - Proportional attention scaling
+
+    Args:
+        None
+
+    Raises:
+        ImportError: If PyTorch version is less than 2.0
+    """
+
+    def __init__(self) -> None:
+        """Initialize the attention processor."""
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError(
+                "BooguImageAttnProcessorFlash2Varlen requires PyTorch 2.0. "
+                "Please upgrade PyTorch to version 2.0 or later."
+            )
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        image_rotary_emb: Optional[torch.Tensor] = None,
+        base_sequence_length: Optional[int] = None,
+    ) -> torch.Tensor:
+        """
+        Process attention computation with flash attention.
+
+        Args:
+            attn: Attention module
+            hidden_states: Hidden states tensor of shape (batch_size, seq_len, hidden_dim)
+            encoder_hidden_states: Encoder hidden states tensor
+            attention_mask: Optional attention mask tensor
+            image_rotary_emb: Optional rotary embeddings for image tokens
+            base_sequence_length: Optional base sequence length for proportional attention
+
+        Returns:
+            torch.Tensor: Processed hidden states after attention computation
+        """
+        batch_size, sequence_length, _ = hidden_states.shape
+
+        # Get Query-Key-Value Pair
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        query_dim = query.shape[-1]
+        inner_dim = key.shape[-1]
+        head_dim = query_dim // attn.heads
+        dtype = query.dtype
+
+        # Get key-value heads
+        kv_heads = inner_dim // head_dim
+
+        # Reshape tensors for attention computation
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, kv_heads, head_dim)
+        value = value.view(batch_size, -1, kv_heads, head_dim)
+
+        # Apply Query-Key normalization
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        # Apply Rotary Position Embeddings
+        if image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, use_real=False)
+            key = apply_rotary_emb(key, image_rotary_emb, use_real=False)
+
+        query, key = query.to(dtype), key.to(dtype)
+
+        # Calculate attention scale
+        if base_sequence_length is not None:
+            softmax_scale = (
+                math.sqrt(math.log(sequence_length, base_sequence_length)) * attn.scale
+            )
+        else:
+            softmax_scale = attn.scale
+
+        # sdpa expects attn_mask with shape (B, H, Q, K) as boolean (True keeps, False masks)
+        if attention_mask is not None:
+            attention_mask = attention_mask.bool()
+            if attention_mask.dim() == 2:
+                # Standard padding mask [B, L] -> [B, 1, 1, L]
+                attention_mask = attention_mask.view(batch_size, 1, 1, -1)
+            elif attention_mask.dim() == 3:
+                # Robust causal + padding mask construction
+                # Infer valid lengths from diagonal, then build lower-triangular mask within valid lengths
+                B, L, _ = attention_mask.shape
+                diag_valid = torch.diagonal(attention_mask, dim1=-2, dim2=-1)
+                lengths = diag_valid.sum(dim=-1)  # [B]
+                arange_L = torch.arange(L, device=attention_mask.device)
+                # Padding masks for queries and keys: shape [B, L]
+                q_valid = arange_L.unsqueeze(0) < lengths.unsqueeze(1)
+                k_valid = q_valid  # same lengths assumed
+                # Lower-triangular causal mask [L, L]
+                causal = torch.tril(
+                    torch.ones(L, L, dtype=torch.bool, device=attention_mask.device)
+                )
+                # Combine: [B, L, L]
+                combined = causal & q_valid.unsqueeze(-1) & k_valid.unsqueeze(-2)
+                attention_mask = combined.unsqueeze(1)  # [B, 1, L, L]
+            else:
+                raise ValueError(
+                    f"Unsupported attention_mask shape: {attention_mask.shape}"
+                )
+
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+
+        # explicitly repeat key and value to match query length, otherwise using enable_gqa=True results in MATH backend of sdpa in our test of pytorch2.6
+        key = key.repeat_interleave(query.size(-3) // key.size(-3), -3)
+        value = value.repeat_interleave(query.size(-3) // value.size(-3), -3)
+
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=attention_mask, scale=softmax_scale
+        )
+        hidden_states = hidden_states.transpose(1, 2).reshape(
+            batch_size, -1, attn.heads * head_dim
+        )
+        hidden_states = hidden_states.type_as(query)
+
+        # Apply output projection
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+
+        return hidden_states

--- a/unirl/models/boogu_image/vendor/attention_processor.py
+++ b/unirl/models/boogu_image/vendor/attention_processor.py
@@ -7,7 +7,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import repeat
 
-from ..utils.import_utils import is_flash_attn_available
+# UniRL vendor edit: flattened same-dir import. See VENDOR_COMMIT.txt.
+from .import_utils import is_flash_attn_available
 
 if is_flash_attn_available():
     from flash_attn import flash_attn_varlen_func

--- a/unirl/models/boogu_image/vendor/block_lumina2.py
+++ b/unirl/models/boogu_image/vendor/block_lumina2.py
@@ -1,0 +1,219 @@
+import os
+import warnings
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+from diffusers.models.embeddings import Timesteps
+
+from ...utils.import_utils import is_flash_attn_available, is_triton_available
+from ..embeddings import TimestepEmbedding
+
+if is_triton_available() and ("cuda" in os.getenv("device", "cpu")):
+    from ...ops.triton.layer_norm import RMSNorm
+else:
+    from torch.nn import RMSNorm
+
+    warnings.warn(
+        "Cannot import triton, install triton to use fused RMSNorm for better performance"
+    )
+
+if is_flash_attn_available() and ("cuda" in os.getenv("device", "cpu")):
+    from flash_attn.ops.activations import swiglu
+
+    from .components import swiglu as torch_swiglu
+else:
+    from .components import swiglu
+    from .components import swiglu as torch_swiglu
+
+    warnings.warn(
+        "Cannot import flash_attn, install flash_attn to use fused SwiGLU for better performance"
+    )
+
+# try:
+# except ImportError:
+
+#     warnings.warn("Cannot import apex RMSNorm, switch to vanilla implementation")
+
+
+class LuminaRMSNormZero(nn.Module):
+    """
+    Norm layer adaptive RMS normalization zero.
+
+    Parameters:
+        embedding_dim (`int`): The size of each embedding vector.
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        norm_eps: float,
+        norm_elementwise_affine: bool,
+    ):
+        super().__init__()
+        self.silu = nn.SiLU()
+        self.linear = nn.Linear(
+            min(embedding_dim, 1024),
+            4 * embedding_dim,
+            bias=True,
+        )
+
+        self.norm = RMSNorm(embedding_dim, eps=norm_eps)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        emb: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        emb = self.linear(self.silu(emb))
+        scale_msa, gate_msa, scale_mlp, gate_mlp = emb.chunk(4, dim=1)
+        x = self.norm(x) * (1 + scale_msa[:, None])
+        return x, gate_msa, scale_mlp, gate_mlp
+
+
+class LuminaLayerNormContinuous(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        conditioning_embedding_dim: int,
+        # NOTE: It is a bit weird that the norm layer can be configured to have scale and shift parameters
+        # because the output is immediately scaled and shifted by the projected conditioning embeddings.
+        # Note that AdaLayerNorm does not let the norm layer have scale and shift parameters.
+        # However, this is how it was implemented in the original code, and it's rather likely you should
+        # set `elementwise_affine` to False.
+        elementwise_affine=True,
+        eps=1e-5,
+        bias=True,
+        norm_type="layer_norm",
+        out_dim: Optional[int] = None,
+    ):
+        super().__init__()
+
+        # AdaLN
+        self.silu = nn.SiLU()
+        self.linear_1 = nn.Linear(conditioning_embedding_dim, embedding_dim, bias=bias)
+
+        if norm_type == "layer_norm":
+            self.norm = nn.LayerNorm(embedding_dim, eps, elementwise_affine, bias)
+        elif norm_type == "rms_norm":
+            self.norm = RMSNorm(
+                embedding_dim, eps=eps, elementwise_affine=elementwise_affine
+            )
+        else:
+            raise ValueError(f"unknown norm_type {norm_type}")
+
+        self.linear_2 = None
+        if out_dim is not None:
+            self.linear_2 = nn.Linear(embedding_dim, out_dim, bias=bias)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        conditioning_embedding: torch.Tensor,
+    ) -> torch.Tensor:
+        # convert back to the original dtype in case `conditioning_embedding`` is upcasted to float32 (needed for hunyuanDiT)
+        emb = self.linear_1(self.silu(conditioning_embedding).to(x.dtype))
+        scale = emb
+        x = self.norm(x) * (1 + scale)[:, None, :]
+
+        if self.linear_2 is not None:
+            x = self.linear_2(x)
+
+        return x
+
+
+class LuminaFeedForward(nn.Module):
+    r"""
+    A feed-forward layer.
+
+    Parameters:
+        hidden_size (`int`):
+            The dimensionality of the hidden layers in the model. This parameter determines the width of the model's
+            hidden representations.
+        intermediate_size (`int`): The intermediate dimension of the feedforward layer.
+        multiple_of (`int`, *optional*): Value to ensure hidden dimension is a multiple
+            of this value.
+        ffn_dim_multiplier (float, *optional*): Custom multiplier for hidden
+            dimension. Defaults to None.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        inner_dim: int,
+        multiple_of: Optional[int] = 256,
+        ffn_dim_multiplier: Optional[float] = None,
+    ):
+        super().__init__()
+        self.swiglu = swiglu
+
+        # custom hidden_size factor multiplier
+        if ffn_dim_multiplier is not None:
+            inner_dim = int(ffn_dim_multiplier * inner_dim)
+        inner_dim = multiple_of * ((inner_dim + multiple_of - 1) // multiple_of)
+
+        self.linear_1 = nn.Linear(
+            dim,
+            inner_dim,
+            bias=False,
+        )
+        self.linear_2 = nn.Linear(
+            inner_dim,
+            dim,
+            bias=False,
+        )
+        self.linear_3 = nn.Linear(
+            dim,
+            inner_dim,
+            bias=False,
+        )
+
+    def forward(self, x):
+        h1, h2 = self.linear_1(x), self.linear_3(x)
+        swiglu_fn = torch_swiglu if torch.compiler.is_compiling() else self.swiglu
+        return self.linear_2(swiglu_fn(h1, h2))
+
+
+class Lumina2CombinedTimestepCaptionEmbedding(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int = 4096,
+        instruction_feat_dim: int = 2048,
+        frequency_embedding_size: int = 256,
+        norm_eps: float = 1e-5,
+        timestep_scale: float = 1.0,
+    ) -> None:
+        super().__init__()
+
+        self.time_proj = Timesteps(
+            num_channels=frequency_embedding_size,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=0.0,
+            scale=timestep_scale,
+        )
+
+        self.timestep_embedder = TimestepEmbedding(
+            in_channels=frequency_embedding_size, time_embed_dim=min(hidden_size, 1024)
+        )
+
+        self.caption_embedder = nn.Sequential(
+            RMSNorm(instruction_feat_dim, eps=norm_eps),
+            nn.Linear(instruction_feat_dim, hidden_size, bias=True),
+        )
+
+        self._initialize_weights()
+
+    def _initialize_weights(self):
+        nn.init.trunc_normal_(self.caption_embedder[1].weight, std=0.02)
+        nn.init.zeros_(self.caption_embedder[1].bias)
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        instruction_hidden_states: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        timestep_proj = self.time_proj(timestep).to(dtype=dtype)
+        time_embed = self.timestep_embedder(timestep_proj)
+        caption_embed = self.caption_embedder(instruction_hidden_states)
+        return time_embed, caption_embed

--- a/unirl/models/boogu_image/vendor/block_lumina2.py
+++ b/unirl/models/boogu_image/vendor/block_lumina2.py
@@ -1,34 +1,18 @@
-import os
-import warnings
 from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
 from diffusers.models.embeddings import Timesteps
 
-from ...utils.import_utils import is_flash_attn_available, is_triton_available
-from ..embeddings import TimestepEmbedding
+# UniRL vendor edit: triton-RMSNorm and flash-swiglu env-var conditionals
+# replaced by the upstream default-env branches (torch.nn.RMSNorm + pure-torch
+# swiglu) so training numerics are environment-independent. See
+# VENDOR_COMMIT.txt.
+from .embeddings import TimestepEmbedding
+from torch.nn import RMSNorm
 
-if is_triton_available() and ("cuda" in os.getenv("device", "cpu")):
-    from ...ops.triton.layer_norm import RMSNorm
-else:
-    from torch.nn import RMSNorm
-
-    warnings.warn(
-        "Cannot import triton, install triton to use fused RMSNorm for better performance"
-    )
-
-if is_flash_attn_available() and ("cuda" in os.getenv("device", "cpu")):
-    from flash_attn.ops.activations import swiglu
-
-    from .components import swiglu as torch_swiglu
-else:
-    from .components import swiglu
-    from .components import swiglu as torch_swiglu
-
-    warnings.warn(
-        "Cannot import flash_attn, install flash_attn to use fused SwiGLU for better performance"
-    )
+from .components import swiglu
+from .components import swiglu as torch_swiglu
 
 # try:
 # except ImportError:

--- a/unirl/models/boogu_image/vendor/components.py
+++ b/unirl/models/boogu_image/vendor/components.py
@@ -1,0 +1,5 @@
+import torch.nn.functional as F
+
+
+def swiglu(x, y):
+    return F.silu(x.float(), inplace=False).to(x.dtype) * y

--- a/unirl/models/boogu_image/vendor/embeddings.py
+++ b/unirl/models/boogu_image/vendor/embeddings.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2026 Boogu Team.
+# This repository is a fork by Boogu Team; modifications have been made.
+#
+# Original work: Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional, Tuple, Union
+
+import torch
+from diffusers.models.activations import get_activation
+from torch import nn
+
+
+class TimestepEmbedding(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        time_embed_dim: int,
+        act_fn: str = "silu",
+        out_dim: int = None,
+        post_act_fn: Optional[str] = None,
+        cond_proj_dim=None,
+        sample_proj_bias=True,
+    ):
+        super().__init__()
+
+        self.linear_1 = nn.Linear(in_channels, time_embed_dim, sample_proj_bias)
+
+        if cond_proj_dim is not None:
+            self.cond_proj = nn.Linear(cond_proj_dim, in_channels, bias=False)
+        else:
+            self.cond_proj = None
+
+        self.act = get_activation(act_fn)
+
+        if out_dim is not None:
+            time_embed_dim_out = out_dim
+        else:
+            time_embed_dim_out = time_embed_dim
+        self.linear_2 = nn.Linear(time_embed_dim, time_embed_dim_out, sample_proj_bias)
+
+        if post_act_fn is None:
+            self.post_act = None
+        else:
+            self.post_act = get_activation(post_act_fn)
+
+        self.initialize_weights()
+
+    def initialize_weights(self):
+        nn.init.normal_(self.linear_1.weight, std=0.02)
+        nn.init.zeros_(self.linear_1.bias)
+        nn.init.normal_(self.linear_2.weight, std=0.02)
+        nn.init.zeros_(self.linear_2.bias)
+
+    def forward(self, sample, condition=None):
+        if condition is not None:
+            sample = sample + self.cond_proj(condition)
+        sample = self.linear_1(sample)
+
+        if self.act is not None:
+            sample = self.act(sample)
+
+        sample = self.linear_2(sample)
+
+        if self.post_act is not None:
+            sample = self.post_act(sample)
+        return sample
+
+
+def apply_rotary_emb(
+    x: torch.Tensor,
+    freqs_cis: Union[torch.Tensor, Tuple[torch.Tensor]],
+    use_real: bool = True,
+    use_real_unbind_dim: int = -1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Apply rotary embeddings to input tensors using the given frequency tensor. This function applies rotary embeddings
+    to the given query or key 'x' tensors using the provided frequency tensor 'freqs_cis'. The input tensors are
+    reshaped as complex numbers, and the frequency tensor is reshaped for broadcasting compatibility. The resulting
+    tensors contain rotary embeddings and are returned as real tensors.
+
+    Args:
+        x (`torch.Tensor`):
+            Query or key tensor to apply rotary embeddings. [B, H, S, D] xk (torch.Tensor): Key tensor to apply
+        freqs_cis (`Tuple[torch.Tensor]`): Precomputed frequency tensor for complex exponentials. ([S, D], [S, D],)
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: Tuple of modified query tensor and key tensor with rotary embeddings.
+    """
+    if use_real:
+        cos, sin = freqs_cis  # [S, D]
+        cos = cos[None, None]
+        sin = sin[None, None]
+        cos, sin = cos.to(x.device), sin.to(x.device)
+
+        if use_real_unbind_dim == -1:
+            # Used for flux, cogvideox, hunyuan-dit
+            x_real, x_imag = x.reshape(*x.shape[:-1], -1, 2).unbind(
+                -1
+            )  # [B, S, H, D//2]
+            x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(3)
+        elif use_real_unbind_dim == -2:
+            # Used for Stable Audio, Boogu and CogView4
+            x_real, x_imag = x.reshape(*x.shape[:-1], 2, -1).unbind(
+                -2
+            )  # [B, S, H, D//2]
+            x_rotated = torch.cat([-x_imag, x_real], dim=-1)
+        else:
+            raise ValueError(
+                f"`use_real_unbind_dim={use_real_unbind_dim}` but should be -1 or -2."
+            )
+
+        out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
+
+        return out
+    else:
+        # used for lumina
+        x_rotated = torch.view_as_complex(
+            x.float().reshape(*x.shape[:-1], x.shape[-1] // 2, 2)
+        )
+        freqs_cis = freqs_cis.unsqueeze(2)
+        x_out = torch.view_as_real(x_rotated * freqs_cis).flatten(3)
+
+        return x_out.type_as(x)

--- a/unirl/models/boogu_image/vendor/import_utils.py
+++ b/unirl/models/boogu_image/vendor/import_utils.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 Boogu Team.
+# This repository is a fork by Boogu Team; modifications have been made.
+#
+# Original work: Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Import utilities: Utilities related to imports and our lazy inits.
+"""
+
+import importlib.util
+import sys
+
+# The package importlib_metadata is in a different place, depending on the python version.
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+
+def _is_package_available(pkg_name: str):
+    pkg_exists = importlib.util.find_spec(pkg_name) is not None
+    pkg_version = "N/A"
+
+    if pkg_exists:
+        try:
+            pkg_version = importlib_metadata.version(pkg_name)
+        except (ImportError, importlib_metadata.PackageNotFoundError):
+            pkg_exists = False
+
+    return pkg_exists, pkg_version
+
+
+_triton_available, _triton_version = _is_package_available("triton")
+_flash_attn_available, _flash_attn_version = _is_package_available("flash_attn")
+
+
+def is_triton_available():
+    return _triton_available
+
+
+def is_flash_attn_available():
+    return _flash_attn_available

--- a/unirl/models/boogu_image/vendor/rope.py
+++ b/unirl/models/boogu_image/vendor/rope.py
@@ -1,0 +1,545 @@
+"""
+# Copyright (C) 2026 Boogu Team.
+# This repository is a fork by Boogu Team; modifications have been made.
+#
+# Original work: Copyright 2025 BAAI, The OmniGen2 Team and The HuggingFace Team. All rights reserved.
+#
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+from diffusers.models.embeddings import get_1d_rotary_pos_embed
+from einops import repeat
+
+
+class BooguImageRotaryPosEmbed(nn.Module):
+    def __init__(
+        self,
+        theta: int,
+        axes_dim: Tuple[int, int, int],
+        axes_lens: Tuple[int, int, int] = (300, 512, 512),
+        patch_size: int = 2,
+    ):
+        super().__init__()
+        self.theta = theta
+        self.axes_dim = axes_dim
+        self.axes_lens = axes_lens
+        self.patch_size = patch_size
+
+    @staticmethod
+    def get_freqs_cis(
+        axes_dim: Tuple[int, int, int], axes_lens: Tuple[int, int, int], theta: int
+    ) -> List[torch.Tensor]:
+        freqs_cis = []
+        freqs_dtype = (
+            torch.float32 if torch.backends.mps.is_available() else torch.float64
+        )
+        for i, (d, e) in enumerate(zip(axes_dim, axes_lens)):
+            emb = get_1d_rotary_pos_embed(d, e, theta=theta, freqs_dtype=freqs_dtype)
+            freqs_cis.append(emb)
+        return freqs_cis
+
+    def _get_freqs_cis(self, freqs_cis, ids: torch.Tensor) -> torch.Tensor:
+        device = ids.device
+        if ids.device.type == "mps":
+            ids = ids.to("cpu")
+
+        result = []
+        for i in range(len(self.axes_dim)):
+            freqs = freqs_cis[i].to(ids.device)
+            index = ids[:, :, i : i + 1].repeat(1, 1, freqs.shape[-1]).to(torch.int64)
+            result.append(
+                torch.gather(
+                    freqs.unsqueeze(0).repeat(index.shape[0], 1, 1), dim=1, index=index
+                )
+            )
+        return torch.cat(result, dim=-1).to(device)
+
+    def forward(
+        self,
+        freqs_cis,
+        attention_mask,
+        l_effective_ref_img_len,
+        l_effective_img_len,
+        ref_img_sizes,
+        img_sizes,
+        device,
+    ):
+        batch_size = len(attention_mask)
+        p = self.patch_size
+
+        encoder_seq_len = attention_mask.shape[1]
+        l_effective_cap_len = attention_mask.sum(dim=1).tolist()
+
+        seq_lengths = [
+            cap_len + sum(ref_img_len) + img_len
+            for cap_len, ref_img_len, img_len in zip(
+                l_effective_cap_len, l_effective_ref_img_len, l_effective_img_len
+            )
+        ]
+
+        max_seq_len = max(seq_lengths)
+        max_ref_img_len = max(
+            [sum(ref_img_len) for ref_img_len in l_effective_ref_img_len]
+        )
+        max_img_len = max(l_effective_img_len)
+
+        # Create position IDs
+        position_ids = torch.zeros(
+            batch_size, max_seq_len, 3, dtype=torch.int32, device=device
+        )
+
+        for i, (cap_seq_len, seq_len) in enumerate(
+            zip(l_effective_cap_len, seq_lengths)
+        ):
+            # add text position ids
+            position_ids[i, :cap_seq_len] = repeat(
+                torch.arange(cap_seq_len, dtype=torch.int32, device=device), "l -> l 3"
+            )
+
+            pe_shift = cap_seq_len
+            pe_shift_len = cap_seq_len
+
+            if ref_img_sizes[i] is not None:
+                for ref_img_size, ref_img_len in zip(
+                    ref_img_sizes[i], l_effective_ref_img_len[i]
+                ):
+                    H, W = ref_img_size
+                    ref_H_tokens, ref_W_tokens = H // p, W // p
+                    assert ref_H_tokens * ref_W_tokens == ref_img_len
+                    # add image position ids
+
+                    row_ids = repeat(
+                        torch.arange(ref_H_tokens, dtype=torch.int32, device=device),
+                        "h -> h w",
+                        w=ref_W_tokens,
+                    ).flatten()
+                    col_ids = repeat(
+                        torch.arange(ref_W_tokens, dtype=torch.int32, device=device),
+                        "w -> h w",
+                        h=ref_H_tokens,
+                    ).flatten()
+                    position_ids[i, pe_shift_len : pe_shift_len + ref_img_len, 0] = (
+                        pe_shift
+                    )
+                    position_ids[i, pe_shift_len : pe_shift_len + ref_img_len, 1] = (
+                        row_ids
+                    )
+                    position_ids[i, pe_shift_len : pe_shift_len + ref_img_len, 2] = (
+                        col_ids
+                    )
+
+                    pe_shift += max(ref_H_tokens, ref_W_tokens)
+                    pe_shift_len += ref_img_len
+
+            H, W = img_sizes[i]
+            H_tokens, W_tokens = H // p, W // p
+            assert H_tokens * W_tokens == l_effective_img_len[i]
+
+            row_ids = repeat(
+                torch.arange(H_tokens, dtype=torch.int32, device=device),
+                "h -> h w",
+                w=W_tokens,
+            ).flatten()
+            col_ids = repeat(
+                torch.arange(W_tokens, dtype=torch.int32, device=device),
+                "w -> h w",
+                h=H_tokens,
+            ).flatten()
+
+            assert pe_shift_len + l_effective_img_len[i] == seq_len
+            position_ids[i, pe_shift_len:seq_len, 0] = pe_shift
+            position_ids[i, pe_shift_len:seq_len, 1] = row_ids
+            position_ids[i, pe_shift_len:seq_len, 2] = col_ids
+
+        # Get combined rotary embeddings
+        freqs_cis = self._get_freqs_cis(freqs_cis, position_ids)
+
+        # create separate rotary embeddings for captions and images
+        cap_freqs_cis = torch.zeros(
+            batch_size,
+            encoder_seq_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        ref_img_freqs_cis = torch.zeros(
+            batch_size,
+            max_ref_img_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        img_freqs_cis = torch.zeros(
+            batch_size,
+            max_img_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+
+        for i, (cap_seq_len, ref_img_len, img_len, seq_len) in enumerate(
+            zip(
+                l_effective_cap_len,
+                l_effective_ref_img_len,
+                l_effective_img_len,
+                seq_lengths,
+            )
+        ):
+            cap_freqs_cis[i, :cap_seq_len] = freqs_cis[i, :cap_seq_len]
+            ref_img_freqs_cis[i, : sum(ref_img_len)] = freqs_cis[
+                i, cap_seq_len : cap_seq_len + sum(ref_img_len)
+            ]
+            img_freqs_cis[i, :img_len] = freqs_cis[
+                i,
+                cap_seq_len + sum(ref_img_len) : cap_seq_len
+                + sum(ref_img_len)
+                + img_len,
+            ]
+
+        return (
+            cap_freqs_cis,
+            ref_img_freqs_cis,
+            img_freqs_cis,
+            freqs_cis,
+            l_effective_cap_len,
+            seq_lengths,
+        )
+
+
+class BooguImageDoubleStreamRotaryPosEmbed(nn.Module):
+    def __init__(
+        self,
+        theta: int,
+        axes_dim: Tuple[int, int, int],
+        axes_lens: Tuple[int, int, int] = (300, 512, 512),
+        patch_size: int = 2,
+    ):
+        super().__init__()
+        self.theta = theta
+        self.axes_dim = axes_dim
+        self.axes_lens = axes_lens
+        self.patch_size = patch_size
+
+    @staticmethod
+    def get_freqs_cis(
+        axes_dim: Tuple[int, int, int], axes_lens: Tuple[int, int, int], theta: int
+    ) -> List[torch.Tensor]:
+        freqs_cis = []
+        freqs_dtype = (
+            torch.float32 if torch.backends.mps.is_available() else torch.float64
+        )
+        for i, (d, e) in enumerate(zip(axes_dim, axes_lens)):
+            emb = get_1d_rotary_pos_embed(d, e, theta=theta, freqs_dtype=freqs_dtype)
+            freqs_cis.append(emb)
+        return freqs_cis
+
+    def _get_freqs_cis(self, freqs_cis, ids: torch.Tensor) -> torch.Tensor:
+        device = ids.device
+        if ids.device.type == "mps":
+            ids = ids.to("cpu")
+
+        result = []
+        for i in range(len(self.axes_dim)):
+            freqs = freqs_cis[i].to(ids.device)
+            index = ids[:, :, i : i + 1].repeat(1, 1, freqs.shape[-1]).to(torch.int64)
+            result.append(
+                torch.gather(
+                    freqs.unsqueeze(0).repeat(index.shape[0], 1, 1), dim=1, index=index
+                )
+            )
+        return torch.cat(result, dim=-1).to(device)
+
+    def forward(
+        self,
+        freqs_cis,
+        attention_mask,
+        l_effective_ref_img_len,
+        l_effective_img_len,
+        ref_img_sizes,
+        img_sizes,
+        device,
+    ):
+        batch_size = len(attention_mask)
+        p = self.patch_size
+
+        encoder_seq_len = attention_mask.shape[1]
+        l_effective_cap_len = attention_mask.sum(dim=1).tolist()
+
+        seq_lengths = [
+            cap_len + sum(ref_img_len) + img_len
+            for cap_len, ref_img_len, img_len in zip(
+                l_effective_cap_len, l_effective_ref_img_len, l_effective_img_len
+            )
+        ]
+
+        max_seq_len = max(seq_lengths)
+        max_ref_img_len = max(
+            [sum(ref_img_len) for ref_img_len in l_effective_ref_img_len]
+        )
+        max_img_len = max(l_effective_img_len)
+
+        # Create position IDs
+        position_ids = torch.zeros(
+            batch_size, max_seq_len, 3, dtype=torch.int32, device=device
+        )
+
+        for i, (cap_seq_len, seq_len) in enumerate(
+            zip(l_effective_cap_len, seq_lengths)
+        ):
+            # add text position ids
+            position_ids[i, :cap_seq_len] = repeat(
+                torch.arange(cap_seq_len, dtype=torch.int32, device=device), "l -> l 3"
+            )
+
+            pe_shift = cap_seq_len
+            pe_shift_len = cap_seq_len
+
+            if ref_img_sizes[i] is not None:
+                for ref_img_size, ref_img_len in zip(
+                    ref_img_sizes[i], l_effective_ref_img_len[i]
+                ):
+                    H, W = ref_img_size
+                    ref_H_tokens, ref_W_tokens = H // p, W // p
+                    assert ref_H_tokens * ref_W_tokens == ref_img_len
+                    # add image position ids
+
+                    row_ids = repeat(
+                        torch.arange(ref_H_tokens, dtype=torch.int32, device=device),
+                        "h -> h w",
+                        w=ref_W_tokens,
+                    ).flatten()
+                    col_ids = repeat(
+                        torch.arange(ref_W_tokens, dtype=torch.int32, device=device),
+                        "w -> h w",
+                        h=ref_H_tokens,
+                    ).flatten()
+                    position_ids[i, pe_shift_len : pe_shift_len + ref_img_len, 0] = (
+                        pe_shift
+                    )
+                    position_ids[i, pe_shift_len : pe_shift_len + ref_img_len, 1] = (
+                        row_ids
+                    )
+                    position_ids[i, pe_shift_len : pe_shift_len + ref_img_len, 2] = (
+                        col_ids
+                    )
+
+                    pe_shift += max(ref_H_tokens, ref_W_tokens)
+                    pe_shift_len += ref_img_len
+
+            H, W = img_sizes[i]
+            H_tokens, W_tokens = H // p, W // p
+            assert H_tokens * W_tokens == l_effective_img_len[i]
+
+            row_ids = repeat(
+                torch.arange(H_tokens, dtype=torch.int32, device=device),
+                "h -> h w",
+                w=W_tokens,
+            ).flatten()
+            col_ids = repeat(
+                torch.arange(W_tokens, dtype=torch.int32, device=device),
+                "w -> h w",
+                h=H_tokens,
+            ).flatten()
+
+            assert pe_shift_len + l_effective_img_len[i] == seq_len
+            position_ids[i, pe_shift_len:seq_len, 0] = pe_shift
+            position_ids[i, pe_shift_len:seq_len, 1] = row_ids
+            position_ids[i, pe_shift_len:seq_len, 2] = col_ids
+
+        # Get combined rotary embeddings
+        freqs_cis = self._get_freqs_cis(freqs_cis, position_ids)
+
+        # create separate rotary embeddings for captions and images
+        cap_freqs_cis = torch.zeros(
+            batch_size,
+            encoder_seq_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        ref_img_freqs_cis = torch.zeros(
+            batch_size,
+            max_ref_img_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        img_freqs_cis = torch.zeros(
+            batch_size,
+            max_img_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+
+        # Calculate combined image sequence lengths (ref_img + img) for each sample
+        combined_img_seq_lengths = [
+            sum(ref_img_len) + img_len
+            for ref_img_len, img_len in zip(
+                l_effective_ref_img_len, l_effective_img_len
+            )
+        ]
+        max_combined_img_len = max(combined_img_seq_lengths)
+
+        # Create combined image rotary embeddings
+        combined_img_freqs_cis = torch.zeros(
+            batch_size,
+            max_combined_img_len,
+            freqs_cis.shape[-1],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+
+        for i, (cap_seq_len, ref_img_len, img_len, seq_len) in enumerate(
+            zip(
+                l_effective_cap_len,
+                l_effective_ref_img_len,
+                l_effective_img_len,
+                seq_lengths,
+            )
+        ):
+            cap_freqs_cis[i, :cap_seq_len] = freqs_cis[i, :cap_seq_len]
+            ref_img_freqs_cis[i, : sum(ref_img_len)] = freqs_cis[
+                i, cap_seq_len : cap_seq_len + sum(ref_img_len)
+            ]
+            img_freqs_cis[i, :img_len] = freqs_cis[
+                i,
+                cap_seq_len + sum(ref_img_len) : cap_seq_len
+                + sum(ref_img_len)
+                + img_len,
+            ]
+
+            # Combined image rotary embeddings: ref_img + img (same order as img_patch_embed_and_refine)
+            combined_img_freqs_cis[i, : sum(ref_img_len)] = freqs_cis[
+                i, cap_seq_len : cap_seq_len + sum(ref_img_len)
+            ]
+            combined_img_freqs_cis[i, sum(ref_img_len) : sum(ref_img_len) + img_len] = (
+                freqs_cis[
+                    i,
+                    cap_seq_len + sum(ref_img_len) : cap_seq_len
+                    + sum(ref_img_len)
+                    + img_len,
+                ]
+            )
+
+        return (
+            cap_freqs_cis,
+            ref_img_freqs_cis,
+            img_freqs_cis,
+            freqs_cis,
+            l_effective_cap_len,
+            seq_lengths,
+            combined_img_freqs_cis,
+            combined_img_seq_lengths,
+        )
+
+
+class BooguImagePromptTuningRotaryPosEmbed(nn.Module):
+    """
+    Rotary Position Embedding for Prompt Tuning tokens.
+
+    This class generates rotary position embeddings specifically for prompt tuning tokens.
+    Since prompt tokens are treated as text tokens, we use text-style position encoding
+    with a fixed sequence length equal to num_trainable_prompt_tokens.
+
+    Args:
+        theta: Base frequency for rotary embeddings
+        axes_dim: Dimensions for each axis (tuple like (32, 32, 32))
+        num_trainable_prompt_tokens: Number of trainable prompt tokens
+    """
+
+    def __init__(self, theta: int, dim: int, num_trainable_prompt_tokens: int):
+        super().__init__()
+        self.theta = theta
+        self.num_trainable_prompt_tokens = num_trainable_prompt_tokens
+        # For text tokens, only use the first dimension (text/temporal dimension)
+        self.dim = dim  # Extract text dimension from tuple
+
+    def forward(
+        self, batch_size: int, device: torch.device, use_causal_mask: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Generate rotary position embeddings and attention mask for prompt tuning.
+
+        Args:
+            batch_size: Batch size
+            device: Target device for tensors
+            use_causal_mask: Whether to use causal attention mask
+
+        Returns:
+            Tuple of (rotary_embeddings, attention_mask)
+            - rotary_embeddings: [B, num_tokens, instruction_dim//2] - RoPE embeddings for prompt tokens (complex form)
+            - attention_mask: [B, num_tokens] or [B, num_tokens, num_tokens] - Attention mask
+        """
+        # Generate 1D rotary embeddings for text-style tokens
+        freqs_dtype = (
+            torch.float32 if torch.backends.mps.is_available() else torch.float64
+        )
+
+        # get_1d_rotary_pos_embed(dim, seq_len) returns [seq_len, dim//2]
+        # Because RoPE uses complex representation, each dimension is split into sin/cos pairs
+        text_freqs_cis = get_1d_rotary_pos_embed(
+            self.dim,  # This should be 32 (text dimension)
+            self.num_trainable_prompt_tokens,  # Sequence length
+            theta=self.theta,
+            freqs_dtype=freqs_dtype,
+        )
+
+        # For prompt tuning, we create simple sequential position embeddings
+        # Each prompt token gets a unique position ID: 0, 1, 2, ..., num_tokens-1
+        position_indices = torch.arange(
+            self.num_trainable_prompt_tokens,
+            dtype=torch.int64,
+            device=text_freqs_cis.device,
+        )
+
+        # Select the appropriate rotary embeddings for each position
+        # text_freqs_cis is [num_tokens, instruction_dim//2], we want [num_tokens, instruction_dim//2]
+        rotary_emb = text_freqs_cis[
+            position_indices
+        ]  # [num_tokens, instruction_dim//2]
+
+        # Expand to batch size and move to target device
+        rotary_emb = (
+            rotary_emb.unsqueeze(0).expand(batch_size, -1, -1).to(device)
+        )  # [B, num_tokens, instruction_dim//2]
+
+        # Create attention mask based on use_causal_mask parameter
+        if use_causal_mask:
+            # Create causal mask: only future tokens can attend to past tokens
+            # Lower triangular matrix where mask[i, j] = True if i >= j
+            causal_mask = torch.tril(
+                torch.ones(
+                    self.num_trainable_prompt_tokens,
+                    self.num_trainable_prompt_tokens,
+                    dtype=torch.bool,
+                    device=device,
+                )
+            )  # [num_tokens, num_tokens]
+
+            # Expand to batch size [B, num_tokens, num_tokens]
+            attention_mask = causal_mask.unsqueeze(0).expand(batch_size, -1, -1)
+        else:
+            # Non-causal mask: all tokens can attend to each other (all True)
+            attention_mask = torch.ones(
+                batch_size,
+                self.num_trainable_prompt_tokens,
+                dtype=torch.bool,
+                device=device,
+            )  # [B, num_tokens]
+
+        return rotary_emb, attention_mask

--- a/unirl/models/boogu_image/vendor/taylorseer_stubs.py
+++ b/unirl/models/boogu_image/vendor/taylorseer_stubs.py
@@ -1,0 +1,58 @@
+"""Raising stubs for the upstream TaylorSeer/TeaCache helper imports.
+
+The vendored ``transformer_boogu.py`` imports these names from the upstream
+``boogu.cache_functions`` / ``boogu.taylorseer_utils`` packages, but every
+call site is gated behind ``enable_taylorseer`` / ``enable_teacache`` flags
+that default to ``False`` and are asserted ``False`` by
+``BooguImageBundle.from_config``. Inference-time caching approximates
+transformer outputs across steps, which would corrupt RL rollout/replay
+log-prob parity — so instead of vendoring the cache machinery, each stub
+raises if it is ever reached.
+"""
+
+from typing import Any, NoReturn
+
+_MSG = (
+    "TeaCache/TaylorSeer is disabled in UniRL's vendored Boogu-Image copy: "
+    "RL rollout and replay must be cache-free for log-prob correctness. "
+    "This stub should be unreachable — check that `enable_teacache` and "
+    "`enable_taylorseer` are False on the transformer."
+)
+
+
+def _raise(*_args: Any, **_kwargs: Any) -> NoReturn:
+    raise RuntimeError(_MSG)
+
+
+def cal_type(*args: Any, **kwargs: Any) -> NoReturn:
+    _raise(*args, **kwargs)
+
+
+def taylor_cache_init(*args: Any, **kwargs: Any) -> NoReturn:
+    _raise(*args, **kwargs)
+
+
+def taylor_formula(*args: Any, **kwargs: Any) -> NoReturn:
+    _raise(*args, **kwargs)
+
+
+def taylor_formula_4_double_stream(*args: Any, **kwargs: Any) -> NoReturn:
+    _raise(*args, **kwargs)
+
+
+def derivative_approximation(*args: Any, **kwargs: Any) -> NoReturn:
+    _raise(*args, **kwargs)
+
+
+def derivative_approximation_4_double_stream(*args: Any, **kwargs: Any) -> NoReturn:
+    _raise(*args, **kwargs)
+
+
+__all__ = [
+    "cal_type",
+    "taylor_cache_init",
+    "taylor_formula",
+    "taylor_formula_4_double_stream",
+    "derivative_approximation",
+    "derivative_approximation_4_double_stream",
+]

--- a/unirl/models/boogu_image/vendor/teacache_util.py
+++ b/unirl/models/boogu_image/vendor/teacache_util.py
@@ -1,0 +1,41 @@
+"""
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class TeaCacheParams:
+    """
+    TeaCache parameters for `BooguImageTransformer2DModel`
+    See https://github.com/ali-vilab/TeaCache/ for a more comprehensive understanding
+
+    Args:
+        previous_residual (Optional[torch.Tensor]):
+            The tensor difference between the output and the input of the transformer layers from the previous timestep.
+        previous_modulated_inp (Optional[torch.Tensor]):
+            The modulated input from the previous timestep used to indicate the change of the transformer layer's output.
+        accumulated_rel_l1_distance (float):
+            The accumulated relative L1 distance.
+        is_first_or_last_step (bool):
+            Whether the current timestep is the first or last step.
+    """
+
+    previous_residual: Optional[torch.Tensor] = None
+    previous_modulated_inp: Optional[torch.Tensor] = None
+    accumulated_rel_l1_distance: float = 0
+    is_first_or_last_step: bool = False

--- a/unirl/models/boogu_image/vendor/transformer_boogu.py
+++ b/unirl/models/boogu_image/vendor/transformer_boogu.py
@@ -1,0 +1,1628 @@
+"""
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import itertools
+import os
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.loaders import PeftAdapterMixin
+from diffusers.loaders.single_file_model import FromOriginalModelMixin
+from diffusers.models.attention_processor import Attention
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from diffusers.models.modeling_utils import ModelMixin
+from diffusers.utils import (
+    USE_PEFT_BACKEND,
+    logging,
+    scale_lora_layers,
+    unscale_lora_layers,
+)
+from einops import rearrange
+
+from ...utils.import_utils import is_triton_available
+from ...utils.teacache_util import TeaCacheParams
+from ..attention_processor import (
+    BooguImageAttnProcessor,
+    BooguImageAttnProcessorFlash2Varlen,
+    BooguImageDoubleStreamSelfAttnProcessor,
+    BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen,
+)
+from .block_lumina2 import (
+    Lumina2CombinedTimestepCaptionEmbedding,
+    LuminaFeedForward,
+    LuminaLayerNormContinuous,
+    LuminaRMSNormZero,
+)
+from .rope import (
+    BooguImageDoubleStreamRotaryPosEmbed,
+    BooguImagePromptTuningRotaryPosEmbed,
+)
+
+if is_triton_available() and ("cuda" in os.getenv("device", "cpu")):
+    from ...ops.triton.layer_norm import RMSNorm
+else:
+    from torch.nn import RMSNorm
+
+from ...cache_functions import cal_type
+from ...taylorseer_utils import (
+    derivative_approximation,
+    derivative_approximation_4_double_stream,
+    taylor_cache_init,
+    taylor_formula,
+    taylor_formula_4_double_stream,
+)
+
+logger = logging.get_logger(__name__)
+
+# Local runtime utilities.
+
+
+class PromptEmbedding(
+    ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin
+):
+    _supports_gradient_checkpointing = True
+    _no_split_modules = ["BooguImageTransformerBlock"]
+    _skip_layerwise_casting_patterns = ["prompt_token_embedding", "norm"]
+
+    def __init__(self, prompt_tuning_configs):
+        super().__init__()
+
+        num_trainable_prompt_tokens = prompt_tuning_configs.get(
+            "num_trainable_prompt_tokens", 32
+        )
+        hidden_size = prompt_tuning_configs.get("hidden_size", 2048)
+        num_attention_heads = prompt_tuning_configs.get("num_attention_heads", 32)
+        num_kv_heads = prompt_tuning_configs.get("num_kv_heads", 8)
+        multiple_of = prompt_tuning_configs.get("multiple_of", 256)
+        ffn_dim_multiplier = prompt_tuning_configs.get("ffn_dim_multiplier", None)
+        norm_eps = prompt_tuning_configs.get("norm_eps", 1e-5)
+        num_layers = prompt_tuning_configs.get("num_layers", 2)
+        theta = prompt_tuning_configs.get("theta", 10000)
+
+        self.register_to_config(
+            num_trainable_prompt_tokens=num_trainable_prompt_tokens,
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            num_kv_heads=num_kv_heads,
+            multiple_of=multiple_of,
+            ffn_dim_multiplier=ffn_dim_multiplier,
+            norm_eps=norm_eps,
+            num_layers=num_layers,
+            theta=theta,
+        )
+
+        self.prompt_tuning_configs = prompt_tuning_configs
+
+        prompt_emb_head_dim = self.config.hidden_size // self.config.num_attention_heads
+
+        self.prompt_token_embedding = nn.Embedding(
+            num_embeddings=self.config.num_trainable_prompt_tokens,
+            embedding_dim=self.config.hidden_size,
+        )
+
+        # Rotary embedding for prompt tokens.
+        self.prompt_rope_embedder = BooguImagePromptTuningRotaryPosEmbed(
+            theta=self.config.theta,
+            dim=prompt_emb_head_dim,
+            num_trainable_prompt_tokens=self.config.num_trainable_prompt_tokens,
+        )
+
+        self.prompt_tuning_layers = nn.ModuleList(
+            [
+                BooguImageTransformerBlock(
+                    dim=self.config.hidden_size,
+                    num_attention_heads=self.config.num_attention_heads,
+                    num_kv_heads=self.config.num_kv_heads,
+                    multiple_of=self.config.multiple_of,
+                    ffn_dim_multiplier=self.config.ffn_dim_multiplier,
+                    norm_eps=self.config.norm_eps,
+                    modulation=False,
+                )
+                for _ in range(self.config.num_layers)
+            ]
+        )
+
+        self.gradient_checkpointing = False
+
+        self.initialize_weights()
+
+    def initialize_weights(self) -> None:
+        # Small std keeps prompt tuning stable at init.
+        nn.init.normal_(self.prompt_token_embedding.weight, mean=0.0, std=0.02)
+
+    def forward(self, idx=None, batch_size=1, device=None, use_causal_mask=True):
+        if idx is None:
+            prompt_embeddings = self.prompt_token_embedding.weight
+        else:
+            prompt_embeddings = self.prompt_token_embedding(idx)
+
+        # Expand to [B, num_tokens, hidden_dim].
+        hidden_states = prompt_embeddings.unsqueeze(0).expand(batch_size, -1, -1)
+
+        rotary_emb, attention_mask = self.prompt_rope_embedder(
+            batch_size, device, use_causal_mask
+        )
+
+        for i, layer in enumerate(self.prompt_tuning_layers):
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                hidden_states = self._gradient_checkpointing_func(
+                    layer,
+                    hidden_states,
+                    attention_mask,
+                    rotary_emb,
+                )
+            else:
+                hidden_states = layer(
+                    hidden_states,
+                    attention_mask,
+                    rotary_emb,
+                )
+        return hidden_states
+
+    @classmethod
+    def from_config(cls, config, **kwargs):
+        # `config` is loaded from config.json.
+        instance = cls(prompt_tuning_configs=config)
+
+        weight_dtype = kwargs.get("weight_dtype", None)
+        if weight_dtype is not None:
+            for p in instance.parameters():
+                p.data = p.data.to(dtype=weight_dtype)
+
+        return instance
+
+
+class BooguImageTransformerBlock(nn.Module):
+    """
+    Basic Boogu-Image transformer block: attention + MLP + RMSNorm.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        num_kv_heads: int,
+        multiple_of: int,
+        ffn_dim_multiplier: float,
+        norm_eps: float,
+        modulation: bool = True,
+    ) -> None:
+        """Initialize the transformer block."""
+        super().__init__()
+        self.head_dim = dim // num_attention_heads
+        self.modulation = modulation
+
+        if "cpu" in os.getenv("device", "cpu"):
+            processor = BooguImageAttnProcessor()
+
+        else:
+            try:
+                processor = BooguImageAttnProcessorFlash2Varlen()
+            except ImportError:
+                processor = BooguImageAttnProcessor()
+
+        # Initialize attention layer
+        self.attn = Attention(
+            query_dim=dim,
+            cross_attention_dim=None,
+            dim_head=dim // num_attention_heads,
+            qk_norm="rms_norm",
+            heads=num_attention_heads,
+            kv_heads=num_kv_heads,
+            eps=1e-5,
+            bias=False,
+            out_bias=False,
+            processor=processor,
+        )
+
+        # Initialize feed-forward network
+        self.feed_forward = LuminaFeedForward(
+            dim=dim,
+            inner_dim=4 * dim,
+            multiple_of=multiple_of,
+            ffn_dim_multiplier=ffn_dim_multiplier,
+        )
+
+        # Initialize normalization layers
+        if modulation:
+            self.norm1 = LuminaRMSNormZero(
+                embedding_dim=dim, norm_eps=norm_eps, norm_elementwise_affine=True
+            )
+        else:
+            self.norm1 = RMSNorm(dim, eps=norm_eps)
+
+        self.ffn_norm1 = RMSNorm(dim, eps=norm_eps)
+        self.norm2 = RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm2 = RMSNorm(dim, eps=norm_eps)
+
+        self.initialize_weights()
+
+    def initialize_weights(self) -> None:
+        """Initialize linear weights and modulation parameters."""
+        nn.init.xavier_uniform_(self.attn.to_q.weight)
+        nn.init.xavier_uniform_(self.attn.to_k.weight)
+        nn.init.xavier_uniform_(self.attn.to_v.weight)
+        nn.init.xavier_uniform_(self.attn.to_out[0].weight)
+
+        nn.init.xavier_uniform_(self.feed_forward.linear_1.weight)
+        nn.init.xavier_uniform_(self.feed_forward.linear_2.weight)
+        nn.init.xavier_uniform_(self.feed_forward.linear_3.weight)
+
+        if self.modulation:
+            nn.init.zeros_(self.norm1.linear.weight)
+            nn.init.zeros_(self.norm1.linear.bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        image_rotary_emb: torch.Tensor,
+        temb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Forward pass of the transformer block.
+
+        Args:
+            hidden_states: Input hidden states tensor
+            attention_mask: Attention mask tensor
+            image_rotary_emb: Rotary embeddings for image tokens
+            temb: Optional timestep embedding tensor
+
+        Returns:
+            torch.Tensor: Output hidden states after transformer block processing
+        """
+
+        enable_taylorseer = getattr(self, "enable_taylorseer", False)
+
+        if enable_taylorseer:
+            if self.modulation:
+                if temb is None:
+                    raise ValueError("temb must be provided when modulation is enabled")
+
+                if self.current["type"] == "full":
+                    self.current["module"] = "total"
+                    taylor_cache_init(cache_dic=self.cache_dic, current=self.current)
+
+                    norm_hidden_states, gate_msa, scale_mlp, gate_mlp = self.norm1(
+                        hidden_states, temb
+                    )
+                    attn_output = self.attn(
+                        hidden_states=norm_hidden_states,
+                        encoder_hidden_states=norm_hidden_states,
+                        attention_mask=attention_mask,
+                        image_rotary_emb=image_rotary_emb,
+                    )
+                    hidden_states = hidden_states + gate_msa.unsqueeze(
+                        1
+                    ).tanh() * self.norm2(attn_output)
+                    mlp_output = self.feed_forward(
+                        self.ffn_norm1(hidden_states) * (1 + scale_mlp.unsqueeze(1))
+                    )
+                    hidden_states = hidden_states + gate_mlp.unsqueeze(
+                        1
+                    ).tanh() * self.ffn_norm2(mlp_output)
+
+                    derivative_approximation(
+                        cache_dic=self.cache_dic,
+                        current=self.current,
+                        feature=hidden_states,
+                    )
+
+                elif self.current["type"] == "Taylor":
+                    self.current["module"] = "total"
+                    hidden_states = taylor_formula(
+                        cache_dic=self.cache_dic, current=self.current
+                    )
+            else:
+                norm_hidden_states = self.norm1(hidden_states)
+                attn_output = self.attn(
+                    hidden_states=norm_hidden_states,
+                    encoder_hidden_states=norm_hidden_states,
+                    attention_mask=attention_mask,
+                    image_rotary_emb=image_rotary_emb,
+                )
+                hidden_states = hidden_states + self.norm2(attn_output)
+                mlp_output = self.feed_forward(self.ffn_norm1(hidden_states))
+                hidden_states = hidden_states + self.ffn_norm2(mlp_output)
+        else:
+            if self.modulation:
+                if temb is None:
+                    raise ValueError("temb must be provided when modulation is enabled")
+                norm_hidden_states, gate_msa, scale_mlp, gate_mlp = self.norm1(
+                    hidden_states, temb
+                )
+
+                attn_output = self.attn(
+                    hidden_states=norm_hidden_states,
+                    encoder_hidden_states=norm_hidden_states,
+                    attention_mask=attention_mask,
+                    image_rotary_emb=image_rotary_emb,
+                )
+                hidden_states = hidden_states + gate_msa.unsqueeze(
+                    1
+                ).tanh() * self.norm2(attn_output)
+                mlp_output = self.feed_forward(
+                    self.ffn_norm1(hidden_states) * (1 + scale_mlp.unsqueeze(1))
+                )
+                hidden_states = hidden_states + gate_mlp.unsqueeze(
+                    1
+                ).tanh() * self.ffn_norm2(mlp_output)
+            else:
+                norm_hidden_states = self.norm1(hidden_states)
+                attn_output = self.attn(
+                    hidden_states=norm_hidden_states,
+                    encoder_hidden_states=norm_hidden_states,
+                    attention_mask=attention_mask,
+                    image_rotary_emb=image_rotary_emb,
+                )
+                hidden_states = hidden_states + self.norm2(attn_output)
+                mlp_output = self.feed_forward(self.ffn_norm1(hidden_states))
+                hidden_states = hidden_states + self.ffn_norm2(mlp_output)
+
+        return hidden_states
+
+
+class BooguImageNoiseRefinerTransformerBlock(BooguImageTransformerBlock):
+    pass
+
+
+class BooguImageRefImgRefinerTransformerBlock(BooguImageTransformerBlock):
+    pass
+
+
+class BooguImageContextRefinerTransformerBlock(BooguImageTransformerBlock):
+    pass
+
+
+class BooguImageSingleStreamTransformerBlock(BooguImageTransformerBlock):
+    pass
+
+
+class BooguImageDoubleStreamTransformerBlock(nn.Module):
+    """
+    Boogu-Image double-stream block.
+    Here "double-stream" is the same idea as a "dual-stream" layer:
+    instruction tokens and image tokens are processed in parallel streams.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        num_kv_heads: int,
+        multiple_of: int,
+        ffn_dim_multiplier: float,
+        norm_eps: float,
+        modulation: bool = True,
+    ) -> None:
+        """Initialize the double stream transformer block."""
+        super().__init__()
+        self.head_dim = dim // num_attention_heads
+        self.num_attention_heads = num_attention_heads
+        self.modulation = modulation
+        self.hidden_size = dim
+
+        if "cpu" in os.getenv("device", "cpu"):
+            processor = BooguImageAttnProcessor()
+        else:
+            try:
+                processor = BooguImageAttnProcessorFlash2Varlen()
+            except ImportError:
+                processor = BooguImageAttnProcessor()
+
+        if "cpu" in os.getenv("device", "cpu"):
+            double_stream_processor = BooguImageDoubleStreamSelfAttnProcessor(
+                head_dim=self.head_dim,
+                num_attention_heads=num_attention_heads,
+                num_kv_heads=num_kv_heads,
+                qkv_bias=False,
+            )
+        else:
+            try:
+                double_stream_processor = (
+                    BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen(
+                        head_dim=self.head_dim,
+                        num_attention_heads=num_attention_heads,
+                        num_kv_heads=num_kv_heads,
+                        qkv_bias=False,
+                    )
+                )
+            except ImportError:
+                double_stream_processor = BooguImageDoubleStreamSelfAttnProcessor(
+                    head_dim=self.head_dim,
+                    num_attention_heads=num_attention_heads,
+                    num_kv_heads=num_kv_heads,
+                    qkv_bias=False,
+                )
+
+        # Image stream components.
+        self.img_instruct_attn = Attention(
+            query_dim=dim,
+            cross_attention_dim=None,
+            dim_head=dim // num_attention_heads,
+            qk_norm="rms_norm",
+            heads=num_attention_heads,
+            kv_heads=num_kv_heads,
+            eps=1e-5,
+            bias=False,
+            out_bias=False,
+            processor=double_stream_processor,
+        )
+
+        self.img_self_attn = Attention(
+            query_dim=dim,
+            cross_attention_dim=None,
+            dim_head=dim // num_attention_heads,
+            qk_norm="rms_norm",
+            heads=num_attention_heads,
+            kv_heads=num_kv_heads,
+            eps=1e-5,
+            bias=False,
+            out_bias=False,
+            processor=processor,
+        )
+
+        self.img_feed_forward = LuminaFeedForward(
+            dim=dim,
+            inner_dim=4 * dim,
+            multiple_of=multiple_of,
+            ffn_dim_multiplier=ffn_dim_multiplier,
+        )
+
+        if modulation:
+            # Image modulation terms: cross-attn, MLP, self-attn.
+            self.img_norm1 = LuminaRMSNormZero(
+                embedding_dim=dim, norm_eps=norm_eps, norm_elementwise_affine=True
+            )
+            self.img_norm2 = LuminaRMSNormZero(
+                embedding_dim=dim, norm_eps=norm_eps, norm_elementwise_affine=True
+            )
+            self.img_norm3 = LuminaRMSNormZero(
+                embedding_dim=dim, norm_eps=norm_eps, norm_elementwise_affine=True
+            )
+        else:
+            self.img_norm1 = RMSNorm(dim, eps=norm_eps)
+            self.img_norm2 = RMSNorm(dim, eps=norm_eps)
+            self.img_norm3 = RMSNorm(dim, eps=norm_eps)
+
+        self.img_ffn_norm1 = RMSNorm(dim, eps=norm_eps)
+        self.img_attn_norm = RMSNorm(dim, eps=norm_eps)
+        self.img_self_attn_norm = RMSNorm(dim, eps=norm_eps)
+        self.img_ffn_norm2 = RMSNorm(dim, eps=norm_eps)
+
+        # Instruction stream components.
+        self.instruct_feed_forward = LuminaFeedForward(
+            dim=dim,
+            inner_dim=4 * dim,
+            multiple_of=multiple_of,
+            ffn_dim_multiplier=ffn_dim_multiplier,
+        )
+
+        if modulation:
+            # Instruction modulation terms: cross-attn, MLP.
+            self.instruct_norm1 = LuminaRMSNormZero(
+                embedding_dim=dim, norm_eps=norm_eps, norm_elementwise_affine=True
+            )
+            self.instruct_norm2 = LuminaRMSNormZero(
+                embedding_dim=dim, norm_eps=norm_eps, norm_elementwise_affine=True
+            )
+        else:
+            self.instruct_norm1 = RMSNorm(dim, eps=norm_eps)
+            self.instruct_norm2 = RMSNorm(dim, eps=norm_eps)
+
+        self.instruct_ffn_norm1 = RMSNorm(dim, eps=norm_eps)
+        self.instruct_attn_norm = RMSNorm(dim, eps=norm_eps)
+        self.instruct_ffn_norm2 = RMSNorm(dim, eps=norm_eps)
+
+        self.initialize_weights()
+
+        # double_stream_processor owns its own q/k/v projections.
+        for param in self.img_instruct_attn.to_q.parameters():
+            param.requires_grad = False
+        for param in self.img_instruct_attn.to_k.parameters():
+            param.requires_grad = False
+        for param in self.img_instruct_attn.to_v.parameters():
+            param.requires_grad = False
+
+        del self.img_instruct_attn.to_k
+        del self.img_instruct_attn.to_v
+        del self.img_instruct_attn.to_q
+
+    def initialize_weights(self) -> None:
+        """Initialize linear weights and modulation parameters."""
+        nn.init.xavier_uniform_(self.img_instruct_attn.to_out[0].weight)
+
+        # Keep Xavier init consistent across Boogu-Image blocks.
+        nn.init.xavier_uniform_(self.img_self_attn.to_q.weight)
+        nn.init.xavier_uniform_(self.img_self_attn.to_k.weight)
+        nn.init.xavier_uniform_(self.img_self_attn.to_v.weight)
+        nn.init.xavier_uniform_(self.img_self_attn.to_out[0].weight)
+
+        nn.init.xavier_uniform_(self.img_feed_forward.linear_1.weight)
+        nn.init.xavier_uniform_(self.img_feed_forward.linear_2.weight)
+        nn.init.xavier_uniform_(self.img_feed_forward.linear_3.weight)
+
+        nn.init.xavier_uniform_(self.instruct_feed_forward.linear_1.weight)
+        nn.init.xavier_uniform_(self.instruct_feed_forward.linear_2.weight)
+        nn.init.xavier_uniform_(self.instruct_feed_forward.linear_3.weight)
+
+        # Initialize modulation parameters
+        if self.modulation:
+            nn.init.zeros_(self.img_norm1.linear.weight)
+            nn.init.zeros_(self.img_norm1.linear.bias)
+            nn.init.zeros_(self.img_norm2.linear.weight)
+            nn.init.zeros_(self.img_norm2.linear.bias)
+            nn.init.zeros_(self.img_norm3.linear.weight)
+            nn.init.zeros_(self.img_norm3.linear.bias)
+
+            nn.init.zeros_(self.instruct_norm1.linear.weight)
+            nn.init.zeros_(self.instruct_norm1.linear.bias)
+            nn.init.zeros_(self.instruct_norm2.linear.weight)
+            nn.init.zeros_(self.instruct_norm2.linear.bias)
+
+    def forward(
+        self,
+        img_hidden_states: torch.Tensor,  # [B, L_img, D] - Image tokens (ref_img + noise_img)
+        instruct_hidden_states: torch.Tensor,  # [B, L_instruct, D] - Instruction tokens
+        img_attention_mask: torch.Tensor,  # [B, L_img] - Attention mask for [ref_img + noise_img]
+        joint_attention_mask: torch.Tensor,  # [B, L_total] - Combined attention mask for [instruct + img]
+        image_rotary_emb: torch.Tensor,  # [B, L_img, head_dim] - Rotary embeddings for [ref_img + noise_img]
+        rotary_emb: torch.Tensor,  # [B, L_total, head_dim] - Rotary embeddings for [instruct + img]
+        temb: Optional[torch.Tensor] = None,  # [B, 1024] - Timestep embeddings
+        encoder_seq_lengths: List[
+            int
+        ] = None,  # [B] - Instruction sequence lengths for each sample
+        seq_lengths: List[int] = None,  # [B] - Total sequence lengths for each sample
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Run one dual-stream (double-stream) block step.
+        Returns updated `(img_hidden_states, instruct_hidden_states)`.
+        """
+        if self.modulation and temb is None:
+            raise ValueError("temb must be provided when modulation is enabled")
+
+        enable_taylorseer = getattr(self, "enable_taylorseer", False)
+        if enable_taylorseer:
+            self.current["module"] = "total"
+            if self.current["type"] == "Taylor":
+                return taylor_formula_4_double_stream(
+                    cache_dic=self.cache_dic, current=self.current
+                )
+            if self.current["type"] == "full":
+                taylor_cache_init(cache_dic=self.cache_dic, current=self.current)
+
+        # Extract dimensions
+        batch_size = img_hidden_states.shape[0]
+        L_instruct = instruct_hidden_states.shape[1]  # Instruction sequence length
+        L_img = img_hidden_states.shape[
+            1
+        ]  # Image sequence length (ref_img + noise_img)
+
+        if self.modulation:
+            # Step 1: modulation for both streams.
+            img_norm1_out, img_gate_msa, img_scale_mlp, img_gate_mlp = self.img_norm1(
+                img_hidden_states, temb
+            )
+            img_norm2_out, img_shift_mlp, _, _ = self.img_norm2(img_hidden_states, temb)
+            img_norm3_out, img_gate_self, _, _ = self.img_norm3(img_hidden_states, temb)
+
+            (
+                instruct_norm1_out,
+                instruct_gate_msa,
+                instruct_scale_mlp,
+                instruct_gate_mlp,
+            ) = self.instruct_norm1(instruct_hidden_states, temb)
+            instruct_norm2_out, instruct_shift_mlp, _, _ = self.instruct_norm2(
+                instruct_hidden_states, temb
+            )
+
+            # Step 2: joint attention on [instruct + img].
+            # Call processor directly because Attention.forward does not expose these dual-stream args.
+            joint_attn_out = self.img_instruct_attn.processor(
+                attn=self.img_instruct_attn,
+                img_hidden_states=img_norm1_out,
+                instruct_hidden_states=instruct_norm1_out,
+                joint_attention_mask=joint_attention_mask,
+                rotary_emb=rotary_emb,
+                encoder_seq_lengths=encoder_seq_lengths,
+                seq_lengths=seq_lengths,
+            )
+
+            # Split back into instruction/image segments.
+            instruct_attn_out = instruct_hidden_states.new_zeros(
+                batch_size, L_instruct, self.hidden_size
+            )
+            img_attn_out = img_hidden_states.new_zeros(
+                batch_size, L_img, self.hidden_size
+            )
+            for i, (encoder_seq_len, seq_len) in enumerate(
+                zip(encoder_seq_lengths, seq_lengths)
+            ):
+                instruct_attn_out[i, :encoder_seq_len] = joint_attn_out[
+                    i, :encoder_seq_len
+                ]
+                img_attn_out[i, : seq_len - encoder_seq_len] = joint_attn_out[
+                    i, encoder_seq_len:seq_len
+                ]
+
+            # Step 3: image self-attention.
+            img_self_attn_out = self.img_self_attn(
+                hidden_states=img_norm3_out,
+                encoder_hidden_states=img_norm3_out,
+                attention_mask=img_attention_mask,
+                image_rotary_emb=image_rotary_emb,
+            )
+
+            # Step 4: residual updates.
+            img_hidden_states = img_hidden_states + img_gate_msa.unsqueeze(
+                1
+            ).tanh() * self.img_attn_norm(img_attn_out)
+            img_hidden_states = img_hidden_states + img_gate_self.unsqueeze(
+                1
+            ).tanh() * self.img_self_attn_norm(img_self_attn_out)
+
+            img_mlp_input = (
+                1 + img_scale_mlp.unsqueeze(1)
+            ) * img_norm2_out + img_shift_mlp.unsqueeze(1)
+            img_mlp_out = self.img_feed_forward(self.img_ffn_norm1(img_mlp_input))
+            img_hidden_states = img_hidden_states + img_gate_mlp.unsqueeze(
+                1
+            ).tanh() * self.img_ffn_norm2(img_mlp_out)
+
+            instruct_hidden_states = (
+                instruct_hidden_states
+                + instruct_gate_msa.unsqueeze(1).tanh()
+                * self.instruct_attn_norm(instruct_attn_out)
+            )
+
+            instruct_mlp_input = (
+                1 + instruct_scale_mlp.unsqueeze(1)
+            ) * instruct_norm2_out + instruct_shift_mlp.unsqueeze(1)
+            instruct_mlp_out = self.instruct_feed_forward(
+                self.instruct_ffn_norm1(instruct_mlp_input)
+            )
+            instruct_hidden_states = (
+                instruct_hidden_states
+                + instruct_gate_mlp.unsqueeze(1).tanh()
+                * self.instruct_ffn_norm2(instruct_mlp_out)
+            )
+
+        else:
+            # Non-modulated branch used by context-style blocks.
+            img_norm1_out = self.img_norm1(img_hidden_states)
+            img_norm3_out = self.img_norm3(img_hidden_states)
+            instruct_norm1_out = self.instruct_norm1(instruct_hidden_states)
+
+            # Same processor path as above.
+            joint_attn_out = self.img_instruct_attn.processor(
+                attn=self.img_instruct_attn,
+                img_hidden_states=img_norm1_out,
+                instruct_hidden_states=instruct_norm1_out,
+                joint_attention_mask=joint_attention_mask,
+                rotary_emb=rotary_emb,
+                encoder_seq_lengths=encoder_seq_lengths,
+                seq_lengths=seq_lengths,
+            )
+
+            instruct_attn_out = instruct_hidden_states.new_zeros(
+                batch_size, L_instruct, self.hidden_size
+            )
+            img_attn_out = img_hidden_states.new_zeros(
+                batch_size, L_img, self.hidden_size
+            )
+            for i, (encoder_seq_len, seq_len) in enumerate(
+                zip(encoder_seq_lengths, seq_lengths)
+            ):
+                instruct_attn_out[i, :encoder_seq_len] = joint_attn_out[
+                    i, :encoder_seq_len
+                ]
+                img_attn_out[i, : seq_len - encoder_seq_len] = joint_attn_out[
+                    i, encoder_seq_len:seq_len
+                ]
+
+            img_self_attn_out = self.img_self_attn(
+                hidden_states=img_norm3_out,
+                encoder_hidden_states=img_norm3_out,
+                attention_mask=img_attention_mask,
+                image_rotary_emb=image_rotary_emb,
+            )
+
+            img_hidden_states = img_hidden_states + self.img_attn_norm(img_attn_out)
+            img_hidden_states = img_hidden_states + self.img_self_attn_norm(
+                img_self_attn_out
+            )
+            img_norm2_out = self.img_norm2(img_hidden_states)
+            img_mlp_out = self.img_feed_forward(self.img_ffn_norm1(img_norm2_out))
+            img_hidden_states = img_hidden_states + self.img_ffn_norm2(img_mlp_out)
+
+            instruct_hidden_states = instruct_hidden_states + self.instruct_attn_norm(
+                instruct_attn_out
+            )
+            instruct_norm2_out = self.instruct_norm2(instruct_hidden_states)
+            instruct_mlp_out = self.instruct_feed_forward(
+                self.instruct_ffn_norm1(instruct_norm2_out)
+            )
+            instruct_hidden_states = instruct_hidden_states + self.instruct_ffn_norm2(
+                instruct_mlp_out
+            )
+
+        if enable_taylorseer and self.current["type"] == "full":
+            derivative_approximation_4_double_stream(
+                cache_dic=self.cache_dic,
+                current=self.current,
+                feature=(img_hidden_states, instruct_hidden_states),
+            )
+
+        return img_hidden_states, instruct_hidden_states
+
+
+class BooguImageTransformer2DModel(
+    ModelMixin, ConfigMixin, PeftAdapterMixin, FromOriginalModelMixin
+):
+    """
+    Boogu-Image transformer with mixed stream topology.
+    Early layers use double-stream (aka dual-stream) processing, then switch
+    to single-stream joint processing.
+    """
+
+    _supports_gradient_checkpointing = True
+    _no_split_modules = [
+        "BooguImageTransformerBlock",
+        "BooguImageNoiseRefinerTransformerBlock",
+        "BooguImageRefImgRefinerTransformerBlock",
+        "BooguImageContextRefinerTransformerBlock",
+        "BooguImageSingleStreamTransformerBlock",
+        "BooguImageDoubleStreamTransformerBlock",
+        "PromptEmbedding",
+        "nn.Embedding",
+    ]
+    # Noise refiner, reference image refiner, and double stream layers
+    # are kept out of regional torch.compile for numerical stability.
+    _repeated_blocks = [
+        "BooguImageTransformerBlock",
+        "BooguImageContextRefinerTransformerBlock",
+        "BooguImageSingleStreamTransformerBlock",
+    ]
+    _skip_layerwise_casting_patterns = ["x_embedder", "norm", "embedding"]
+
+    @register_to_config
+    def __init__(
+        self,
+        patch_size: int = 2,
+        in_channels: int = 16,
+        out_channels: Optional[int] = None,
+        hidden_size: int = 2304,
+        num_layers: int = 26,
+        num_double_stream_layers: int = 2,
+        num_refiner_layers: int = 2,
+        num_attention_heads: int = 24,
+        num_kv_heads: int = 8,
+        multiple_of: int = 256,
+        ffn_dim_multiplier: Optional[float] = None,
+        norm_eps: float = 1e-5,
+        axes_dim_rope: Tuple[int, int, int] = (40, 40, 40),
+        axes_lens: Tuple[int, int, int] = (2048, 1664, 1664),
+        # instruction_feat_dim: int = 1024,
+        instruction_feature_configs: Dict[str, Any] = dict(
+            instruction_feat_dim=1024,
+            reduce_type="mean",
+            num_instruction_feat_layers=1,
+        ),
+        prompt_tuning_configs: Dict[str, Any] = dict(use_prompt_tuning=False),
+        timestep_scale: float = 1.0,
+    ) -> None:
+        """Initialize the Boogu-Image mixed single-double stream transformer model."""
+        super().__init__()
+
+        # Validate configuration
+        if (hidden_size // num_attention_heads) != sum(axes_dim_rope):
+            raise ValueError(
+                f"hidden_size // num_attention_heads ({hidden_size // num_attention_heads}) "
+                f"must equal sum(axes_dim_rope) ({sum(axes_dim_rope)})"
+            )
+
+        if num_double_stream_layers > num_layers:
+            raise ValueError(
+                f"num_double_stream_layers ({num_double_stream_layers}) cannot be greater than "
+                f"num_layers ({num_layers})"
+            )
+
+        self.out_channels = out_channels or in_channels
+        self.num_double_stream_layers = num_double_stream_layers
+        self.num_single_stream_layers = num_layers - num_double_stream_layers
+        self.instruction_feature_configs = instruction_feature_configs
+        self.prompt_tuning_configs = prompt_tuning_configs
+        self.preprocessed_instruction_feat_dim = (
+            self.cal_preprocessed_instruction_feat_dim(instruction_feature_configs)
+        )
+
+        # Initialize embeddings
+        self.rope_embedder = BooguImageDoubleStreamRotaryPosEmbed(
+            theta=10000,
+            axes_dim=axes_dim_rope,
+            axes_lens=axes_lens,
+            patch_size=patch_size,
+        )
+
+        self.x_embedder = nn.Linear(
+            in_features=patch_size * patch_size * in_channels,
+            out_features=hidden_size,
+        )
+
+        self.ref_image_patch_embedder = nn.Linear(
+            in_features=patch_size * patch_size * in_channels,
+            out_features=hidden_size,
+        )
+
+        self.time_caption_embed = Lumina2CombinedTimestepCaptionEmbedding(
+            hidden_size=hidden_size,
+            instruction_feat_dim=self.preprocessed_instruction_feat_dim,
+            norm_eps=norm_eps,
+            timestep_scale=timestep_scale,
+        )
+
+        # Refiner layers.
+        self.noise_refiner = nn.ModuleList(
+            [
+                BooguImageNoiseRefinerTransformerBlock(
+                    hidden_size,
+                    num_attention_heads,
+                    num_kv_heads,
+                    multiple_of,
+                    ffn_dim_multiplier,
+                    norm_eps,
+                    modulation=True,
+                )
+                for _ in range(num_refiner_layers)
+            ]
+        )
+
+        self.ref_image_refiner = nn.ModuleList(
+            [
+                BooguImageRefImgRefinerTransformerBlock(
+                    hidden_size,
+                    num_attention_heads,
+                    num_kv_heads,
+                    multiple_of,
+                    ffn_dim_multiplier,
+                    norm_eps,
+                    modulation=True,
+                )
+                for _ in range(num_refiner_layers)
+            ]
+        )
+
+        self.context_refiner = nn.ModuleList(
+            [
+                BooguImageContextRefinerTransformerBlock(
+                    hidden_size,
+                    num_attention_heads,
+                    num_kv_heads,
+                    multiple_of,
+                    ffn_dim_multiplier,
+                    norm_eps,
+                    modulation=False,
+                )
+                for _ in range(num_refiner_layers)
+            ]
+        )
+
+        # Mixed architecture: dual-stream first, then single-stream.
+        # Here "double-stream" and "dual-stream" mean the same thing.
+        self.double_stream_layers = nn.ModuleList(
+            [
+                BooguImageDoubleStreamTransformerBlock(
+                    hidden_size,
+                    num_attention_heads,
+                    num_kv_heads,
+                    multiple_of,
+                    ffn_dim_multiplier,
+                    norm_eps,
+                    modulation=True,
+                )
+                for _ in range(num_double_stream_layers)
+            ]
+        )
+
+        # Single-stream layers process the fused sequence.
+        self.single_stream_layers = nn.ModuleList(
+            [
+                BooguImageSingleStreamTransformerBlock(
+                    hidden_size,
+                    num_attention_heads,
+                    num_kv_heads,
+                    multiple_of,
+                    ffn_dim_multiplier,
+                    norm_eps,
+                    modulation=True,
+                )
+                for _ in range(self.num_single_stream_layers)
+            ]
+        )
+
+        # Output norm and projection.
+        self.norm_out = LuminaLayerNormContinuous(
+            embedding_dim=hidden_size,
+            conditioning_embedding_dim=min(hidden_size, 1024),
+            elementwise_affine=False,
+            eps=1e-6,
+            bias=True,
+            out_dim=patch_size * patch_size * self.out_channels,
+        )
+
+        # Distinguish multiple reference images.
+        self.image_index_embedding = nn.Parameter(
+            torch.randn(5, hidden_size)
+        )  # support max 5 ref images
+
+        self.gradient_checkpointing = False
+
+        self.initialize_weights()
+
+        # TeaCache settings
+        self.enable_teacache = False
+        self.enable_taylorseer = False
+        self.enable_teacache_for_all_layers = False
+        self.enable_taylorseer_for_all_layers = False
+        self.teacache_rel_l1_thresh = 0.05
+        self.teacache_params = TeaCacheParams()
+
+        coefficients = [-5.48259225, 11.48772289, -4.47407401, 2.47730926, -0.03316487]
+        self.rescale_func = np.poly1d(coefficients)
+
+        self.layers = list(self.double_stream_layers) + list(self.single_stream_layers)
+
+    def initialize_weights(self) -> None:
+        """
+        Initialize the weights of the model.
+
+        Uses Xavier uniform initialization for linear layers.
+        """
+        nn.init.xavier_uniform_(self.x_embedder.weight)
+        nn.init.constant_(self.x_embedder.bias, 0.0)
+
+        nn.init.xavier_uniform_(self.ref_image_patch_embedder.weight)
+        nn.init.constant_(self.ref_image_patch_embedder.bias, 0.0)
+
+        nn.init.zeros_(self.norm_out.linear_1.weight)
+        nn.init.zeros_(self.norm_out.linear_1.bias)
+        nn.init.zeros_(self.norm_out.linear_2.weight)
+        nn.init.zeros_(self.norm_out.linear_2.bias)
+
+        nn.init.normal_(self.image_index_embedding, std=0.02)
+
+    def img_patch_embed_and_refine(
+        self,
+        hidden_states,
+        ref_image_hidden_states,
+        padded_img_mask,
+        padded_ref_img_mask,
+        noise_rotary_emb,
+        ref_img_rotary_emb,
+        l_effective_ref_img_len,
+        l_effective_img_len,
+        temb,
+    ):
+        """Embed image patches and run the refiner blocks."""
+        batch_size = len(hidden_states)
+        max_combined_img_len = max(
+            [
+                img_len + sum(ref_img_len)
+                for img_len, ref_img_len in zip(
+                    l_effective_img_len, l_effective_ref_img_len
+                )
+            ]
+        )
+
+        hidden_states = self.x_embedder(hidden_states)
+        ref_image_hidden_states = self.ref_image_patch_embedder(ref_image_hidden_states)
+
+        for i in range(batch_size):
+            shift = 0
+            for j, ref_img_len in enumerate(l_effective_ref_img_len[i]):
+                ref_image_hidden_states[i, shift : shift + ref_img_len, :] = (
+                    ref_image_hidden_states[i, shift : shift + ref_img_len, :]
+                    + self.image_index_embedding[j]
+                )
+                shift += ref_img_len
+
+        for layer in self.noise_refiner:
+            hidden_states = layer(
+                hidden_states, padded_img_mask, noise_rotary_emb, temb
+            )
+
+        flat_l_effective_ref_img_len = list(itertools.chain(*l_effective_ref_img_len))
+        num_ref_images = len(flat_l_effective_ref_img_len)
+        max_ref_img_len = max(flat_l_effective_ref_img_len)
+
+        batch_ref_img_mask = ref_image_hidden_states.new_zeros(
+            num_ref_images, max_ref_img_len, dtype=torch.bool
+        )
+        batch_ref_image_hidden_states = ref_image_hidden_states.new_zeros(
+            num_ref_images, max_ref_img_len, self.config.hidden_size
+        )
+        batch_ref_img_rotary_emb = hidden_states.new_zeros(
+            num_ref_images,
+            max_ref_img_len,
+            ref_img_rotary_emb.shape[-1],
+            dtype=ref_img_rotary_emb.dtype,
+        )
+        batch_temb = temb.new_zeros(num_ref_images, *temb.shape[1:], dtype=temb.dtype)
+
+        # Flatten reference images into a temporary batch.
+        idx = 0
+        for i in range(batch_size):
+            shift = 0
+            for ref_img_len in l_effective_ref_img_len[i]:
+                batch_ref_img_mask[idx, :ref_img_len] = True
+                batch_ref_image_hidden_states[idx, :ref_img_len] = (
+                    ref_image_hidden_states[i, shift : shift + ref_img_len]
+                )
+                batch_ref_img_rotary_emb[idx, :ref_img_len] = ref_img_rotary_emb[
+                    i, shift : shift + ref_img_len
+                ]
+                batch_temb[idx] = temb[i]
+                shift += ref_img_len
+                idx += 1
+
+        # Refine each reference-image sample.
+        for layer in self.ref_image_refiner:
+            batch_ref_image_hidden_states = layer(
+                batch_ref_image_hidden_states,
+                batch_ref_img_mask,
+                batch_ref_img_rotary_emb,
+                batch_temb,
+            )
+
+        # Restore reference-image sequence layout.
+        idx = 0
+        for i in range(batch_size):
+            shift = 0
+            for ref_img_len in l_effective_ref_img_len[i]:
+                ref_image_hidden_states[i, shift : shift + ref_img_len] = (
+                    batch_ref_image_hidden_states[idx, :ref_img_len]
+                )
+                shift += ref_img_len
+                idx += 1
+
+        combined_img_hidden_states = hidden_states.new_zeros(
+            batch_size, max_combined_img_len, self.config.hidden_size
+        )
+        for i, (ref_img_len, img_len) in enumerate(
+            zip(l_effective_ref_img_len, l_effective_img_len)
+        ):
+            combined_img_hidden_states[i, : sum(ref_img_len)] = ref_image_hidden_states[
+                i, : sum(ref_img_len)
+            ]
+            combined_img_hidden_states[
+                i, sum(ref_img_len) : sum(ref_img_len) + img_len
+            ] = hidden_states[i, :img_len]
+
+        return combined_img_hidden_states
+
+    def flat_and_pad_to_seq(self, hidden_states, ref_image_hidden_states):
+        """Flatten patch tokens and pad to batched sequences."""
+        batch_size = len(hidden_states)
+        p = self.config.patch_size
+        device = hidden_states[0].device
+
+        img_sizes = [(img.size(1), img.size(2)) for img in hidden_states]
+        l_effective_img_len = [(H // p) * (W // p) for (H, W) in img_sizes]
+
+        if ref_image_hidden_states is not None:
+            ref_img_sizes = [
+                [(img.size(1), img.size(2)) for img in imgs]
+                if imgs is not None
+                else None
+                for imgs in ref_image_hidden_states
+            ]
+            l_effective_ref_img_len = [
+                [
+                    (ref_img_size[0] // p) * (ref_img_size[1] // p)
+                    for ref_img_size in _ref_img_sizes
+                ]
+                if _ref_img_sizes is not None
+                else [0]
+                for _ref_img_sizes in ref_img_sizes
+            ]
+        else:
+            ref_img_sizes = [None for _ in range(batch_size)]
+            l_effective_ref_img_len = [[0] for _ in range(batch_size)]
+
+        max_ref_img_len = max(
+            [sum(ref_img_len) for ref_img_len in l_effective_ref_img_len]
+        )
+        max_img_len = max(l_effective_img_len)
+
+        # Reference-image patch embeddings.
+        flat_ref_img_hidden_states = []
+        for i in range(batch_size):
+            if ref_img_sizes[i] is not None:
+                imgs = []
+                for ref_img in ref_image_hidden_states[i]:
+                    C, H, W = ref_img.size()
+                    ref_img = rearrange(
+                        ref_img, "c (h p1) (w p2) -> (h w) (p1 p2 c)", p1=p, p2=p
+                    )
+                    imgs.append(ref_img)
+
+                img = torch.cat(imgs, dim=0)
+                flat_ref_img_hidden_states.append(img)
+            else:
+                flat_ref_img_hidden_states.append(None)
+
+        # Noise-image patch embeddings.
+        flat_hidden_states = []
+        for i in range(batch_size):
+            img = hidden_states[i]
+            C, H, W = img.size()
+
+            img = rearrange(img, "c (h p1) (w p2) -> (h w) (p1 p2 c)", p1=p, p2=p)
+            flat_hidden_states.append(img)
+
+        padded_ref_img_hidden_states = torch.zeros(
+            batch_size,
+            max_ref_img_len,
+            flat_hidden_states[0].shape[-1],
+            device=device,
+            dtype=flat_hidden_states[0].dtype,
+        )
+        padded_ref_img_mask = torch.zeros(
+            batch_size, max_ref_img_len, dtype=torch.bool, device=device
+        )
+        for i in range(batch_size):
+            if ref_img_sizes[i] is not None:
+                padded_ref_img_hidden_states[i, : sum(l_effective_ref_img_len[i])] = (
+                    flat_ref_img_hidden_states[i]
+                )
+                padded_ref_img_mask[i, : sum(l_effective_ref_img_len[i])] = True
+
+        padded_hidden_states = torch.zeros(
+            batch_size,
+            max_img_len,
+            flat_hidden_states[0].shape[-1],
+            device=device,
+            dtype=flat_hidden_states[0].dtype,
+        )
+        padded_img_mask = torch.zeros(
+            batch_size, max_img_len, dtype=torch.bool, device=device
+        )
+        for i in range(batch_size):
+            padded_hidden_states[i, : l_effective_img_len[i]] = flat_hidden_states[i]
+            padded_img_mask[i, : l_effective_img_len[i]] = True
+
+        return (
+            padded_hidden_states,
+            padded_ref_img_hidden_states,
+            padded_img_mask,
+            padded_ref_img_mask,
+            l_effective_ref_img_len,
+            l_effective_img_len,
+            ref_img_sizes,
+            img_sizes,
+        )
+
+    def cal_preprocessed_instruction_feat_dim(
+        self, instruction_feature_configs: Dict[str, Any]
+    ):
+        num_instruction_feat_layers = max(
+            instruction_feature_configs.get("num_instruction_feat_layers", 1), 1
+        )
+        instruction_feat_dim = instruction_feature_configs.get(
+            "instruction_feat_dim", 4096
+        )
+        reduce_type = instruction_feature_configs.get("reduce_type", "concat")
+        if "cat" in reduce_type.lower():
+            return num_instruction_feat_layers * instruction_feat_dim
+        elif "mean" in reduce_type.lower():
+            return instruction_feat_dim
+        else:
+            raise ValueError(f"Invalid reduce_type: {reduce_type}")
+
+    def preprocess_instruction_hidden_states(
+        self, raw_instruction_hidden_states, instruction_feature_configs: Dict[str, Any]
+    ):
+        num_instruction_feat_layers = max(
+            instruction_feature_configs.get("num_instruction_feat_layers", 1), 1
+        )
+        instruction_feat_dim = instruction_feature_configs.get(
+            "instruction_feat_dim", 4096
+        )
+        reduce_type = instruction_feature_configs.get("reduce_type", "concat")
+
+        instruction_hidden_states = None
+        if isinstance(raw_instruction_hidden_states, torch.Tensor):
+            instruction_hidden_states = raw_instruction_hidden_states
+        elif isinstance(raw_instruction_hidden_states, (list, tuple)):
+            assert len(raw_instruction_hidden_states) == num_instruction_feat_layers
+            if "cat" in reduce_type.lower():
+                instruction_hidden_states = torch.cat(
+                    raw_instruction_hidden_states, dim=-1
+                )
+            elif "mean" in reduce_type.lower():
+                instruction_hidden_states = torch.mean(
+                    torch.stack(raw_instruction_hidden_states), dim=0
+                )
+            else:
+                raise ValueError(f"Invalid reduce_type: {reduce_type}")
+        else:
+            raise ValueError(
+                f"Invalid type of raw_instruction_hidden_states, expected torch.Tensor or list, but got {type(raw_instruction_hidden_states)}"
+            )
+
+        assert (
+            self.preprocessed_instruction_feat_dim
+            == instruction_hidden_states.shape[-1]
+        )
+
+        return instruction_hidden_states
+
+    def forward(
+        self,
+        hidden_states: Union[torch.Tensor, List[torch.Tensor]],
+        timestep: torch.Tensor,
+        instruction_hidden_states: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        instruction_attention_mask: torch.Tensor,
+        ref_image_hidden_states: Optional[List[List[torch.Tensor]]] = None,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        return_dict: bool = False,
+    ) -> Union[torch.Tensor, Transformer2DModelOutput]:
+        """
+        Forward pass:
+        context/refiner -> dual-stream (double-stream) -> fusion -> single-stream -> projection.
+        """
+        instruction_hidden_states = self.preprocess_instruction_hidden_states(
+            instruction_hidden_states, self.instruction_feature_configs
+        )
+
+        enable_taylorseer = getattr(self, "enable_taylorseer", False)
+        if enable_taylorseer:
+            cal_type(self.cache_dic, self.current)
+
+        if attention_kwargs is not None:
+            attention_kwargs = attention_kwargs.copy()
+            lora_scale = attention_kwargs.pop("scale", 1.0)
+        else:
+            lora_scale = 1.0
+
+        if USE_PEFT_BACKEND:
+            # weight the lora layers by setting `lora_scale` for each PEFT layer
+            scale_lora_layers(self, lora_scale)
+        else:
+            if (
+                attention_kwargs is not None
+                and attention_kwargs.get("scale", None) is not None
+            ):
+                logger.warning(
+                    "Passing `scale` via `attention_kwargs` when not using the PEFT backend is ineffective."
+                )
+
+        # === 1. Initial processing (same as original Boogu-Image) ===
+        batch_size = len(hidden_states)
+        is_hidden_states_tensor = isinstance(hidden_states, torch.Tensor)
+
+        if is_hidden_states_tensor:
+            assert hidden_states.ndim == 4
+            hidden_states = [_hidden_states for _hidden_states in hidden_states]
+
+        device = hidden_states[0].device
+
+        # Timestep and instruction embedding.
+        temb, instruction_hidden_states = self.time_caption_embed(
+            timestep, instruction_hidden_states, hidden_states[0].dtype
+        )
+
+        # Flatten and pad token sequences.
+        (
+            hidden_states,
+            ref_image_hidden_states,
+            img_mask,
+            ref_img_mask,
+            l_effective_ref_img_len,
+            l_effective_img_len,
+            ref_img_sizes,
+            img_sizes,
+        ) = self.flat_and_pad_to_seq(hidden_states, ref_image_hidden_states)
+
+        # Build rotary embeddings and sequence lengths.
+        (
+            context_rotary_emb,
+            ref_img_rotary_emb,
+            noise_rotary_emb,
+            rotary_emb,
+            encoder_seq_lengths,
+            seq_lengths,
+            combined_img_rotary_emb,
+            combined_img_seq_lengths,
+        ) = self.rope_embedder(
+            freqs_cis,
+            instruction_attention_mask,
+            l_effective_ref_img_len,
+            l_effective_img_len,
+            ref_img_sizes,
+            img_sizes,
+            device,
+        )
+
+        # Context refinement.
+        for layer in self.context_refiner:
+            instruction_hidden_states = layer(
+                instruction_hidden_states,
+                instruction_attention_mask,
+                context_rotary_emb,
+            )
+
+        # Image patch embedding and refinement.
+        combined_img_hidden_states = self.img_patch_embed_and_refine(
+            hidden_states,
+            ref_image_hidden_states,
+            img_mask,
+            ref_img_mask,
+            noise_rotary_emb,
+            ref_img_rotary_emb,
+            l_effective_ref_img_len,
+            l_effective_img_len,
+            temb,
+        )
+
+        # Dual-stream (double-stream) stage.
+        instruct_hidden_states = instruction_hidden_states
+        img_hidden_states = combined_img_hidden_states
+
+        # Joint mask for [instruct + image].
+        max_seq_len = max(seq_lengths)
+        joint_attention_mask = hidden_states.new_zeros(
+            batch_size, max_seq_len, dtype=torch.bool
+        )
+        for i, seq_len in enumerate(seq_lengths):
+            joint_attention_mask[i, :seq_len] = True
+
+        # Run dual-stream blocks.
+        if self.num_double_stream_layers > 0:
+            # Image-only mask for [ref + noise].
+            max_img_len = max(combined_img_seq_lengths)
+            img_attention_mask = hidden_states.new_zeros(
+                batch_size, max_img_len, dtype=torch.bool
+            )
+            for i, img_seq_len in enumerate(combined_img_seq_lengths):
+                img_attention_mask[i, :img_seq_len] = True
+
+            enable_double_stream_taylorseer = (
+                enable_taylorseer and self.enable_taylorseer_for_all_layers
+            )
+            enable_double_stream_teacache = (
+                self.enable_teacache and self.enable_teacache_for_all_layers
+            )
+
+            if enable_double_stream_teacache:
+                first_double_stream_layer = self.double_stream_layers[0]
+                img_modulated_inp, _, _, _ = first_double_stream_layer.img_norm1(
+                    img_hidden_states.clone(), temb
+                )
+                instruct_modulated_inp, _, _, _ = (
+                    first_double_stream_layer.instruct_norm1(
+                        instruct_hidden_states.clone(), temb
+                    )
+                )
+                previous_double_modulated_inp = getattr(
+                    self.teacache_params, "previous_double_modulated_inp", None
+                )
+                if (
+                    self.teacache_params.is_first_or_last_step
+                    or previous_double_modulated_inp is None
+                ):
+                    should_calc_double_stream = True
+                    self.teacache_params.double_accumulated_rel_l1_distance = 0
+                else:
+                    img_rel_l1 = (
+                        img_modulated_inp - previous_double_modulated_inp[0]
+                    ).abs().mean() / previous_double_modulated_inp[0].abs().mean()
+                    instruct_rel_l1 = (
+                        instruct_modulated_inp - previous_double_modulated_inp[1]
+                    ).abs().mean() / previous_double_modulated_inp[1].abs().mean()
+                    rel_l1 = (img_rel_l1 + instruct_rel_l1) * 0.5
+                    self.teacache_params.double_accumulated_rel_l1_distance += (
+                        self.rescale_func(rel_l1.cpu().item())
+                    )
+                    if (
+                        self.teacache_params.double_accumulated_rel_l1_distance
+                        < self.teacache_rel_l1_thresh
+                    ):
+                        should_calc_double_stream = False
+                    else:
+                        should_calc_double_stream = True
+                        self.teacache_params.double_accumulated_rel_l1_distance = 0
+                self.teacache_params.previous_double_modulated_inp = (
+                    img_modulated_inp,
+                    instruct_modulated_inp,
+                )
+            else:
+                should_calc_double_stream = True
+
+            if enable_double_stream_teacache and not should_calc_double_stream:
+                img_residual, instruct_residual = (
+                    self.teacache_params.previous_double_residual
+                )
+                img_hidden_states = img_hidden_states + img_residual
+                instruct_hidden_states = instruct_hidden_states + instruct_residual
+            else:
+                if enable_double_stream_taylorseer:
+                    self.current["stream"] = "double_stream_layers"
+
+                if enable_double_stream_teacache:
+                    ori_img_hidden_states = img_hidden_states.clone()
+                    ori_instruct_hidden_states = instruct_hidden_states.clone()
+
+                for layer_idx, layer in enumerate(self.double_stream_layers):
+                    if enable_double_stream_taylorseer:
+                        layer.current = self.current
+                        layer.cache_dic = self.cache_dic
+                        layer.enable_taylorseer = True
+                        self.current["layer"] = layer_idx
+                    else:
+                        layer.enable_taylorseer = False
+
+                    if torch.is_grad_enabled() and self.gradient_checkpointing:
+                        img_hidden_states, instruct_hidden_states = (
+                            self._gradient_checkpointing_func(
+                                layer,
+                                img_hidden_states,
+                                instruct_hidden_states,
+                                img_attention_mask,
+                                joint_attention_mask,
+                                combined_img_rotary_emb,
+                                rotary_emb,
+                                temb,
+                                encoder_seq_lengths,
+                                seq_lengths,
+                            )
+                        )
+                    else:
+                        img_hidden_states, instruct_hidden_states = layer(
+                            img_hidden_states,
+                            instruct_hidden_states,
+                            img_attention_mask,
+                            joint_attention_mask,
+                            combined_img_rotary_emb,
+                            rotary_emb,
+                            temb,
+                            encoder_seq_lengths,
+                            seq_lengths,
+                        )
+
+                if enable_double_stream_teacache:
+                    self.teacache_params.previous_double_residual = (
+                        img_hidden_states - ori_img_hidden_states,
+                        instruct_hidden_states - ori_instruct_hidden_states,
+                    )
+
+        # Fuse streams to joint sequence.
+        joint_hidden_states = hidden_states.new_zeros(
+            batch_size, max(seq_lengths), self.config.hidden_size
+        )
+        for i, (encoder_seq_len, seq_len) in enumerate(
+            zip(encoder_seq_lengths, seq_lengths)
+        ):
+            joint_hidden_states[i, :encoder_seq_len] = instruct_hidden_states[
+                i, :encoder_seq_len
+            ]
+            joint_hidden_states[i, encoder_seq_len:seq_len] = img_hidden_states[
+                i, : seq_len - encoder_seq_len
+            ]
+
+        # Single-stream stage.
+        hidden_states = joint_hidden_states
+
+        # TeaCache optimization.
+        if self.enable_teacache and len(self.single_stream_layers) > 0:
+            teacache_hidden_states = hidden_states.clone()
+            teacache_temb = temb.clone()
+            modulated_inp, _, _, _ = self.single_stream_layers[0].norm1(
+                teacache_hidden_states, teacache_temb
+            )
+            if self.teacache_params.is_first_or_last_step:
+                should_calc = True
+                self.teacache_params.accumulated_rel_l1_distance = 0
+            else:
+                self.teacache_params.accumulated_rel_l1_distance += self.rescale_func(
+                    (
+                        (modulated_inp - self.teacache_params.previous_modulated_inp)
+                        .abs()
+                        .mean()
+                        / self.teacache_params.previous_modulated_inp.abs().mean()
+                    )
+                    .cpu()
+                    .item()
+                )
+                if (
+                    self.teacache_params.accumulated_rel_l1_distance
+                    < self.teacache_rel_l1_thresh
+                ):
+                    should_calc = False
+                else:
+                    should_calc = True
+                    self.teacache_params.accumulated_rel_l1_distance = 0
+            self.teacache_params.previous_modulated_inp = modulated_inp
+        else:
+            should_calc = True
+
+        if self.enable_teacache and not should_calc:
+            hidden_states += self.teacache_params.previous_residual
+        else:
+            if enable_taylorseer:
+                self.current["stream"] = "single_stream_layers"
+
+            if self.enable_teacache:
+                ori_hidden_states = hidden_states.clone()
+
+            for layer_idx, layer in enumerate(self.single_stream_layers):
+                if enable_taylorseer:
+                    layer.current = self.current
+                    layer.cache_dic = self.cache_dic
+                    layer.enable_taylorseer = True
+                    self.current["layer"] = self.num_double_stream_layers + layer_idx
+
+                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                    hidden_states = self._gradient_checkpointing_func(
+                        layer, hidden_states, joint_attention_mask, rotary_emb, temb
+                    )
+                else:
+                    hidden_states = layer(
+                        hidden_states, joint_attention_mask, rotary_emb, temb
+                    )
+
+            if self.enable_teacache:
+                self.teacache_params.previous_residual = (
+                    hidden_states - ori_hidden_states
+                )
+
+        # Output projection.
+        hidden_states = self.norm_out(hidden_states, temb)
+
+        # Reshape back to image format.
+        p = self.config.patch_size
+        output = []
+        for i, (img_size, img_len, seq_len) in enumerate(
+            zip(img_sizes, l_effective_img_len, seq_lengths)
+        ):
+            height, width = img_size
+            img_tokens = hidden_states[i][seq_len - img_len : seq_len]
+            img_output = rearrange(
+                img_tokens,
+                "(h w) (p1 p2 c) -> c (h p1) (w p2)",
+                h=height // p,
+                w=width // p,
+                p1=p,
+                p2=p,
+            )
+            output.append(img_output)
+
+        if is_hidden_states_tensor:
+            output = torch.stack(output, dim=0)
+
+        # Reset LoRA scaling.
+        if USE_PEFT_BACKEND:
+            unscale_lora_layers(self, lora_scale)
+
+        # TaylorSeer step counter.
+        if enable_taylorseer:
+            self.current["step"] += 1
+
+        if not return_dict:
+            return output
+        return Transformer2DModelOutput(sample=output)

--- a/unirl/models/boogu_image/vendor/transformer_boogu.py
+++ b/unirl/models/boogu_image/vendor/transformer_boogu.py
@@ -13,7 +13,6 @@ limitations under the License.
 """
 
 import itertools
-import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -33,9 +32,10 @@ from diffusers.utils import (
 )
 from einops import rearrange
 
-from ...utils.import_utils import is_triton_available
-from ...utils.teacache_util import TeaCacheParams
-from ..attention_processor import (
+# UniRL vendor edit: flattened same-dir imports; triton RMSNorm conditional
+# replaced by torch.nn.RMSNorm; TaylorSeer/TeaCache helpers routed to raising
+# stubs (RL rollout/replay must be cache-free). See VENDOR_COMMIT.txt.
+from .attention_processor import (
     BooguImageAttnProcessor,
     BooguImageAttnProcessorFlash2Varlen,
     BooguImageDoubleStreamSelfAttnProcessor,
@@ -51,20 +51,16 @@ from .rope import (
     BooguImageDoubleStreamRotaryPosEmbed,
     BooguImagePromptTuningRotaryPosEmbed,
 )
-
-if is_triton_available() and ("cuda" in os.getenv("device", "cpu")):
-    from ...ops.triton.layer_norm import RMSNorm
-else:
-    from torch.nn import RMSNorm
-
-from ...cache_functions import cal_type
-from ...taylorseer_utils import (
+from .taylorseer_stubs import (
+    cal_type,
     derivative_approximation,
     derivative_approximation_4_double_stream,
     taylor_cache_init,
     taylor_formula,
     taylor_formula_4_double_stream,
 )
+from .teacache_util import TeaCacheParams
+from torch.nn import RMSNorm
 
 logger = logging.get_logger(__name__)
 
@@ -206,14 +202,11 @@ class BooguImageTransformerBlock(nn.Module):
         self.head_dim = dim // num_attention_heads
         self.modulation = modulation
 
-        if "cpu" in os.getenv("device", "cpu"):
-            processor = BooguImageAttnProcessor()
-
-        else:
-            try:
-                processor = BooguImageAttnProcessorFlash2Varlen()
-            except ImportError:
-                processor = BooguImageAttnProcessor()
+        # UniRL vendor edit: attention backend is pinned to SDPA instead of the
+        # upstream `device` env-var gate — training numerics must not depend on
+        # process environment. Swap to Flash2Varlen post-load via the bundle's
+        # `attention_backend` config if desired.
+        processor = BooguImageAttnProcessor()
 
         # Initialize attention layer
         self.attn = Attention(
@@ -416,38 +409,15 @@ class BooguImageDoubleStreamTransformerBlock(nn.Module):
         self.modulation = modulation
         self.hidden_size = dim
 
-        if "cpu" in os.getenv("device", "cpu"):
-            processor = BooguImageAttnProcessor()
-        else:
-            try:
-                processor = BooguImageAttnProcessorFlash2Varlen()
-            except ImportError:
-                processor = BooguImageAttnProcessor()
-
-        if "cpu" in os.getenv("device", "cpu"):
-            double_stream_processor = BooguImageDoubleStreamSelfAttnProcessor(
-                head_dim=self.head_dim,
-                num_attention_heads=num_attention_heads,
-                num_kv_heads=num_kv_heads,
-                qkv_bias=False,
-            )
-        else:
-            try:
-                double_stream_processor = (
-                    BooguImageDoubleStreamSelfAttnProcessorFlash2Varlen(
-                        head_dim=self.head_dim,
-                        num_attention_heads=num_attention_heads,
-                        num_kv_heads=num_kv_heads,
-                        qkv_bias=False,
-                    )
-                )
-            except ImportError:
-                double_stream_processor = BooguImageDoubleStreamSelfAttnProcessor(
-                    head_dim=self.head_dim,
-                    num_attention_heads=num_attention_heads,
-                    num_kv_heads=num_kv_heads,
-                    qkv_bias=False,
-                )
+        # UniRL vendor edit: attention backends pinned to SDPA (see the note in
+        # BooguImageTransformerBlock.__init__).
+        processor = BooguImageAttnProcessor()
+        double_stream_processor = BooguImageDoubleStreamSelfAttnProcessor(
+            head_dim=self.head_dim,
+            num_attention_heads=num_attention_heads,
+            num_kv_heads=num_kv_heads,
+            qkv_bias=False,
+        )
 
         # Image stream components.
         self.img_instruct_attn = Attention(


### PR DESCRIPTION
## Summary

Adds RL post-training support for **Boogu-Image-0.1-Base** (T2I): a new
`unirl/models/boogu_image/` bundle + a trainside FlowGRPO recipe.

- **Vendored DiT** (`vendor/`, pinned at boogu-project/Boogu-Image `434fb56`,
  documented in `VENDOR_COMMIT.txt`): the 10.29B Lumina-2-lineage
  single/double-stream transformer is not in diffusers, and the HF
  checkpoint's "custom code" file is a shim importing the GitHub package, so
  vendoring (bagel precedent) is the only clean path. Mechanical edits only:
  flattened imports, SDPA processors pinned (upstream selects attention
  backends from a `device` env var — unacceptable for training numerics),
  torch RMSNorm/swiglu default branches, raising TaylorSeer/TeaCache stubs
  (RL must be cache-free).
- **Bundle package**: Qwen3-VL chat-template embed stage (fixed T2I system
  prompt; the CFG negative `""` routes to the DROP prompt per the reference's
  dataset logic), diffusion step/stage with the t-convention sign flip
  (t = 1 − σ), sequential CFG gated `> 1.0` with plain linear combine,
  resolution-independent cached RoPE tables, FLUX.1 `AutoencoderKL` fp32
  decode, trivial-case meta-init (the vendored tree has zero registered
  buffers), and `build_schedule_policy = static_only(e^1.15)` — Boogu's
  released static-v1 time shift (seq_len 4096) is algebraically the standard
  static σ-shift with `s = e^1.15` (verified to 1 fp32 ulp; Boogu's
  scheduler JSON uses custom field names the generic loader would silently
  ignore).
- **Recipe** `examples/diffusion/boogu_image/boogu_image_trainside.yaml`:
  FlowGRPO + LoRA r64 + PickScore at 512², CFG-off (Boogu's off value is
  1.0). FSDP `block_class_names` lists the 5 concrete instantiated block
  classes (exact type-name matching; the DoubleStream block is a separate
  class, not a subclass). LoRA targets include the double-stream
  joint-attention projections that live *inside* the attention processors
  (`img_to_q`/`instruct_to_q`/… — dot-boundary suffix matching cannot reach
  them via `to_q`). `master_dtype: fp32`, `old_logp_source: replay`.
- `pyproject.toml`: `einops>=0.7` (imported by the vendored DiT; pure-python,
  engine-agnostic). `.pre-commit-config.yaml`: vendored tree joins
  `bagel/vendor/` in the hook exclude.

**Update (2026-07-27):** rebased onto current main and migrated to the
Sample-native rollout model (#214): `generate()` is now the
`Sample -> Sample` endomorphism — prompt via `sample.conditioning()`,
`DiffusionSamplingParams` (with pinned `sigmas`) from the frontier gen Part,
noise groups from `frontier.group_ids`, x_T via `NoiseRecipe.from_sample`,
frontier filled with segment + decoded images + replay conditions. Also
adopts the new `build_meta_init_transformer` API and adds `load_vae`
(mirrors the z_image migration). Re-verified on 8×H20: the full parity gate
re-PASSED with byte-identical metrics (teacher-forced velocities still
bit-exact, replay ratio exactly 1), and the Sample-native trainer loop runs
clean (pre-check rewards match the pre-port run's same-seed values).

## Related Issue

N/A (README roadmap invites model requests; no existing issue or PR for
Boogu-Image — checked open PRs/issues).

## Test Plan

Current-head refresh (`ca2b647f954698467d1a743af79d7feba04a4299`): merged current `main` and resolved the two shared-file conflicts by retaining both the Boogu vendor exclusion and the benchmark-data exclusion, plus both the current dependency floors and Boogu’s `einops` dependency. On the merged head: 25 existing repository tests passed; `python -m compileall -q unirl/models/boogu_image` passed; the checked-in recipe composed and resolved; 1,997 Hydra `_target_` paths resolved; and pre-commit passed on every file in the final PR diff. The final diff adds no test files. The GPU evidence below is the contributor’s original Boogu checkpoint validation and was not re-run during this current-main refresh.

All run on 8×H20-96G (gz), checkpoint `Boogu/Boogu-Image-0.1-Base` @ HF
revision `7f464b5cabb4b0699b85409ab942337d8188124c` staged pod-local;
venv torch 2.11.0+cu129 / diffusers 0.38.0 / transformers 5.11.0.

- `python -m unirl.train_diffusion --config-name=diffusion/boogu_image/boogu_image_trainside --cfg job --resolve` — passes with and without `BOOGU_IMAGE_PATH`.
- `python -m compileall -q unirl`; `bash -n examples/*.sh`; `SKIP=no-commit-to-branch pre-commit run --all-files` — green (incl. the recipe-`_target_` hook).
- **Step-level parity vs the reference `BooguImagePipeline`** (1024², 50
  steps, CFG 4.0, seed 0, SDPA both sides): σ grid max|Δ| 1.19e-7;
  state-dict keys exactly match the checkpoint index; chat-template
  attention masks byte-equal; **teacher-forced per-step velocity bit-exact
  (cosine 1.0, max|Δ| 0 at all 50 steps)**; free-running from shared x_T
  (η=0): final-latent cosine 0.9953, decoded PSNR 32.7 dB; isolated VAE
  decode PSNR 56 dB (fp32 stage vs the reference's bf16 decode);
  diffuse↔replay ratio exactly 1; replay-backward smoke: 942 finite grads.
- **Wiring pre-check** `num_rollouts=2 batch_size=8 sampling.samples_per_prompt=4`:
  full loop clean, first-update ratio 1.0000±0.0000.
- **RL smoke** `num_rollouts=100` (48 prompts × 16 samples @ 512², 12 steps,
  LoRA) — **completed 100/100**: PickScore reward mean rose monotonically
  from **0.7519 ± 0.018 (first 20) to 0.8687 (last 20)** — +0.117 ≈ 6.5×
  the early-window std (max 0.8857) — with ratio_mean ≡ 1.0000 on first
  updates, approx_kl ≈ 0, and zero degenerate groups throughout
  (W&B run `unirl-boogu-image/c3h5ddt4`).

## Compatibility / Risk

Additive: new model package + new recipe dir. Shared-file touches are one
dependency line (`einops`, engine-agnostic pure python) and one pre-commit
exclude entry. No runtime/trainer/SDE/reward changes. Note: validation ran
on transformers 5.11.0 (venv) vs the pyproject `>=5.6,<5.7` pin — Qwen3-VL
encoding was bit-exact vs the reference on 5.11; flagging in case the pin
should be revisited separately.

## Reviewer Notes

- Start with `unirl/models/boogu_image/vendor/VENDOR_COMMIT.txt` (every
  mechanical edit + re-vendor recipe), then `diffusion.py` (the convention
  adapter: sign flip, timestep dtype, bare-tensor return, CFG gate).
- Follow-ups out of scope here: Edit (TI2I) overlay, Turbo (DMD few-step)
  RL, SGLang/vLLM serving (fork-side model support required), VeOmni SP wrap.
- AI-assisted implementation; the full diff was reviewed and every gate
  above executed on hardware before publishing. Duplicate-work check: no
  open upstream PRs/issues mention Boogu.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.


