### PR TITLE
perf(sft): optimize supervised data preparation

### DIFF
--- a/examples/sft/bagel_agent_sft.yaml
+++ b/examples/sft/bagel_agent_sft.yaml
@@ -16,7 +16,7 @@
 # Env:
 #   BAGEL_PATH      HF id or local ckpt (default ByteDance-Seed/BAGEL-7B-MoT)
 #   SFT_DATA        train manifest (searchgen prepare_sft train.jsonl)
-#   SFT_EVAL_DATA   eval manifest (defaults to SFT_DATA — supply a real split!)
+#   SFT_EVAL_DATA   optional eval manifest (validation is disabled when unset)
 #
 # Download/cook guide: datasets/searchgen/README.md (manifests shared with qwen_vl_agent_sft).
 #
@@ -135,6 +135,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42

--- a/examples/sft/bagel_sft_lora.yaml
+++ b/examples/sft/bagel_sft_lora.yaml
@@ -12,7 +12,9 @@
 #   BAGEL_PATH      HF id or local ckpt (default ByteDance-Seed/BAGEL-7B-MoT)
 #   SFT_DATA        train manifest (.jsonl rows: {"prompt",
 #                   "media": [{"modality": "image", "role": "target", "uri": ...}]})
-#   SFT_EVAL_DATA   eval manifest (defaults to SFT_DATA — supply a real split!)
+#   SFT_EVAL_DATA   optional eval manifest (validation is disabled when unset)
+#   SFT_CACHE_DIR / SFT_CACHE_FINGERPRINT
+#                   optional cache root + explicit model/config revision
 #
 # Data prep: shared with sd3_sft_lora (python datasets/sft_manifests/prepare_sft_t2i.py).
 #
@@ -123,11 +125,14 @@ track_builder:
   height: 512
   width: 512
   guidance_scale: 1.0
+  cache_dir: ${oc.env:SFT_CACHE_DIR,null}
+  cache_fingerprint: ${oc.env:SFT_CACHE_FINGERPRINT,null}
+  cache_vae_latents: ${oc.decode:${oc.env:SFT_CACHE_VAE_LATENTS,false}}
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42
 
 # Params object FlowMatchSFT forwards into predict_noise_at_step. cfg scales

--- a/examples/sft/cosmos3_droid100_action_bc.yaml
+++ b/examples/sft/cosmos3_droid100_action_bc.yaml
@@ -119,6 +119,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA,datasets/droid100_debug/manifest.jsonl}
+  train_manifest_path: ${oc.env:SFT_DATA,datasets/droid100_debug/manifest.jsonl}
   eval_manifest_path: ${oc.env:SFT_EVAL_DATA,datasets/droid100_debug/eval_manifest.jsonl}
   seed: 42

--- a/examples/sft/cosmos3_droid100_videopred.yaml
+++ b/examples/sft/cosmos3_droid100_videopred.yaml
@@ -107,6 +107,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA,datasets/droid100_debug/manifest.jsonl}
+  train_manifest_path: ${oc.env:SFT_DATA,datasets/droid100_debug/manifest.jsonl}
   eval_manifest_path: ${oc.env:SFT_EVAL_DATA,datasets/droid100_debug/eval_manifest.jsonl}
   seed: 42

--- a/examples/sft/qwen3_agent_sft_lora.yaml
+++ b/examples/sft/qwen3_agent_sft_lora.yaml
@@ -100,6 +100,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA,datasets/sft_agent_toolcall_12k/train.jsonl}
+  train_manifest_path: ${oc.env:SFT_DATA,datasets/sft_agent_toolcall_12k/train.jsonl}
   eval_manifest_path: ${oc.env:SFT_EVAL_DATA,datasets/sft_agent_toolcall_12k/val.jsonl}
   seed: 42

--- a/examples/sft/qwen3_omni_audio_sft_lora.yaml
+++ b/examples/sft/qwen3_omni_audio_sft_lora.yaml
@@ -112,6 +112,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA,datasets/dcase2025_audio_qa_sft/train.jsonl}
+  train_manifest_path: ${oc.env:SFT_DATA,datasets/dcase2025_audio_qa_sft/train.jsonl}
   eval_manifest_path: ${oc.env:SFT_EVAL_DATA,datasets/dcase2025_audio_qa_sft/val.jsonl}
   seed: 42

--- a/examples/sft/qwen3_sft.yaml
+++ b/examples/sft/qwen3_sft.yaml
@@ -10,7 +10,7 @@
 # Env:
 #   QWEN3_PATH      HF id or local checkpoint (default Qwen/Qwen3-4B-Base)
 #   SFT_DATA        train manifest (.jsonl rows: {"prompt", "response"})
-#   SFT_EVAL_DATA   eval manifest (defaults to SFT_DATA — supply a real split!)
+#   SFT_EVAL_DATA   optional eval manifest (validation is disabled when unset)
 #
 # Data prep (HF alpaca-cleaned subset):
 #   python datasets/sft_manifests/prepare_sft_text.py --dataset yahma/alpaca-cleaned --out-dir data/sft_alpaca
@@ -98,6 +98,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42

--- a/examples/sft/qwen3_sft_lora.yaml
+++ b/examples/sft/qwen3_sft_lora.yaml
@@ -2,6 +2,7 @@
 # Validation run: Qwen3-8B LoRA SFT on alpaca-cleaned (~20k rows, ~3 epochs).
 #
 # Launch (1×8):
+#   SFT_DATA=/path/to/train.jsonl SFT_EVAL_DATA=/path/to/val.jsonl \
 #   ENTRY=train_sft bash examples/run_experiment_single_node.sh sft/qwen3_sft_lora
 
 num_devices: 8
@@ -93,6 +94,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42

--- a/examples/sft/qwen_vl_agent_sft.yaml
+++ b/examples/sft/qwen_vl_agent_sft.yaml
@@ -17,7 +17,7 @@
 # Env:
 #   QWEN_VL_PATH    HF id or local checkpoint (default Qwen/Qwen2.5-VL-7B-Instruct)
 #   SFT_DATA        train manifest (searchgen prepare_sft train.jsonl)
-#   SFT_EVAL_DATA   eval manifest (defaults to SFT_DATA — supply a real split!)
+#   SFT_EVAL_DATA   optional eval manifest (validation is disabled when unset)
 #
 # Download/cook guide:
 #   datasets/searchgen/README.md
@@ -107,6 +107,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42

--- a/examples/sft/qwen_vl_sft.yaml
+++ b/examples/sft/qwen_vl_sft.yaml
@@ -9,7 +9,7 @@
 #   QWEN_VL_PATH    HF id or local checkpoint (default Qwen/Qwen2.5-VL-7B-Instruct)
 #   SFT_DATA        train manifest (.jsonl rows: {"prompt", "response",
 #                   "media": [{"modality": "image", "role": "condition", "uri": ...}]})
-#   SFT_EVAL_DATA   eval manifest (defaults to SFT_DATA — supply a real split!)
+#   SFT_EVAL_DATA   optional eval manifest (validation is disabled when unset)
 #
 # Data prep (HF llava-instruct sample):
 #   python datasets/sft_manifests/prepare_sft_vlm.py --out-dir data/sft_vlm
@@ -24,6 +24,7 @@ num_steps: 200
 eval_interval: 20
 eval_batch_size: 16
 eval_num_samples: -1        # -1 = full eval set
+prefetch_next_batch: true    # overlap next-batch CPU tokenize/image I/O with GPU train
 save_interval: 0
 save_mode: auto
 
@@ -96,6 +97,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42

--- a/examples/sft/qwen_vl_sft_lora.yaml
+++ b/examples/sft/qwen_vl_sft_lora.yaml
@@ -2,6 +2,7 @@
 # Validation run: Qwen2.5-VL-7B LoRA SFT on llava-instruct-mix (~8k rows).
 #
 # Launch (1×8):
+#   SFT_DATA=/path/to/train.jsonl SFT_EVAL_DATA=/path/to/val.jsonl \
 #   ENTRY=train_sft bash examples/run_experiment_single_node.sh sft/qwen_vl_sft_lora
 
 num_devices: 8
@@ -10,6 +11,7 @@ num_steps: 400
 eval_interval: 40
 eval_batch_size: 16
 eval_num_samples: -1
+prefetch_next_batch: true
 save_interval: 100
 save_dir: ${oc.env:SFT_SAVE_DIR,checkpoints/sft_qwen_vl}
 save_mode: auto
@@ -95,6 +97,6 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42

--- a/examples/sft/sd3_sft_lora.yaml
+++ b/examples/sft/sd3_sft_lora.yaml
@@ -11,7 +11,9 @@
 #   PRETRAINED_MODEL  HF id or local ckpt (default stabilityai/stable-diffusion-3.5-medium)
 #   SFT_DATA          train manifest (.jsonl rows: {"prompt",
 #                     "media": [{"modality": "image", "role": "target", "uri": ...}]})
-#   SFT_EVAL_DATA     eval manifest (defaults to SFT_DATA — supply a real split!)
+#   SFT_EVAL_DATA     optional eval manifest (validation is disabled when unset)
+#   SFT_CACHE_DIR / SFT_CACHE_FINGERPRINT
+#                     optional cache root + explicit model/config revision
 #
 # Data prep (HF naruto-blip-captions):
 #   python datasets/sft_manifests/prepare_sft_t2i.py --out-dir data/sft_t2i
@@ -122,11 +124,15 @@ track_builder:
   height: 512
   width: 512
   guidance_scale: 1.0              # pure conditional branch — no CFG double-forward
+  cache_dir: ${oc.env:SFT_CACHE_DIR,null}
+  cache_fingerprint: ${oc.env:SFT_CACHE_FINGERPRINT,null}
+  cache_text_conditions: ${oc.decode:${oc.env:SFT_CACHE_TEXT_CONDITIONS,false}}
+  cache_vae_latents: ${oc.decode:${oc.env:SFT_CACHE_VAE_LATENTS,false}}
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42
 
 # Params object FlowMatchSFT forwards into predict_noise_at_step (only

--- a/examples/sft/wan21_t2v_ucf101_full.yaml
+++ b/examples/sft/wan21_t2v_ucf101_full.yaml
@@ -103,8 +103,8 @@ track_builder:
 
 data_source:
   _target_: unirl.data.sft.SupervisedDataSource
-  manifest_path: ${oc.env:SFT_DATA}
-  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  train_manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,null}
   seed: 42
 
 sampling:

--- a/unirl/data/sft.py
+++ b/unirl/data/sft.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import random
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from unirl.data.datasets import _LEGACY_EMBEDDING_FIELDS, _normalize_media_refs, _resolve_media_uri
 
 logger = logging.getLogger(__name__)
+
+
+def _compute_manifest_fingerprint(path: str) -> str:
+    """Hash a training manifest for resume identity."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
 
 _SUPERVISED_EXCLUDED_KEYS = {
     "prompt",
@@ -177,8 +188,8 @@ class SupervisedDataset:
     @staticmethod
     def _iter_raw(path: str) -> Iterator[Dict[str, Any]]:
         if path.endswith(".jsonl"):
-            with open(path) as fh:
-                for line_num, line in enumerate(fh, 1):
+            with open(path, "rb") as handle:
+                for line_num, line in enumerate(handle, 1):
                     line = line.strip()
                     if not line:
                         continue
@@ -187,8 +198,8 @@ class SupervisedDataset:
                     except json.JSONDecodeError as exc:
                         raise ValueError(f"{path}:{line_num}: invalid JSON — {exc}") from exc
         elif path.endswith(".json"):
-            with open(path) as fh:
-                data = json.load(fh)
+            with open(path, "rb") as handle:
+                data = json.load(handle)
             if not isinstance(data, list):
                 raise ValueError(f"{path}: .json supervised manifests must be a list of objects.")
             yield from data
@@ -207,24 +218,21 @@ class SupervisedDataSource:
 
     def __init__(
         self,
-        manifest_path: str,
+        train_manifest_path: str,
         *,
         eval_manifest_path: Optional[str] = None,
         seed: int = 42,
         shuffle: bool = True,
     ) -> None:
-        self.dataset = SupervisedDataset(manifest_path)
+        self.dataset = SupervisedDataset(train_manifest_path)
+        self._manifest_fingerprint: Optional[str] = None
         self.eval_dataset = SupervisedDataset(eval_manifest_path) if eval_manifest_path else None
-        if self.eval_dataset is None:
-            logger.warning(
-                "SupervisedDataSource: no eval_manifest_path — eval batches fall back to the "
-                "TRAIN set (eval loss then measures training data)."
-            )
         self.seed = seed
         self.shuffle = shuffle
         self._epoch = 0
         self._pos = 0
         self._order = self._make_order()
+        self._pending_batch: Optional[Tuple[List[Dict[str, Any]], int, int, List[int]]] = None
 
     def _make_order(self) -> List[int]:
         order = list(range(len(self.dataset)))
@@ -233,6 +241,8 @@ class SupervisedDataSource:
         return order
 
     def get_samples(self, batch_size: int) -> List[Dict[str, Any]]:
+        if self._pending_batch is not None:
+            raise RuntimeError("SupervisedDataSource.get_samples: commit the pending batch before advancing.")
         batch: List[Dict[str, Any]] = []
         while len(batch) < batch_size:
             if self._pos >= len(self._order):
@@ -243,34 +253,91 @@ class SupervisedDataSource:
             self._pos += 1
         return batch
 
+    def peek_next_batch(self, batch_size: int) -> List[Dict[str, Any]]:
+        """Prepare the next batch without advancing the checkpointed cursor."""
+        if self._pending_batch is not None:
+            raise RuntimeError("SupervisedDataSource.peek_next_batch: a batch is already pending.")
+        before = (self._epoch, self._pos, self._order)
+        batch = self.get_samples(batch_size)
+        self._pending_batch = (batch, self._epoch, self._pos, self._order)
+        self._epoch, self._pos, self._order = before
+        return batch
+
+    def commit_peeked_batch(self) -> List[Dict[str, Any]]:
+        """Advance to and return the batch previously produced by ``peek_next_batch``."""
+        if self._pending_batch is None:
+            raise RuntimeError("SupervisedDataSource.commit_peeked_batch: no batch is pending.")
+        batch, self._epoch, self._pos, self._order = self._pending_batch
+        self._pending_batch = None
+        return batch
+
     @property
     def epoch(self) -> float:
         """Fractional epochs consumed — for logging."""
         return self._epoch + self._pos / max(1, len(self.dataset))
 
-    def state_dict(self) -> Dict[str, int]:
-        return {"epoch": self._epoch, "position": self._pos, "seed": self.seed}
+    @property
+    def has_eval_data(self) -> bool:
+        return self.eval_dataset is not None
 
-    def load_state_dict(self, state: Dict[str, int]) -> None:
-        if state.get("seed", self.seed) != self.seed:
+    @property
+    def manifest_fingerprint(self) -> str:
+        if self._manifest_fingerprint is None:
+            self._manifest_fingerprint = _compute_manifest_fingerprint(self.dataset.file_path)
+        return self._manifest_fingerprint
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {
+            "epoch": self._epoch,
+            "position": self._pos,
+            "seed": self.seed,
+            "shuffle": self.shuffle,
+            "manifest_fingerprint": self.manifest_fingerprint,
+        }
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        checkpoint_fingerprint = state.get("manifest_fingerprint")
+        if checkpoint_fingerprint is None:
             logger.warning(
-                "SupervisedDataSource.load_state_dict: checkpoint seed %s != configured seed %s — "
-                "the resumed shuffle order will differ from the original run.",
-                state.get("seed"),
-                self.seed,
+                "SupervisedDataSource.load_state_dict: legacy checkpoint has no manifest fingerprint; "
+                "dataset identity cannot be verified."
             )
-        self._epoch = state["epoch"]
-        self._pos = state["position"]
-        self._order = self._make_order()
-        if self._pos > len(self._order):
+        elif checkpoint_fingerprint != self.manifest_fingerprint:
             raise ValueError(
-                f"SupervisedDataSource.load_state_dict: cursor position {self._pos} exceeds "
-                f"dataset size {len(self._order)} — dataset changed since the checkpoint?"
+                "SupervisedDataSource.load_state_dict: manifest fingerprint mismatch "
+                f"(checkpoint={checkpoint_fingerprint}, current={self.manifest_fingerprint}) — "
+                "refusing to resume against changed data."
             )
+        checkpoint_order_config = (
+            state.get("seed", self.seed),
+            state.get("shuffle", self.shuffle),
+        )
+        configured_order = (self.seed, self.shuffle)
+        if checkpoint_order_config != configured_order:
+            raise ValueError(
+                "SupervisedDataSource.load_state_dict: checkpoint (seed, shuffle)="
+                f"{checkpoint_order_config!r} != configured {configured_order!r}; "
+                "refusing to restore a cursor into a different sample order."
+            )
+        epoch = state["epoch"]
+        position = state["position"]
+        if not isinstance(epoch, int) or epoch < 0:
+            raise ValueError(f"SupervisedDataSource.load_state_dict: epoch must be a non-negative int, got {epoch!r}.")
+        if not isinstance(position, int) or not 0 <= position <= len(self.dataset):
+            raise ValueError(
+                "SupervisedDataSource.load_state_dict: position must be an int in "
+                f"[0, {len(self.dataset)}], got {position!r}."
+            )
+        self._pending_batch = None
+        self._epoch = epoch
+        self._pos = position
+        self._order = self._make_order()
 
     def iter_eval_batches(self, batch_size: int, *, eval_num_samples: int = -1) -> Iterator[List[Dict[str, Any]]]:
-        """Deterministic-order eval batches (manifest order, no shuffle)."""
-        pool = self.eval_dataset if self.eval_dataset is not None else self.dataset
+        """Yield deterministic eval batches; ``-1`` means all rows and ``0`` means none."""
+        if self.eval_dataset is None:
+            return
+        pool = self.eval_dataset
         n = len(pool)
         limit = n if eval_num_samples < 0 else min(eval_num_samples, n)
         for start in range(0, limit, batch_size):

--- a/unirl/train/sft/track_builder.py
+++ b/unirl/train/sft/track_builder.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
 import inspect
+import json
 import logging
-from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple, cast
 
 import torch
 
@@ -24,6 +30,7 @@ from unirl.utils.video import load_video
 logger = logging.getLogger(__name__)
 
 Record = Dict[str, Any]
+_TENSOR_CACHE_SCHEMA_VERSION = 1
 
 
 class _VideoSFTPipeline(Protocol):
@@ -48,11 +55,123 @@ def _require_local_uri(uri: str, *, context: str) -> str:
     return uri
 
 
+def _cache_key(payload: Dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _prefetch_batch_key(records: Sequence[Record]) -> str:
+    return _cache_key({"records": records})
+
+
+class _TensorDiskCache:
+    """Small atomic torch-object cache namespaced by an explicit model fingerprint."""
+
+    def __init__(self, root: str, *, fingerprint: str, kind: str, max_entries: int) -> None:
+        if max_entries < 1:
+            raise ValueError(f"_TensorDiskCache: max_entries must be >= 1; got {max_entries!r}")
+        namespace = hashlib.sha256(f"{_TENSOR_CACHE_SCHEMA_VERSION}:{fingerprint}".encode()).hexdigest()[:20]
+        self.directory = Path(root).expanduser().resolve() / namespace / kind
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self.max_entries = max_entries
+        self._writes = 0
+        self._known_entries = {path.stem for path in self.directory.glob("*.pt")}
+        if len(self._known_entries) > self.max_entries:
+            self._evict()
+
+    def get(self, key: str) -> Optional[Any]:
+        path = self.directory / f"{key}.pt"
+        if not path.is_file():
+            return None
+        try:
+            return torch.load(path, map_location="cpu", weights_only=False)
+        except FileNotFoundError:
+            return None
+
+    def put(self, key: str, value: Any) -> None:
+        path = self.directory / f"{key}.pt"
+        if path.exists():
+            self._known_entries.add(key)
+            return
+        temp = self.directory / f".{key}.{os.getpid()}.{time.time_ns()}.tmp"
+        try:
+            torch.save(value, temp)
+            os.replace(temp, path)
+        finally:
+            if temp.exists():
+                temp.unlink()
+        self._writes += 1
+        self._known_entries.add(key)
+        if len(self._known_entries) > self.max_entries or self._writes % 64 == 0:
+            self._evict()
+
+    def _evict(self) -> None:
+        entries = []
+        for path in self.directory.glob("*.pt"):
+            try:
+                entries.append((path.stat().st_mtime_ns, path))
+            except FileNotFoundError:
+                pass
+        if len(entries) <= self.max_entries:
+            return
+        entries.sort(key=lambda item: item[0])
+        for _, path in entries[: len(entries) - self.max_entries]:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+        self._known_entries = {path.stem for _, path in entries[-self.max_entries :] if path.exists()}
+
+
+def _media_stat_fingerprint(uri: str) -> Dict[str, Any]:
+    path = _require_local_uri(uri, context="DiffusionSupervisedTrackBuilder")
+    stat = os.stat(path)
+    return {
+        "path": os.path.abspath(path),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _encoder_cache_is_safe(modules: Sequence[Any]) -> bool:
+    has_parameters = False
+    for module in modules:
+        if (
+            module is None
+            or getattr(module, "training", None) is not False
+            or not callable(getattr(module, "parameters", None))
+        ):
+            return False
+        for parameter in module.parameters():
+            has_parameters = True
+            if parameter.requires_grad:
+                return False
+    return has_parameters
+
+
 def _load_pil_image(uri: str):
     """Load one local image as RGB PIL (worker-side; driver never touches pixels)."""
     from PIL import Image as PILImage
 
-    return PILImage.open(_require_local_uri(uri, context="SupervisedTrackBuilder")).convert("RGB")
+    with PILImage.open(_require_local_uri(uri, context="SupervisedTrackBuilder")) as image:
+        return image.convert("RGB")
+
+
+def _load_pil_images(uris: Sequence[Optional[str]], *, max_workers: int) -> List[Optional[Any]]:
+    """Load local images concurrently while preserving input order and ``None`` rows."""
+    present = [(index, uri) for index, uri in enumerate(uris) if uri is not None]
+    images: List[Optional[Any]] = [None] * len(uris)
+    if not present:
+        return images
+    worker_count = min(max_workers, len(present))
+    if worker_count == 1:
+        loaded = [_load_pil_image(uri) for _, uri in present]
+    else:
+        with ThreadPoolExecutor(max_workers=worker_count, thread_name_prefix="sft-image") as executor:
+            loaded = list(executor.map(_load_pil_image, [uri for _, uri in present]))
+    for (index, _), image in zip(present, loaded):
+        images[index] = image
+    return images
 
 
 def _media_uris(record: Record, *, role: str, modality: Optional[str] = None) -> List[str]:
@@ -89,6 +208,7 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
         chat_stage_attr: str = "chat_template",
         max_response_length: int = 4096,
         append_eos: bool = True,
+        image_load_workers: int = 4,
     ) -> None:
         super().__init__()
         self.pipeline = pipeline
@@ -106,6 +226,13 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
             raise ValueError(f"ARSupervisedTrackBuilder: max_response_length must be >= 1; got {max_response_length!r}")
         self.max_response_length = max_response_length
         self.append_eos = append_eos
+        if image_load_workers < 1:
+            raise ValueError(f"ARSupervisedTrackBuilder: image_load_workers must be >= 1; got {image_load_workers!r}")
+        self.image_load_workers = image_load_workers
+        self._prefetch_executor: Optional[ThreadPoolExecutor] = None
+        self._prefetch_future = None
+        self._prefetch_key = None
+        # VLM chat stages take (texts, images); text-only ones take (texts).
         self._embed_takes_images = "images" in inspect.signature(self._chat_stage.embed).parameters
         self._embed_sft_prompt = getattr(self._chat_stage, "embed_sft_prompt", None)
         self._warned_truncation = False
@@ -115,9 +242,10 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
         """Tokenize + embed one shard of supervised records into a training Part."""
         if not records:
             raise ValueError("ARSupervisedTrackBuilder.build: empty record shard.")
+        images, batch_ids = self._take_prefetched(records)
         with torch.no_grad():
-            conditions = self._embed_prompts(records)
-            tokens, loss_masks = self._tokenize_responses(records)
+            conditions = self._embed_prompts(records, images=images)
+            tokens, loss_masks = self._tokenize_responses(records, batch_ids=batch_ids)
         segment = TextSegment.pack(tokens=tokens, loss_mask=loss_masks)
         part = Part(
             sample_ids=_sample_ids(records),
@@ -132,12 +260,70 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
             )
         return part
 
-    def _embed_prompts(self, records: Sequence[Record]) -> Any:
-        agent_flags = ["messages" in r for r in records]
+    @distributed(dispatch_mode=Dispatch.DP_SCATTER)
+    def prefetch(self, records: List[Record]) -> None:
+        if not records:
+            raise ValueError("ARSupervisedTrackBuilder.prefetch: empty record shard.")
+        if self._prefetch_future is not None:
+            raise RuntimeError("ARSupervisedTrackBuilder.prefetch: previous prefetch was not consumed.")
+        if self._prefetch_executor is None:
+            self._prefetch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="sft-prefetch")
+        self._prefetch_key = _prefetch_batch_key(records)
+        self._prefetch_future = self._prefetch_executor.submit(self._prepare_cpu_inputs, tuple(records))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _take_prefetched(
+        self,
+        records: Sequence[Record],
+    ) -> Tuple[Optional[List[Optional[Any]]], Optional[List[List[int]]]]:
+        if self._prefetch_future is None:
+            return None, None
+        expected = _prefetch_batch_key(records)
+        if expected != self._prefetch_key:
+            # Avoid using the tokenizer concurrently when eval runs between the
+            # train step that launched this prefetch and the step that consumes it.
+            self._prefetch_future.result()
+            return None, None
+        future = self._prefetch_future
+        self._prefetch_future = None
+        self._prefetch_key = None
+        return future.result()
+
+    def _prepare_cpu_inputs(
+        self,
+        records: Sequence[Record],
+    ) -> Tuple[Optional[List[Optional[Any]]], Optional[List[List[int]]]]:
+        if any("messages" in record for record in records):
+            return None, None
+        images = self._load_prompt_images(records) if self._embed_takes_images else None
+        return images, self._batch_token_ids(records)
+
+    def _load_prompt_images(self, records: Sequence[Record]) -> List[Optional[Any]]:
+        image_uris: List[Optional[str]] = []
+        for record in records:
+            uris = _media_uris(record, role="condition", modality="image")
+            if len(uris) > 1:
+                raise ValueError(
+                    f"ARSupervisedTrackBuilder: at most one role='condition' image per record "
+                    f"(sample {record.get('sample_id')!r} has {len(uris)})."
+                )
+            image_uris.append(uris[0] if uris else None)
+        return _load_pil_images(image_uris, max_workers=self.image_load_workers)
+
+    def _embed_prompts(
+        self,
+        records: Sequence[Record],
+        *,
+        images: Optional[List[Optional[Any]]] = None,
+    ) -> Any:
+        agent_flags = ["messages" in record for record in records]
         if any(agent_flags):
             if not all(agent_flags):
                 raise ValueError("ARSupervisedTrackBuilder: a batch may not mix prompt/response and agent records.")
-            if any(r.get("media_refs") for r in records):
+            if any(record.get("media_refs") for record in records):
                 raise ValueError(
                     "ARSupervisedTrackBuilder: agent records carry images inside message content parts, not media_refs."
                 )
@@ -176,17 +362,10 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
                     "Embedding them as text-only would train the model without the media, undetectably."
                 )
             return self._chat_stage.embed(texts)
-        images: List[Optional[Any]] = []
-        for r in records:
-            uris = _media_uris(r, role="condition", modality="image")
-            if len(uris) > 1:
-                raise ValueError(
-                    f"ARSupervisedTrackBuilder: at most one role='condition' image per record "
-                    f"(sample {r.get('sample_id')!r} has {len(uris)})."
-                )
-            images.append(_load_pil_image(uris[0]) if uris else None)
+        if images is None:
+            images = self._load_prompt_images(records)
         if all(img is None for img in images):
-            images = None  # type: ignore[assignment]
+            return self._chat_stage.embed(texts, None)
         return self._chat_stage.embed(texts, images)
 
     def _load_history_images(self, record: Record) -> List[Dict[str, Any]]:
@@ -214,34 +393,58 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
             loaded.append({**message, "content": parts})
         return loaded
 
-    def _tokenize_responses(self, records: Sequence[Record]) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    def _batch_token_ids(self, records: Sequence[Record]) -> List[List[int]]:
+        responses: List[str] = []
+        for record in records:
+            response = record.get("response")
+            if not isinstance(response, str) or not response:
+                raise ValueError(
+                    f"ARSupervisedTrackBuilder: record {record.get('sample_id')!r} has no non-empty 'response' — "
+                    "AR SFT manifests must carry the target text."
+                )
+            responses.append(response)
+        encoded = self._tokenizer(
+            responses,
+            add_special_tokens=False,
+            padding=False,
+            truncation=False,
+        )
+        batch_ids = encoded["input_ids"]
+        if len(batch_ids) != len(records):
+            raise RuntimeError(
+                f"ARSupervisedTrackBuilder: tokenizer returned {len(batch_ids)} rows for {len(records)} responses."
+            )
+        return [list(ids) for ids in batch_ids]
+
+    def _tokenize_responses(
+        self,
+        records: Sequence[Record],
+        *,
+        batch_ids: Optional[List[List[int]]] = None,
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
         device = getattr(self.pipeline.bundle, "device", torch.device("cpu"))
         eos_id = self._tokenizer.eos_token_id
         if isinstance(eos_id, (list, tuple)):
             eos_id = eos_id[0] if eos_id else None
         if self.append_eos and eos_id is None:
             raise ValueError("ARSupervisedTrackBuilder: append_eos=True but the tokenizer has no eos_token_id.")
+        if batch_ids is None:
+            batch_ids = (
+                [self._tokenize_agent_target(record) for record in records]
+                if any("messages" in record for record in records)
+                else self._batch_token_ids(records)
+            )
 
         tokens: List[torch.Tensor] = []
         masks: List[torch.Tensor] = []
         truncated = 0
-        for r, is_pad in zip(records, _pad_flags(records)):
-            if "messages" in r:
-                ids = self._tokenize_agent_target(r)
-            else:
-                response = r.get("response")
-                if not isinstance(response, str) or not response:
-                    raise ValueError(
-                        f"ARSupervisedTrackBuilder: record {r.get('sample_id')!r} has no non-empty 'response' — "
-                        "AR SFT manifests must carry the target text."
-                    )
-                ids = self._tokenizer(response, add_special_tokens=False)["input_ids"]
+        for r, is_pad, ids in zip(records, _pad_flags(records), batch_ids):
             if not ids:
                 raise ValueError(
                     f"ARSupervisedTrackBuilder: target of record {r.get('sample_id')!r} tokenized to zero "
                     "tokens — a sample with no supervision would poison the loss denominator."
                 )
-            needs_eos = self.append_eos and (not ids or ids[-1] != eos_id)
+            needs_eos = self.append_eos and ids[-1] != eos_id
             budget = self.max_response_length - (1 if needs_eos else 0)
             if len(ids) > budget:
                 if "messages" in r:
@@ -250,12 +453,12 @@ class ARSupervisedTrackBuilder(SupervisedTrackBuilder):
                         f"max_response_length={self.max_response_length}; filter overlong agent targets "
                         "during manifest preparation instead of truncating a structured assistant turn."
                     )
-                ids = list(ids[:budget])
+                ids = ids[:budget]
                 truncated += 1
-                if self.append_eos and not needs_eos and eos_id is not None:
+                if self.append_eos and not needs_eos:
                     ids[-1] = eos_id
             if needs_eos:
-                ids = list(ids) + [eos_id]
+                ids = ids + [eos_id]
             tokens.append(torch.tensor(ids, dtype=torch.long, device=device))
             fill = 0.0 if is_pad else 1.0
             masks.append(torch.full((len(ids),), fill, dtype=torch.float32, device=device))
@@ -295,12 +498,50 @@ class DiffusionSupervisedTrackBuilder(SupervisedTrackBuilder):
         encode_stage_attr: str = "vae_encode",
         guidance_scale: float = 1.0,
         resolution_align: int = 16,
+        image_load_workers: int = 4,
+        cache_dir: Optional[str] = None,
+        cache_fingerprint: Optional[str] = None,
+        cache_text_conditions: bool = False,
+        cache_vae_latents: bool = False,
+        cache_max_entries: int = 4096,
     ) -> None:
         super().__init__()
         self.pipeline = pipeline
         self.height = height
         self.width = width
         self.guidance_scale = guidance_scale
+        if image_load_workers < 1:
+            raise ValueError(
+                f"DiffusionSupervisedTrackBuilder: image_load_workers must be >= 1; got {image_load_workers!r}"
+            )
+        self.image_load_workers = image_load_workers
+        cache_requested = cache_text_conditions or cache_vae_latents
+        if cache_requested and (not cache_dir or not cache_fingerprint):
+            raise ValueError(
+                "DiffusionSupervisedTrackBuilder: cache_dir and cache_fingerprint are required "
+                "when an encoder cache is enabled."
+            )
+        self._validate_encoder_cache_targets(cache_text_conditions, cache_vae_latents)
+        self._text_cache = (
+            _TensorDiskCache(
+                cache_dir,
+                fingerprint=cache_fingerprint,
+                kind="text-conditions",
+                max_entries=cache_max_entries,
+            )
+            if cache_text_conditions
+            else None
+        )
+        self._vae_cache = (
+            _TensorDiskCache(
+                cache_dir,
+                fingerprint=cache_fingerprint,
+                kind="vae-latents",
+                max_entries=cache_max_entries,
+            )
+            if cache_vae_latents
+            else None
+        )
         align = resolution_align
         if self.height % align or self.width % align:
             raise ValueError(
@@ -331,10 +572,8 @@ class DiffusionSupervisedTrackBuilder(SupervisedTrackBuilder):
         if not records:
             raise ValueError("DiffusionSupervisedTrackBuilder.build: empty record shard.")
         with torch.no_grad():
-            texts = Texts(texts=[str(r["prompt"]) for r in records])
-            conditions = self.pipeline.build_conditions(texts, **self._conditions_kwargs)
-            pixels = self._load_target_pixels(records)
-            latents = self._encode.encode(Images.from_dense(pixels)).latents
+            conditions = self._build_conditions(records)
+            latents = self._encode_latents(records)
         if latents.shape[0] != len(records):
             raise RuntimeError(
                 f"DiffusionSupervisedTrackBuilder.build: encoded {latents.shape[0]} latents "
@@ -352,12 +591,90 @@ class DiffusionSupervisedTrackBuilder(SupervisedTrackBuilder):
             metadata=[dict(record.get("metadata") or {}) for record in records],
         )
 
-    def _load_target_pixels(self, records: Sequence[Record]) -> torch.Tensor:
-        """Load + resize target images → ``[B, 3, H, W]`` fp32 in ``[0, 1]``."""
-        import numpy as np
-        from PIL import Image as PILImage
+    def _validate_encoder_cache_targets(
+        self,
+        cache_text_conditions: bool,
+        cache_vae_latents: bool,
+    ) -> None:
+        bundle = self.pipeline.bundle
+        if cache_text_conditions:
+            text_modules = []
+            for name in ("text_encoder", "text_encoder_2", "text_encoder_3"):
+                module = getattr(bundle, name, None)
+                if module is not None:
+                    text_modules.append(module)
+            if not _encoder_cache_is_safe(text_modules):
+                raise ValueError(
+                    "DiffusionSupervisedTrackBuilder: cache_text_conditions requires non-empty, "
+                    "frozen text encoders in eval mode."
+                )
+        if cache_vae_latents:
+            vae = getattr(bundle, "vae", None)
+            if not _encoder_cache_is_safe([vae]):
+                raise ValueError(
+                    "DiffusionSupervisedTrackBuilder: cache_vae_latents requires a frozen VAE in eval mode."
+                )
 
-        rows: List[torch.Tensor] = []
+    def _text_cache_key(self, record: Record) -> str:
+        return _cache_key(
+            {
+                "prompt": str(record["prompt"]),
+                "conditions": self._conditions_kwargs,
+            }
+        )
+
+    def _vae_cache_key(self, uri: str) -> str:
+        return _cache_key(
+            {
+                "media": _media_stat_fingerprint(uri),
+                "height": self.height,
+                "width": self.width,
+                "resize": "pil-bicubic-stretch-v1",
+            }
+        )
+
+    def _build_conditions(self, records: Sequence[Record]) -> Any:
+        if self._text_cache is None:
+            texts = Texts(texts=[str(record["prompt"]) for record in records])
+            return self.pipeline.build_conditions(texts, **self._conditions_kwargs)
+
+        keys = [self._text_cache_key(record) for record in records]
+        items: List[Optional[Any]] = [self._text_cache.get(key) for key in keys]
+        missing = [index for index, item in enumerate(items) if item is None]
+        if missing:
+            texts = Texts(texts=[str(records[index]["prompt"]) for index in missing])
+            encoded = self.pipeline.build_conditions(texts, **self._conditions_kwargs)
+            for encoded_index, record_index in enumerate(missing):
+                item = encoded.slice(encoded_index, encoded_index + 1)
+                self._text_cache.put(keys[record_index], item.to_device("cpu"))
+                items[record_index] = item
+        concrete = cast(List[Any], items)
+        device = self.pipeline.bundle.device
+        on_device = [item.to_device(device) for item in concrete]
+        return type(on_device[0]).concat(on_device)
+
+    def _encode_latents(self, records: Sequence[Record]) -> torch.Tensor:
+        target_uris = self._target_image_uris(records)
+        if self._vae_cache is None:
+            pixels = self._load_target_pixels(target_uris)
+            return self._encode.encode(Images.from_dense(pixels)).latents
+
+        keys = [self._vae_cache_key(uri) for uri in target_uris]
+        items: List[Optional[torch.Tensor]] = [self._vae_cache.get(key) for key in keys]
+        missing = [index for index, item in enumerate(items) if item is None]
+        if missing:
+            pixels = self._load_target_pixels([target_uris[index] for index in missing])
+            encoded = self._encode.encode(Images.from_dense(pixels)).latents
+            for encoded_index, record_index in enumerate(missing):
+                item = encoded[encoded_index].detach()
+                self._vae_cache.put(keys[record_index], item.cpu())
+                items[record_index] = item
+        concrete = cast(List[torch.Tensor], items)
+        device = self.pipeline.bundle.device
+        return torch.stack([item.to(device) for item in concrete], dim=0)
+
+    def _target_image_uris(self, records: Sequence[Record]) -> List[str]:
+        target_uris: List[str] = []
         for r in records:
             uris = _media_uris(r, role="target", modality="image")
             if len(uris) != 1:
@@ -366,7 +683,17 @@ class DiffusionSupervisedTrackBuilder(SupervisedTrackBuilder):
                     f"role='target' image media ref (got {len(uris)}) — diffusion SFT manifests are "
                     "(prompt, target image) pairs."
                 )
-            img = _load_pil_image(uris[0])
+            target_uris.append(uris[0])
+        return target_uris
+
+    def _load_target_pixels(self, target_uris: Sequence[str]) -> torch.Tensor:
+        """Load + resize target images → ``[B, 3, H, W]`` fp32 in ``[0, 1]``."""
+        import numpy as np
+        from PIL import Image as PILImage
+
+        images = _load_pil_images(target_uris, max_workers=self.image_load_workers)
+        rows: List[torch.Tensor] = []
+        for img in images:
             if img.size != (self.width, self.height):
                 img = img.resize((self.width, self.height), PILImage.BICUBIC)
             arr = np.asarray(img, dtype=np.float32) / 255.0  # [H, W, 3]

--- a/unirl/train_sft.py
+++ b/unirl/train_sft.py
@@ -25,6 +25,7 @@ def main(cfg: DictConfig) -> None:
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_batch_size=int(cfg.get("eval_batch_size", 8)),
         eval_num_samples=int(cfg.get("eval_num_samples", -1)),
+        prefetch_next_batch=cfg.get("prefetch_next_batch", False),
     )
     trainer.train(
         num_steps=int(cfg.get("num_steps", 100)),

--- a/unirl/trainer/sft.py
+++ b/unirl/trainer/sft.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import time
 from typing import Any, Dict, List, Optional
 
 from hydra.utils import instantiate
@@ -15,6 +14,8 @@ from unirl.distributed.group.placement import placement
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer
 from unirl.trainer.hydra import remote_hydra
+from unirl.types.sample import Part
+from unirl.utils.wandb_logger import PhaseTimer
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,7 @@ class SFTTrainer(BaseTrainer):
         eval_interval: int = 0,
         eval_batch_size: int = 8,
         eval_num_samples: int = -1,
+        prefetch_next_batch: bool,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
         self.batch_size = batch_size
@@ -54,8 +56,26 @@ class SFTTrainer(BaseTrainer):
                 "dataset batch. Multi-update SFT is supported by TrainStack but not yet by "
                 "this trainer's outer-step accounting."
             )
+        if not isinstance(prefetch_next_batch, bool):
+            raise TypeError(
+                f"SFTTrainer: prefetch_next_batch must be a bool; got {type(prefetch_next_batch).__name__}."
+            )
+        self.prefetch_next_batch = prefetch_next_batch
 
         self.data_source = instantiate(data_source_cfg)
+        if self.eval_interval > 0 and not self.data_source.has_eval_data:
+            logger.warning(
+                "SFTTrainer: eval_interval=%d but no eval manifest is configured; validation is disabled.",
+                self.eval_interval,
+            )
+            self.eval_interval = 0
+        if self.prefetch_next_batch and not all(
+            callable(getattr(self.data_source, name, None)) for name in ("peek_next_batch", "commit_peeked_batch")
+        ):
+            raise ValueError(
+                "SFTTrainer: prefetch_next_batch requires a data source with "
+                "peek_next_batch() and commit_peeked_batch()."
+            )
 
         with placement(self.pool, fraction=1.0, shared_workers=True):
             self.bundle = remote_hydra(bundle_cfg)
@@ -65,16 +85,32 @@ class SFTTrainer(BaseTrainer):
             self.stack = remote_hydra(stack_cfg, fsdp_backend=self.backend, algorithm=self.algorithm)
             self.track_builder = remote_hydra(track_builder_cfg, pipeline=self.pipeline)
 
+        if self.prefetch_next_batch and not callable(getattr(self.track_builder, "prefetch", None)):
+            raise ValueError("SFTTrainer: prefetch_next_batch requires a track builder with prefetch().")
         self.dp_size = self.stack.dp_size
         if self.batch_size % self.dp_size:
             raise ValueError(f"SFTTrainer: batch_size={self.batch_size} must be divisible by dp={self.dp_size}")
         logger.info("SFTTrainer ready: dp=%d batch=%d", self.dp_size, self.batch_size)
 
-    def train_step(self, records: List[Dict[str, Any]], *, training_progress: float = 0.0) -> TrainStepResult:
-        """records → worker-side track build → stack train. No rollout legs."""
-        part = self.track_builder.build(records)
+    def _build_part(self, records: List[Dict[str, Any]], timer: PhaseTimer) -> Part:
+        with timer.phase("build"):
+            part = self.track_builder.build(records)
         if part.batch_size != len(records):
             raise RuntimeError(f"SFTTrainer: Part builder built {part.batch_size} rows from {len(records)} records.")
+        return part
+
+    def train_step(
+        self,
+        records: List[Dict[str, Any]],
+        *,
+        training_progress: float = 0.0,
+        prefetch_records: Optional[List[Dict[str, Any]]] = None,
+    ) -> TrainStepResult:
+        """records → worker-side track build → stack train. No rollout legs."""
+        part = self._build_part(records, self._step_timer)
+        with self._step_timer.phase("prefetch"):
+            if prefetch_records is not None:
+                self.track_builder.prefetch(prefetch_records)
         return self.stack.train_track(part, training_progress=training_progress)
 
     def evaluate(self, step: int) -> float:
@@ -82,9 +118,12 @@ class SFTTrainer(BaseTrainer):
         loss_sum = 0.0
         weight_sum = 0.0
         batches = 0
+        timer = PhaseTimer()
         for records in self.data_source.iter_eval_batches(self.eval_batch_size, eval_num_samples=self.eval_num_samples):
             records = self._pad_to_dp(records)
-            metrics = self.stack.eval_track(self.track_builder.build(records))
+            part = self._build_part(records, timer)
+            with timer.phase("forward"):
+                metrics = self.stack.eval_track(part)
             loss_sum += float(metrics["loss"]) * float(metrics["weight"])
             weight_sum += float(metrics["weight"])
             batches += 1
@@ -92,15 +131,26 @@ class SFTTrainer(BaseTrainer):
             logger.warning("SFTTrainer.evaluate: no eval data (eval_num_samples=%s).", self.eval_num_samples)
             return float("nan")
         eval_loss = loss_sum / weight_sum
+        eval_time = timer.total()
         logger.info(
-            "EVAL step %d  eval_loss=%.5f  (weight=%.0f over %d batches of <=%d)",
+            "EVAL step %d  eval_loss=%.5f  (weight=%.0f over %d batches of <=%d)  %.1fs (build=%.3fs forward=%.3fs)",
             step + 1,
             eval_loss,
             weight_sum,
             batches,
             self.eval_batch_size,
+            eval_time,
+            timer.phases["build"],
+            timer.phases["forward"],
         )
-        self.wandb_logger.log_eval(step + 1, {"loss": eval_loss})
+        self.wandb_logger.log_eval(
+            step + 1,
+            {
+                "loss": eval_loss,
+                "time_s": eval_time,
+                **{f"{name}_time_s": seconds for name, seconds in timer.phases.items()},
+            },
+        )
         return eval_loss
 
     def _pad_to_dp(self, records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -163,15 +213,28 @@ class SFTTrainer(BaseTrainer):
         self._init_wandb(num_rollouts=num_steps)
         try:
             if self.eval_interval > 0:
-                self.evaluate(step=-1)
+                self.evaluate(step=-1)  # baseline eval-loss at step 0
             for step in range(start_step, num_steps):
-                t0 = time.perf_counter()
+                timer = PhaseTimer()
                 training_progress = step / max(1, num_steps - 1)
-                records = self.data_source.get_samples(self.batch_size)
-                result = self.train_step(records, training_progress=training_progress)
-                dt = time.perf_counter() - t0
+                with timer.phase("data"):
+                    if self.prefetch_next_batch and step > start_step:
+                        records = self.data_source.commit_peeked_batch()
+                    else:
+                        records = self.data_source.get_samples(self.batch_size)
+                    prefetch_records = None
+                    if self.prefetch_next_batch and step + 1 < num_steps:
+                        prefetch_records = self.data_source.peek_next_batch(self.batch_size)
+                result = self.train_step(
+                    records,
+                    training_progress=training_progress,
+                    prefetch_records=prefetch_records,
+                )
+                timer.phases.update(self._step_timer.phases)
+                dt = timer.total()
                 logger.info(
-                    "step %d/%d  loss=%.5f grad_norm=%.4f lr=%.2e epoch=%.3f  %.1fs",
+                    "step %d/%d  loss=%.5f grad_norm=%.4f lr=%.2e epoch=%.3f  "
+                    "%.1fs (data=%.3fs build=%.3fs prefetch=%.3fs train=%.3fs)",
                     step + 1,
                     num_steps,
                     result.loss,
@@ -179,6 +242,10 @@ class SFTTrainer(BaseTrainer):
                     result.lr,
                     self.data_source.epoch,
                     dt,
+                    timer.phases["data"],
+                    timer.phases["build"],
+                    timer.phases["prefetch"],
+                    timer.phases["train"],
                 )
                 self.wandb_logger.log_step(
                     step + 1,
@@ -188,6 +255,7 @@ class SFTTrainer(BaseTrainer):
                         "train/lr": result.lr,
                         "train/epoch": self.data_source.epoch,
                         "perf/step_time_s": dt,
+                        **{f"perf/{name}_time_s": seconds for name, seconds in timer.phases.items()},
                         **{f"train/{k}": v for k, v in dict(result.metrics).items()},
                     },
                     prefix="",


### PR DESCRIPTION
## Summary
- rebase the PR onto current `main` (`27be70b3`) and preserve current agent, audio, image, and video SFT behavior
- name the two data inputs symmetrically as `train_manifest_path` and `eval_manifest_path`
- make resume fail closed when the train manifest content, seed, or shuffle mode changes
- require an explicit validation split across all affected SFT recipes
- batch response tokenization, parallelize image loading, and overlap Qwen-VL CPU preprocessing with training
- add opt-in, fingerprinted caches for frozen eval-mode text conditions and deterministic VAE latents
- validate cache targets at construction, version the disk-cache schema, and reject unsafe cache requests
- reuse the existing `PhaseTimer` for train and eval phase breakdowns
- keep prefetch cursor updates O(batch), serialize eval against in-flight tokenizer work, and treat concurrent cache eviction as a miss

## Results
- SD3 frozen text cache: `1.20x` step speedup
- SD3 frozen VAE cache: `1.50x` step speedup
- BAGEL frozen VAE cache: `10.86x` second-epoch encode speedup with zero latent difference
- batched tokenizer: `3.41x` tokenizer-phase speedup
- parallel cold image loading: `3.51x` image-load speedup
- micro loss-weight batching and fused dispatch were measured and intentionally excluded

## Test Plan
- [x] Full repository pre-commit suite on rebased head
- [x] All 13 SFT recipes compose with `train_manifest_path`; all nine eval-policy-affected recipes resolve without an implicit train fallback
- [x] Focused CPU checks for lazy manifest-aware exact resume and epoch-crossing peek/commit equivalence without per-step reshuffles
- [x] Focused checks for batched tokenization, parallel image loading, eval/prefetch serialization, cache target validation, cache hits/invalidation, and concurrent cache eviction
- [x] Shared `PhaseTimer` integration on the first train step and eval phase metric emission
- [x] Final diff against `main` contains no test-tree changes
- [x] Original Qwen3 and Qwen-VL LoRA SFT smoke runs
- [x] Original SD3 text-condition and VAE-cache A/B runs
- [x] Original BAGEL VAE-cache A/B and one-step full SFT smoke
- [x] Original checkpoint-sidecar resume through the next optimizer step

## Compatibility / Risk
- `SupervisedDataSource.manifest_path` is renamed to `train_manifest_path`; every in-repository caller is migrated.
- Encoder caches remain opt-in and require an explicit cache fingerprint; cache requests for missing, trainable, or training-mode encoders fail during construction.
- Cache directories are explicit trusted training artifacts; cache files are loaded through PyTorch serialization.
- Evaluation no longer silently reuses the training manifest; it is disabled unless an eval manifest is explicit.
- Qwen-VL prefetch has one trainer-level opt-in and is enabled in the two Qwen-VL example recipes; builders without the capability are rejected.
- The measured GPU A/B and smoke results above are author-provided historical evidence; the current rebase pass is CPU/static validation.
