### PR TITLE
feat(rollout/sglang_diffusion): support ti2i on FLUX.2-Klein

### DIFF
--- a/examples/diffusion/flux2_klein/flux2_klein_4b_editreward_sglang.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_4b_editreward_sglang.yaml
@@ -1,0 +1,226 @@
+# @package _global_
+# FLUX.2-klein-4B GRPO — SGLANG rollout + RemoteRewardBackend (EditReward).
+#
+# 4B sibling of flux2_klein_editreward_sglang.yaml: identical objective, dataset,
+# algorithm, sampling, and engine wiring — only pretrained_model_ckpt_path (base-4B)
+# and batch_size (64, the lighter model affords a larger rollout) differ, mirroring
+# how the trainside flux2_klein_4b_editreward.yaml differs from its 9B sibling.
+#
+# Klein serves BOTH t2i and text+image→image off one checkpoint; the
+# Flux2KleinAdapter branches on Sample.has_image_input(), so an edit dataset
+# (prompt + condition image) drives the ti2i path and a t2i dataset the t2i
+# path — no task flag.
+#
+# DEVIATIONS from the trainside recipe, all forced by the engine swap:
+#   1. rollout / sync / weight_sync_interval — the engine itself. Trainside
+#      trains the sampler in place; SGLang pushes the LoRA to the engine each
+#      interval (LocalLoraWeightSync).
+#   2. param_dtype fp32 → bf16 + master_dtype fp32. The synced LoRA wire dtype
+#      must be bf16 for the SGLang kernels; master_dtype restores the proven
+#      recipe's fp32 optimizer precision (load-bearing at the ~1e-3 gradient
+#      scale — a bf16 master rounds those updates away).
+#   3. init_same_noise true → false. NOT a preference: the engine's
+#      init_same_noise=true path sizes x_T via the SGLang fork's flux2
+#      prepare_latent_shape, which mis-sizes FLUX.2 latent channels. GRPO
+#      correctness does not require shared init noise (per-group advantages
+#      don't need it; it's variance reduction only).
+#   4. activation_checkpointing false → true (memory: each actor colocates its
+#      own SGLang engine, and ti2i concatenates source tokens onto the noise
+#      sequence during replay). Numerically neutral.
+#   5. bundle.config inlined → ${model_config} anchor + strategy anchor, and
+#      use_lora / lora_target_modules surfaced onto model_config (SGLang builds
+#      its LoRA ServerArgs from these).
+#
+# 2-node deployment (reward service off the training GPUs):
+#   Node 0 (reward): ray start --head --port=6379 --num-gpus=1
+#                    python -m reward_service --config configs/editreward_service.yaml
+#   Node 1 (train):  export REWARD_SERVICE_URL=http://<node0_ip>:8080
+#                    export DATA_PATH=... EVAL_DATA_PATH=...
+#                    bash examples/run_experiment_single_node.sh diffusion/flux2_klein/flux2_klein_4b_editreward_sglang
+
+num_devices: 8
+batch_size: 64                # prompts_per_rollout (64 x 16 samples = 1024 global)
+num_rollouts: 10000
+weight_sync_interval: 1       # LoRA sync cadence: every rollout push adapter into the engine
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,unirl-flux2klein-editreward}
+  run_name: ${oc.env:WANDB_RUN_NAME,flux2klein_4b_editreward_it2i_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [flux2_klein, flux2_klein_4b, it2i, edit, editreward, lora, sglang]
+  log_media: true
+  media_max_items: 8
+  media_log_interval: 1
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (the sglang engine needs both at init).
+model_config:
+  _target_: unirl.models.flux2_klein.config.Flux2KleinPipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:FLUX2_KLEIN_PATH,black-forest-labs/FLUX.2-klein-base-4B}
+  model_precision: bf16
+  max_sequence_length: 512
+  shift: 1.0
+  use_lora: true
+  lora_target_modules: &lora_targets
+    - to_q
+    - to_k
+    - to_v
+    - to_out.0
+    - add_q_proj
+    - add_k_proj
+    - add_v_proj
+    - to_add_out
+    - ff.linear_in
+    - ff.linear_out
+    - ff_context.linear_in
+    - ff_context.linear_out
+    - to_qkv_mlp_proj
+
+strategy:
+  _target_: unirl.sde.kernels.DanceSDEStrategy
+
+bundle:
+  _target_: unirl.models.flux2_klein.bundle.Flux2KleinBundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.flux2_klein.pipeline.Flux2KleinPipeline
+  shift: 1.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  qwen3_extraction_layers: [9, 18, 27]
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Flux2TransformerBlock", "Flux2SingleTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    # fp32 → bf16 forced by the synced LoRA wire dtype; master_dtype restores
+    # the proven recipe's fp32 optimizer precision.
+    param_dtype: bf16
+    master_dtype: fp32
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    # Memory, not math: 8 colocated SGLang engines + ti2i source tokens on the
+    # noise sequence during replay.
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 5.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 16
+    alpha: 32
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules: *lora_targets
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  model_config: ${model_config}
+  strategy: ${strategy}
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    # Klein serves t2i and ti2i off one checkpoint; the adapter branches on
+    # Sample.has_image_input(). An edit dataset drives the ti2i path.
+    model_family: flux2_klein
+    # LOAD-BEARING for ti2i: replay consumes the SERVER's packed condition
+    # tokens + their RoPE ids, shipped back as image_latent/image_latent_ids.
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 16
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    target_modules: *lora_targets
+    engine_kwargs:
+      model_type: flux2_klein
+
+sync:
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
+  verify: false                # only vLLM-Omni implements the checksum read-back
+  param_prefix: "transformer."
+  adapter_name: default
+
+# Remote EditReward service. The 2-turn history (source + generated) is built by
+# RemoteRewardBackend automatically when the request Sample carries an image.
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.remote.RemoteRewardBackend
+    base_device: cpu
+    config:
+      _target_: unirl.reward.remote.RemoteRewardSpec
+      base_url: ${oc.env:REWARD_SERVICE_URL,http://localhost:8080}
+      required_rewards: [editreward]
+      reward_weights:
+        editreward: 1.0
+      batch_size: 8
+      timeout: 300.0
+      sub_metric_reduce: mean
+      aggregation_method: weighted_sum
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.flux2_klein.conditions.Flux2KleinConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      # REQUIRED. datasets/image_edit/*.jsonl ships PLACEHOLDER uris that do not
+      # resolve; point these at a real, pod-local edit dataset.
+      data_path: ${oc.env:DATA_PATH,???}
+      eval_data_path: ${oc.env:EVAL_DATA_PATH,???}
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  # FORCED false: the engine's init_same_noise=true path mis-sizes FLUX.2 latent
+  # channels. GRPO does not require shared init noise (variance reduction only).
+  init_same_noise: false
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 3
+    timestep_fraction: [0, 0.5]

--- a/examples/diffusion/flux2_klein/flux2_klein_editreward_sglang.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_editreward_sglang.yaml
@@ -1,0 +1,223 @@
+# @package _global_
+# FLUX.2-klein GRPO — SGLANG rollout + RemoteRewardBackend (EditReward).
+#
+# SGLang sibling of the proven trainside flux2_klein_editreward.yaml: same
+# EditReward objective, dataset, algorithm, and sampling — only the rollout
+# engine differs (SGLangDiffusionRolloutEngine instead of trainside). Klein
+# serves BOTH t2i and text+image→image off one checkpoint; the Flux2KleinAdapter
+# branches on Sample.has_image_input(), so an edit dataset (prompt + condition
+# image) drives the ti2i path and a t2i dataset the t2i path — no task flag.
+#
+# DEVIATIONS from flux2_klein_editreward.yaml, all forced by the engine swap:
+#   1. rollout / sync / weight_sync_interval — the engine itself. Trainside
+#      trains the sampler in place; SGLang pushes the LoRA to the engine each
+#      interval (LocalLoraWeightSync).
+#   2. param_dtype fp32 → bf16 + master_dtype fp32. The synced LoRA wire dtype
+#      must be bf16 for the SGLang kernels; master_dtype restores the proven
+#      recipe's fp32 optimizer precision (load-bearing at the ~1e-3 gradient
+#      scale — a bf16 master rounds those updates away).
+#   3. init_same_noise true → false. NOT a preference: the engine's
+#      init_same_noise=true path sizes x_T via the SGLang fork's flux2
+#      prepare_latent_shape, which mis-sizes FLUX.2 latent channels. GRPO
+#      correctness does not require shared init noise (per-group advantages
+#      don't need it; it's variance reduction only).
+#   4. activation_checkpointing false → true (memory: each actor colocates its
+#      own SGLang engine, and ti2i concatenates source tokens onto the noise
+#      sequence during replay). Numerically neutral.
+#   5. bundle.config inlined → ${model_config} anchor + strategy anchor, and
+#      use_lora / lora_target_modules surfaced onto model_config (SGLang builds
+#      its LoRA ServerArgs from these).
+#
+# 2-node deployment (reward service off the training GPUs):
+#   Node 0 (reward): ray start --head --port=6379 --num-gpus=1
+#                    python -m reward_service --config configs/editreward_service.yaml
+#   Node 1 (train):  export REWARD_SERVICE_URL=http://<node0_ip>:8080
+#                    export DATA_PATH=... EVAL_DATA_PATH=...
+#                    bash examples/run_experiment_single_node.sh diffusion/flux2_klein/flux2_klein_editreward_sglang
+
+num_devices: 8
+batch_size: 48                # prompts_per_rollout (48 x 16 samples = 768 global)
+num_rollouts: 10000
+weight_sync_interval: 1       # LoRA sync cadence: every rollout push adapter into the engine
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,unirl-flux2klein-editreward}
+  run_name: ${oc.env:WANDB_RUN_NAME,flux2klein_editreward_it2i_sglang}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [flux2_klein, it2i, edit, editreward, lora, sglang]
+  log_media: true
+  media_max_items: 8
+  media_log_interval: 1
+
+# Shared nodes: model_config + strategy defined once, referenced by
+# bundle / pipeline / rollout (the sglang engine needs both at init).
+model_config:
+  _target_: unirl.models.flux2_klein.config.Flux2KleinPipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:FLUX2_KLEIN_PATH,black-forest-labs/FLUX.2-klein-base-9B}
+  model_precision: bf16
+  max_sequence_length: 512
+  shift: 1.0
+  use_lora: true
+  lora_target_modules: &lora_targets
+    - to_q
+    - to_k
+    - to_v
+    - to_out.0
+    - add_q_proj
+    - add_k_proj
+    - add_v_proj
+    - to_add_out
+    - ff.linear_in
+    - ff.linear_out
+    - ff_context.linear_in
+    - ff_context.linear_out
+    - to_qkv_mlp_proj
+
+strategy:
+  _target_: unirl.sde.kernels.DanceSDEStrategy
+
+bundle:
+  _target_: unirl.models.flux2_klein.bundle.Flux2KleinBundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.flux2_klein.pipeline.Flux2KleinPipeline
+  shift: 1.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  qwen3_extraction_layers: [9, 18, 27]
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Flux2TransformerBlock", "Flux2SingleTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    # fp32 → bf16 forced by the synced LoRA wire dtype; master_dtype restores
+    # the proven recipe's fp32 optimizer precision.
+    param_dtype: bf16
+    master_dtype: fp32
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    # Memory, not math: 8 colocated SGLang engines + ti2i source tokens on the
+    # noise sequence during replay.
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 5.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 10000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 16
+    alpha: 32
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules: *lora_targets
+
+rollout:
+  _target_: unirl.rollout.engine.sglang_diffusion.engine.SGLangDiffusionRolloutEngine
+  model_config: ${model_config}
+  strategy: ${strategy}
+  config:
+    _target_: unirl.rollout.engine.sglang_diffusion.config.SGLangDiffusionEngineConfig
+    # Klein serves t2i and ti2i off one checkpoint; the adapter branches on
+    # Sample.has_image_input(). An edit dataset drives the ti2i path.
+    model_family: flux2_klein
+    # LOAD-BEARING for ti2i: replay consumes the SERVER's packed condition
+    # tokens + their RoPE ids, shipped back as image_latent/image_latent_ids.
+    populate_conditions: true
+    init_same_noise: ${sampling.init_same_noise}
+    forward_batch_size: 16
+    num_gpus: 1
+    tp_size: 1
+    local_mode: true
+    target_modules: *lora_targets
+    engine_kwargs:
+      model_type: flux2_klein
+
+sync:
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
+  verify: false                # only vLLM-Omni implements the checksum read-back
+  param_prefix: "transformer."
+  adapter_name: default
+
+# Remote EditReward service. The 2-turn history (source + generated) is built by
+# RemoteRewardBackend automatically when the request Sample carries an image.
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.remote.RemoteRewardBackend
+    base_device: cpu
+    config:
+      _target_: unirl.reward.remote.RemoteRewardSpec
+      base_url: ${oc.env:REWARD_SERVICE_URL,http://localhost:8080}
+      required_rewards: [editreward]
+      reward_weights:
+        editreward: 1.0
+      batch_size: 8
+      timeout: 300.0
+      sub_metric_reduce: mean
+      aggregation_method: weighted_sum
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.flux2_klein.conditions.Flux2KleinConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      # REQUIRED. datasets/image_edit/*.jsonl ships PLACEHOLDER uris that do not
+      # resolve; point these at a real, pod-local edit dataset.
+      data_path: ${oc.env:DATA_PATH,???}
+      eval_data_path: ${oc.env:EVAL_DATA_PATH,???}
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 1.0
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  # FORCED false: the engine's init_same_noise=true path mis-sizes FLUX.2 latent
+  # channels. GRPO does not require shared init noise (variance reduction only).
+  init_same_noise: false
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    num_sde_steps: 3
+    timestep_fraction: [0, 0.5]

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_conditions.py
@@ -93,6 +93,14 @@ logger = logging.getLogger(__name__)
 # ``image_latent`` from packed ``[S_img, C*4]`` to spatial ``[C, H_img, W_img]``
 # (S_img alone is ambiguous — multiple H×W grids give the same token count).
 # Wrapped as ``[value]`` to fit the list-based merge/slice path.
+#
+# ``condition_image_latent_ids`` (9th field, FLUX.2-Klein ti2i only) carries the
+# 4-axis RoPE ids ``[B, N, 4]`` upstream's ``prepare_condition_image_latent_ids``
+# sets alongside ``image_latent``. FLUX.2 replay needs both the condition tokens
+# and their ids, and the grid factorization can't be recovered from N alone (see
+# the Flux2KleinAdapter.build_condition note), so the ids are captured rather than
+# recomputed. Single ``[B, N, 4]`` tensor, wrapped as ``[tensor]`` like
+# ``image_latent``; ``None`` for every non-Klein-ti2i adapter.
 _COND_FIELDS = (
     "prompt_embeds",
     "pooled_prompt_embeds",
@@ -102,6 +110,7 @@ _COND_FIELDS = (
     "negative_attention_mask",
     "image_latent",
     "image_latent_sizes",
+    "condition_image_latent_ids",
 )
 
 # result(Req) source attr -> OutputBatch dest attr (the fork's gpu_worker mapping).
@@ -324,6 +333,20 @@ def _copy_conditions(src, output_batch) -> None:
     vae_image_sizes = getattr(src, "vae_image_sizes", None)
     if vae_image_sizes is not None:
         output_batch.image_latent_sizes = [vae_image_sizes]
+    # FLUX.2-Klein ti2i condition_image_latent_ids: a single [B, N, 4] RoPE-id
+    # tensor set by upstream's prepare_condition_image_latent_ids alongside
+    # image_latent. Same presence-is-the-gate + [tensor]-wrap contract as
+    # image_latent; None for every non-Klein-ti2i adapter.
+    condition_image_latent_ids = getattr(src, "condition_image_latent_ids", None)
+    if condition_image_latent_ids is not None:
+        import torch
+
+        if torch.is_tensor(condition_image_latent_ids):
+            output_batch.condition_image_latent_ids = [condition_image_latent_ids.detach().cpu()]
+        elif isinstance(condition_image_latent_ids, (list, tuple)):
+            output_batch.condition_image_latent_ids = [
+                t.detach().cpu() if torch.is_tensor(t) else t for t in condition_image_latent_ids
+            ]
 
 
 def _copy_mapped_conditions(src, output_batch, mapping) -> None:

--- a/unirl/rollout/engine/sglang_diffusion/adapters/flux.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/flux.py
@@ -1,22 +1,26 @@
 """FLUX-family image adapters: plain FLUX + FLUX.2-Klein.
 
 ``FluxAdapter`` is the default image path (5-D passthrough). ``Flux2KleinAdapter``
-overrides two stages: ``build_segment`` (Klein's transformer is a pure sequence
-model emitting packed ``[B, T, H*W, C_packed]`` tokens, so the trajectory is
-unpacked to image form before segment assembly) and the schedule policy (Klein
-needs a model-specific ``compute_mu`` the generic FlowMatch path can't synthesize).
-The Dance-GRPO SDE label rides on the base ``resolve_sde_label``.
+overrides ``build_segment`` (Klein emits packed ``[B, T, H*W, C]`` tokens, unpacked
+to image form before assembly) and the schedule policy, and serves BOTH t2i and
+text+image→image off one checkpoint — branching on ``Sample.has_image_input()``,
+like the trainside ``Flux2KleinPipeline``. The ti2i deltas are in ``build_prompts`` /
+``build_condition`` and no-op for t2i.
 """
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
+
+import torch
 
 from unirl.config.require import require
 from unirl.rollout.engine.sglang_diffusion import utils
 from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
 from unirl.rollout.engine.sglang_diffusion.backends import RawResult
+from unirl.types.conditions.image import ImageLatentCondition
+from unirl.types.primitives import Texts
 from unirl.types.sample import Sample
 from unirl.types.sampling import DiffusionSamplingParams
 
@@ -40,13 +44,115 @@ class Flux2KleinAdapter(ImageAdapter):
         super().validate()
         require(
             callable(getattr(self.model_config, "build_schedule_policy", None)),
-            "flux2_klein adapter requires model_config.build_schedule_policy() "
-            "(Klein needs a model-specific compute_mu the generic FlowMatch path "
-            "cannot synthesize from scheduler_config.json).",
+            "flux2_klein adapter requires model_config.build_schedule_policy() (model-specific compute_mu).",
         )
 
     def schedule_policy(self):
         return self.model_config.build_schedule_policy()
+
+    # ---- Request side: ti2i delta (no-op without an image) ---- #
+
+    def build_prompts(self, sample: Sample) -> Dict[str, Any]:
+        """T2I payload, plus the source image when the request carries one.
+
+        Without an image, the inherited T2I payload verbatim. With one, the PIL
+        rides the ``condition_image`` sampling kwarg (``patch_sampling_io`` indexes
+        it per prompt); upstream VAE-encodes it into ``image_latent`` +
+        ``condition_image_latent_ids``.
+        """
+        if not sample.has_image_input():
+            return super().build_prompts(sample)
+
+        turns, image_batches = sample.vision_conditioning()
+        text_turns = [turn.content for turn in turns if isinstance(turn.content, Texts)]
+        if len(text_turns) != 1 or len(image_batches) != 1:
+            raise ValueError(
+                f"{self.model_family!r} ti2i needs exactly 1 text and 1 image turn; "
+                f"got {len(text_turns)} text, {len(image_batches)} image."
+            )
+        gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
+        prompts = list(text_turns[0].texts)
+        unique_prompts, k = self._deexpand_prompts(prompts, gen_part.group_ids)
+        pil_images = image_batches[0].to_pils()
+        if len(pil_images) != len(prompts):
+            raise ValueError(f"image count {len(pil_images)} != prompt count {len(prompts)}")
+        # One source image per group, first-seen order (mirrors the prompt collapse;
+        # ``pil_images[::k]`` would misalign interleaved group_ids).
+        if k > 1:
+            unique_pils = self._first_per_group(pil_images, list(gen_part.group_ids))
+            if len(unique_pils) != len(unique_prompts):
+                raise ValueError(f"collapsed image count {len(unique_pils)} != unique prompts {len(unique_prompts)}")
+        else:
+            unique_pils = pil_images
+        out: Dict[str, Any] = {
+            "prompt": unique_prompts if len(unique_prompts) > 1 else unique_prompts[0],
+            "condition_image": unique_pils if len(unique_pils) > 1 else unique_pils[0],
+        }
+        if k > 1:
+            out["num_outputs_per_prompt"] = k
+        return out
+
+    # ---- Response side ---- #
+
+    def build_condition(self, results: List[RawResult]) -> Dict[str, Any]:
+        """Inherited text conditions, plus the ti2i source-image slots.
+
+        Emits ``image_latent`` (packed ``[B, N, 128]`` tokens) and ``image_latent_ids``
+        (4-axis RoPE ids ``[B, N, 4]``); ``predict_noise`` needs both. The ids are
+        captured, not recomputed — ``N`` alone does not give the ``h_pat × w_pat`` grid
+        and FLUX.2 never sets ``vae_image_sizes``. Both ``None`` for pure T2I.
+        """
+        cond_dict = super().build_condition(results)
+        tokens = self._stack_condition_field(results, "image_latent")
+        if tokens is None:
+            return cond_dict  # pure T2I
+        ids = self._stack_condition_field(results, "condition_image_latent_ids")
+        require(ids is not None, "ti2i returned image_latent but no condition_image_latent_ids; replay needs both.")
+        cond_dict["image_latent"] = ImageLatentCondition(latents=tokens)
+        cond_dict["image_latent_ids"] = ImageLatentCondition(latents=ids)
+        return cond_dict
+
+    def _stack_condition_field(self, results: List[RawResult], name: str) -> Optional[torch.Tensor]:
+        """Concat a per-result single-tensor conditions field over dim 0.
+
+        ``patch_conditions`` ships each field as a one-element list holding that
+        result's ``[1, N, ...]`` slice. ``None`` when no result carries it (T2I).
+        """
+        tensors: List[torch.Tensor] = []
+        for r in results:
+            value = getattr(r, name, None)
+            if not value:
+                continue
+            tensors.append(value[0])
+        if not tensors:
+            return None
+        require(
+            len(tensors) == len(results),
+            f"{name} on {len(tensors)}/{len(results)} results — expected all or none.",
+        )
+        shapes = {tuple(t.shape) for t in tensors}
+        require(
+            len(shapes) == 1,
+            f"{name} has mixed shapes {sorted(shapes)} — bucket by aspect ratio or normalize the dataset.",
+        )
+        return torch.cat(tensors, dim=0)
+
+    @staticmethod
+    def _first_per_group(items: List[Any], group_ids: List[str]) -> List[Any]:
+        """First item of each group, in first-seen group order."""
+        seen: set[str] = set()
+        out: List[Any] = []
+        for item, gid in zip(items, group_ids):
+            if gid not in seen:
+                seen.add(gid)
+                out.append(item)
+        return out
+
+    def _deexpand_prompts(self, prompts: List[str], group_ids: List[str]):
+        """Collapse K-expanded prompts back to unique + repeat count."""
+        return utils.deexpand_prompts_from_groups(prompts, list(group_ids))
+
+    # ---- Segment (inherited shape, Klein packed-token unpack) ---- #
 
     def build_segment(
         self,
@@ -59,8 +165,9 @@ class Flux2KleinAdapter(ImageAdapter):
     ):
         """Collect, unpack Klein's packed ``[B, T, H*W, C]`` to image form, assemble.
 
-        Klein keeps the packed channels at patch resolution (a token→spatial
-        reshape). 5-D arrivals (image-form) skip the unpack.
+        5-D arrivals (image-form) skip the unpack. Condition tokens never enter the
+        recorded trajectory (SGLang keeps them in a separate ``latent_model_input``),
+        so this is identical for t2i and ti2i.
         """
         diffusion = sample.frontier_gen_part(DiffusionSamplingParams).sampling_params
         traj = utils.collect_trajectory_latents(results)


### PR DESCRIPTION
> **Rebased onto the Sample/Part agentic migration (2026-07-28).** Main has adopted
> the `Sample`/`Part` model (`RolloutReq`/`RolloutResp` retired). This PR is
> re-implemented on top of it and force-pushed in place. The practical consequence:
> the earlier `task_config`/`stage_config` compatibility layer added in review is
> **gone** — there is no `stage_config` to migrate anymore. The ti2i branch is now
> driven by `Sample.has_image_input()` and the edit dataset, so no task flag or
> cross-PR (#255) coupling remains. The single commit rebases cleanly on current
> `main` (base was an exact match at force-push time).

## Summary

Adds text+image→image (ti2i) support to the `sglang_diffusion` rollout engine for
FLUX.2-Klein, so image-editing GRPO can run out-of-process instead of only through
`TrainsideRolloutEngine`.

Klein serves both modalities off one checkpoint, so this extends the existing
`flux2_klein` adapter rather than registering a second edit key. Every layer already
branches on *image presence* rather than a mode flag — upstream SGLang's pipeline
config is `ModelTaskType.TI2I` unconditionally and its `ImageVAEEncodingStage` no-ops
without a condition image; the trainside `Flux2KleinPipeline` branches on
`req.primitives['image']`; and `Flux2KleinConditions` already declares
`image_latent` / `image_latent_ids` optional and round-trips both. **The trainside
half needs no changes.**

- `Flux2KleinAdapter.build_prompts(sample)` returns the inherited t2i payload verbatim
  when `not sample.has_image_input()`; otherwise it pulls the source PIL from
  `sample.vision_conditioning()` and ships it via the `condition_image` sampling kwarg.
  The `patch_sampling_io` plumbing built for Edit-Plus is not gated on model family and
  already handles per-prompt indexing and preserving the driver-pinned output size.
  Images collapse in lockstep with the prompt collapse (`first_per_group`), so image
  *i* stays paired with prompt *i* under interleaved `group_ids`.
- `build_condition` emits the packed condition tokens (`image_latent`) plus their 4-axis
  RoPE ids (`condition_image_latent_ids`) as two `ImageLatentCondition` entries. No
  unpack is needed — FLUX.2 returns the packed `[B, N, 128]` token form the trainside
  slot already wants. The ids are **captured, not recomputed**: `N` alone does not give
  the `h_pat × w_pat` factorization, and FLUX.2 never populates `vae_image_sizes` (it
  does not override the base `preprocess_vae_image` no-op), so deriving the grid
  driver-side would duplicate upstream's condition-image resize math and desync replay
  whenever it changes.
- `patch_conditions` captures `condition_image_latent_ids` alongside `image_latent`,
  riding the existing list-based merge/slice path with no special case (it is a uniform
  `[B, N, 4]` per-sample tensor, unlike the `image_latent_sizes` pair Edit-Plus needs).
- `build_segment` is inherited unchanged. SGLang concatenates condition tokens into a
  separate `latent_model_input` and never writes them back to `ctx.latents`, so the
  recorded trajectory stays noise-only and the existing Klein packed-token unpack is
  correct for both t2i and ti2i.
- Recipes: `flux2_klein_editreward_sglang.yaml` (base-9B) and
  `flux2_klein_4b_editreward_sglang.yaml` (base-4B) — the SGLang siblings of the proven
  trainside `flux2_klein_editreward.yaml` / `flux2_klein_4b_editreward.yaml`.

## Related Issue

N/A

## Test Plan

### A. Migrated engine (this PR's code) — validated on GPU now

**GPU round-trip through `SGLangDiffusionRolloutEngine`** — 1×H20, FLUX.2-Klein-4B,
8 steps @ 512², `guidance_scale=1.0`, `eta=0.7`, `sde_indices=[0,1,2]`, K=2,
`use_lora=False`. The harness builds `Sample`s (`Part.input` + `input_child({'image': …})`,
`Sample.request`, `sample.fork(...)`) and drives them through the engine directly (no
trainer), then reads `result.frontier_gen_part(DiffusionSamplingParams).conditions`.
**24/24 checks passed.**

- **T1 — ti2i, 1 prompt × K=2** → `image_latent (2, 1024, 128)` +
  `image_latent_ids (2, 1024, 4)`; the ids are **exactly**
  `cartesian_prod(10, arange(32), arange(32), arange(1))` (`torch.equal`), confirming
  SGLang's `_prepare_image_ids(scale=10)` matches trainside `REFERENCE_TIME_SCALE = 10`;
  the two K-samples share one source latent.
- **T2 — ti2i, 2 prompts × K=2** → `image_latent (4, 1024, 128)` + `(4, 1024, 4)`;
  samples within a group share the source latent, different groups do not — per-prompt
  `condition_image` indexing under the grouped merge/slice path is correct.
- **T3 — t2i non-regression** (no image) → conditions are `['text']` only; the image
  branch is a true no-op, and `build_condition` emits neither `image_latent` nor
  `image_latent_ids`.

**Recipe + static** (both recipes, `.venv-sglang`, migrated `main`):
- `python -m unirl.train_diffusion --config-name=diffusion/flux2_klein/flux2_klein_editreward_sglang --cfg job` → composes; `model_family=flux2_klein`, `populate_conditions=true`, `init_same_noise=false`, `base-9B`, `batch_size=48`.
- same for `…/flux2_klein_4b_editreward_sglang --cfg job` → `base-4B`, `batch_size=64`.
- `python scripts/check_recipe_targets.py` → **2193 `_target_` paths resolve** (both new recipes included).
- `ruff check` + `ruff format --check` on `adapters/flux.py` and `_patches/patch_conditions.py` → clean.

### B. Engine-equivalence A/Bs — pre-migration implementation of this same path

> These two multi-hour A/Bs were run on the **pre-migration** implementation of this
> exact ti2i path (before `main` adopted Sample/Part). The migration is a mechanical
> port of the type plumbing (`RolloutReq` → `Sample`); the ti2i logic — ship
> `condition_image` → capture `image_latent` + `condition_image_latent_ids` → replay —
> is unchanged, and **§A confirms the migrated code emits the identical conditioning
> tensors**. I did not re-run the A/Bs on the migrated branch.

The acceptance question is: **does the conditions round-trip reproduce what the engine
actually sampled under?** The GRPO `ratio` cannot answer it — with
`old_logp_source: replay`, both π_old and the current-policy log-probs come from the
same replay path, so `ratio ≈ 1` by construction. So instead I ran the **same task on
both rollout engines** and compared reward curves; the only variable is the engine.

**PickScore A/B — 55 rollouts per arm** (Klein-4B, in-process PickScore, 1×H20 each),
identical dataset (same md5), seed, model bytes, venv, commit:

| | mean | slope / rollout | t (df=53) | verdict |
|---|---|---|---|---|
| SGLang | 0.7884 | −0.000023 | −0.41 | flat |
| Trainside (control) | 0.7886 | −0.000023 | −0.40 | flat |

Slopes match to six decimals, **r = 0.9983**, between-arm spread 17× tighter than each
arm's own rollout-to-rollout noise. Both curves are *flat* rather than growing, but that
is a property of the **reward** — PickScore scores text↔image alignment and never sees
the source image, so an edit task gives it little to reward.

**EditReward A/B — 60 rollouts per arm**, on a reward that *does* score edit quality
(`TIGER-Lab/EditReward-MiMo-VL-7B-SFT-2508`, Klein-4B, one dedicated scorer GPU + 7
training GPUs). wandb:
- baseline (trainside): https://wandb.ai/linyuwus/unirl-lin584-editreward-ab/runs/5ucncrko
- sglang: https://wandb.ai/linyuwus/unirl-lin584-editreward-ab/runs/yhgy1r1z

| | mean | slope / rollout | t (df=58) |
|---|---|---|---|
| SGLang | −0.292 | +0.00008 | +0.21 |
| Trainside (control) | −0.300 | +0.00060 | +1.41 |

**Cross-arm r = 0.93**, the arms move the **same direction on 52 of 59 rollout-to-rollout
steps (88%)**, between-arm spread 2.7× tighter than each arm's own noise. The small early
level offset (+0.025) decayed monotonically to +0.008 by rollout 60 — consistent with the
one documented confound (SGLang is forced to `init_same_noise: false`, which shifts the
level, not the slope).

**On growth:** *neither* arm grew significantly in 60 rollouts — a power limitation, not
an engine one. The proven recipe is configured for 10,000 rollouts and EditReward is
noisy (sd ≈ 0.05), so a small true slope cannot clear significance at n=60. A definitive
growth demonstration needs a longer run; it is out of scope for validating the engine
code, which the equivalence results already do.

**Bottom line:** two independent A/Bs — PickScore (r = 0.998) and EditReward (r = 0.93,
88% same-direction) — establish that this ti2i path produces the same
rollout→replay→update dynamics as the known-good trainside engine, and §A shows the
migrated code reproduces the conditioning tensors those A/Bs relied on.

### Recipe correctness (carried into both migrated recipes)

Standing up an end-to-end run earlier surfaced four defects in the *recipe*, not the
engine path. All are in both sglang recipes here:

| Fix | Why it mattered |
|---|---|
| `master_dtype: fp32` (with `param_dtype: bf16`) | An all-bf16 master rounds ~1e-3 grad-scale updates away (bf16 ulp ~4e-5 at \|w\|~0.01). The proven trainside recipe trains in fp32. |
| `activation_checkpointing: true` | Memory: each of the 8 actors colocates its own SGLang engine, and ti2i concatenates source-image tokens onto the noise sequence during replay. |
| `data_path` **requires** `DATA_PATH` | It previously defaulted to `datasets/image_edit/train.jsonl`, whose media uris are placeholders that do not resolve — the recipe failed at image load on rollout 1. Now it fails at compose with a clear `???`. |
| dropped `sampling.autocast_precision: bf16` | Redundant (already the default) and an unjustified divergence from the proven recipe. |

### Not validated

- **Numerical rollout↔replay log-prob parity.** With `old_logp_source: replay`, `ratio`
  shows replay is self-consistent, not that it matches what the engine sampled under. A
  real parity gate compares replay against the engine's emitted `trajectory_log_probs`.
  The §A round-trip proves the conditioning tensors are correct; it does not run replay.
- **LoRA weight sync under ti2i** (the round-trip ran `use_lora=False`).
- **base-9B** (the checkpoint pulled for all GPU work was 4B; both Klein variants inherit
  the identical TI2I condition path from `Flux2PipelineConfig`, which differs only in
  guidance embeddings and negative-CFG kwargs).
- **Full training-memory envelope of `batch_size: 64` (4B recipe)** — the value mirrors
  the trainside 4B recipe's larger batch; the round-trip used `forward_batch_size=4` and
  did not exercise the training path at that batch.

## Compatibility / Risk

- **Additive and opt-in.** The image branch is a no-op when `sample.has_image_input()`
  is false, so the existing t2i `flux2_klein` path is unchanged (regression-tested in
  §A/T3). No config migration; no checkpoint or data-format change.
- `patch_conditions` gains one captured field, gated on presence on the batch, so it
  stays `None` for every text-only rollout and for families that never set it.
- **`populate_conditions: true` is load-bearing for ti2i** (not merely a nicety as in
  t2i): replay has no source-image conditioning without it. Both recipes set it.
- The adapter keeps a local `first_per_group` / `_deexpand_prompts`, mirroring the
  Edit-Plus adapter (the established pattern for a per-sample payload that collapses
  alongside the prompts). No shared-module move in this PR.
- Throughput: SGLang rejects cross-request dynamic batching for image-bearing requests,
  so ti2i is somewhat slower per sample than t2i. `num_outputs_per_prompt` K-expansion
  still applies, so per-group efficiency is retained.

## Reviewer Notes

- **AI-assisted.** Adapter, patches, recipes, and the GPU round-trip harness were written
  with AI assistance; every line was reviewed, and the GPU validation in §A was run and
  inspected by the author.
- **Duplicate-work check:** no other open PR adds ti2i to `sglang_diffusion` for FLUX.2;
  the EditReward scorer batching fix is a separate PR (#269) and not part of this change.
- Inspect first: `build_prompts` / `build_condition` in
  `unirl/rollout/engine/sglang_diffusion/adapters/flux.py` and the
  `condition_image_latent_ids` capture in `_patches/patch_conditions.py`.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
