### PR TITLE
fix(vllm_omni/adapters): gate shift assertion on needs_sigmas

### DIFF
--- a/unirl/rollout/engine/vllm_omni/adapters/base.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/base.py
@@ -168,6 +168,12 @@ class ModelAdapter(ABC):
 
     # ---- construction-time validation (v1 engine.py:404-409) ----
     def validate(self) -> None:
+        # ``shift`` parametrizes the FlowMatch σ schedule and only matters for
+        # adapters that actually run one. AR-only adapters (``needs_sigmas`` is
+        # False) never call :meth:`schedule_policy`, so requiring a diffusion
+        # ``model_config.shift`` from them is spurious.
+        if not self.needs_sigmas:
+            return
         mc = self.model_config
         require(
             mc is not None and hasattr(mc, "shift"),

--- a/unirl/rollout/engine/vllm_omni/adapters/base.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/base.py
@@ -172,15 +172,14 @@ class ModelAdapter(ABC):
         # adapters that actually run one. AR-only adapters (``needs_sigmas`` is
         # False) never call :meth:`schedule_policy`, so requiring a diffusion
         # ``model_config.shift`` from them is spurious.
-        if not self.needs_sigmas:
-            return
-        mc = self.model_config
-        require(
-            mc is not None and hasattr(mc, "shift"),
-            f"{type(self).__name__} requires model_config.shift; got "
-            f"{type(mc).__name__}. Use a registered model preset "
-            f"(e.g. ``sd3``, ``wan21``, ``wan22``, ``hunyuan_image3``).",
-        )
+        if self.needs_sigmas:
+            mc = self.model_config
+            require(
+                mc is not None and hasattr(mc, "shift"),
+                f"{type(self).__name__} requires model_config.shift; got "
+                f"{type(mc).__name__}. Use a registered model preset "
+                f"(e.g. ``sd3``, ``wan21``, ``wan22``, ``hunyuan_image3``).",
+            )
 
     # ---- per-request validation (ports v1 ``_validate_request``) ----
     def validate_request(self, req: RolloutReq) -> None:

--- a/unirl/rollout/engine/vllm_omni/engine.py
+++ b/unirl/rollout/engine/vllm_omni/engine.py
@@ -70,6 +70,11 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
             config, model_config, strategy=strategy, tokenize_fn=self._tokenize_prompt
         )
 
+        # Resolve the σ schedule before spawning the backend so a bad diffusion
+        # configuration fails fast. AR-only adapters have no diffusion schedule
+        # and must not touch ``model_config.shift``.
+        self.schedule_policy = self.adapter.schedule_policy() if self.adapter.needs_sigmas else None
+
         # Ports — engine-reserved on this node at the last moment before the
         # spawn (bind-to-0; replaces v1's base + rank*stride math). Tests
         # inject a fixed set.
@@ -94,10 +99,6 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
             lora_copy_transport=self.adapter.lora_copy_transport,
         )
 
-        # σ schedule policy comes from the adapter; ``ensure_req_sigmas``
-        # consumes it in ``generate`` (gated on the adapter's needs_sigmas).
-        self.schedule_policy = self.adapter.schedule_policy()
-
     def _tokenize_prompt(self, text: str, *, task: str, sys_type: str) -> List[int]:
         """Late-bound bridge handed to the adapter as ``tokenize_fn``."""
         return self._backend.tokenize_prompt(text, task=task, sys_type=sys_type)
@@ -121,6 +122,7 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
         # worker echoed it back. AR-only modalities have no diffusion params,
         # so the adapter opts out (ensure_req_sigmas would raise on them).
         if self.adapter.needs_sigmas:
+            require(self.schedule_policy is not None, f"{type(self.adapter).__name__} has no sigma schedule policy")
             ensure_req_sigmas(req, self.schedule_policy)
         calls = self.adapter.build_inputs(req)
         per_request = self._backend.generate(


### PR DESCRIPTION
## Summary
Gate the base adapter's construction-time `shift` assertion on `needs_sigmas`, so that AR-only adapters are no longer rejected for lacking a diffusion-only config field. Diffusion adapters are unaffected.

<!--
Explain what changed and why. Keep this focused on the reviewer-facing context,
not a file-by-file changelog.
-->

## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan
No test, reason: no need
<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [ ] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
