### PR TITLE
fix(train): align unified loss reporting with backward scaling

### DIFF
--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -213,7 +213,7 @@ class UnifiedModelTrainStack(Remote):
                 loss_scale=loss_scale,
             )
             micros.append(result)
-            total_loss += result.loss
+            total_loss += result.loss * loss_scale
             has_backward = has_backward or result.has_backward
 
         aggregated: Mapping[str, object] = aggregate_numeric_metrics([r.metrics for r in micros if r.metrics])


### PR DESCRIPTION
## Summary

Report unified-model loss with the same micro-batch weights used for backward.

The unified stack already passes `loss_scale = 1 / num_micros` to each
algorithm, but previously summed the algorithms' unscaled returned losses. For
micro losses `2.0` and `4.0`, it therefore reported `6.0` while optimizing
`3.0`.

Applying `loss_scale` during reporting aligns `TrainStepResult.loss` with the
optimized objective and with the regular `TrainStack`. Gradient computation and
optimizer behavior are unchanged.

## Related Issue

Fixes #247

## Test Plan

- Direct CPU `_backward_track` regression:
  - one micro: reported `2.0`, expected `2.0`
  - two micros: reported `3.0`, expected `3.0`
  - three micros: reported approximately `4.0`, expected `4.0`
  - the two-micro assertion reports `6.0` on the previous tree
- `python3 -m compileall -q unirl/train/unified_model_stack.py`
- `ruff check unirl/train/unified_model_stack.py`
- `ruff format --check unirl/train/unified_model_stack.py`
- `SKIP=no-commit-to-branch pre-commit run --files unirl/train/unified_model_stack.py --show-diff-on-failure`

All checks passed.

## Compatibility / Risk

No API, configuration, checkpoint, data-format, gradient, or optimizer changes.
The single-micro path remains numerically identical; only multi-micro loss
telemetry changes.

## Reviewer Notes

The regular `TrainStack` already applies the same weighted-reporting rule. No
overlapping open issue or PR was found.

AI assistance was used for investigation, implementation, and draft
preparation.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
