### PR TITLE
fix(train/stack): set train mode before update for AR models.

### DIFF
--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -337,10 +337,10 @@ class TrainStack(Remote):
         ``num_updates_per_batch`` optimizer steps run over disjoint updates, and
         ``on_rollout_end`` runs once — see :meth:`_run_updates`.
         """
-        # Put the trainable module in train mode before the update (specifically for
-        # AR models). HF ``from_pretrained`` returns the model in eval mode and nothing
-        # else in the AR path flips it. 
-        self.fsdp_backend.model.train()
+        # Freeze the old-policy anchor without train-mode stochasticity (notably
+        # dropout). The gradient-bearing replay below switches back to train mode
+        # so HF gradient checkpointing, which is gated on ``self.training``, engages.
+        self.fsdp_backend.model.eval()
         self._align_track_inputs(resp_track)
         # Arrange once: reorder the track so packed micros are contiguous (no-op for
         # CountPlanner) and produce the plan. The SAME (track, plans) feed both the
@@ -357,6 +357,7 @@ class TrainStack(Remote):
         profiler = self._train_step_profiler() if profile_scope() == "train" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             self.prepare_segment(resp_track, plans=plans)
+            self.fsdp_backend.model.train()
             result = self._run_updates(resp_track, plans=plans, training_progress=float(training_progress))
         if profiler is not None:
             profiler.step()

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -337,14 +337,9 @@ class TrainStack(Remote):
         ``num_updates_per_batch`` optimizer steps run over disjoint updates, and
         ``on_rollout_end`` runs once — see :meth:`_run_updates`.
         """
-        # HF ``from_pretrained`` returns the model in eval mode and nothing else in
-        # the AR path flips it. ``GradientCheckpointingLayer.__call__`` only
-        # checkpoints when ``self.gradient_checkpointing and self.training`` — so
-        # eval mode silently no-ops the bundle's ``use_gradient_checkpointing=True``,
-        # and the differentiable replay forward retains every decoder layer's
-        # activations → OOM on long sequences. Put the trainable module in train
-        # mode before the update (mirrors ReFLPolicy.sample_and_decode's
-        # ``self.backend.model.train()`` on the diffusion path).
+        # Put the trainable module in train mode before the update (specifically for
+        # AR models). HF ``from_pretrained`` returns the model in eval mode and nothing
+        # else in the AR path flips it. 
         self.fsdp_backend.model.train()
         self._align_track_inputs(resp_track)
         # Arrange once: reorder the track so packed micros are contiguous (no-op for

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -337,6 +337,15 @@ class TrainStack(Remote):
         ``num_updates_per_batch`` optimizer steps run over disjoint updates, and
         ``on_rollout_end`` runs once — see :meth:`_run_updates`.
         """
+        # HF ``from_pretrained`` returns the model in eval mode and nothing else in
+        # the AR path flips it. ``GradientCheckpointingLayer.__call__`` only
+        # checkpoints when ``self.gradient_checkpointing and self.training`` — so
+        # eval mode silently no-ops the bundle's ``use_gradient_checkpointing=True``,
+        # and the differentiable replay forward retains every decoder layer's
+        # activations → OOM on long sequences. Put the trainable module in train
+        # mode before the update (mirrors ReFLPolicy.sample_and_decode's
+        # ``self.backend.model.train()`` on the diffusion path).
+        self.fsdp_backend.model.train()
         self._align_track_inputs(resp_track)
         # Arrange once: reorder the track so packed micros are contiguous (no-op for
         # CountPlanner) and produce the plan. The SAME (track, plans) feed both the


### PR DESCRIPTION
## Summary
HF ``from_pretrained`` returns the model in eval mode and nothing else in the AR path flips it. ``GradientCheckpointingLayer.__call__`` only checkpoints when ``self.gradient_checkpointing and self.training`` — so eval mode silently no-ops the bundle's ``use_gradient_checkpointing=True``, and the differentiable replay forward retains every decoder layer's activations → OOM on long sequences. Put the trainable module in train mode before the update (mirrors ReFLPolicy.sample_and_decode's ``self.backend.model.train()`` on the diffusion path).
<!--
Explain what changed and why. Keep this focused on the reviewer-facing context,
not a file-by-file changelog.
-->

## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan
No test, reason: no need
<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [ ] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
