### PR TITLE
perf(unified-model): per-track micro-batch geometry for AR and image

### DIFF
--- a/examples/unified_model/bagel_trainside_unigrpo.yaml
+++ b/examples/unified_model/bagel_trainside_unigrpo.yaml
@@ -191,6 +191,10 @@ algorithm:
 stack:
   _target_: unirl.train.unified_model_stack.UnifiedModelTrainStack
   micro_batch_size: 1
+  # Optional per-track override of micro_batch_size (null = use the shared value).
+  # See hi3_vllmomni.yaml for the AR-vs-image trade-off and the loss_agg_mode caveat.
+  ar_micro_batch_size: null
+  image_micro_batch_size: null
   max_grad_norm: 1.0
   num_updates_per_batch: 2
 

--- a/examples/unified_model/hi3_vllmomni.yaml
+++ b/examples/unified_model/hi3_vllmomni.yaml
@@ -184,6 +184,13 @@ algorithm:
 stack:
   _target_: unirl.train.unified_model_stack.UnifiedModelTrainStack
   micro_batch_size: 1
+  # Optional per-track override of micro_batch_size (null = use the shared value).
+  # The image track is fixed-shape latents, so a larger micro is clean parallelism;
+  # the AR track is variable-length responses, where a larger micro pads to the
+  # longest row. Raising ar_micro_batch_size also needs a seq-mean-* loss_agg_mode
+  # (GRPO's default token-mean weights by token count, not by row count).
+  ar_micro_batch_size: null
+  image_micro_batch_size: null
   max_grad_norm: 1.0
 
 data_source:

--- a/examples/unified_model/hi3_vllmomni_veomni_ep.yaml
+++ b/examples/unified_model/hi3_vllmomni_veomni_ep.yaml
@@ -191,6 +191,12 @@ algorithm:
 stack:
   _target_: unirl.train.unified_model_stack.UnifiedModelTrainStack
   micro_batch_size: 1
+  # Optional per-track override of micro_batch_size (null = use the shared value).
+  # See hi3_vllmomni.yaml: the image track is fixed-shape latents (a larger micro is
+  # clean parallelism), the AR track is variable-length responses (a larger micro
+  # pads, and needs a seq-mean-* loss_agg_mode to stay loss-equivalent).
+  ar_micro_batch_size: null
+  image_micro_batch_size: null
   max_grad_norm: 1.0
 
 data_source:

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -27,6 +27,12 @@ disjoint mini-batches and runs one optimizer step per mini-batch, with each trac
 clip / ratio trust region actually engages (the UniGRPO / FlowGRPO PPO schedule).
 Mirrors :class:`~unirl.train.stack.TrainStack` but for the two-algorithm backbone.
 
+``ar_micro_batch_size`` / ``image_micro_batch_size`` (both defaulting to the shared
+``micro_batch_size``) let the two tracks use different gradient-accumulation
+geometry. The lineage levels differ in row count (AR is ``P*N``, image is
+``P*N*M``) and in row shape (variable-length AR responses vs fixed-shape latents),
+so the micro size that fits one is rarely the best for the other.
+
 This is the multi-stage train stack — several stage algorithms share one
 optimizer step, in contrast to the single-stage ``TrainStack``.
 """
@@ -36,7 +42,7 @@ from __future__ import annotations
 import logging
 from contextlib import nullcontext
 from dataclasses import replace
-from typing import Dict, List, Mapping, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
 
 import torch
 
@@ -76,6 +82,8 @@ class UnifiedModelTrainStack(Remote):
         micro_batch_size: int,
         max_grad_norm: float,
         num_updates_per_batch: int = 1,
+        ar_micro_batch_size: Optional[int] = None,
+        image_micro_batch_size: Optional[int] = None,
     ) -> None:
         super().__init__()
         if int(micro_batch_size) < 1:
@@ -86,6 +94,30 @@ class UnifiedModelTrainStack(Remote):
         self.ar_algorithm = ar_algorithm
         self.image_algorithm = image_algorithm
         self.micro_batch_size = int(micro_batch_size)
+        # Per-track micro-batch size. The two lineage levels have different shapes:
+        # AR rows are variable-length responses (a larger micro pads to the longest
+        # and raises the activation peak), while image rows are fixed-shape latents
+        # (a larger micro is clean parallelism). Both default to the shared
+        # ``micro_batch_size``, so omitting them keeps the previous behavior.
+        #
+        # Micro-batching is only loss-equivalent to one full-batch backward when the
+        # per-micro ``loss_scale`` (sample share) reconstructs the whole-batch mean.
+        # That holds for a per-row mean (FlowGRPO's flat latent mean; GRPO's
+        # ``seq-mean-*`` modes, which average per sequence then over sequences), but
+        # NOT for GRPO's default ``token-mean`` when responses differ in length —
+        # there the exact objective weights by token count, not by row count. Raise
+        # ``ar_micro_batch_size`` above 1 only with a ``seq-mean-*``
+        # ``loss_agg_mode``, or accept that shift.
+        self.micro_batch_sizes = {
+            "ar": _positive_int(
+                name="UnifiedModelTrainStack.ar_micro_batch_size",
+                value=self.micro_batch_size if ar_micro_batch_size is None else ar_micro_batch_size,
+            ),
+            "image": _positive_int(
+                name="UnifiedModelTrainStack.image_micro_batch_size",
+                value=self.micro_batch_size if image_micro_batch_size is None else image_micro_batch_size,
+            ),
+        }
         self.max_grad_norm = float(max_grad_norm)
         # PPO-style multi-update: split each rollout shard into this many disjoint
         # mini-batches and run ONE optimizer step per mini-batch, with the π_old
@@ -106,27 +138,45 @@ class UnifiedModelTrainStack(Remote):
                         f"num_updates_per_batch=1."
                     )
 
-    def _optimizer_step_slices(self, total: int) -> List[List[Tuple[int, int]]]:
+    def _optimizer_step_slices(
+        self,
+        total: int,
+        *,
+        micro_batch_size: Optional[int] = None,
+    ) -> List[List[Tuple[int, int]]]:
         """Per-optimizer-step lists of absolute ``(start, end)`` micro-batch slices.
 
         One inner list per ``num_updates_per_batch`` mini-batch (one optimizer step),
-        each split into ``micro_batch_size`` micro-batches. Shared by
+        each split into the requested micro-batch size (or the shared
+        ``micro_batch_size`` fallback). Shared by
         :meth:`prepare_segment` (to freeze the anchor at the exact geometry) and the
         train loop. Mirrors :meth:`unirl.train.stack.TrainStack._optimizer_step_slices`.
         """
+        resolved_micro_batch_size = (
+            self.micro_batch_size
+            if micro_batch_size is None
+            else _positive_int(name="micro_batch_size", value=micro_batch_size)
+        )
         steps: List[List[Tuple[int, int]]] = []
         for mini_start, mini_end in _update_ranges(total_size=total, num_updates=self.num_updates_per_batch):
             steps.append(
                 [
                     (mini_start + ms, mini_start + me)
                     for ms, me in _build_micro_batch_slices(
-                        total_size=mini_end - mini_start, micro_batch_size=self.micro_batch_size
+                        total_size=mini_end - mini_start,
+                        micro_batch_size=resolved_micro_batch_size,
                     )
                 ]
             )
         return steps
 
-    def prepare_segment(self, algorithm: StageAlgorithm, part: Part) -> None:
+    def prepare_segment(
+        self,
+        algorithm: StageAlgorithm,
+        part: Part,
+        *,
+        micro_batch_size: Optional[int] = None,
+    ) -> None:
         """Freeze one algorithm's π_old anchor once, before the multi-update loop.
 
         No-op if ``segment`` is None or the algorithm has no ``prepare_segment``. If
@@ -134,7 +184,9 @@ class UnifiedModelTrainStack(Remote):
         — e.g. FlowGRPO under ``old_logp_source='replay'``), the declared
         ``anchor_fields`` are recomputed at the SAME (mini, micro) slices training will
         use, so the on-policy ratio is exactly 1 (mirrors
-        :meth:`TrainStack.prepare_segment`). Rollout-anchored algorithms (the BAGEL
+        :meth:`TrainStack.prepare_segment`). ``micro_batch_size`` must therefore be the
+        SAME per-track value the train loop will use for this Part; passing None falls
+        back to the shared ``micro_batch_size``. Rollout-anchored algorithms (the BAGEL
         UniGRPO recipe: AR GRPO + image ``old_logp_source='rollout'``) take the
         one-shot path — the anchor is the rollout emission, geometry-independent.
         """
@@ -147,7 +199,11 @@ class UnifiedModelTrainStack(Remote):
         if recomputes is None or not recomputes():
             prepare(conditions=part.conditions, segment=part.segment)
             return
-        micro_slices = [sl for step in self._optimizer_step_slices(int(part.batch_size)) for sl in step]
+        micro_slices = [
+            sl
+            for step in self._optimizer_step_slices(int(part.batch_size), micro_batch_size=micro_batch_size)
+            for sl in step
+        ]
         if len(micro_slices) == 1:
             prepare(conditions=part.conditions, segment=part.segment)
             return
@@ -195,6 +251,7 @@ class UnifiedModelTrainStack(Remote):
         bs = int(part.batch_size)
         update_total = sum(end - start for start, end in micro_slices)
         micros: List[AlgorithmStepResult] = []
+        micro_weights: List[float] = []
         total_loss = 0.0
         has_backward = False
 
@@ -210,10 +267,19 @@ class UnifiedModelTrainStack(Remote):
                 loss_scale=loss_scale,
             )
             micros.append(result)
+            micro_weights.append(loss_scale)
             total_loss += result.loss * loss_scale
             has_backward = has_backward or result.has_backward
 
-        aggregated: Mapping[str, object] = aggregate_numeric_metrics([r.metrics for r in micros if r.metrics])
+        # Weight each micro's metrics by its sample share, matching the weighted
+        # objective used for backward. A ragged final micro (batch not divisible by
+        # the micro size) otherwise skews an unweighted mean toward its fewer rows.
+        # Equal-sized micros reduce to the previous plain average.
+        metric_items = [(result.metrics, weight) for result, weight in zip(micros, micro_weights) if result.metrics]
+        aggregated: Mapping[str, object] = aggregate_numeric_metrics(
+            [metrics for metrics, _ in metric_items],
+            weights=[weight for _, weight in metric_items],
+        )
         # grad_norm / lr are filled by ``_train_one_step`` after the shared optimizer step.
         partial = TrainStepResult(
             loss=total_loss,
@@ -337,13 +403,19 @@ class UnifiedModelTrainStack(Remote):
         profiler = self._train_step_profiler() if scope == "train" else None
         with profiler.record("train_track") if profiler is not None else nullcontext():
             # Freeze each Part's π_old anchor once, before the multi-update loop.
-            self.prepare_segment(self.ar_algorithm, ar_part)
-            self.prepare_segment(self.image_algorithm, image_part)
+            # Each track's anchor geometry must match the micro size training uses.
+            self.prepare_segment(self.ar_algorithm, ar_part, micro_batch_size=self.micro_batch_sizes["ar"])
+            self.prepare_segment(self.image_algorithm, image_part, micro_batch_size=self.micro_batch_sizes["image"])
 
-            # N optimizer steps over disjoint mini-batches (each Part sliced by the same
-            # shared _optimizer_step_slices; M=1 keeps ar/image 1:1 and equally sized).
-            ar_steps = self._optimizer_step_slices(int(ar_part.batch_size))
-            image_steps = self._optimizer_step_slices(int(image_part.batch_size))
+            # N optimizer steps over disjoint mini-batches. Each Part is sliced at its
+            # own micro size (the two lineage levels differ in both row count and row
+            # shape), so ar/image micro counts need not match.
+            ar_steps = self._optimizer_step_slices(
+                int(ar_part.batch_size), micro_batch_size=self.micro_batch_sizes["ar"]
+            )
+            image_steps = self._optimizer_step_slices(
+                int(image_part.batch_size), micro_batch_size=self.micro_batch_sizes["image"]
+            )
             per_update: List[Dict[str, TrainStepResult]] = []
             for u in range(self.num_updates_per_batch):
                 per_update.append(

--- a/unirl/utils/misc.py
+++ b/unirl/utils/misc.py
@@ -142,11 +142,27 @@ def flatten_dict(d: dict, parent_key: str = "", sep: str = "/") -> dict:
     return dict(items)
 
 
-def aggregate_numeric_metrics(metrics_list: List[Dict[str, Any]]) -> Dict[str, float]:
-    """Average numeric metric keys across repeated metric dictionaries."""
+def aggregate_numeric_metrics(
+    metrics_list: List[Dict[str, Any]],
+    *,
+    weights: Optional[List[float]] = None,
+) -> Dict[str, float]:
+    """Average numeric metric keys across repeated metric dictionaries.
+
+    ``weights`` (same length as ``metrics_list``) gives a weighted mean instead of a
+    plain one — used when the entries cover unequal sample counts, e.g. gradient-
+    accumulation micro-batches whose final micro is ragged. Weights are renormalized
+    per key over the entries that actually carry it, so a key present in only some
+    dictionaries still averages correctly. Non-positive total weight for a key falls
+    back to the unweighted mean.
+    """
     aggregated: Dict[str, float] = {}
     if not metrics_list:
         return aggregated
+    if weights is not None and len(weights) != len(metrics_list):
+        raise ValueError(
+            f"aggregate_numeric_metrics: weights has length {len(weights)} but metrics_list has {len(metrics_list)}."
+        )
 
     all_keys = set()
     for metrics in metrics_list:
@@ -154,7 +170,8 @@ def aggregate_numeric_metrics(metrics_list: List[Dict[str, Any]]) -> Dict[str, f
 
     for key in all_keys:
         values: List[float] = []
-        for metrics in metrics_list:
+        value_weights: List[float] = []
+        for index, metrics in enumerate(metrics_list):
             if key not in metrics:
                 continue
             value = metrics[key]
@@ -164,7 +181,15 @@ def aggregate_numeric_metrics(metrics_list: List[Dict[str, Any]]) -> Dict[str, f
                 values.append(float(value))
             elif isinstance(value, (int, float)):
                 values.append(float(value))
-        if values:
+            else:
+                continue
+            value_weights.append(1.0 if weights is None else float(weights[index]))
+        if not values:
+            continue
+        total_weight = sum(value_weights)
+        if total_weight > 0.0:
+            aggregated[key] = sum(v * w for v, w in zip(values, value_weights)) / total_weight
+        else:
             aggregated[key] = sum(values) / len(values)
 
     return aggregated


### PR DESCRIPTION
## Summary

`UnifiedModelTrainStack` slices both lineage levels with one shared `micro_batch_size`, but the two tracks are shaped differently:

- **AR** rows are variable-length responses — a larger micro pads to the longest row in the micro, so the activation peak is set by the worst row.
- **image** rows are fixed-shape latents — a larger micro is clean parallelism with no padding waste.

One number cannot suit both, so today the image track is pinned to whatever the AR track can afford.

This adds optional `ar_micro_batch_size` / `image_micro_batch_size`. Both default to the shared `micro_batch_size`, so omitting them is a behavioral no-op. `_optimizer_step_slices` and `prepare_segment` now take the size explicitly, which matters for correctness: a replay-anchored track (FlowGRPO under `old_logp_source='replay'`) recomputes its π_old anchor at the exact `(mini, micro)` slices training will use, so the anchor must be frozen at the *same* per-track micro size or the on-policy ratio stops being 1.

Second, smaller change: `_backward_part` weights each micro's **metrics** by its sample share. The backward pass already uses a sample-share `loss_scale`, but metrics were averaged unweighted, so a ragged final micro (batch not divisible by the micro size) skewed the reported mean toward its fewer rows. `aggregate_numeric_metrics` grows a keyword-only `weights` argument, renormalized per key so a metric present in only some micros still averages correctly. Equal-sized micros reduce to the previous plain average.

**Loss-equivalence caveat (documented in code):** micro-batching only reconstructs the whole-batch objective when the per-micro sample share is the right weight. That holds for a per-row mean — FlowGRPO's flat latent mean, and GRPO's `seq-mean-*` modes — but **not** for GRPO's default `token-mean` when responses differ in length, where the exact objective weights by token count rather than row count. So `ar_micro_batch_size > 1` wants a `seq-mean-*` `loss_agg_mode`. The image track (FlowGRPO) has no such constraint. This is why the recipes ship both knobs as `null` rather than raising the image default here.

## Related Issue

N/A

## Test Plan

All commands run from the repo root at `133c11c`, venv with torch 2.13.0+cu130.

**1. Behavior harness** (24 assertions; uncommitted per the `tests/`-removal policy, source quoted below):

```
$ PYTHONPATH=$PWD python /tmp/verify_pertrack_mbs.py
PASS  unweighted mean unchanged          PASS  omitted arg uses shared mbs
PASS  equal weights == plain mean        PASS  ragged final micro
PASS  ragged weighted mean               PASS  sample shares sum to 1
PASS  ragged differs from unweighted     PASS  ragged share is smaller
PASS  missing key renormalizes           PASS  2 updates -> 2 step lists
PASS  length mismatch raises             PASS  each update 4 micros of 2
PASS  zero weight falls back             PASS  updates are disjoint+ordered
PASS  empty list                         PASS  ar_mbs=0 rejected
PASS  bool+tensor with weights           PASS  ar_mbs=-1 rejected
PASS  defaults fall back to shared       PASS  ar mbs=1 -> 8 micros
PASS  image mbs=2 -> 8 micros            PASS  image slices are width 2
PASS  ar covers all rows                 PASS  image covers all rows

all checks passed
```

Covers: defaults reproduce the shared value; `_optimizer_step_slices` omitting the new kwarg is identical to passing the shared size; AR=8@mbs1 → 8 micros while image=16@mbs2 → 8 micros of width 2, each covering all rows; ragged 5@mbs2 → `[(0,2),(2,4),(4,5)]` with shares summing to 1 and the ragged share strictly smaller; `num_updates=2` splits before micro-batching into disjoint ordered mini-batches; non-positive sizes rejected; and for `aggregate_numeric_metrics` — unweighted path unchanged, equal weights == plain mean, ragged weights give 3.0 where the unweighted mean gives 2.5, per-key renormalization when a key is missing, length mismatch raises, zero total weight falls back, bool/tensor coercion preserved.

**2. Recipe keys resolve against the constructor:**

```
$ PYTHONPATH=$PWD python -c "<yaml load + inspect.signature check>"
hi3_vllmomni.yaml: ar=None image=None unknown_keys=[]
hi3_vllmomni_veomni_ep.yaml: ar=None image=None unknown_keys=[]
bagel_trainside_unigrpo.yaml: ar=None image=None unknown_keys=[]
all stack keys map to __init__ params
```

**3. Repo gates:**

```
$ ruff check unirl/train/unified_model_stack.py unirl/utils/misc.py
All checks passed!
$ ruff format --check unirl/train/unified_model_stack.py unirl/utils/misc.py
2 files already formatted
$ python lint/check_recipe_targets.py
check-recipe-targets: 2311 recipe _target_ paths resolve.
$ python lint/check_experimental_boundaries.py
check-experimental-boundaries: ok
```

**Not run: multi-GPU training A/B on this branch.** See Reviewer Notes — the measurement I have is from a different base and I am not presenting it as a result for this diff.

## Compatibility / Risk

- **No behavior change by default.** Both knobs default to the shared `micro_batch_size`; the three shipped recipes set them to `null`. `_optimizer_step_slices` / `prepare_segment` keep their old call form working (the new argument is keyword-only with a `None` default).
- `aggregate_numeric_metrics(weights=...)` is keyword-only and defaults to `None`; the three existing callers (`diffusionnft.py`, `train/stack/base.py` ×2) are untouched and unaffected.
- Metrics values *do* change for a ragged final micro — that is the intended fix. Equal-sized micros are unchanged.
- No config-schema break: the new recipe keys are additive and optional.
- Raising `ar_micro_batch_size` above 1 shifts the AR objective under `loss_agg_mode: token-mean` (see Summary). Left at the default, nothing shifts.

## Reviewer Notes

**Verification:** every line is mine to defend; the diff and all commands above were reviewed and run.

**Duplicate-work check:** scanned the 33 open PRs. Nothing else touches `unirl/train/unified_model_stack.py` or `unirl/utils/misc.py`. #299 (share single-stream sampling/replay loops) and #156 (batched-step replay to more models) are in the diffusion-replay area and do not overlap this change; #253 (batch trainside UniGRPO rollout forwards) touches `bagel/*` model code plus the same recipe file, but a different section — worth a glance for recipe conflict, not for logic.

**On the performance claim — please read before merging.** I measured `image_micro_batch_size=2` at roughly **−20% train-step time** on 8×H20 HI3 (batch_size 8, 4 diffusion steps / 2 SDE, 512px, 1 step), at the cost of ~5 GB more peak allocated. But that run sat on a **different, older base with a different fix for the DP-sharding problem** — I had independently hit the "image Part gets replicated to every rank" bug and solved it with a new per-argument `DP_SCATTER_INDEPENDENT` dispatch mode, before finding that `main` already fixes it (and better) by passing the whole lineage `Sample` and tree-sharding it. So:

- That number is **not** a measurement of this diff. Treat it as motivation, not as a result.
- It was a single run, not repeated. Same-config repeats elsewhere in that matrix spread ~4–9%.
- I no longer hold the GPUs to re-run it on this base.

Happy to re-measure if someone can point me at capacity, and equally happy for this to sit as draft until then. The code is correctness-complete and default-inert regardless; the open question is purely how much the knob buys on current `main`.

**Suggested review order:** the `prepare_segment` anchor-geometry coupling is the only subtle part — if a replay-anchored track's anchor were frozen at a different micro size than training uses, the ratio would silently stop being 1. Everything else is plumbing.

