### PR TITLE
fix(ci): restore pull-requests write for PR label workflows

### DIFF
--- a/.github/workflows/pr-review-status-labels.yml
+++ b/.github/workflows/pr-review-status-labels.yml
@@ -10,7 +10,9 @@ on:
 
 permissions:
   actions: read
-  pull-requests: read
+  # Labeling a PR goes through the issues API endpoint, but GitHub scopes the
+  # token check to the target resource: PRs require pull-requests write.
+  pull-requests: write
   issues: write
 
 concurrency:

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
 
 permissions:
+  # Labeling a PR goes through the issues API endpoint, but GitHub scopes the
+  # token check to the target resource: PRs require pull-requests write.
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

- restore `pull-requests: write` in `pr-status-labels.yml` and upgrade `pull-requests: read` to `write` in `pr-review-status-labels.yml`

#245 narrowed both label workflows to `issues: write` only. GitHub scopes the `GITHUB_TOKEN` permission check to the target resource, not the API route: adding/removing labels on a **pull request** via the `/issues/{number}/labels` endpoint requires `pull-requests: write`, and `issues: write` alone yields `HTTP 403 Resource not accessible by integration`. Since #245 merged (2026-07-30 02:39 +0800):

- every PR created after it (#274 onward) has no status label — the `pull_request_target` runs that actually attempt a write all fail (e.g. runs 30604978090, 30605327515); the interleaved "success" runs are early-exit no-ops, not real writes
- the new privileged review workflow 403s the same way on its first real write (run 30608729025), so the fork review-label sync #245 set out to fix still doesn't work

The two-stage `workflow_run` privilege-separation design from #245 is kept as-is; this only fixes the token scope.

## Related Issue

N/A (regression from #245).

## Test Plan

- `SKIP=no-commit-to-branch uvx --from pre-commit pre-commit run --files .github/workflows/pr-status-labels.yml .github/workflows/pr-review-status-labels.yml` — all hooks pass
- parsed both workflows with PyYAML
- verified the root cause from Actions logs: with `issues: write` only, every real label write fails `HTTP 403`; pre-#245 the same script with `pull-requests: write` labeled PRs correctly for three weeks (#180)
- verified `gh pr view --json reviewDecision` returns real values on this repo (e.g. #266 `APPROVED`), so the `workflow_dispatch` bulk reconciliation is safe to run
- end-to-end Actions verification requires the workflows on the default branch; after merge, run `gh workflow run pr-review-status-labels.yml` once to backfill labels for the ~10 PRs opened since #274

## Compatibility / Risk

CI-only change; no application code touched. Widens the two workflows' token from `issues: write` to also allow PR writes — both run repo-side scripts only and never check out or execute pull-request-controlled content, so the #245 security boundary is unchanged.

## Reviewer Notes

Root-caused and implemented with Claude Code assistance; the diff was reviewed before publication. Duplicate-work check: #237 is the superseded predecessor of #245 (suppresses fork writes instead of fixing them) and can be closed independently; no other open PR touches these workflows.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
