### PR TITLE
fix(rollout/sglang_diffusion): port video adapters off the deleted RolloutReq

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/adapters/video.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/video.py
@@ -33,7 +33,6 @@ from unirl.rollout.engine.sglang_diffusion.adapters.base import register_adapter
 from unirl.rollout.engine.sglang_diffusion.adapters.image import ImageAdapter
 from unirl.rollout.engine.sglang_diffusion.backends import RawResult
 from unirl.types.conditions.text import TextEmbedCondition
-from unirl.types.rollout_req import RolloutReq
 from unirl.types.sample import Sample
 from unirl.types.sampling import DiffusionSamplingParams
 from unirl.types.segments.latent import make_video_segment
@@ -224,14 +223,14 @@ class Ltx2T2VAdapter(VideoAdapter):
 
         return build_ltx2_schedule_policy(float(self.model_config.shift))
 
-    def build_sampling(self, req: RolloutReq, *, diffusion: Any) -> Dict[str, Any]:
-        kwargs = super().build_sampling(req, diffusion=diffusion)
+    def build_sampling(self, sample: Sample, *, diffusion: Any) -> Dict[str, Any]:
+        kwargs = super().build_sampling(sample, diffusion=diffusion)
         kwargs["max_sequence_length"] = int(self.model_config.max_sequence_length)
 
         from unirl.models.ltx2.diffusion import audio_latent_shape
         from unirl.types.noise_recipe import NoiseRecipe
 
-        audio_noise = NoiseRecipe.from_rollout_req(req).resolve(
+        audio_noise = NoiseRecipe.from_sample(sample).resolve(
             salt="audio",
             latent_shape=audio_latent_shape(diffusion),
         )
@@ -282,7 +281,7 @@ class Ltx2T2VAdapter(VideoAdapter):
 
     def build_segment(
         self,
-        req: RolloutReq,
+        sample: Sample,
         results: List[RawResult],
         *,
         num_steps: int,
@@ -312,7 +311,7 @@ class Ltx2T2VAdapter(VideoAdapter):
         return utils.build_latent_segment(
             traj,
             results=results,
-            expected_sigmas=req.sigmas,
+            expected_sigmas=sample.frontier_gen_part(DiffusionSamplingParams).sampling_params.sigmas,
             num_steps=num_steps,
             sde_indices=sde_indices,
             emit_native_logprob=emit_native_logprob,


### PR DESCRIPTION
## Summary

`unirl/rollout/engine/sglang_diffusion/adapters/video.py` on `main` still imports
`unirl.types.rollout_req`, which #214 deleted when `Sample`/`Part` replaced the
`RolloutReq`/`RolloutResp` triplet. The import is unguarded and
`adapters/__init__.py` pulls the whole module in for its `@register_adapter`
side-effects, so importing the `sglang_diffusion` engine currently fails:

```
File "unirl/rollout/engine/sglang_diffusion/adapters/video.py", line 36, in <module>
    from unirl.types.rollout_req import RolloutReq
ModuleNotFoundError: No module named 'unirl.types.rollout_req'
```

Because all the video families share that module, this takes down WAN 2.1 / 2.2,
HunyuanVideo and Mochi along with LTX-2 — not just the family added in #233.

Behind that import, `Ltx2T2VAdapter` has two more leftovers that would each raise
`AttributeError` once the module loads:

- `NoiseRecipe.from_rollout_req(req)` — renamed to `from_sample`.
- `expected_sigmas=req.sigmas` — `Sample` has no `sigmas` field; the schedule now
  lives on the frontier gen part.

This PR ports all three to the current API. The replacements are not new
conventions: `sample.frontier_gen_part(DiffusionSamplingParams).sampling_params.sigmas`
is exactly what the already-ported `image.py` and the `VideoAdapter` base class in
this same file do — the parent method was migrated and the LTX-2 subclass was not.

## Related Issue

N/A

## Test Plan

Reproduced against pristine `main` (`5d034c3`) and re-run after the fix:

- Repro before the fix — `python -c "import unirl.rollout.engine.sglang_diffusion.adapters"`
  → `ModuleNotFoundError: No module named 'unirl.types.rollout_req'`.
- After the fix the same import succeeds and every family resolves:
  `python -c "from unirl.rollout.engine.sglang_diffusion.adapters import get_adapter, registered_adapters"`
  → registry `['flux', 'flux2_klein', 'hunyuan_video', 'ltx2', 'mochi', 'qwen_image', 'qwen_image_edit_plus', 'sd3', 'wan21', 'wan22', 'z_image']`;
  `get_adapter` returns `Wan21T2VAdapter` / `Wan22T2VAdapter` / `HunyuanVideoAdapter` /
  `MochiAdapter` / `Ltx2T2VAdapter` respectively.
- `SKIP=no-commit-to-branch pre-commit run --from-ref upstream/main --to-ref HEAD`
  → `ruff check` / `ruff format` / `recipe _target_ paths resolve` all pass
  (`check-recipe-targets: 2209 unirl _target_ paths resolve`).
- `pytest`: not run; reason: the tests directory was removed in #267, so there is
  no suite on `main` to run.
- LTX-2 rollout smoke: not run; reason: no LTX-2 checkpoint or AV-capable node
  available here. The two `AttributeError` sites are only reachable inside an
  LTX-2 rollout, so they are verified by API inspection against `Sample` and by
  parity with `image.py` / `VideoAdapter.build_segment`, not by execution. Someone
  with the #233 setup should confirm `ltx2_t2v_sglang_loramerge.yaml` end to end.

## Compatibility / Risk

No config, checkpoint, data-format or resource changes. The only externally
visible change is the parameter name on two `Ltx2T2VAdapter` methods (`req` →
`sample`); both are called positionally and both now match the base-class
signature they override, so this removes a mismatch rather than introducing one.

The `expected_sigmas` line is the one behavioral change worth a close look: it
must read the same schedule the worker actually used, and it now takes the
frontier gen part's `sampling_params.sigmas`. If LTX-2 is meant to source its
sigmas from somewhere else, that is the line to correct.

## Reviewer Notes

- Found while merging `main` into a downstream branch; the breakage is on
  pristine `main`, not a merge artifact. No bisect needed — #214 deleted the
  module and #233 added `Ltx2T2VAdapter` against the old API in the same range.
- No regression test is included because #267 removed the tests directory. If you
  want a guard against this class of breakage, an import-only smoke over
  `unirl.rollout.engine.*` in CI would have caught it.
- Duplicate-work check: no open PR touches `adapters/video.py` and no open issue
  reports the import failure, as of opening this PR.
- AI assistance: prepared with Claude Code. The diff is five lines and was
  reviewed line by line against the current `Sample` API.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
