### PR TITLE
fix(distributed): fail fast on rank errors

### DIFF
--- a/unirl/distributed/group/device_pool.py
+++ b/unirl/distributed/group/device_pool.py
@@ -72,10 +72,29 @@ class DevicePool:
         self._worker_id_to_slot: Dict[str, int] = {}
         self._device_to_workers: Dict[int, List] = {}  # device_id → [slot0, slot1, ...]
         self._worker_by_id: Dict[str, Any] = {}  # worker_id → handle
+        self._poison_reason: Optional[str] = None
 
     @property
     def num_gpus(self) -> int:
         return self.num_devices
+
+    def mark_poisoned(self, *, rank: int, role_name: str, method_name: str, error: BaseException) -> None:
+        """Poison the pool with the first rank-local failure context."""
+        if self._poison_reason is not None:
+            return
+        error_text = str(error)
+        error_summary = error_text.splitlines()[0] if error_text else "<no message>"
+        self._poison_reason = (
+            f"rank={rank}, role={role_name!r}, method={method_name!r}, error={type(error).__name__}: {error_summary}"
+        )
+        logger.error("DevicePool poisoned: %s", self._poison_reason)
+
+    def assert_usable(self) -> None:
+        """Reject distributed RPCs after any rank-local actor task failure."""
+        if self._poison_reason is not None:
+            raise RuntimeError(
+                f"DevicePool is poisoned; refusing to issue another distributed RPC ({self._poison_reason})"
+            )
 
     @property
     def transport_cls(self) -> type:
@@ -292,6 +311,8 @@ class DevicePool:
         slot_id: Optional[int] = None,
     ) -> Handle:
         """Create a Handle for role_cls on this pool."""
+        self.assert_usable()
+
         from unirl.distributed.group.placement import current_placement
 
         if device_ids is None:

--- a/unirl/distributed/group/handle.py
+++ b/unirl/distributed/group/handle.py
@@ -255,12 +255,7 @@ class PendingHandleCall:
         self._discard_futures: Optional[List[Any]] = None
 
     def ready(self) -> bool:
-        """True once every worker succeeded. Raises on a ready rank-local error.
-
-        A failed rank is surfaced immediately even if peers are still pending
-        (for example stuck in NCCL). ``RolloutPool`` polls this path, so waiting
-        for every ref would hide the original error behind those peers.
-        """
+        """True when every rank succeeded; raise immediately on a ready rank-local error."""
         return inspect_ready_actor_results(
             self._refs,
             pool=self._handle.pool,

--- a/unirl/distributed/group/handle.py
+++ b/unirl/distributed/group/handle.py
@@ -17,6 +17,7 @@ from unirl.distributed.group.dispatch import (
     Execute,
     resolve_backward_dispatch_mode,
 )
+from unirl.distributed.group.ray_utils import get_actor_results, inspect_ready_actor_results
 from unirl.distributed.group.remote import RankInfo, Remote
 from unirl.distributed.tensor import TensorRef, WorkerLocalTransport, map_tree
 from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
@@ -254,9 +255,18 @@ class PendingHandleCall:
         self._discard_futures: Optional[List[Any]] = None
 
     def ready(self) -> bool:
-        """True once every worker's ref is resolved (non-blocking probe)."""
-        done, _ = ray.wait(self._refs, num_returns=len(self._refs), timeout=0)
-        return len(done) == len(self._refs)
+        """True once every worker succeeded. Raises on a ready rank-local error.
+
+        A failed rank is surfaced immediately even if peers are still pending
+        (for example stuck in NCCL). ``RolloutPool`` polls this path, so waiting
+        for every ref would hide the original error behind those peers.
+        """
+        return inspect_ready_actor_results(
+            self._refs,
+            pool=self._handle.pool,
+            role_name=self._handle.role_name,
+            method_name=self._method_name,
+        )
 
     def wait(self) -> None:
         """Block until completion and safely discard the collected return value."""
@@ -314,6 +324,7 @@ class PendingHandleCall:
                 self._refs,
                 worker_local=self._worker_local,
                 targets=self._targets,
+                method_name=self._method_name,
             )
         finally:
             self._release_leases()
@@ -347,6 +358,7 @@ class Slot:
     def launch(self, method_name: str, *args, **kwargs) -> PendingHandleCall:
         """Launch an undecorated role method on this worker."""
         handle = self._handle
+        handle.pool.assert_usable()
         if method_name in handle._method_configs:
             raise AttributeError(f"{method_name!r} is distributed; call it on the Handle")
         if not hasattr(_owning_class(handle.role_cls), method_name):
@@ -392,6 +404,7 @@ class Handle:
         init_kwargs: Optional[Dict[str, Any]] = None,
         slot_id: int = 0,
     ) -> None:  # noqa: D107 (args documented in class docstring)
+        pool.assert_usable()
         self.role_cls = role_cls
         self.pool = pool
         self.role_name = role_name or _make_role_name(role_cls)
@@ -440,8 +453,18 @@ class Handle:
         is_tp_engine = _is_sglang_rollout_role(role_cls)
         tp_visible_device_map: Dict[int, List[str]] = {}
         if is_tp_engine and any(rank_info.tp_size > 1 for rank_info in self.rank_infos):
-            node_ips = ray.get([worker.get_node_ip.remote() for worker in self.workers])
-            cuda_visible_devices = ray.get([worker.get_cuda_visible_devices.remote() for worker in self.workers])
+            node_ips = get_actor_results(
+                [worker.get_node_ip.remote() for worker in self.workers],
+                pool=self.pool,
+                role_name=self.role_name,
+                method_name="get_node_ip",
+            )
+            cuda_visible_devices = get_actor_results(
+                [worker.get_cuda_visible_devices.remote() for worker in self.workers],
+                pool=self.pool,
+                role_name=self.role_name,
+                method_name="get_cuda_visible_devices",
+            )
             tp_visible_device_map = _build_tp_visible_device_map(
                 self.rank_infos,
                 node_ips=node_ips,
@@ -470,7 +493,7 @@ class Handle:
                 kwargs["tp_visible_devices"] = tp_visible_device_map[i]
             return kwargs
 
-        ray.get(
+        get_actor_results(
             [
                 w.add_remote.remote(
                     self.role_name,
@@ -480,7 +503,10 @@ class Handle:
                     dist_env={"RANK": str(i), **self._dist_env_base},
                 )
                 for i, w in enumerate(self.workers)
-            ]
+            ],
+            pool=self.pool,
+            role_name=self.role_name,
+            method_name="add_remote",
         )
 
         self._method_configs: Dict[str, tuple] = {}
@@ -541,11 +567,22 @@ class Handle:
 
     def initialize(self, *args, **kwargs) -> None:
         """Call role.initialize(*args, **kwargs) on all workers."""
+        self.pool.assert_usable()
         ray.get(self.workers[0]._release_port.remote(self._group_port))
 
-        ray.get([w.call.remote(self.role_name, "initialize", args, kwargs) for w in self.workers])
+        get_actor_results(
+            [w.call.remote(self.role_name, "initialize", args, kwargs) for w in self.workers],
+            pool=self.pool,
+            role_name=self.role_name,
+            method_name="initialize",
+        )
 
-        self.rank_infos = ray.get([w.get_rank_info.remote(self.role_name) for w in self.workers])
+        self.rank_infos = get_actor_results(
+            [w.get_rank_info.remote(self.role_name) for w in self.workers],
+            pool=self.pool,
+            role_name=self.role_name,
+            method_name="get_rank_info",
+        )
 
     def _bind_methods(self, role_cls) -> None:
         """Scan role_cls for @distributed methods and create handle functions."""
@@ -611,6 +648,7 @@ class Handle:
                     refs,
                     worker_local=worker_local,
                     ray_get_timeout=ray_get_timeout,
+                    method_name=method_name,
                 )
             finally:
                 leases.clear()
@@ -646,6 +684,7 @@ class Handle:
         call_id: Optional[str],
     ) -> Tuple[List, bool, List]:
         """Launch a distributed call and retain localized argument leases."""
+        self.pool.assert_usable()
         batch_size = infer_batch_size(args, kwargs)
         if (
             dispatch_mode in (Dispatch.DP_SCATTER, Dispatch.DP_SCATTER_HEAD)
@@ -669,9 +708,16 @@ class Handle:
         worker_local: bool,
         ray_get_timeout: Optional[float] = None,
         targets: Optional[List[Any]] = None,
+        method_name: str = "call",
     ):
         """Resolve a launched call into its collected method return value."""
-        results = ray.get(refs, timeout=ray_get_timeout)
+        results = get_actor_results(
+            refs,
+            pool=self.pool,
+            role_name=self.role_name,
+            method_name=method_name,
+            timeout=ray_get_timeout,
+        )
         workers = self.workers if targets is None else targets
         results = [self._rebind_tree(r, workers[i], worker_local=worker_local) for i, r in enumerate(results)]
         return collect_fn(self, results)

--- a/unirl/distributed/group/ray_utils.py
+++ b/unirl/distributed/group/ray_utils.py
@@ -42,12 +42,7 @@ def inspect_ready_actor_results(
     role_name: str,
     method_name: str,
 ) -> bool:
-    """Non-blocking probe: True iff all ranks succeeded; raise on a ready failure.
-
-    Peers still running (for example stuck in NCCL) stay pending. A rank that has
-    already failed is surfaced immediately so ``PendingHandleCall.ready`` /
-    ``RolloutPool`` do not wait for those peers.
-    """
+    """True iff every rank succeeded; raise on a ready failure without waiting for peers."""
     ordered_refs = list(refs)
     if not ordered_refs:
         return True
@@ -81,16 +76,7 @@ def get_actor_results(
     method_name: str,
     timeout: Optional[float] = None,
 ) -> List[Any]:
-    """Collect actor task refs in completion order while returning rank order.
-
-    A list passed directly to ``ray.get`` waits for every ref before surfacing a
-    rank-local failure. Polling one completion at a time lets the controller
-    poison the pool as soon as the first failed actor task becomes observable.
-
-    ``timeout`` bounds the whole gather, matching ``ray.get(refs, timeout=)``:
-    on expiry it raises ``GetTimeoutError`` and leaves the pool unpoisoned, since
-    a slow peer is not yet an observed rank failure.
-    """
+    """Collect refs in completion order, returning rank order; poison the pool on the first failure."""
     ordered_refs = list(refs)
     if not ordered_refs:
         return []

--- a/unirl/distributed/group/ray_utils.py
+++ b/unirl/distributed/group/ray_utils.py
@@ -1,0 +1,126 @@
+"""Controller-side helpers for collecting Ray actor task results."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, List, Optional, Sequence
+
+import ray
+from ray.exceptions import GetTimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+def _poison_and_cancel(
+    *,
+    pool: Any,
+    rank: int,
+    role_name: str,
+    method_name: str,
+    error: BaseException,
+    pending: Sequence[Any],
+) -> None:
+    try:
+        pool.mark_poisoned(rank=rank, role_name=role_name, method_name=method_name, error=error)
+    except Exception:
+        logger.exception("Failed to mark DevicePool poisoned after actor task failure")
+
+    for pending_ref in pending:
+        try:
+            # Actor tasks cannot be force-cancelled safely. This is
+            # best-effort: a running task may continue until it exits.
+            ray.cancel(pending_ref, force=False)
+        except Exception:
+            logger.debug("Failed to cancel pending actor task", exc_info=True)
+
+
+def inspect_ready_actor_results(
+    refs: Sequence[Any],
+    *,
+    pool: Any,
+    role_name: str,
+    method_name: str,
+) -> bool:
+    """Non-blocking probe: True iff all ranks succeeded; raise on a ready failure.
+
+    Peers still running (for example stuck in NCCL) stay pending. A rank that has
+    already failed is surfaced immediately so ``PendingHandleCall.ready`` /
+    ``RolloutPool`` do not wait for those peers.
+    """
+    ordered_refs = list(refs)
+    if not ordered_refs:
+        return True
+
+    ready, pending = ray.wait(ordered_refs, num_returns=len(ordered_refs), timeout=0)
+    if not ready:
+        return False
+
+    index_by_ref = {ref: index for index, ref in enumerate(ordered_refs)}
+    for ready_ref in ready:
+        try:
+            ray.get(ready_ref)
+        except Exception as error:
+            _poison_and_cancel(
+                pool=pool,
+                rank=index_by_ref[ready_ref],
+                role_name=role_name,
+                method_name=method_name,
+                error=error,
+                pending=pending,
+            )
+            raise
+    return not pending
+
+
+def get_actor_results(
+    refs: Sequence[Any],
+    *,
+    pool: Any,
+    role_name: str,
+    method_name: str,
+    timeout: Optional[float] = None,
+) -> List[Any]:
+    """Collect actor task refs in completion order while returning rank order.
+
+    A list passed directly to ``ray.get`` waits for every ref before surfacing a
+    rank-local failure. Polling one completion at a time lets the controller
+    poison the pool as soon as the first failed actor task becomes observable.
+
+    ``timeout`` bounds the whole gather, matching ``ray.get(refs, timeout=)``:
+    on expiry it raises ``GetTimeoutError`` and leaves the pool unpoisoned, since
+    a slow peer is not yet an observed rank failure.
+    """
+    ordered_refs = list(refs)
+    if not ordered_refs:
+        return []
+
+    index_by_ref = {ref: index for index, ref in enumerate(ordered_refs)}
+    results: List[Any] = [None] * len(ordered_refs)
+    pending = ordered_refs
+    deadline = None if timeout is None else time.monotonic() + timeout
+
+    while pending:
+        remaining = None if deadline is None else max(deadline - time.monotonic(), 0.0)
+        ready, pending = ray.wait(pending, num_returns=1, timeout=remaining)
+        if not ready:
+            raise GetTimeoutError(
+                f"Timed out after {timeout}s waiting for {len(pending)} of "
+                f"{len(ordered_refs)} {role_name}.{method_name} actor tasks"
+            )
+        ready_ref = ready[0]
+        rank = index_by_ref[ready_ref]
+        try:
+            results[rank] = ray.get(ready_ref)
+        except Exception as error:
+            _poison_and_cancel(
+                pool=pool,
+                rank=rank,
+                role_name=role_name,
+                method_name=method_name,
+                error=error,
+                pending=pending,
+            )
+            raise
+
+    return results


### PR DESCRIPTION
## Summary
- collect Ray actor results in completion order while preserving rank-ordered outputs
- surface the first rank-local exception immediately and best-effort cancel pending sibling tasks
- poison the DevicePool after a distributed failure so checkpoint/teardown handles cannot enter another blocking RPC

## Root cause
`ray.get(refs)` waits for every rank result before raising any contained exception. If rank 0 OOMs before an FSDP collective while peers have already entered NCCL, the original OOM remains hidden until peer watchdogs time out roughly 30 minutes later. Teardown can then issue another distributed call and wait again.

Regular Ray actor tasks blocked in native NCCL cannot be force-cancelled safely. This change therefore makes the driver fail fast, marks the shared pool terminal, and prevents further Handle dispatch; actor cleanup remains owned by Ray when the driver exits.

## Validation
External tests are intentionally kept out of tree.

- mock success/error/order/poison regressions plus real local Ray actor integration: 5 passed
- Ruff check/format, compile, `git diff --check`, and repository hooks passed
- exact BAGEL 6-GPU full-FT OOM reproduction:
  - before: original OOM surfaced after ~50 minutes, following the 30-minute NCCL reduce-scatter watchdog
  - after: `RayTaskError(OutOfMemoryError)` surfaced in 1201s (~20 minutes total startup/generate/backward), immediately when rank 0 failed
  - DevicePool was poisoned at `UnifiedModelTrainStack_0.train_track`
  - checkpoint teardown was rejected immediately instead of dispatching another RPC
  - no NCCL watchdog wait; GPUs returned to the occupy workload

The e2e validation checkout also carried #252 locally to bypass the earlier, orthogonal TensorRef P2P lazy-communicator deadlock. This PR remains independently based on `main`.

## Test Plan
- [x] completion-order result collection preserves rank order
- [x] original first exception is re-raised
- [x] pending actor tasks receive best-effort cancellation
- [x] poisoned pool blocks subsequent Handle calls
- [x] real Ray actor first-error latency
- [x] exact 6-GPU OOM failure latency and teardown behavior
