### PR TITLE
feat(models): add AR value head and GAE wiring

### DIFF
--- a/unirl/models/qwen3/ar.py
+++ b/unirl/models/qwen3/ar.py
@@ -23,7 +23,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from types import MethodType
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
@@ -31,6 +31,7 @@ import torch.nn.functional as F
 from torch.utils.checkpoint import checkpoint
 
 from unirl.models.types.ar import ARSamplingParams, ARStage, ARStep, left_pad_prompt
+from unirl.models.types.replay_result import ReplayResult
 from unirl.types.segments import TextSegment
 from unirl.utils.dtypes import parse_torch_dtype
 
@@ -87,6 +88,7 @@ def _replay_aware_forward(
     temperature: float = 1.0,
     autocast_dtype: Optional[torch.dtype] = None,
     packed_predict_index: Optional[torch.Tensor] = None,
+    return_values: bool = False,
     **kw: Any,
 ) -> Any:
     """Dual-mode ``forward`` installed on the Qwen3 CausalLM instance.
@@ -107,6 +109,8 @@ def _replay_aware_forward(
             if f is not None and f is not _replay_aware_forward:
                 return f(self, **kw)
         raise RuntimeError("_replay_aware_forward: no class-level forward found in the MRO")
+
+    _require_value_head_for_replay(self, return_values)
 
     # cuDNN's fused SDPA backward (ScaledDotProductCudnnAttentionBackward0) returns
     # NaN grads on some bf16 sequences while the forward stays finite (confirmed via
@@ -129,6 +133,7 @@ def _replay_aware_forward(
     # [B, chunk, vocab] FP32 transient stays ~1.2 GiB, and each chunk is
     # gradient-checkpointed (recomputed in backward rather than held).
     T = float(temperature) if float(temperature) > 0.0 else 1.0
+    value_head = getattr(self, "value_head", None) if return_values else None
 
     if packed_predict_index is not None:
         # Packed varlen replay: ``hidden`` is one packed row [1, L_total, H]
@@ -155,8 +160,16 @@ def _replay_aware_forward(
             else:
                 flat_parts.append(_flat_logp_chunk(h, tok))
         if not flat_parts:
-            return hidden.new_zeros((0,), dtype=torch.float32)
-        return torch.cat(flat_parts, dim=0)
+            empty = hidden.new_zeros((0,), dtype=torch.float32)
+            if value_head is None:
+                return empty
+            return ReplayResult(log_probs=empty, values=empty)
+        log_probs = torch.cat(flat_parts, dim=0)
+        if value_head is None:
+            return log_probs
+        value_parts = [value_head(h_pred[s : s + flat_chunk]) for s in range(0, int(h_pred.size(0)), flat_chunk)]
+        values = torch.cat(value_parts, dim=0) if value_parts else log_probs.new_zeros(0)
+        return ReplayResult(log_probs=log_probs, values=values)
     T_max = int(response_tokens.size(1))
     resp_hidden = hidden[:, prompt_len - 1 : prompt_len - 1 + T_max, :]
 
@@ -176,8 +189,51 @@ def _replay_aware_forward(
         else:
             parts.append(_logp_chunk(h, tok))
     if not parts:
-        return resp_hidden.new_zeros((bsz, 0), dtype=torch.float32)  # T_max == 0
-    return torch.cat(parts, dim=1)
+        empty = resp_hidden.new_zeros((bsz, 0), dtype=torch.float32)
+        if value_head is None:
+            return empty
+        return ReplayResult(log_probs=empty, values=empty)
+    log_probs = torch.cat(parts, dim=1)
+    if value_head is None:
+        return log_probs
+    value_parts = [value_head(resp_hidden[:, s : s + chunk, :]) for s in range(0, T_max, chunk)]
+    values = torch.cat(value_parts, dim=1) if value_parts else log_probs.new_zeros((bsz, 0))
+    return ReplayResult(log_probs=log_probs, values=values)
+
+
+def _require_value_head_for_replay(model: Any, return_values: bool) -> None:
+    if return_values and getattr(model, "value_head", None) is None:
+        raise ValueError(
+            "Qwen3 replay: return_values=True requires a value head (set use_value_head=True in the pipeline config)"
+        )
+
+
+def _finalize_replay_output(
+    out: Union[torch.Tensor, ReplayResult],
+    *,
+    segment: TextSegment,
+    return_values: bool,
+    logprob_dtype: torch.dtype,
+) -> Union[torch.Tensor, ReplayResult]:
+    """Cast log-probs and flatten padded critic values to segment order."""
+    if not isinstance(out, ReplayResult):
+        if return_values:
+            raise ValueError("Qwen3ARStage.replay: return_values=True but critic returned no values")
+        return out.to(dtype=logprob_dtype)
+
+    log_probs = out.log_probs.to(dtype=logprob_dtype)
+    if not return_values:
+        return log_probs
+    if out.values is None:
+        raise ValueError("Qwen3ARStage.replay: return_values=True but critic returned no values")
+    if log_probs.ndim == 1:
+        return ReplayResult(log_probs=log_probs, values=out.values.float())
+    if segment.lengths is None:
+        raise ValueError("Qwen3ARStage.replay: segment requires lengths to flatten critic values")
+
+    flat_values = [out.values[b, : int(length)] for b, length in enumerate(segment.lengths.tolist()) if int(length) > 0]
+    values = torch.cat(flat_values, dim=0) if flat_values else out.values.new_zeros(0)
+    return ReplayResult(log_probs=log_probs, values=values.float())
 
 
 # Attention backends with a sparse packed kernel (skip cross-sequence blocks):
@@ -421,22 +477,32 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
         *,
         segment: TextSegment,
         temperature: float = 1.0,
-    ) -> torch.Tensor:
+        return_values: bool = False,
+    ) -> Union[torch.Tensor, ReplayResult]:
         """Per-token log-prob replay over a stored rollout segment.
 
         Branch: prefer :meth:`packed_replay` (packed-varlen, zero padding, B > 1)
         and fall back to :meth:`padding_replay` (the dense ``[B, P_max + T_max]``
-        padded path) when packing does not apply. Returns packed varlen
-        ``[total_tokens]`` aligned with ``segment.log_probs``; caller controls
-        grad / ``.train()`` scope. ``temperature`` divides logits before
-        ``log_softmax`` to match SGLang's sampler (``1.0`` is a no-op).
+        padded path) when packing does not apply. Returns packed varlen log-probs,
+        or a :class:`ReplayResult` with aligned critic values when requested.
         """
+        _require_value_head_for_replay(self.model.transformer, return_values)
         attn_impl = getattr(getattr(self.model.transformer, "config", None), "_attn_implementation", None)
         if _packed_replay_supported(attn_impl):
-            packed = self.packed_replay(conditions, segment=segment, temperature=temperature)
+            packed = self.packed_replay(
+                conditions,
+                segment=segment,
+                temperature=temperature,
+                return_values=return_values,
+            )
             if packed is not None:
                 return packed
-        return self.padding_replay(conditions, segment=segment, temperature=temperature)
+        return self.padding_replay(
+            conditions,
+            segment=segment,
+            temperature=temperature,
+            return_values=return_values,
+        )
 
     def packed_replay(
         self,
@@ -444,7 +510,8 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
         *,
         segment: TextSegment,
         temperature: float = 1.0,
-    ) -> Optional[torch.Tensor]:
+        return_values: bool = False,
+    ) -> Optional[Union[torch.Tensor, ReplayResult]]:
         """Packed-varlen replay (B > 1): zero padding anywhere.
 
         Concatenate every sample's REAL prompt tokens + its flat response tokens
@@ -520,9 +587,15 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
             packed_predict_index=predict_index,
             prompt_len=0,
             temperature=temperature,
+            return_values=return_values,
             autocast_dtype=(self.autocast_dtype if device.type == "cuda" else None),
         )
-        return per_token_flat.to(dtype=self.logprob_dtype)
+        return _finalize_replay_output(
+            per_token_flat,
+            segment=segment,
+            return_values=return_values,
+            logprob_dtype=self.logprob_dtype,
+        )
 
     def padding_replay(
         self,
@@ -530,7 +603,8 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
         *,
         segment: TextSegment,
         temperature: float = 1.0,
-    ) -> torch.Tensor:
+        return_values: bool = False,
+    ) -> Union[torch.Tensor, ReplayResult]:
         """Dense ``[B, P_max + T_max]`` padded replay — the default / fallback path.
 
         One teacher-forced forward over padded ``prompt + response``; gather
@@ -629,28 +703,44 @@ class Qwen3ARStage(ARStage[Qwen3ARConditions]):
         # root-wrapped or plain) and never materializes [B, L, vocab] logits.
         # The cuda-vs-cpu autocast decision lives here; dtype validity and the
         # autocast scope live in the patched forward.
-        per_token = self.model.transformer(
+        out = self.model.transformer(
             input_ids=full_ids,
             attention_mask=full_mask,
             position_ids=position_ids,
             response_tokens=response_tokens,
             prompt_len=prompt_len,
             temperature=temperature,
+            return_values=return_values,
             autocast_dtype=(self.autocast_dtype if device.type == "cuda" else None),
-        )  # [B, T_max] FP32
+        )  # [B, T_max] FP32 tensor or ReplayResult
 
-        if T_max == 0:
-            return torch.zeros(0, dtype=self.logprob_dtype, device=device)
+        finalized = _finalize_replay_output(
+            out,
+            segment=segment,
+            return_values=return_values,
+            logprob_dtype=self.logprob_dtype,
+        )
+        if isinstance(finalized, ReplayResult):
+            per_token = finalized.log_probs
+            values = finalized.values
+        else:
+            per_token = finalized
+            values = None
 
-        flat: List[torch.Tensor] = []
-        for b in range(batch_size):
-            n = lengths[b]
-            if n == 0:
-                continue
-            flat.append(per_token[b, :n])
-        if not flat:
-            return torch.zeros(0, dtype=self.logprob_dtype, device=device)
-        return torch.cat(flat, dim=0).to(dtype=self.logprob_dtype)
+        flat_log_probs: List[torch.Tensor] = []
+        for b, n in enumerate(lengths):
+            if n > 0:
+                flat_log_probs.append(per_token[b, :n])
+        log_probs = (
+            torch.cat(flat_log_probs, dim=0)
+            if flat_log_probs
+            else torch.zeros(0, dtype=self.logprob_dtype, device=device)
+        )
+        if not return_values:
+            return log_probs
+        if values is None:
+            raise ValueError("Qwen3ARStage.replay: return_values=True but critic returned no values")
+        return ReplayResult(log_probs=log_probs, values=values)
 
     def _resolve_stop_ids(
         self,

--- a/unirl/models/qwen3/bundle.py
+++ b/unirl/models/qwen3/bundle.py
@@ -28,11 +28,30 @@ import torch.nn as nn
 
 from unirl.models.types.bundle import Bundle
 from unirl.models.types.meta_init import build_meta_init_transformer
+from unirl.models.types.value_head import ValueHead
 from unirl.utils.dtypes import parse_torch_dtype
 
 from .config import Qwen3PipelineConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _stamp_value_head_reset(transformer: nn.Module) -> None:
+    """Zero checkpoint-absent value-head params after meta materialization."""
+    from unirl.train.deferred import _stamp
+
+    def _reset(model: nn.Module) -> None:
+        reset: list[str] = []
+        with torch.no_grad():
+            for name, param in model.named_parameters():
+                if name.startswith("value_head."):
+                    param.zero_()
+                    reset.append(name)
+        if not reset:
+            raise RuntimeError("Qwen3 meta-init: value_head parameters disappeared before post-load reset")
+        logger.info("Qwen3 meta-init: zero-initialized checkpoint-absent value head: %s", reset)
+
+    _stamp(transformer, _reset)
 
 
 class Qwen3Bundle(Bundle):
@@ -114,6 +133,16 @@ class Qwen3Bundle(Bundle):
         )
         if tokenizer.pad_token is None and tokenizer.eos_token is not None:
             tokenizer.pad_token = tokenizer.eos_token
+
+        if config.use_value_head:
+            hidden_size = int(getattr(transformer.config, "hidden_size"))
+            transformer_device = next(transformer.parameters()).device
+            transformer.value_head = ValueHead(hidden_size, device=transformer_device)
+            if config.meta_init_transformer:
+                # The base checkpoint has no value_head.* tensors. ``to_empty``
+                # materializes the meta head as uninitialized storage, so reset
+                # it only after the sharded checkpoint load has completed.
+                _stamp_value_head_reset(transformer)
 
         bundle = cls(
             transformer=transformer,

--- a/unirl/models/qwen3/config.py
+++ b/unirl/models/qwen3/config.py
@@ -69,6 +69,9 @@ class Qwen3PipelineConfig:
     use_lora: bool = False
     lora_target_modules: Optional[List[str]] = None
 
+    # Attach a scalar critic to the causal LM for PPO / GAE training.
+    use_value_head: bool = False
+
     system_instruction: Optional[str] = None
     # Chat-template thinking switch; MUST agree with the rollout engine's
     # chat_template_kwargs.enable_thinking or train/rollout prompts diverge.

--- a/unirl/models/types/replay_result.py
+++ b/unirl/models/types/replay_result.py
@@ -8,10 +8,8 @@ stored ``segment.sde_logp`` (or its slice when ``step_indices`` subsets).
 
 Diffusion stages populate ``log_probs`` and ``prev_sample_means`` (the
 mean of the SDE Gaussian — μ_θ — used as the second moment in the KL
-penalty). AR stages currently return a plain ``Tensor`` (signature
-divergence with diffusion is intentional for now); when AR replay grows
-``logits``-based KL support, the ``logits`` field on this result will be
-the canonical home.
+penalty). AR stages return a plain ``Tensor`` for policy-only replay, or
+a :class:`ReplayResult` when optional critic ``values`` are requested.
 """
 
 from __future__ import annotations
@@ -41,6 +39,10 @@ class ReplayResult:
     ``[B, S', V]`` for AR. Reserved for future full-categorical KL
     or entropy penalty support; not needed for Binary KL (which uses
     only per-token log-probs). Currently not populated."""
+
+    values: Optional[torch.Tensor] = None
+    """Per-token critic predictions ``V_t``. Packed ``[total_tokens]`` for AR.
+    ``None`` when replay did not request a value head."""
 
 
 __all__ = ["ReplayResult"]

--- a/unirl/models/types/value_head.py
+++ b/unirl/models/types/value_head.py
@@ -1,0 +1,35 @@
+"""Scalar value head for PPO-style critic training on AR hidden states."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ValueHead(nn.Module):
+    """Linear critic ``V(h)`` on the hidden state that predicts each action."""
+
+    def __init__(self, hidden_size: int, *, device: Any = None) -> None:
+        super().__init__()
+        self.proj = nn.Linear(hidden_size, 1, bias=True, dtype=torch.float32, device=device)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Start from ``V(s)=0``; deterministic and safe after sharded meta-init."""
+        nn.init.zeros_(self.proj.weight)
+        if self.proj.bias is not None:
+            nn.init.zeros_(self.proj.bias)
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        """Map ``[..., H]`` hidden states to FP32 scalar values ``[...]``."""
+        # FSDP mixed precision may expose gathered parameters in its compute
+        # dtype even when the sharded masters are FP32.
+        weight = self.proj.weight.float()
+        bias = self.proj.bias.float() if self.proj.bias is not None else None
+        return F.linear(hidden.float(), weight, bias).squeeze(-1)
+
+
+__all__ = ["ValueHead"]

--- a/unirl/types/advantages.py
+++ b/unirl/types/advantages.py
@@ -71,6 +71,34 @@ def compute_gae_advantages(
     return advantages, returns
 
 
+def scatter_terminal_rewards(
+    rewards_per_sample: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor,
+) -> torch.Tensor:
+    """Scatter each trajectory reward onto its final packed response token."""
+    if rewards_per_sample.ndim != 1:
+        raise ValueError(f"scatter_terminal_rewards: expected 1D rewards, got shape {tuple(rewards_per_sample.shape)}")
+    if cu_seqlens.ndim != 1 or cu_seqlens.numel() == 0:
+        raise ValueError("scatter_terminal_rewards: cu_seqlens must be a non-empty 1D tensor")
+    batch_size = int(cu_seqlens.numel()) - 1
+    if int(rewards_per_sample.numel()) != batch_size:
+        raise ValueError(
+            f"scatter_terminal_rewards: rewards batch ({int(rewards_per_sample.numel())}) "
+            f"!= packed batch ({batch_size})"
+        )
+
+    cu = [int(offset) for offset in cu_seqlens.tolist()]
+    if cu[0] != 0 or any(end < start for start, end in zip(cu, cu[1:])):
+        raise ValueError(f"scatter_terminal_rewards: invalid cumulative offsets {cu}")
+
+    token_rewards = rewards_per_sample.new_zeros(cu[-1])
+    for reward, start, end in zip(rewards_per_sample, cu, cu[1:]):
+        if end > start:
+            token_rewards[end - 1] = reward
+    return token_rewards
+
+
 def _gae_1d(
     rewards: torch.Tensor,
     values: torch.Tensor,

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -31,12 +31,14 @@ from unirl.distributed.tensor.batch import (
     shared_field,
 )
 from unirl.distributed.tensor.ref import hydrate
+from unirl.types.advantages import compute_gae_advantages as _compute_gae
+from unirl.types.advantages import scatter_terminal_rewards
 from unirl.types.conditions import Condition
 from unirl.types.media_preview import MediaPreview
 from unirl.types.primitives import Audios, Images, Texts, Videos, primitive_modality_key
 from unirl.types.sample_id import ancestor_id, child_id, parent_id
 from unirl.types.sampling import BaseSamplingParams
-from unirl.types.segments import Segment
+from unirl.types.segments import Segment, TextSegment
 from unirl.utils.shard_balance import lpt_shard_permutation, shard_token_spread
 
 logger = logging.getLogger(__name__)
@@ -417,6 +419,89 @@ class Part(Batch):
         else:
             adv = reshaped - mean
         return _part_with_field(self, "advantages", adv.flatten())
+
+    def compute_gae_advantages(
+        self,
+        *,
+        gamma: float = 1.0,
+        gae_lambda: float = 0.95,
+    ) -> "Part":
+        """Attach packed token advantages and returns for an AR PPO update.
+
+        ``loss_mask`` controls which tokens later contribute to the policy and
+        value losses. It deliberately does not control the GAE recursion:
+        masked actions are still states in the same trajectory, so terminal
+        reward must propagate across them.
+        """
+        if self.rewards is None:
+            raise ValueError("Part.compute_gae_advantages: part has no rewards")
+        if not isinstance(self.segment, TextSegment):
+            raise ValueError("Part.compute_gae_advantages: requires a TextSegment")
+        segment = self.segment
+        if segment.values is None:
+            raise ValueError("Part.compute_gae_advantages: segment.values is None")
+        if segment.cu_seqlens is None or segment.lengths is None:
+            raise ValueError(
+                "Part.compute_gae_advantages: segment requires framework-managed "
+                "cu_seqlens (construct via TextSegment.pack)"
+            )
+
+        values = hydrate(segment.values).to(torch.float32)
+        cu_seqlens = segment.cu_seqlens.to(device=values.device)
+        total_tokens = int(cu_seqlens[-1].item())
+        if values.ndim != 1 or int(values.numel()) != total_tokens:
+            raise ValueError(
+                "Part.compute_gae_advantages: values must be a packed 1D tensor "
+                f"with {total_tokens} elements, got shape {tuple(values.shape)}"
+            )
+
+        rewards = hydrate(self.rewards).to(device=values.device, dtype=torch.float32)
+        token_rewards = scatter_terminal_rewards(rewards, cu_seqlens=cu_seqlens)
+        token_advantages = values.new_zeros(values.shape)
+        token_returns = values.new_zeros(values.shape)
+        cu = [int(offset) for offset in cu_seqlens.tolist()]
+        for start, end in zip(cu, cu[1:]):
+            if end <= start:
+                continue
+            advantages, returns = _compute_gae(
+                token_rewards[start:end],
+                values[start:end],
+                gamma=gamma,
+                gae_lambda=gae_lambda,
+            )
+            token_advantages[start:end] = advantages
+            token_returns[start:end] = returns
+
+        segment_fields = {f.name: getattr(segment, f.name) for f in dc_fields(segment)}
+        segment_fields["token_advantages"] = token_advantages
+        segment_fields["returns"] = token_returns
+        updated_segment = segment._rebuild(segment_fields)
+
+        # Keep the existing per-sample advantage metric meaningful. The loss
+        # mask applies here only as a reduction mask, never as a done signal.
+        loss_mask = None
+        if segment.loss_mask is not None:
+            loss_mask = hydrate(segment.loss_mask).to(device=values.device, dtype=torch.bool)
+            if loss_mask.shape != values.shape:
+                raise ValueError(
+                    "Part.compute_gae_advantages: loss_mask shape "
+                    f"{tuple(loss_mask.shape)} != values shape {tuple(values.shape)}"
+                )
+        sample_advantages: List[torch.Tensor] = []
+        for start, end in zip(cu, cu[1:]):
+            if end <= start:
+                sample_advantages.append(values.new_zeros(()))
+                continue
+            selected = token_advantages[start:end]
+            if loss_mask is not None:
+                selected = selected[loss_mask[start:end]]
+            sample_advantages.append(selected.mean() if selected.numel() else values.new_zeros(()))
+        mean_advantages = (
+            torch.stack(sample_advantages) if sample_advantages else values.new_zeros((0,), dtype=torch.float32)
+        )
+
+        updated = _part_with_field(self, "segment", updated_segment)
+        return _part_with_field(updated, "advantages", mean_advantages)
 
 
 def _part_with_field(part: Part, field_name: str, value: Any) -> Part:

--- a/unirl/types/segments/text.py
+++ b/unirl/types/segments/text.py
@@ -43,6 +43,10 @@ class TextSegment(Segment):
     # Original engine emission retained when an algorithm replaces ``log_probs``
     # with a train-side replay anchor.
     rollout_log_probs: Optional[torch.Tensor] = packed_field(default=None)
+    # Optional PPO critic state, aligned one-to-one with packed response tokens.
+    values: Optional[torch.Tensor] = packed_field(default=None)
+    returns: Optional[torch.Tensor] = packed_field(default=None)
+    token_advantages: Optional[torch.Tensor] = packed_field(default=None)
 
     def as_condition_with(self, encoder: Callable[..., Any]) -> Condition:
         """Re-embed packed tokens via the supplied encoder into a TextEmbedCondition.


### PR DESCRIPTION
## Summary

Part 2/3 of #86: add the critic/value and GAE data path required by AR PPO. This branch has been rebuilt on the current `main`.

- Adds an optional scalar FP32 `ValueHead` for Qwen3.
- Keeps value-head initialization deterministically zero for both eager construction and meta-init + sharded checkpoint loading.
- Lets packed and padded Qwen3 replay return aligned per-token values through `ReplayResult.values`.
- Adds packed `values`, `returns`, and `token_advantages` fields to `TextSegment`.
- Adds terminal-reward scattering and per-trajectory GAE without cross-trajectory leakage.
- Preserves packed-segment metadata during GAE preparation and treats `loss_mask` as an optimization mask, not as an artificial trajectory boundary.

The PPO optimizer and trainer wiring remain in #259.

## Related Issue

Part of #86. #259 is stacked on this PR and should be reviewed/merged after this one.

## Test Plan

No PR-specific test files are included.

- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure` — all hooks passed.
- `python -m compileall -q unirl` — passed.
- Temporary, uncommitted correctness harness — passed:
  - eager and meta-init value heads start at exactly zero;
  - meta-init + real sharded checkpoint load matches eager load (`max_state_diff=0.0`);
  - packed replay values and log-probabilities stay token-aligned;
  - multi-trajectory GAE does not leak across sequence boundaries;
  - reward propagation continues across masked tokens while masked tokens remain excluded from optimization;
  - value-head backward gradient is finite and nonzero.
- GPU smoke on an H20 with a 9.8M-parameter tiny Qwen3 checkpoint — passed.

## Compatibility / Risk

- `use_value_head` defaults to `false`; existing Qwen3 GRPO behavior is unchanged.
- `return_values=false` preserves the legacy replay return type.
- Base Hugging Face checkpoints do not contain critic weights; the new head is initialized from scratch at zero.
- The value head is train-side only and must be excluded from rollout-engine weight sync; #259's recipe does this.

## Reviewer Notes

Please review packed/padded replay alignment and the meta-init post-load zeroing first. AI assistance was used; the final diff was reviewed and validated against the current repository state.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I validated the change without adding PR-specific test files.
