### PR TITLE
fix(ci): skip fork review label writes

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -15,6 +15,11 @@ concurrency:
 
 jobs:
   sync-label:
+    # Fork-triggered review workflows receive a read-only GITHUB_TOKEN, so the
+    # cosmetic label update cannot succeed. Native reviewDecision still gates merge.
+    if: >-
+      github.event_name != 'pull_request_review' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     name: Sync PR status label
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- skip status-label mutation for fork-triggered `pull_request_review` runs, whose `GITHUB_TOKEN` is read-only
- preserve label synchronization for same-repository reviews and all existing `pull_request_target` events
- rely on GitHub's native `reviewDecision` to gate merges when the cosmetic fork label update is skipped

## Test Plan
- [x] run repository pre-commit checks on `.github/workflows/pr-status-labels.yml`
- [x] validate YAML and whitespace
- [ ] submit or dismiss a review on a fork PR after merge and confirm the label job is skipped rather than failed
