### PR TITLE
fix(vllm_omni/lora-sync): fix verify readback manager level and packed tensors.

### DIFF
--- a/tests/distributed/weight_sync/test_lora_verify.py
+++ b/tests/distributed/weight_sync/test_lora_verify.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(name: str, relative_path: str):
+    spec = importlib.util.spec_from_file_location(name, _REPO_ROOT / relative_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {relative_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeTensor:
+    def __init__(self, fingerprint: str) -> None:
+        self.fingerprint = fingerprint
+
+
+class LoraVerifyTest(unittest.TestCase):
+    def test_readback_descends_into_worker_manager_and_hashes_packed_shards(self) -> None:
+        torch = types.ModuleType("torch")
+        torch.Tensor = _FakeTensor
+
+        transfer = types.ModuleType("unirl.distributed.weight_sync.transfer")
+        transfer.__path__ = []
+
+        bucketed_transfer = types.ModuleType("unirl.distributed.weight_sync.transfer.bucketed_transfer")
+        bucketed_transfer.BucketedWeightReceiver = object
+
+        ipc_dispatch = types.ModuleType("unirl.distributed.weight_sync.transfer.ipc_dispatch")
+        ipc_dispatch.DIFFRL_LORA_INT_ID = 1
+        ipc_dispatch.DIFFRL_LORA_NAME = "test"
+        ipc_dispatch.DIFFRL_LORA_PATH = "/tmp/test"
+        ipc_dispatch.replica_rank_from_env = lambda: 0
+        ipc_dispatch.zmq_handle = lambda **kwargs: kwargs
+
+        checksum = types.ModuleType("unirl.distributed.weight_sync.transfer.checksum")
+        checksum.fingerprint_tensor = lambda tensor: tensor.fingerprint
+
+        patches = types.ModuleType("unirl.rollout.engine.vllm_omni.patches")
+        patches.__path__ = []
+
+        runtime = types.ModuleType("unirl.rollout.engine.vllm_omni.patches.runtime")
+        runtime.OmniTensorLoRARequest = object
+
+        class _VLLMOmniHijack:
+            @staticmethod
+            def hijack() -> None:
+                pass
+
+        runtime.VLLMOmniHijack = _VLLMOmniHijack
+
+        stubs = {
+            "torch": torch,
+            "unirl.distributed.weight_sync.transfer": transfer,
+            "unirl.distributed.weight_sync.transfer.bucketed_transfer": bucketed_transfer,
+            "unirl.distributed.weight_sync.transfer.ipc_dispatch": ipc_dispatch,
+            "unirl.distributed.weight_sync.transfer.checksum": checksum,
+            "unirl.rollout.engine.vllm_omni.patches": patches,
+            "unirl.rollout.engine.vllm_omni.patches.runtime": runtime,
+        }
+        with patch.dict(sys.modules, stubs):
+            module = _load_module(
+                "_test_ipc_receive_mixin",
+                "unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py",
+            )
+
+            flat = types.SimpleNamespace(
+                lora_a=_FakeTensor("flat-a"),
+                lora_b=_FakeTensor("flat-b"),
+                bias=None,
+                embeddings_tensor=None,
+            )
+            packed = types.SimpleNamespace(
+                lora_a=[_FakeTensor("q-a"), None, _FakeTensor("v-a")],
+                lora_b=(_FakeTensor("q-b"), None, _FakeTensor("v-b")),
+                bias=None,
+                embeddings_tensor=None,
+            )
+            lora_model = types.SimpleNamespace(loras={"flat": flat, "qkv_proj": packed})
+            inner_manager = types.SimpleNamespace(_registered_adapters={7: lora_model})
+            outer_manager = types.SimpleNamespace(_adapter_manager=inner_manager)
+
+            worker = object.__new__(module.BucketedIPCReceiveMixin)
+            worker.lora_manager = outer_manager
+            worker.model_runner = None
+
+            loaded = worker._diffrl_loaded_lora_checksums(adapter_id=7)
+
+        self.assertEqual(
+            loaded,
+            {
+                "flat": {"lora_a": "flat-a", "lora_b": "flat-b"},
+                "qkv_proj": {
+                    "lora_a.0": "q-a",
+                    "lora_a.2": "v-a",
+                    "lora_b.0": "q-b",
+                    "lora_b.2": "v-b",
+                },
+            },
+        )
+
+    def test_assert_loaded_accepts_mixed_flat_and_packed_checksums(self) -> None:
+        remote = types.ModuleType("unirl.distributed.group.remote")
+
+        class _Remote:
+            pass
+
+        remote.Remote = _Remote
+        with patch.dict(sys.modules, {"unirl.distributed.group.remote": remote}):
+            module = _load_module(
+                "_test_lora_sync_base",
+                "unirl/distributed/weight_sync/lora/base.py",
+            )
+
+        sync = object.__new__(module.LoraWeightSyncBase)
+        sync._param_prefix = ""
+        loaded = {
+            0: [
+                {
+                    "flat": {"lora_a": "flat-a", "lora_b": "flat-b"},
+                    "qkv_proj": {
+                        "lora_a.0": "q-a",
+                        "lora_a.2": "v-a",
+                        "lora_b.0": "q-b",
+                        "lora_b.2": "v-b",
+                    },
+                }
+            ]
+        }
+
+        sync._assert_loaded(
+            ["flat-a", "q-a", "v-a"],
+            ["flat-b", "q-b", "v-b"],
+            loaded,
+            label="mixed flat/packed",
+        )
+
+    def test_assert_loaded_still_rejects_a_missing_packed_shard(self) -> None:
+        remote = types.ModuleType("unirl.distributed.group.remote")
+
+        class _Remote:
+            pass
+
+        remote.Remote = _Remote
+        with patch.dict(sys.modules, {"unirl.distributed.group.remote": remote}):
+            module = _load_module(
+                "_test_lora_sync_base_missing",
+                "unirl/distributed/weight_sync/lora/base.py",
+            )
+
+        sync = object.__new__(module.LoraWeightSyncBase)
+        sync._param_prefix = ""
+        loaded = {
+            0: [
+                {
+                    "qkv_proj": {
+                        "lora_a.0": "q-a",
+                        "lora_b.0": "q-b",
+                    }
+                }
+            ]
+        }
+
+        with self.assertRaisesRegex(RuntimeError, r"engine loaded 1 / 1"):
+            sync._assert_loaded(
+                ["k-a", "q-a"],
+                ["k-b", "q-b"],
+                loaded,
+                label="missing packed shard",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unirl/distributed/weight_sync/lora/base.py
+++ b/unirl/distributed/weight_sync/lora/base.py
@@ -133,8 +133,22 @@ class LoraWeightSyncBase(Remote):
         """
         for stage_id, per_rank in loaded.items():
             for rank_idx, layer_map in enumerate(per_rank):
-                act_a = sorted(f["lora_a"] for f in layer_map.values() if "lora_a" in f)
-                act_b = sorted(f["lora_b"] for f in layer_map.values() if "lora_b" in f)
+                # Plain layers expose ``lora_a`` / ``lora_b`` directly. Packed
+                # layers expose one checksum per fused projection as
+                # ``lora_a.<index>`` / ``lora_b.<index>``. Flatten both shapes
+                # into the same multisets before comparing with the trainer.
+                act_a = sorted(
+                    checksum
+                    for fields in layer_map.values()
+                    for field, checksum in fields.items()
+                    if field == "lora_a" or field.startswith("lora_a.")
+                )
+                act_b = sorted(
+                    checksum
+                    for fields in layer_map.values()
+                    for field, checksum in fields.items()
+                    if field == "lora_b" or field.startswith("lora_b.")
+                )
                 if act_a != exp_a or act_b != exp_b:
                     raise RuntimeError(
                         f"[LoRA-SYNC] verify FAILED on {label}, stage {stage_id} rank "

--- a/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
+++ b/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
@@ -476,10 +476,12 @@ class BucketedIPCReceiveMixin:
     ) -> dict:
         """Full-byte SHA-256 of the worker's loaded LoRA adapter tensors.
 
-        Walks ``lora_manager._registered_adapters[adapter_id].loras`` and
-        hashes ``lora_a`` / ``lora_b`` / ``bias`` / ``embeddings_tensor``
-        when present. ``lora.optimize()`` has already run by this point
-        — ``lora_b`` is post-scaling — so the trainer must apply the
+        Walks the inner ``LoRAModelManager._registered_adapters[adapter_id].loras``
+        and hashes ``lora_a`` / ``lora_b`` / ``bias`` / ``embeddings_tensor``
+        when present. Packed modules store their ``lora_a`` / ``lora_b`` as a
+        list of sub-tensors (one per fused projection), which are hashed
+        per-shard as ``<field>.<i>``. ``lora.optimize()`` has already run by
+        this point — ``lora_b`` is post-scaling — so the trainer must apply the
         matching ``alpha / r`` scaling before hashing for equality. The
         helper :func:`weight_sync.checksum.compute_lora_checksums_post_optimize`
         does that.
@@ -504,6 +506,11 @@ class BucketedIPCReceiveMixin:
         )
         if manager is None:
             return {}
+        # vLLM wraps the registry: the outer ``WorkerLoRAManager`` delegates to
+        # an inner ``LoRAModelManager`` (``_adapter_manager``) that actually owns
+        # ``_registered_adapters``. Reading the outer object returns an empty
+        # mapping, so descend when the inner manager is present.
+        manager = getattr(manager, "_adapter_manager", manager)
         registered = getattr(manager, "_registered_adapters", None)
         if registered is None:
             return {}
@@ -520,6 +527,14 @@ class BucketedIPCReceiveMixin:
                 t = getattr(layer, field, None)
                 if isinstance(t, torch.Tensor):
                     per_field[field] = fingerprint_tensor(t)
+                elif isinstance(t, (list, tuple)):
+                    # Packed modules (``qkv_proj``, ``gate_up_proj``) store one
+                    # sub-tensor per fused projection; ``None`` slots mark
+                    # absent shards. Hash each present shard separately so the
+                    # readback covers the whole fused layer, not just the first.
+                    for i, sub in enumerate(t):
+                        if isinstance(sub, torch.Tensor):
+                            per_field[f"{field}.{i}"] = fingerprint_tensor(sub)
             out[layer_name] = per_field
         return out
 


### PR DESCRIPTION
## Summary
Fix two latent bugs in the LoRA weight-sync verify read-back (BucketedIPCReceiveMixin._diffrl_loaded_lora_checksums) so that RemoteLoraWeightSync(verify=True) produces a trustworthy N/N match signal instead of false negatives. Both are read-only fixes to the check-sum read-back path; no sync/write behavior changes.

### Background
When verify=True, LoRA sync does a checksum reconciliation after every push:

the trainer hashes the LoRA tensors it pushed (the expected set), and
the rollout worker reads back the LoRA tensors actually registered in the vLLM engine and hashes them (_diffrl_loaded_lora_checksums), so the two multisets can be compared.
This verify path is off by default (verify=False), so this read-back had effectively never executed in anger — which is exactly why the two bugs below sat undetected. They only surface the moment someone turns verify=True on (e.g. to debug a train/inference mismatch), and when they do, they manifest as false "verify FAILED" with loaded 0 / a wrong count — actively misleading, because the LoRA was in fact loaded correctly.

Note: this PR is only about making the verify tool itself correct. It is model-agnostic — _diffrl_loaded_lora_checksums is shared by every model that uses RemoteLoraWeightSync verify (HI3 included) — and does not touch any model-specific weight-naming logic.
<!--
Explain what changed and why. Keep this focused on the reviewer-facing context,
not a file-by-file changelog.
-->

## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan
- `pytest -q tests/distributed/weight_sync/test_lora_verify.py`
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [ ] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.

