### PR TITLE
feat(types): add GAE advantage computation

### DIFF
--- a/tests/types/test_advantages_gae.py
+++ b/tests/types/test_advantages_gae.py
@@ -1,0 +1,109 @@
+"""CPU unit tests for GAE advantage computation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from unirl.types.advantages import compute_gae_advantages
+
+
+def test_gae_hand_computed_lambda_one() -> None:
+    """Sparse terminal reward; λ=1; hand-computed backward pass."""
+    rewards = torch.tensor([0.0, 0.0, 1.0])
+    values = torch.tensor([0.2, 0.5, 0.8])
+    advantages, returns = compute_gae_advantages(
+        rewards, values, gamma=1.0, gae_lambda=1.0
+    )
+    # δ = [0.3, 0.3, 0.2]; backward GAE with λ=1 → [0.8, 0.5, 0.2]
+    expected_adv = torch.tensor([0.8, 0.5, 0.2])
+    assert torch.allclose(advantages, expected_adv, atol=1e-6)
+    assert torch.allclose(returns, expected_adv + values, atol=1e-6)
+
+
+def test_gae_lambda_zero_td_only() -> None:
+    """λ=0 → advantages equal TD errors only."""
+    rewards = torch.tensor([0.0, 0.0, 1.0])
+    values = torch.tensor([0.2, 0.5, 0.8])
+    advantages, _ = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=0.0)
+    expected = torch.tensor([0.3, 0.3, 0.2])
+    assert torch.allclose(advantages, expected, atol=1e-6)
+
+
+def test_gae_flat_critic_sparse_reward() -> None:
+    """Perfect flat critic on sparse terminal reward → zero advantages."""
+    rewards = torch.tensor([0.0, 0.0, 0.0, 1.0])
+    values = torch.tensor([1.0, 1.0, 1.0, 1.0])
+    advantages, _ = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=1.0)
+    assert torch.allclose(advantages, torch.zeros(4), atol=1e-6)
+
+
+def test_gae_uniform_reward_zero_advantage() -> None:
+    """Constant rewards and matching flat values → zero TD errors."""
+    rewards = torch.tensor([1.0, 1.0, 1.0])
+    values = torch.tensor([2.0, 2.0, 2.0])
+    advantages, _ = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=0.95)
+    assert torch.allclose(advantages, torch.zeros(3), atol=1e-6)
+
+
+def test_gae_batched_independent_rows() -> None:
+    """Batched [B, T] matches row-wise 1D computation."""
+    rewards = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+    values = torch.tensor([[0.1, 0.4], [0.2, 0.5]])
+    batched_adv, _ = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=1.0)
+    for b in range(2):
+        row_adv, _ = compute_gae_advantages(rewards[b], values[b], gamma=1.0, gae_lambda=1.0)
+        assert torch.allclose(batched_adv[b], row_adv, atol=1e-6)
+
+
+def test_gae_mask_resets_carry() -> None:
+    """Padding mask prevents GAE from crossing sequence boundaries."""
+    rewards = torch.tensor([[0.0, 0.0, 1.0, 0.0]])
+    values = torch.tensor([[0.2, 0.5, 0.8, 0.0]])
+    mask = torch.tensor([[1.0, 1.0, 1.0, 0.0]])
+    advantages, _ = compute_gae_advantages(
+        rewards, values, gamma=1.0, gae_lambda=1.0, mask=mask
+    )
+    unmasked_adv, _ = compute_gae_advantages(
+        rewards[0, :3], values[0, :3], gamma=1.0, gae_lambda=1.0
+    )
+    assert torch.allclose(advantages[0, :3], unmasked_adv, atol=1e-6)
+    assert advantages[0, 3].item() == 0.0
+
+
+def test_gae_gamma_discount() -> None:
+    """γ < 1 discounts bootstrap from future values."""
+    rewards = torch.tensor([0.0, 0.0, 1.0])
+    values = torch.tensor([0.0, 0.0, 0.0])
+    gamma = 0.9
+    advantages, _ = compute_gae_advantages(rewards, values, gamma=gamma, gae_lambda=1.0)
+    # δ2=1, δ1=0, δ0=0 → backward: A2=1, A1=0.9, A0=0.81
+    expected = torch.tensor([gamma**2, gamma, 1.0])
+    assert torch.allclose(advantages, expected, atol=1e-6)
+
+
+def test_gae_shape_mismatch_raises() -> None:
+    rewards = torch.tensor([0.0, 1.0])
+    values = torch.tensor([0.0, 1.0, 0.0])
+    with pytest.raises(ValueError, match="shape"):
+        compute_gae_advantages(rewards, values)
+
+
+def test_gae_invalid_hyperparams_raise() -> None:
+    rewards = torch.tensor([1.0])
+    values = torch.tensor([0.5])
+    with pytest.raises(ValueError, match="gamma"):
+        compute_gae_advantages(rewards, values, gamma=1.1)
+    with pytest.raises(ValueError, match="gae_lambda"):
+        compute_gae_advantages(rewards, values, gae_lambda=-0.1)
+
+
+def test_gae_single_step() -> None:
+    """Degenerate T=1: advantage = r + γ·0 - V."""
+    rewards = torch.tensor([1.0])
+    values = torch.tensor([0.25])
+    advantages, returns = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=0.95)
+    assert math.isclose(float(advantages.item()), 0.75, rel_tol=0, abs_tol=1e-6)
+    assert math.isclose(float(returns.item()), 1.0, rel_tol=0, abs_tol=1e-6)

--- a/tests/types/test_advantages_gae.py
+++ b/tests/types/test_advantages_gae.py
@@ -14,9 +14,7 @@ def test_gae_hand_computed_lambda_one() -> None:
     """Sparse terminal reward; λ=1; hand-computed backward pass."""
     rewards = torch.tensor([0.0, 0.0, 1.0])
     values = torch.tensor([0.2, 0.5, 0.8])
-    advantages, returns = compute_gae_advantages(
-        rewards, values, gamma=1.0, gae_lambda=1.0
-    )
+    advantages, returns = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=1.0)
     # δ = [0.3, 0.3, 0.2]; backward GAE with λ=1 → [0.8, 0.5, 0.2]
     expected_adv = torch.tensor([0.8, 0.5, 0.2])
     assert torch.allclose(advantages, expected_adv, atol=1e-6)
@@ -41,9 +39,9 @@ def test_gae_flat_critic_sparse_reward() -> None:
 
 
 def test_gae_uniform_reward_zero_advantage() -> None:
-    """Constant rewards and matching flat values → zero TD errors."""
+    """Constant rewards and matching finite-horizon values → zero TD errors."""
     rewards = torch.tensor([1.0, 1.0, 1.0])
-    values = torch.tensor([2.0, 2.0, 2.0])
+    values = torch.tensor([3.0, 2.0, 1.0])
     advantages, _ = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=0.95)
     assert torch.allclose(advantages, torch.zeros(3), atol=1e-6)
 
@@ -63,14 +61,35 @@ def test_gae_mask_resets_carry() -> None:
     rewards = torch.tensor([[0.0, 0.0, 1.0, 0.0]])
     values = torch.tensor([[0.2, 0.5, 0.8, 0.0]])
     mask = torch.tensor([[1.0, 1.0, 1.0, 0.0]])
-    advantages, _ = compute_gae_advantages(
-        rewards, values, gamma=1.0, gae_lambda=1.0, mask=mask
-    )
-    unmasked_adv, _ = compute_gae_advantages(
-        rewards[0, :3], values[0, :3], gamma=1.0, gae_lambda=1.0
-    )
+    advantages, _ = compute_gae_advantages(rewards, values, gamma=1.0, gae_lambda=1.0, mask=mask)
+    unmasked_adv, _ = compute_gae_advantages(rewards[0, :3], values[0, :3], gamma=1.0, gae_lambda=1.0)
     assert torch.allclose(advantages[0, :3], unmasked_adv, atol=1e-6)
     assert advantages[0, 3].item() == 0.0
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_gae_mask_zeros_bootstrap_from_padding_values(batched: bool) -> None:
+    """The last valid step is terminal even when padding contains nonzero values."""
+    rewards = torch.tensor([0.0, 0.0, 0.0])
+    values = torch.tensor([0.25, 123.0, 456.0])
+    mask = torch.tensor([1.0, 0.0, 0.0])
+    if batched:
+        rewards = rewards.unsqueeze(0)
+        values = values.unsqueeze(0)
+        mask = mask.unsqueeze(0)
+
+    advantages, _ = compute_gae_advantages(
+        rewards,
+        values,
+        gamma=1.0,
+        gae_lambda=1.0,
+        mask=mask,
+    )
+
+    expected = torch.tensor([-0.25, 0.0, 0.0])
+    if batched:
+        expected = expected.unsqueeze(0)
+    assert torch.allclose(advantages, expected, atol=1e-6)
 
 
 def test_gae_gamma_discount() -> None:

--- a/unirl/types/advantages.py
+++ b/unirl/types/advantages.py
@@ -49,8 +49,7 @@ def compute_gae_advantages(
     """
     if rewards.shape != values.shape:
         raise ValueError(
-            f"compute_gae_advantages: rewards shape {tuple(rewards.shape)} != "
-            f"values shape {tuple(values.shape)}"
+            f"compute_gae_advantages: rewards shape {tuple(rewards.shape)} != values shape {tuple(values.shape)}"
         )
     if not (0.0 <= gamma <= 1.0):
         raise ValueError(f"compute_gae_advantages: gamma must be in [0, 1], got {gamma}")
@@ -58,8 +57,7 @@ def compute_gae_advantages(
         raise ValueError(f"compute_gae_advantages: gae_lambda must be in [0, 1], got {gae_lambda}")
     if mask is not None and mask.shape != rewards.shape:
         raise ValueError(
-            f"compute_gae_advantages: mask shape {tuple(mask.shape)} != "
-            f"rewards shape {tuple(rewards.shape)}"
+            f"compute_gae_advantages: mask shape {tuple(mask.shape)} != rewards shape {tuple(rewards.shape)}"
         )
 
     if rewards.ndim == 1:
@@ -67,9 +65,7 @@ def compute_gae_advantages(
     elif rewards.ndim == 2:
         advantages = _gae_2d(rewards, values, gamma=gamma, gae_lambda=gae_lambda, mask=mask)
     else:
-        raise ValueError(
-            f"compute_gae_advantages: expected 1D or 2D tensors, got ndim={rewards.ndim}"
-        )
+        raise ValueError(f"compute_gae_advantages: expected 1D or 2D tensors, got ndim={rewards.ndim}")
 
     returns = advantages + values
     return advantages, returns
@@ -85,18 +81,19 @@ def _gae_1d(
 ) -> torch.Tensor:
     t_steps = int(rewards.shape[0])
     next_values = torch.cat([values[1:], values.new_zeros(1)])
+    if mask is not None:
+        valid = mask.to(dtype=values.dtype)
+        next_valid = torch.cat([valid[1:], valid.new_zeros(1)])
+        next_values = next_values * next_valid
     deltas = rewards + gamma * next_values - values
 
     advantages = rewards.new_zeros(t_steps)
     gae = rewards.new_zeros(())
     for t in range(t_steps - 1, -1, -1):
-        if mask is not None and mask[t].item() == 0:
-            gae = rewards.new_zeros(())
-        else:
-            gae = deltas[t] + gamma * gae_lambda * gae
+        gae = deltas[t] + gamma * gae_lambda * gae
+        if mask is not None:
+            gae = gae * mask[t].to(dtype=gae.dtype)
         advantages[t] = gae
-    if mask is not None:
-        advantages = advantages * mask.to(dtype=advantages.dtype)
     return advantages
 
 
@@ -110,6 +107,10 @@ def _gae_2d(
 ) -> torch.Tensor:
     batch, t_steps = rewards.shape
     next_values = torch.cat([values[:, 1:], values.new_zeros(batch, 1)], dim=1)
+    if mask is not None:
+        valid = mask.to(dtype=values.dtype)
+        next_valid = torch.cat([valid[:, 1:], valid.new_zeros(batch, 1)], dim=1)
+        next_values = next_values * next_valid
     deltas = rewards + gamma * next_values - values
 
     advantages = rewards.new_zeros(batch, t_steps)
@@ -122,6 +123,4 @@ def _gae_2d(
         else:
             gae = deltas[:, t] + gamma * gae_lambda * gae
         advantages[:, t] = gae
-    if mask is not None:
-        advantages = advantages * mask.to(dtype=advantages.dtype)
     return advantages

--- a/unirl/types/advantages.py
+++ b/unirl/types/advantages.py
@@ -1,0 +1,127 @@
+"""Advantage computation helpers for rollout tracks.
+
+GRPO-style group normalization lives on :meth:`RolloutTrack.compute_advantages`
+in :mod:`unirl.types.rollout_resp`. GAE and other per-step estimators live here
+as pure tensor utilities consumed by trainers before the train step.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+
+
+def compute_gae_advantages(
+    rewards: torch.Tensor,
+    values: torch.Tensor,
+    *,
+    gamma: float = 1.0,
+    gae_lambda: float = 0.95,
+    mask: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute GAE advantages and returns from step rewards and value predictions.
+
+    For each step ``t`` (backward in time):
+
+        δ_t = r_t + γ V_{t+1} - V_t
+        A_t = δ_t + (γλ) δ_{t+1} + (γλ)² δ_{t+2} + ...
+
+    After the last valid step, ``V_{T}`` bootstraps with zero (episodic terminal).
+
+    Args:
+        rewards: Step rewards ``[T]`` or ``[B, T]``.
+        values: Critic predictions ``V_t``, same shape as ``rewards``.
+        gamma: Discount factor γ.
+        gae_lambda: GAE smoothing λ.
+        mask: Optional validity mask (1 = include, 0 = padding / ignore).
+            When provided, GAE does not carry across zero-mask positions.
+
+    Returns:
+        ``(advantages, returns)`` with the same shape as ``rewards``.
+        ``returns = advantages + values`` (standard GAE-return convention).
+
+    Raises:
+        ValueError: On shape mismatch or invalid hyperparameters.
+
+    Reference: Schulman et al., "High-Dimensional Continuous Control Using
+    Generalized Advantage Estimation" (2016).
+    """
+    if rewards.shape != values.shape:
+        raise ValueError(
+            f"compute_gae_advantages: rewards shape {tuple(rewards.shape)} != "
+            f"values shape {tuple(values.shape)}"
+        )
+    if not (0.0 <= gamma <= 1.0):
+        raise ValueError(f"compute_gae_advantages: gamma must be in [0, 1], got {gamma}")
+    if not (0.0 <= gae_lambda <= 1.0):
+        raise ValueError(f"compute_gae_advantages: gae_lambda must be in [0, 1], got {gae_lambda}")
+    if mask is not None and mask.shape != rewards.shape:
+        raise ValueError(
+            f"compute_gae_advantages: mask shape {tuple(mask.shape)} != "
+            f"rewards shape {tuple(rewards.shape)}"
+        )
+
+    if rewards.ndim == 1:
+        advantages = _gae_1d(rewards, values, gamma=gamma, gae_lambda=gae_lambda, mask=mask)
+    elif rewards.ndim == 2:
+        advantages = _gae_2d(rewards, values, gamma=gamma, gae_lambda=gae_lambda, mask=mask)
+    else:
+        raise ValueError(
+            f"compute_gae_advantages: expected 1D or 2D tensors, got ndim={rewards.ndim}"
+        )
+
+    returns = advantages + values
+    return advantages, returns
+
+
+def _gae_1d(
+    rewards: torch.Tensor,
+    values: torch.Tensor,
+    *,
+    gamma: float,
+    gae_lambda: float,
+    mask: Optional[torch.Tensor],
+) -> torch.Tensor:
+    t_steps = int(rewards.shape[0])
+    next_values = torch.cat([values[1:], values.new_zeros(1)])
+    deltas = rewards + gamma * next_values - values
+
+    advantages = rewards.new_zeros(t_steps)
+    gae = rewards.new_zeros(())
+    for t in range(t_steps - 1, -1, -1):
+        if mask is not None and mask[t].item() == 0:
+            gae = rewards.new_zeros(())
+        else:
+            gae = deltas[t] + gamma * gae_lambda * gae
+        advantages[t] = gae
+    if mask is not None:
+        advantages = advantages * mask.to(dtype=advantages.dtype)
+    return advantages
+
+
+def _gae_2d(
+    rewards: torch.Tensor,
+    values: torch.Tensor,
+    *,
+    gamma: float,
+    gae_lambda: float,
+    mask: Optional[torch.Tensor],
+) -> torch.Tensor:
+    batch, t_steps = rewards.shape
+    next_values = torch.cat([values[:, 1:], values.new_zeros(batch, 1)], dim=1)
+    deltas = rewards + gamma * next_values - values
+
+    advantages = rewards.new_zeros(batch, t_steps)
+    gae = rewards.new_zeros(batch)
+    for t in range(t_steps - 1, -1, -1):
+        if mask is not None:
+            step_mask = mask[:, t].to(dtype=deltas.dtype)
+            gae = deltas[:, t] + gamma * gae_lambda * gae
+            gae = gae * step_mask
+        else:
+            gae = deltas[:, t] + gamma * gae_lambda * gae
+        advantages[:, t] = gae
+    if mask is not None:
+        advantages = advantages * mask.to(dtype=advantages.dtype)
+    return advantages


### PR DESCRIPTION
## Summary

Part 1/3 for #86. Adds pure-tensor Generalized Advantage Estimation (GAE) under `unirl/types/advantages.py`, alongside the existing GRPO advantage path in `RolloutTrack.compute_advantages`. This keeps advantage computation in `types/` (pre-train signal) rather than `algorithms/` (loss classes). No trainer or model wiring yet — that lands in follow-up PRs.

AI-assisted implementation; checked open PRs — no overlapping GAE work found.

## Related Issue

Part of #86

## Test Plan

- `pytest tests/types/test_advantages_gae.py -q` on Python 3.12 — 12 passed, including 1D/2D nonzero-padding mask regressions.
- `SKIP=no-commit-to-branch pre-commit run --files unirl/types/advantages.py tests/types/test_advantages_gae.py` — all hooks passed.
- `git diff --check origin/main...HEAD` — clean.

## Compatibility / Risk

N/A — new module and tests only; no config, checkpoint, or API changes to existing training paths.

## Reviewer Notes

Follow-ups (separate PRs): AR value head + replay values (part 2), `PPO` algorithm with value loss + recipe (part 3). GAE uses episodic bootstrap `V_{T+1}=0` and optional validity masks for packed sequences.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.