### PR TITLE
fix(bagel): rebuild replay KV contexts in eval() so navit keeps inference dispatch

### DIFF
--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -308,30 +308,21 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         clean_prompt = str(prompt).removeprefix("<|im_start|>").removesuffix("<|im_end|>")
         gen = inf.init_gen_context()
         cfg_img = deepcopy(gen)
-        # eval() is load-bearing, same contract as ``rl_ops.forward_flow``: the
-        # vendored inferencer reaches the navit through its *inference*
-        # (packed-query) signature, and every navit module dispatches
-        # ``forward_train`` vs ``forward_inference`` on ``self.training``, so
-        # train() mode routes the packed kwargs into ``forward_train`` →
-        # "unexpected keyword argument 'packed_query_sequence'".
-        # ``TrainStack.train_track`` puts the model in train() before the
-        # gradient-bearing replay (HF gradient checkpointing is gated on it), so
-        # replay arrives here in train() mode. Restoring the caller's mode is safe
-        # because nothing here is gradient-bearing — the und/text path is frozen
-        # and the whole block runs under ``no_grad``, so no activation-checkpoint
-        # recompute can revisit it during ``.backward()``.
+        # eval() is load-bearing (same contract as ``rl_ops.forward_flow``): navit
+        # dispatches ``forward_train`` vs ``forward_inference`` on ``self.training``
+        # and ``update_context_text`` uses the packed-query inference signature,
+        # while ``TrainStack.train_track`` leaves the model in train() before the
+        # gradient-bearing replay.
         mot = self.model.transformer
         was_training = mot.training
-        if was_training:
-            mot.eval()
+        mot.eval()
         try:
             with torch.no_grad(), self._autocast_ctx(device):
                 cfg_text = deepcopy(gen)  # snapshot before the prompt text → unconditional
                 gen = inf.update_context_text(clean_prompt, gen)
                 cfg_img = inf.update_context_text(clean_prompt, cfg_img)
         finally:
-            if was_training:
-                mot.train()
+            mot.train(was_training)
         return gen, cfg_text, cfg_img
 
     def _resolve_single(self, conditions: BagelDiffusionConditions) -> Tuple[Any, Any, Any, Tuple[int, int]]:

--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -308,10 +308,30 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         clean_prompt = str(prompt).removeprefix("<|im_start|>").removesuffix("<|im_end|>")
         gen = inf.init_gen_context()
         cfg_img = deepcopy(gen)
-        with torch.no_grad(), self._autocast_ctx(device):
-            cfg_text = deepcopy(gen)  # snapshot before the prompt text → unconditional
-            gen = inf.update_context_text(clean_prompt, gen)
-            cfg_img = inf.update_context_text(clean_prompt, cfg_img)
+        # eval() is load-bearing, same contract as ``rl_ops.forward_flow``: the
+        # vendored inferencer reaches the navit through its *inference*
+        # (packed-query) signature, and every navit module dispatches
+        # ``forward_train`` vs ``forward_inference`` on ``self.training``, so
+        # train() mode routes the packed kwargs into ``forward_train`` →
+        # "unexpected keyword argument 'packed_query_sequence'".
+        # ``TrainStack.train_track`` puts the model in train() before the
+        # gradient-bearing replay (HF gradient checkpointing is gated on it), so
+        # replay arrives here in train() mode. Restoring the caller's mode is safe
+        # because nothing here is gradient-bearing — the und/text path is frozen
+        # and the whole block runs under ``no_grad``, so no activation-checkpoint
+        # recompute can revisit it during ``.backward()``.
+        mot = self.model.transformer
+        was_training = mot.training
+        if was_training:
+            mot.eval()
+        try:
+            with torch.no_grad(), self._autocast_ctx(device):
+                cfg_text = deepcopy(gen)  # snapshot before the prompt text → unconditional
+                gen = inf.update_context_text(clean_prompt, gen)
+                cfg_img = inf.update_context_text(clean_prompt, cfg_img)
+        finally:
+            if was_training:
+                mot.train()
         return gen, cfg_text, cfg_img
 
     def _resolve_single(self, conditions: BagelDiffusionConditions) -> Tuple[Any, Any, Any, Tuple[int, int]]:


### PR DESCRIPTION
## Summary

BAGEL FlowGRPO died in the training forward with:

```
TypeError: Qwen2Model.forward_train() got an unexpected keyword argument 'packed_query_sequence'
```

Every vendored navit module dispatches `forward_train` vs `forward_inference` on `self.training`. The vllm_omni rollout ships only the prompt text (KV caches cannot cross the worker->driver IPC boundary), so replay rebuilds the three KV contexts trainer-side through the vendored inferencer's *inference* (packed-query) signature. `TrainStack.train_track` puts the model in `train()` before the gradient-bearing replay so HF gradient checkpointing engages, so the rebuild arrived in `train()` mode and the packed kwargs were routed into `forward_train`.

`rl_ops.forward_flow` already forces `eval()` for exactly this reason, and `require_inference_dispatch` documents the contract ("replay runs in eval() with grads enabled") — the context rebuild was the one vendored inference-signature call in the replay path still missing the guard. Restoring the caller's mode afterwards is safe: the und/text path is frozen and the block already runs under `no_grad`, so no activation-checkpoint recompute revisits it during `.backward()`.

Only the deferred-prompt path is affected; a trainside/colocate rollout carries opaque contexts and `has_contexts()` short-circuits before the rebuild, which is why this surfaced only on the vllm_omni BAGEL recipe.

## Related Issue

N/A

## Test Plan

Ran on one 8xH20 pod with `main`'s own recipe forced onto two slabs:

```
python -m unirl.train_diffusion --config-name=diffusion/bagel/bagel_vllmomni \
  +layout=separate +train_fraction=0.5 num_devices=8 +devices_per_node=8 \
  num_rollouts=1 weight_sync_interval=4 \
  sync._target_=unirl.distributed.weight_sync.lora.RemoteLoraWeightSync \
  rollout.config.enable_sleep_mode=false transport_kind=colocate_store
```

Result: a complete `generate -> reward -> train` step, `navit_dispatch_errors=0`, optimizer step finishing.

Reaching the training forward at all on this recipe additionally requires #276, which fixes an unrelated `PR_SET_PDEATHSIG` bug that SIGKILLs healthy `DiffusionWorker`s before the first `generate`. The acceptance run above was executed with that fix also applied. This PR is independent of it and touches a disjoint file.

`ruff check` / `ruff format` clean, and the full pre-commit suite (including `check-recipe-targets`) passes via the pre-push hook.

## Compatibility / Risk

No config, checkpoint, data-format or API change. One behavioural change confined to one function: the `eval()` guard is scoped to the frozen, `no_grad` context rebuild and restores the caller's mode, so gradient checkpointing for the trained surface is untouched.

## Reviewer Notes

This PR was originally filed bundled with a `PR_SET_PDEATHSIG` fix in `unirl/rollout/engine/vllm_omni/patches/runtime.py`. That half has been dropped and the branch rewritten (force-push `1c20d989` -> `81ca0c23`), because #276 fixes the same bug, was filed first, and carries the correct root-cause account. See the discussion on #276 for the kernel probe that settles it.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.