### PR TITLE
fix(vllm-omni): gather LoRA checksum read-backs from every TP rank

### DIFF
--- a/unirl/rollout/engine/vllm_omni/backends/native.py
+++ b/unirl/rollout/engine/vllm_omni/backends/native.py
@@ -43,6 +43,7 @@ from unirl.rollout.engine.vllm_omni.backends.base import (
     OmniRawResult,
     StageSampling,
 )
+from unirl.rollout.engine.vllm_omni.tp_readback import unwrap_tp_rank_readbacks
 from unirl.utils.graceful_shutdown import terminate_descendants
 
 logger = logging.getLogger(__name__)
@@ -761,9 +762,10 @@ class VLLMOmniBackend:
                 args=(list(names),),
                 stage_ids=[int(sid)],
             )
-            # collective_rpc returns ``[stage_results]`` where stage_results
-            # is ``[rank0, rank1, ...]`` — strip the outer list.
-            out[int(sid)] = results[0] if isinstance(results, list) and results else results
+            # ``collective_rpc`` runs on every rank but only rank 0's reply is
+            # returned, so the per-rank list has to come from the worker-side
+            # gather rather than from this transport.
+            out[int(sid)] = unwrap_tp_rank_readbacks(results)
         return out
 
     def lora_checksums(self, *, adapter_id: int, names: Optional[List[str]]) -> dict:
@@ -776,7 +778,7 @@ class VLLMOmniBackend:
                 args=(int(adapter_id), list(names) if names else None),
                 stage_ids=[int(sid)],
             )
-            out[int(sid)] = results[0] if isinstance(results, list) and results else results
+            out[int(sid)] = unwrap_tp_rank_readbacks(results)
         return out
 
 

--- a/unirl/rollout/engine/vllm_omni/tp_readback.py
+++ b/unirl/rollout/engine/vllm_omni/tp_readback.py
@@ -1,15 +1,8 @@
 """Envelope for returning one result per TP rank from a worker RPC.
 
-vLLM-Omni's ``collective_rpc`` executes the method on every rank, but only
-rank 0 owns a result queue — the other ranks' return values are dropped. A
-worker method that needs to report per-rank state therefore has to gather it
-itself and hand the whole set back inside rank 0's single reply.
-
-The key lives here, rather than in either side, so it cannot drift between the
-worker process that writes the envelope and the driver-side backend that reads
-it. This module deliberately imports nothing: the worker side already pulls in
-torch and vllm, while ``backends/native.py`` defers its vllm-omni import to keep
-the driver process light, so neither can import the other at module scope.
+``collective_rpc`` runs on every rank but only rank 0's reply survives, so
+per-rank state must be gathered worker-side. Imports nothing: the worker and
+driver processes cannot import each other's modules at module scope.
 """
 
 from __future__ import annotations
@@ -28,14 +21,9 @@ _MAX_TRANSPORT_NESTING = 4
 def unwrap_tp_rank_readbacks(results: Any) -> Any:
     """Strip RPC transport wrappers and return the per-TP-rank list.
 
-    Checks for the envelope *before* each unwrap step, so a reply that is
-    itself a one-element list is returned intact rather than being unwrapped
-    into its only element.
-
-    A payload with no envelope passes through unchanged rather than raising:
-    it then reaches ``_assert_loaded``, whose existing shape check reports it
-    precisely ("expected N TP rank readbacks, got ..."). Failing here instead
-    would replace that message with a less specific one.
+    Checks for the envelope before each unwrap step, so a genuine one-element
+    payload is not unwrapped past itself. A payload with no envelope passes
+    through, leaving ``_assert_loaded`` to report the shape.
     """
     value = results
     for _ in range(_MAX_TRANSPORT_NESTING):

--- a/unirl/rollout/engine/vllm_omni/tp_readback.py
+++ b/unirl/rollout/engine/vllm_omni/tp_readback.py
@@ -5,16 +5,16 @@ rank 0 owns a result queue — the other ranks' return values are dropped. A
 worker method that needs to report per-rank state therefore has to gather it
 itself and hand the whole set back inside rank 0's single reply.
 
-Both halves of that envelope live here so the key cannot drift between the
-worker process that writes it and the driver-side backend that reads it. This
-module deliberately imports nothing: the worker side already pulls in torch and
-vllm, while ``backends/native.py`` defers its vllm-omni import to keep the
-driver process light, so neither can import the other at module scope.
+The key lives here, rather than in either side, so it cannot drift between the
+worker process that writes the envelope and the driver-side backend that reads
+it. This module deliberately imports nothing: the worker side already pulls in
+torch and vllm, while ``backends/native.py`` defers its vllm-omni import to keep
+the driver process light, so neither can import the other at module scope.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Sequence
+from typing import Any
 
 TP_RANK_RESULTS_KEY = "__diffrl_tp_rank_results__"
 
@@ -25,18 +25,17 @@ TP_RANK_RESULTS_KEY = "__diffrl_tp_rank_results__"
 _MAX_TRANSPORT_NESTING = 4
 
 
-def wrap_tp_rank_results(per_rank: Sequence[Any]) -> Dict[str, List[Any]]:
-    """Package one entry per TP rank for the trip back through rank 0."""
-    return {TP_RANK_RESULTS_KEY: list(per_rank)}
-
-
 def unwrap_tp_rank_readbacks(results: Any) -> Any:
     """Strip RPC transport wrappers and return the per-TP-rank list.
 
     Checks for the envelope *before* each unwrap step, so a reply that is
     itself a one-element list is returned intact rather than being unwrapped
-    into its only element. Payloads without the envelope (a worker build
-    predating it, or a backend that never gathers) pass through unchanged.
+    into its only element.
+
+    A payload with no envelope passes through unchanged rather than raising:
+    it then reaches ``_assert_loaded``, whose existing shape check reports it
+    precisely ("expected N TP rank readbacks, got ..."). Failing here instead
+    would replace that message with a less specific one.
     """
     value = results
     for _ in range(_MAX_TRANSPORT_NESTING):
@@ -55,4 +54,4 @@ def unwrap_tp_rank_readbacks(results: Any) -> Any:
     return value
 
 
-__all__ = ["TP_RANK_RESULTS_KEY", "unwrap_tp_rank_readbacks", "wrap_tp_rank_results"]
+__all__ = ["TP_RANK_RESULTS_KEY", "unwrap_tp_rank_readbacks"]

--- a/unirl/rollout/engine/vllm_omni/tp_readback.py
+++ b/unirl/rollout/engine/vllm_omni/tp_readback.py
@@ -1,0 +1,58 @@
+"""Envelope for returning one result per TP rank from a worker RPC.
+
+vLLM-Omni's ``collective_rpc`` executes the method on every rank, but only
+rank 0 owns a result queue — the other ranks' return values are dropped. A
+worker method that needs to report per-rank state therefore has to gather it
+itself and hand the whole set back inside rank 0's single reply.
+
+Both halves of that envelope live here so the key cannot drift between the
+worker process that writes it and the driver-side backend that reads it. This
+module deliberately imports nothing: the worker side already pulls in torch and
+vllm, while ``backends/native.py`` defers its vllm-omni import to keep the
+driver process light, so neither can import the other at module scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+TP_RANK_RESULTS_KEY = "__diffrl_tp_rank_results__"
+
+# ``AsyncOmniEngine`` and the diffusion multiprocess executor each wrap a
+# stage's rank-0 reply in a singleton list, so the envelope arrives nested a
+# couple of layers deep. Bounded so a genuinely single-element payload cannot
+# be unwrapped past itself.
+_MAX_TRANSPORT_NESTING = 4
+
+
+def wrap_tp_rank_results(per_rank: Sequence[Any]) -> Dict[str, List[Any]]:
+    """Package one entry per TP rank for the trip back through rank 0."""
+    return {TP_RANK_RESULTS_KEY: list(per_rank)}
+
+
+def unwrap_tp_rank_readbacks(results: Any) -> Any:
+    """Strip RPC transport wrappers and return the per-TP-rank list.
+
+    Checks for the envelope *before* each unwrap step, so a reply that is
+    itself a one-element list is returned intact rather than being unwrapped
+    into its only element. Payloads without the envelope (a worker build
+    predating it, or a backend that never gathers) pass through unchanged.
+    """
+    value = results
+    for _ in range(_MAX_TRANSPORT_NESTING):
+        if isinstance(value, dict) and TP_RANK_RESULTS_KEY in value:
+            per_rank = value[TP_RANK_RESULTS_KEY]
+            if not isinstance(per_rank, (list, tuple)):
+                raise RuntimeError(
+                    f"Malformed TP-rank readback envelope: expected a list under "
+                    f"{TP_RANK_RESULTS_KEY!r}, got {type(per_rank).__name__}."
+                )
+            return list(per_rank)
+        if isinstance(value, (list, tuple)) and len(value) == 1:
+            value = value[0]
+            continue
+        break
+    return value
+
+
+__all__ = ["TP_RANK_RESULTS_KEY", "unwrap_tp_rank_readbacks", "wrap_tp_rank_results"]

--- a/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
+++ b/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
@@ -432,25 +432,10 @@ class BucketedIPCReceiveMixin:
     def _diffrl_gather_tp_rank_results(local_result: dict) -> dict:
         """Gather this rank's checksum map into the reply rank 0 sends back.
 
-        ``collective_rpc`` runs the method on every rank but only rank 0's
-        return value survives, so a per-rank readback has to be gathered
-        worker-side. Doing it here keeps vLLM-Omni's control-plane protocol
-        untouched — the driver still receives exactly one reply, it just
-        carries every rank's entry.
-
-        This is a collective, so every rank must reach it — including a rank
-        that has nothing to report. The public entry points below are therefore
-        thin wrappers whose only statement is this call; everything that can
-        bail out early lives in a ``_local_*`` helper that returns ``{}``
-        instead of returning from the RPC. That matters most in exactly the
-        case this read-back exists to catch: when an adapter failed to register
-        on one rank, that rank still joins the gather and contributes ``{}``,
-        and ``_assert_loaded`` then names it —
-
-            [LoRA-SYNC] verify FAILED on ..., stage 1 rank 2:
-            engine returned no loaded LoRA layers.
-
-        — rather than the whole sync hanging on a collective one rank skipped.
+        Collective: every rank must reach it, including one with nothing to report.
+        The two RPC entry points are therefore body-free — anything that can return
+        early lives in a ``_local_*`` helper returning ``{}``, so a rank that bailed
+        out cannot leave its peers blocked in the gather.
         """
         per_rank: list = [local_result]
         if torch.distributed.is_available() and torch.distributed.is_initialized():
@@ -468,10 +453,7 @@ class BucketedIPCReceiveMixin:
         self,
         names: Optional[list] = None,
     ) -> dict:
-        """Per-TP-rank wrapper around :meth:`_diffrl_local_param_checksums`.
-
-        Body-free by design — see :meth:`_diffrl_gather_tp_rank_results`.
-        """
+        """Per-TP-rank wrapper — body-free, see :meth:`_diffrl_gather_tp_rank_results`."""
         return self._diffrl_gather_tp_rank_results(self._diffrl_local_param_checksums(names))
 
     def _diffrl_local_param_checksums(
@@ -521,10 +503,7 @@ class BucketedIPCReceiveMixin:
         adapter_id: int,
         names: Optional[list] = None,
     ) -> dict:
-        """Per-TP-rank wrapper around :meth:`_diffrl_local_lora_checksums`.
-
-        Body-free by design — see :meth:`_diffrl_gather_tp_rank_results`.
-        """
+        """Per-TP-rank wrapper — body-free, see :meth:`_diffrl_gather_tp_rank_results`."""
         return self._diffrl_gather_tp_rank_results(self._diffrl_local_lora_checksums(adapter_id, names))
 
     def _diffrl_local_lora_checksums(

--- a/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
+++ b/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
@@ -438,9 +438,19 @@ class BucketedIPCReceiveMixin:
         untouched — the driver still receives exactly one reply, it just
         carries every rank's entry.
 
-        This is a collective: every rank must reach it. The callers' early
-        ``return {}`` paths are uniform across ranks (they test worker-class
-        state, not per-rank state), so they cannot desynchronise it.
+        This is a collective, so every rank must reach it — including a rank
+        that has nothing to report. The public entry points below are therefore
+        thin wrappers whose only statement is this call; everything that can
+        bail out early lives in a ``_local_*`` helper that returns ``{}``
+        instead of returning from the RPC. That matters most in exactly the
+        case this read-back exists to catch: when an adapter failed to register
+        on one rank, that rank still joins the gather and contributes ``{}``,
+        and ``_assert_loaded`` then names it —
+
+            [LoRA-SYNC] verify FAILED on ..., stage 1 rank 2:
+            engine returned no loaded LoRA layers.
+
+        — rather than the whole sync hanging on a collective one rank skipped.
         """
         if not torch.distributed.is_available() or not torch.distributed.is_initialized():
             return wrap_tp_rank_results([local_result])
@@ -458,6 +468,16 @@ class BucketedIPCReceiveMixin:
         return wrap_tp_rank_results(per_rank)
 
     def _diffrl_loaded_param_checksums(
+        self,
+        names: Optional[list] = None,
+    ) -> dict:
+        """Per-TP-rank wrapper around :meth:`_diffrl_local_param_checksums`.
+
+        Body-free by design — see :meth:`_diffrl_gather_tp_rank_results`.
+        """
+        return self._diffrl_gather_tp_rank_results(self._diffrl_local_param_checksums(names))
+
+    def _diffrl_local_param_checksums(
         self,
         names: Optional[list] = None,
     ) -> dict:
@@ -497,9 +517,20 @@ class BucketedIPCReceiveMixin:
             if target is not None and name not in target:
                 continue
             out[name] = fingerprint_tensor(p)
-        return self._diffrl_gather_tp_rank_results(out)
+        return out
 
     def _diffrl_loaded_lora_checksums(
+        self,
+        adapter_id: int,
+        names: Optional[list] = None,
+    ) -> dict:
+        """Per-TP-rank wrapper around :meth:`_diffrl_local_lora_checksums`.
+
+        Body-free by design — see :meth:`_diffrl_gather_tp_rank_results`.
+        """
+        return self._diffrl_gather_tp_rank_results(self._diffrl_local_lora_checksums(adapter_id, names))
+
+    def _diffrl_local_lora_checksums(
         self,
         adapter_id: int,
         names: Optional[list] = None,
@@ -566,7 +597,7 @@ class BucketedIPCReceiveMixin:
                         if isinstance(sub, torch.Tensor):
                             per_field[f"{field}.{i}"] = fingerprint_tensor(sub)
             out[layer_name] = per_field
-        return self._diffrl_gather_tp_rank_results(out)
+        return out
 
 
 __all__ = ["BucketedIPCReceiveMixin"]

--- a/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
+++ b/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
@@ -37,6 +37,7 @@ from unirl.rollout.engine.vllm_omni.patches.runtime import (
     OmniTensorLoRARequest,
     VLLMOmniHijack,
 )
+from unirl.rollout.engine.vllm_omni.tp_readback import wrap_tp_rank_results
 
 logger = logging.getLogger(__name__)
 
@@ -427,6 +428,35 @@ class BucketedIPCReceiveMixin:
     # the ``compute_*_checksums`` helpers in ``weight_sync.checksum``.
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _diffrl_gather_tp_rank_results(local_result: dict) -> dict:
+        """Gather this rank's checksum map into the reply rank 0 sends back.
+
+        ``collective_rpc`` runs the method on every rank but only rank 0's
+        return value survives, so a per-rank readback has to be gathered
+        worker-side. Doing it here keeps vLLM-Omni's control-plane protocol
+        untouched — the driver still receives exactly one reply, it just
+        carries every rank's entry.
+
+        This is a collective: every rank must reach it. The callers' early
+        ``return {}`` paths are uniform across ranks (they test worker-class
+        state, not per-rank state), so they cannot desynchronise it.
+        """
+        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+            return wrap_tp_rank_results([local_result])
+
+        from vllm.distributed.parallel_state import get_tp_group
+
+        tp_group = get_tp_group()
+        world_size = int(tp_group.world_size)
+        if world_size <= 1:
+            return wrap_tp_rank_results([local_result])
+
+        per_rank: list = [None] * world_size
+        group = getattr(tp_group, "cpu_group", None) or tp_group.device_group
+        torch.distributed.all_gather_object(per_rank, local_result, group=group)
+        return wrap_tp_rank_results(per_rank)
+
     def _diffrl_loaded_param_checksums(
         self,
         names: Optional[list] = None,
@@ -467,7 +497,7 @@ class BucketedIPCReceiveMixin:
             if target is not None and name not in target:
                 continue
             out[name] = fingerprint_tensor(p)
-        return out
+        return self._diffrl_gather_tp_rank_results(out)
 
     def _diffrl_loaded_lora_checksums(
         self,
@@ -536,7 +566,7 @@ class BucketedIPCReceiveMixin:
                         if isinstance(sub, torch.Tensor):
                             per_field[f"{field}.{i}"] = fingerprint_tensor(sub)
             out[layer_name] = per_field
-        return out
+        return self._diffrl_gather_tp_rank_results(out)
 
 
 __all__ = ["BucketedIPCReceiveMixin"]

--- a/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
+++ b/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
@@ -37,7 +37,7 @@ from unirl.rollout.engine.vllm_omni.patches.runtime import (
     OmniTensorLoRARequest,
     VLLMOmniHijack,
 )
-from unirl.rollout.engine.vllm_omni.tp_readback import wrap_tp_rank_results
+from unirl.rollout.engine.vllm_omni.tp_readback import TP_RANK_RESULTS_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -452,20 +452,17 @@ class BucketedIPCReceiveMixin:
 
         — rather than the whole sync hanging on a collective one rank skipped.
         """
-        if not torch.distributed.is_available() or not torch.distributed.is_initialized():
-            return wrap_tp_rank_results([local_result])
+        per_rank: list = [local_result]
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            from vllm.distributed.parallel_state import get_tp_group
 
-        from vllm.distributed.parallel_state import get_tp_group
-
-        tp_group = get_tp_group()
-        world_size = int(tp_group.world_size)
-        if world_size <= 1:
-            return wrap_tp_rank_results([local_result])
-
-        per_rank: list = [None] * world_size
-        group = getattr(tp_group, "cpu_group", None) or tp_group.device_group
-        torch.distributed.all_gather_object(per_rank, local_result, group=group)
-        return wrap_tp_rank_results(per_rank)
+            tp_group = get_tp_group()
+            world_size = int(tp_group.world_size)
+            if world_size > 1:
+                per_rank = [None] * world_size
+                group = getattr(tp_group, "cpu_group", None) or tp_group.device_group
+                torch.distributed.all_gather_object(per_rank, local_result, group=group)
+        return {TP_RANK_RESULTS_KEY: per_rank}
 
     def _diffrl_loaded_param_checksums(
         self,


### PR DESCRIPTION
## Summary

`LoraWeightSyncBase._assert_loaded` verifies the LoRA read-back one TP rank at a time: it requires `tp` entries and compares each rank's checksum multisets. The read-back it receives carries a single rank's map, because `collective_rpc` returns only rank 0's reply. At `tensor_parallel_size > 1` the count check therefore fails and `sync.verify: true` cannot be used.

This has not surfaced because `verify` defaults to `False`, and the shipped recipes that enable it (`bagel_vllmomni{,_async}`, `hunyuan_video15_t2v_vllmomni_colocate`, `qwen_image_{grpo,dancegrpo}_vllmomni`, `sd3_{vllmomni,flowdppo_vllmomni}`) all run `tensor_parallel_size: 1`, where one reply is the complete set.

This gathers the per-rank maps inside the worker so rank 0's single reply carries all of them. vLLM-Omni's control-plane protocol is unchanged — the driver still receives one result per stage — and `_assert_loaded` is untouched.

- `rollout/engine/vllm_omni/tp_readback.py` (new) holds the envelope key and the unwrap helper. The key crosses a process boundary, so it lives in one place rather than being declared on both sides. The module imports nothing, which is what lets both sides use it: the worker already pulls in torch and vllm, while `backends/native.py` defers its vllm-omni import to keep the driver light.
- `BucketedIPCReceiveMixin._diffrl_gather_tp_rank_results` all-gathers over the TP group, degrading to a one-element set when `torch.distributed` is uninitialised or `world_size == 1`.
- The two RPC entry points now contain nothing but that call, with everything that can return early moved into a `_diffrl_local_*` helper. This is required rather than cosmetic: `_diffrl_local_lora_checksums` returns `{}` when the adapter is not registered on that rank — the condition the read-back exists to detect — and an early return from the RPC would let that rank skip the collective while its peers block in it. Routed through the wrapper it contributes `{}`, the gather completes, and the existing check reports `stage N rank K: engine returned no loaded LoRA layers`.
- `unwrap_tp_rank_readbacks` looks for the envelope before each unwrap step, so a reply that is itself a one-element list survives intact. A payload without the envelope passes through, leaving `_assert_loaded` to report the shape.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files unirl/rollout/engine/vllm_omni/tp_readback.py unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py unirl/rollout/engine/vllm_omni/backends/native.py` — all hooks pass.
- `python -m py_compile` over the three changed files — clean.
- Live TP>1 read-back: **Not run; reason:** no free multi-GPU node. This is the gate for leaving draft.

## Compatibility / Risk

- Confined to `loaded_param_checksums` and `lora_checksums`. No other `collective_rpc` caller is affected.
- At `tensor_parallel_size: 1` the returned shape is unchanged, so every recipe that currently enables `verify` behaves identically.
- No config, recipe, checkpoint or public API change. One new module, which imports nothing.
- The gather is a collective, so every rank must reach it. That is now structural: the RPC entry points contain only the gather call, so a future early return cannot be placed where it would skip it.

## Reviewer Notes

- Draft until the live TP>1 read-back is run.
- Scope check worth a maintainer's eye: I confirmed the single-reply shape for the stage path these two read-backs use. AR and diffusion stages route through different executors (`engine/stage_engine_core_client` vs `diffusion/executor/multiproc_executor`), so I have not claimed it holds for both. The four `examples/ar/qwen3_omni_*_gspo_lora_vllm_omni_*.yaml` recipes pair `verify: true` with a `tensor_parallel_size: 4` stage config, so whether they are affected depends on that answer.
- Suggested reading order: `tp_readback.py`, then `_diffrl_gather_tp_rank_results`, then the two `native.py` call sites.
- `unwrap_tp_rank_readbacks` is pure and dependency-free; happy to add a unit test for it if there is a preferred location.
- Duplicate-work check: no open PR touches `worker/ipc_receive_mixin.py` or the read-back path.
- AI-assisted.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.