### PR TITLE
fix: implement cosine scheduler warmup

### DIFF
--- a/unirl/train/optim.py
+++ b/unirl/train/optim.py
@@ -11,6 +11,7 @@ uses; the standard ``torch.optim.AdamW`` /
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple, runtime_checkable
 
 import torch
@@ -146,6 +147,17 @@ def build_lr_scheduler(
     if scheduler_type == "constant":
         return torch.optim.lr_scheduler.LambdaLR(optimizer, lambda step: 1.0)
 
+    if scheduler_type in {"linear", "cosine"}:
+        if warmup_steps < 0:
+            raise ValueError(f"warmup_steps must be >= 0, got {warmup_steps}.")
+        if total_steps < 1:
+            raise ValueError(f"total_steps must be >= 1, got {total_steps}.")
+        if warmup_steps >= total_steps:
+            raise ValueError(
+                "warmup_steps must be less than total_steps for a decaying "
+                f"schedule, got warmup_steps={warmup_steps}, total_steps={total_steps}."
+            )
+
     if scheduler_type == "linear":
 
         def lr_lambda(step: int) -> float:
@@ -156,11 +168,15 @@ def build_lr_scheduler(
         return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
     if scheduler_type == "cosine":
-        return torch.optim.lr_scheduler.CosineAnnealingLR(
-            optimizer,
-            T_max=total_steps - warmup_steps,
-            eta_min=0,
-        )
+
+        def lr_lambda(step: int) -> float:
+            if step < warmup_steps:
+                return step / max(1, warmup_steps)
+            progress = (step - warmup_steps) / (total_steps - warmup_steps)
+            progress = min(1.0, max(0.0, progress))
+            return 0.5 * (1.0 + math.cos(math.pi * progress))
+
+        return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
     return None
 


### PR DESCRIPTION
## Summary

Fix the cosine learning-rate scheduler so configured warmup is applied correctly and the learning rate does not rebound after reaching zero.

The previous implementation used:

```python
CosineAnnealingLR(
    optimizer,
    T_max=total_steps - warmup_steps,
    eta_min=0,
)
```

This shortened the cosine period but did not implement warmup, and it caused the learning rate to reach zero early and increase again before training ended.

The fix uses a clamped `LambdaLR` schedule with linear warmup followed by cosine decay.

## Related Issue

N/A

## Test Plan

- `git diff --check`
- `ruff check unirl/train/optim.py`
- `ruff format --check unirl/train/optim.py`
- Task-local scheduler tests: `12 passed`.
- Real GPU A/B validation with SD3.5-medium, FlowGRPO, local PickScore, one NVIDIA H20, `warmup_steps=5`, `total_steps=15`, and `num_rollouts=15`.
- Both runs completed 15 finite optimizer updates and saved checkpoints with `step == optimizer_step_count == 15`.

Observed LR used by each optimizer update:

| Step | Existing scheduler | Fixed scheduler |
|---:|---:|---:|
| 1 | `3.000e-4` | `0` |
| 2 | `2.927e-4` | `6.000e-5` |
| 3 | `2.714e-4` | `1.200e-4` |
| 4 | `2.382e-4` | `1.800e-4` |
| 5 | `1.964e-4` | `2.400e-4` |
| 6 | `1.500e-4` | `3.000e-4` |
| 7 | `1.036e-4` | `2.927e-4` |
| 8 | `6.183e-5` | `2.714e-4` |
| 9 | `2.865e-5` | `2.382e-4` |
| 10 | `7.342e-6` | `1.964e-4` |
| 11 | `0` | `1.500e-4` |
| 12 | `7.342e-6` | `1.036e-4` |
| 13 | `2.865e-5` | `6.183e-5` |
| 14 | `6.183e-5` | `2.865e-5` |
| 15 | `1.036e-4` | `7.342e-6` |

The existing scheduler reaches zero at step 11 and rebounds through steps 12–15, while the fixed scheduler warms up through step 6 and decays monotonically to zero at step 15.

## Compatibility / Risk

This changes the scheduler class from `CosineAnnealingLR` to `LambdaLR`.

Existing cosine jobs should finish with their pinned old revision.

Old cosine scheduler state cannot be loaded directly into the new scheduler; cross-version resume requires explicit migration based on `optimizer_step_count`, and automatic migration is not included in this PR.

## Reviewer Notes

The upstream `main` branch currently has no tracked `tests/` directory, so the scheduler tests were retained as task-local validation evidence rather than added to this minimal product diff.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
