### PR TITLE
feat(advantage): add GDPO per-reward-dimension decoupled group normalization

### DIFF
--- a/examples/diffusion/wan21_t2v_videoalign_gdpo.yaml
+++ b/examples/diffusion/wan21_t2v_videoalign_gdpo.yaml
@@ -1,0 +1,147 @@
+# @package _global_
+# GDPO Wan2.1 T2V — VideoAlign multi-dimension reward, 32 GPU (4x8) direct sampling.
+#
+# Variant of wan21_t2v_videoalign_dancegrpo.yaml that switches the advantage
+# estimator from scalar GRPO to GDPO: normalize each VideoAlign dimension
+# (vq/mq/ta) within its group, then aggregate — so a large-magnitude dimension
+# can't dominate the group signal. Only the advantage knobs differ:
+#   adv_decoupled: true                 -> use Part.compute_gdpo_advantages
+#   adv_component_weights: {vq,mq,ta}   -> the derived 'overall' (= vq+mq+ta) is
+#                                          excluded to avoid double-counting
+#
+# Requires VideoAlign checkpoint; set VIDEOALIGN_CKPT (+ VIDEOALIGN_QWEN_CKPT).
+
+num_devices: 32               # 4 nodes x 8 GPUs
+batch_size: 32                # prompts_per_rollout (x samples_per_prompt=24 -> 768 total)
+num_rollouts: 202
+
+# GDPO advantage: decouple the three VideoAlign reward dimensions.
+adv_decoupled: true
+adv_component_weights:
+  vq: 1.0
+  mq: 1.0
+  ta: 1.0
+
+bundle:
+  _target_: unirl.models.wan21.bundle.WAN21Bundle.from_config
+  config:
+    _target_: unirl.models.wan21.config.WAN21PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,/tmp/Wan2.1-T2V-1.3B-Diffusers}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp32
+    logprob_precision: fp32
+    shift: 3.0
+    max_sequence_length: 512
+
+pipeline:
+  _target_: unirl.models.wan21.pipeline.WAN21Pipeline
+  shift: 3.0
+  autocast_precision: bf16
+  trajectory_precision: fp32
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 5.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [diffusion]
+  forward_batch_size: 1
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.videoalign.VideoAlignRewardScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.videoalign.VideoAlignSpec
+      weight: 1.0
+      batch_size: 1
+      device: auto
+      checkpoint_path: ${oc.env:VIDEOALIGN_CKPT,./videoalign_ckpt}
+      dtype: bf16
+      vq_coef: 1.0
+      mq_coef: 1.0
+      ta_coef: 1.0
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 16
+  guidance_scale: 5.0
+  height: 480
+  width: 480
+  num_frames: 9
+  eta: 0.25
+  samples_per_prompt: 24
+  seed: 42
+  init_same_noise: true
+  autocast_precision: bf16
+  trajectory_precision: fp32
+  logprob_precision: fp32
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.6]
+    num_sde_steps: 8
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v-videoalign}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan21_t2v_videoalign_gdpo_32gpu}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan21", "t2v", "gdpo", "videoalign", "32gpu", "direct-sampling"]
+  log_media: false
+  media_max_items: 0
+  media_log_interval: 1

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -55,6 +55,8 @@ def main(cfg: DictConfig) -> None:
         reward_fraction=cfg.get("reward_fraction", 0.0),
         enable_fsdp_offload=cfg.get("enable_fsdp_offload", False),
         adv_use_global_std=cfg.get("adv_use_global_std", False),
+        adv_decoupled=cfg.get("adv_decoupled", False),
+        adv_component_weights=cfg.get("adv_component_weights"),
         eval_interval=cfg.get("eval_interval", 0),
         eval_num_prompts=cfg.get("eval_num_prompts", 64),
         eval_samples_per_prompt=cfg.get("eval_samples_per_prompt", 4),

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -51,6 +51,8 @@ class DiffusionTrainer(BaseTrainer):
         reward_fraction: float = 0.0,
         enable_fsdp_offload: bool = False,
         adv_use_global_std: bool = False,
+        adv_decoupled: bool = False,
+        adv_component_weights: Optional[Dict[str, float]] = None,
         eval_interval: int = 0,
         eval_num_prompts: int = 64,
         eval_samples_per_prompt: int = 4,
@@ -74,6 +76,12 @@ class DiffusionTrainer(BaseTrainer):
         # ``use_global_std=True`` scale) instead of each prompt's own std. Off by
         # default → unchanged per-group GRPO normalization for every other recipe.
         self._adv_use_global_std = bool(adv_use_global_std)
+        # GDPO: when True, normalize each component_rewards dimension per group
+        # (via Part.compute_gdpo_advantages) instead of the pre-summed scalar.
+        # adv_component_weights selects + weights the dims (None ⇒ all at 1.0).
+        # Off by default → unchanged scalar GRPO advantage.
+        self._adv_decoupled = bool(adv_decoupled)
+        self._adv_component_weights = dict(adv_component_weights) if adv_component_weights else None
         # Periodic eval on the eval set (run.eval_data_path), logged under eval/*.
         # eval_interval=0 disables it (zero-impact for runs that don't set it).
         # Diffusion eval generates at the deterministic best-quality setting
@@ -511,7 +519,16 @@ class DiffusionTrainer(BaseTrainer):
             if isinstance(part.component_rewards, dict):
                 part.component_rewards = {name: hydrate(value) for name, value in part.component_rewards.items()}
             mean_reward = float(part.rewards.to(torch.float32).mean().item())
-            part = part.compute_advantages(normalize=True, use_global_std=self._adv_use_global_std)
+            if self._adv_decoupled:
+                if not (isinstance(part.component_rewards, dict) and part.component_rewards):
+                    raise ValueError(
+                        "adv_decoupled=True but the scored part has no component_rewards; "
+                        "GDPO needs a multi-dimension reward (e.g. VideoAlign vq/mq/ta or a "
+                        "composite scorer). Set adv_decoupled=false for a scalar reward."
+                    )
+                part = part.compute_gdpo_advantages(weights=self._adv_component_weights)
+            else:
+                part = part.compute_advantages(normalize=True, use_global_std=self._adv_use_global_std)
             sample = sample.with_parts([*sample.parts[:-1], part])
 
         self._drop_decoded(sample, rollout_id=rollout_id)

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -418,6 +418,66 @@ class Part(Batch):
             adv = reshaped - mean
         return _part_with_field(self, "advantages", adv.flatten())
 
+    def compute_gdpo_advantages(
+        self,
+        weights: Optional[Dict[str, float]] = None,
+        *,
+        eps: float = 1e-8,
+        group_layer: Optional[int] = None,
+        whiten: bool = True,
+    ) -> "Part":
+        """GDPO — per-reward-dimension decoupled group normalization.
+
+        Normalizes each dimension in :attr:`component_rewards` within its group
+        (the GRPO step, per dimension), weighted-sums the results, then
+        batch-whitens — so a large-magnitude reward can't drown out a weaker one,
+        unlike scalar :meth:`compute_advantages` on the pre-summed reward.
+        Mirrors verl ``compute_gdpo_outcome_advantage``.
+
+        ``weights`` maps a component key to its weight and doubles as a selector:
+        only listed keys participate (each must exist in ``component_rewards``);
+        ``None`` uses all with weight 1.0. Pass explicit keys to exclude a derived
+        component (e.g. VideoAlign ``overall`` = vq+mq+ta) from double-counting.
+        """
+        if not self.component_rewards:
+            raise ValueError(
+                "Part.compute_gdpo_advantages: part has no component_rewards; "
+                "GDPO requires a multi-dimension reward (e.g. VideoAlign vq/mq/ta or a "
+                "composite scorer). Use compute_advantages for a scalar reward."
+            )
+        components = self.component_rewards
+        if weights is not None:
+            missing = [k for k in weights if k not in components]
+            if missing:
+                raise ValueError(
+                    f"compute_gdpo_advantages: weight keys {missing} not in "
+                    f"component_rewards (have {sorted(components.keys())})."
+                )
+            selected = {k: float(w) for k, w in weights.items()}
+        else:
+            selected = {k: 1.0 for k in components}
+
+        n = len(self.sample_ids)
+        adv_sum: Optional[torch.Tensor] = None
+        for key, w in selected.items():
+            comp = hydrate(components[key]).to(torch.float32)
+            if comp.numel() != n:
+                raise ValueError(
+                    f"compute_gdpo_advantages: component {key!r} has {comp.numel()} "
+                    f"values but the part has {n} samples."
+                )
+            # Per-group normalize this component (reuse the scalar GRPO path).
+            comp_part = _part_with_field(self, "rewards", comp)
+            a_k = comp_part.compute_advantages(
+                normalize=True, scope="group", eps=eps, group_layer=group_layer
+            ).advantages
+            term = w * a_k
+            adv_sum = term if adv_sum is None else adv_sum + term
+
+        if whiten:
+            adv_sum = (adv_sum - adv_sum.mean()) / (adv_sum.std() + eps)
+        return _part_with_field(self, "advantages", adv_sum)
+
 
 def _part_with_field(part: Part, field_name: str, value: Any) -> Part:
     """Copy of ``part`` with one field replaced."""


### PR DESCRIPTION
## Summary

Adds **GDPO** (per-reward-dimension decoupled group normalization) as an opt-in
advantage estimator for diffusion RL.

For a multi-dimension reward (e.g. VideoAlign's `vq`/`mq`/`ta`, or any composite
scorer that emits `component_rewards`), scalar GRPO first weighted-sums the
dimensions into one reward and normalizes that single scalar per group — so the
largest-magnitude dimension dominates the group signal and a weak-but-real one
gets drowned out. GDPO instead:

1. normalizes **each** reward dimension within its group (`A_k = (r_k - μ_group)/(σ_group + ε)`),
2. weighted-aggregates the per-dimension advantages (`A_sum = Σ_k w_k·A_k`), then
3. batch-whitens (`(A_sum - mean)/(std + ε)`).

Changes:
- `Part.compute_gdpo_advantages` in `unirl/types/sample.py`. Step 1 reuses
  `Part.compute_advantages(scope="group")` per dimension, so the group-by-parent
  contiguity/uniform-size validation and `branch=1` degeneration are shared with
  the scalar path. Mirrors verl `compute_gdpo_outcome_advantage`.
- Wired through `DiffusionTrainer` behind two recipe knobs: `adv_decoupled`
  (default `false`) and `adv_component_weights` (selects + weights the
  participating dimensions). When `adv_decoupled=true` but the scored part has no
  `component_rewards`, it fails loud rather than silently falling back to GRPO.
- Demo recipe `examples/diffusion/wan21_t2v_videoalign_gdpo.yaml` (WAN2.1 T2V +
  VideoAlign; the derived `overall` component is deliberately excluded from
  `adv_component_weights` to avoid double-counting `vq+mq+ta`).

## Related Issue

N/A

## Test Plan

- Hydra compose+resolve through the entrypoint:
  `python -m unirl.train_diffusion --config-name=diffusion/wan21_t2v_videoalign_gdpo --cfg job --resolve`
  → exit 0; `adv_decoupled: true` and `adv_component_weights: {vq,mq,ta}` resolve.
- Recipe `_target_` guard:
  `python scripts/check_recipe_targets.py examples/diffusion/wan21_t2v_videoalign_gdpo.yaml`
  → all paths resolve.
- Import smoke:
  `python -c "from unirl.trainer.diffusion import DiffusionTrainer; import unirl.train_diffusion"`
  → OK.
- Logic: validated locally with 9 CPU unit tests (hand-computed per-component
  group norm, whiten, weighting, selector-excludes-derived-component,
  single-component ≡ GRPO, all-constant → zero advantage / no-NaN, and 3 error
  paths) → **9 passed**. Not included in this PR since `main` currently has no
  `tests/` suite; happy to add them under a tests dir if maintainers prefer.
- Full 32-GPU training run: **Not run; reason:** no multi-node GPU access in this
  environment.

## Compatibility / Risk

Additive and opt-in. `adv_decoupled` defaults to `false`, so every existing
scalar-reward recipe keeps unchanged per-group GRPO normalization. No checkpoint,
data-format, or API changes. The only behavior change is for recipes that
explicitly set `adv_decoupled: true`, which additionally requires the reward to
emit `component_rewards` (enforced with a fail-loud error).

## Reviewer Notes

- **AI assistance:** implemented with Claude Code; the submitter reviewed every
  changed line.
- **Duplicate-work check:** no open PR or issue on this repo addresses GDPO /
  per-reward-dimension decoupled normalization (checked open PRs and issues).
- **Design choice to sanity-check:** `compute_gdpo_advantages` reuses
  `compute_advantages(scope="group")` per component instead of duplicating the
  group-reshape/validation, and `weights` doubles as a component *selector* so a
  derived component (VideoAlign `overall`) can be left out. Open to feedback if
  you'd prefer an explicit `keys` argument separate from `weights`.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated configs (demo recipe) where needed; tests validated locally and
      omitted from the PR as explained in the Test Plan.
