### PR TITLE
feat(reward): add rank-affine managed image scorers

### DIFF
--- a/examples/diffusion/bagel/bagel_editreward.yaml
+++ b/examples/diffusion/bagel/bagel_editreward.yaml
@@ -145,7 +145,7 @@ reward:
         editreward: 1.0
       batch_size: 8
       timeout: 300.0
-      sub_metric_reduce: mean
+      sub_metric_reduce: first
       aggregation_method: weighted_sum
 
 algorithm:

--- a/examples/diffusion/flux2_klein/flux2_klein_4b_editreward.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_4b_editreward.yaml
@@ -121,7 +121,7 @@ reward:
         editreward: 1.0
       batch_size: 8
       timeout: 300.0
-      sub_metric_reduce: mean
+      sub_metric_reduce: first
       aggregation_method: weighted_sum
 
 algorithm:

--- a/examples/diffusion/flux2_klein/flux2_klein_4b_editreward_sglang.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_4b_editreward_sglang.yaml
@@ -175,7 +175,7 @@ reward:
         editreward: 1.0
       batch_size: 8
       timeout: 300.0
-      sub_metric_reduce: mean
+      sub_metric_reduce: first
       aggregation_method: weighted_sum
 
 algorithm:

--- a/examples/diffusion/flux2_klein/flux2_klein_editreward.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_editreward.yaml
@@ -122,7 +122,7 @@ reward:
         editreward: 1.0
       batch_size: 8
       timeout: 300.0
-      sub_metric_reduce: mean
+      sub_metric_reduce: first
       aggregation_method: weighted_sum
 
 algorithm:

--- a/examples/diffusion/flux2_klein/flux2_klein_editreward_sglang.yaml
+++ b/examples/diffusion/flux2_klein/flux2_klein_editreward_sglang.yaml
@@ -172,7 +172,7 @@ reward:
         editreward: 1.0
       batch_size: 8
       timeout: 300.0
-      sub_metric_reduce: mean
+      sub_metric_reduce: first
       aggregation_method: weighted_sum
 
 algorithm:

--- a/examples/unified_model/hi3_it2i.yaml
+++ b/examples/unified_model/hi3_it2i.yaml
@@ -172,7 +172,7 @@ reward:
         editreward: 1.0
       batch_size: 8
       timeout: 300.0
-      sub_metric_reduce: mean
+      sub_metric_reduce: first
       aggregation_method: weighted_sum
 
 algorithm:

--- a/unirl-reward-service/docs/ARCHITECTURE.md
+++ b/unirl-reward-service/docs/ARCHITECTURE.md
@@ -299,6 +299,25 @@ Request `0` asked for `clip + hpsv2`; `clip` failed → only `hpsv2` has a score
 - A client can safely pack unrelated rewards into the same batch — **they will not drag each other down**.
 - A client must **read both `results[i]` and `errors[i]`** — looking only at `results` would silently miss a failed reward.
 
+### 4.4 Rank-affine direct scorer server
+
+`reward_service.direct_server` is a lighter deployment for one managed image
+scorer. It does not create a nested Ray runtime: the parent UniRL reward worker
+launches it with an explicit Python interpreter and an inherited listening socket.
+The server:
+
+- owns exactly one registered scorer;
+- accepts image/image-edit histories only in the initial protocol;
+- serializes calls unless a future scorer capability says otherwise;
+- echoes request/sample/group/policy/scorer identity;
+- caches idempotency keys for safe retries;
+- rejects non-finite outputs;
+- exposes explicit `health`, `onload`, `offload`, `drain`, and `shutdown`
+  lifecycle operations.
+
+The full gateway remains the multi-reward, multi-replica deployment. The direct
+server is a rank-local process/environment boundary, not a replacement for it.
+
 ---
 
 ## 5. Extension Points
@@ -418,6 +437,8 @@ For **vLLM-style scorers** (`unified_reward` / `geneval2` / `wise`), the `dtype 
 ```
 reward_service/
 ├── server.py            # HTTP gateway — /score /health /rewards
+├── direct_server.py     # one managed scorer — /score + lifecycle
+├── wire.py              # shared image/video wire decoding
 ├── __main__.py          # CLI entry — argparse + uvicorn.run
 ├── config.py            # YAML → ServiceCfg / RewardModelCfg
 ├── schemas.py           # Pydantic HTTP schemas

--- a/unirl-reward-service/docs/ARCHITECTURE.md
+++ b/unirl-reward-service/docs/ARCHITECTURE.md
@@ -308,12 +308,12 @@ The server:
 
 - owns exactly one registered scorer;
 - accepts image/image-edit histories only in the initial protocol;
-- serializes calls unless a future scorer capability says otherwise;
+- serializes scoring and lifecycle transitions;
 - echoes request/sample/group/policy/scorer identity;
 - caches idempotency keys for safe retries;
 - rejects non-finite outputs;
-- exposes explicit `health`, `onload`, `offload`, `drain`, and `shutdown`
-  lifecycle operations.
+- exposes `GET /health` plus explicit `onload`, `offload`, `drain`, and
+  `shutdown` lifecycle operations.
 
 The full gateway remains the multi-reward, multi-replica deployment. The direct
 server is a rank-local process/environment boundary, not a replacement for it.

--- a/unirl-reward-service/envs/editreward.txt
+++ b/unirl-reward-service/envs/editreward.txt
@@ -13,6 +13,9 @@
 pyarrow<19
 datasets
 pillow
+fastapi
+uvicorn
+pydantic
 openai
 megfile
 sentencepiece

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -148,6 +148,14 @@ def create_direct_app(
                 f"managed image server requires scorer input_kind='image'; "
                 f"{scorer_name!r} declares {scorer_input_kind!r}"
             )
+        if boot_offloaded and not getattr(scorer_cls, "supports_offload", False):
+            # Checked on the CLASS, before construction: a per_call
+            # misconfiguration must not pay a full model load (possibly onto the
+            # exact GPU the protocol protects) just to be told no.
+            raise ValueError(
+                f"--boot-offloaded requires scorer {scorer_name!r} to support offload "
+                "(needed for lifecycle='per_call')"
+            )
         logger.info("direct scorer loading name=%s params=%s", scorer_name, params)
         scorer = await asyncio.to_thread(scorer_cls, **params)
         if not tuple(scorer.sub_metric_names):
@@ -163,11 +171,6 @@ def create_direct_app(
             # boot. Scorers that honor UNIRL_SCORER_BOOT_OFFLOADED construct on
             # CPU and make this offload a no-op; engine-backed scorers at least
             # shrink the window to construction itself.
-            if not scorer.supports_offload:
-                raise ValueError(
-                    f"--boot-offloaded requires scorer {scorer_name!r} to support offload "
-                    "(needed for lifecycle='per_call')"
-                )
             await asyncio.to_thread(scorer.offload)
             app.state.lifecycle_state = "offloaded"
         else:
@@ -353,13 +356,26 @@ def _spawn_group_reaper() -> None:
     import subprocess
     import sys
 
+    if os.getpgrp() != os.getpid():
+        # Not the group leader: the group belongs to whoever launched us (a
+        # wrapper script, a Popen without start_new_session), and sweeping it
+        # would kill unrelated processes. The managed parent always starts the
+        # frontend with start_new_session, so this only skips manual launches.
+        logger.warning(
+            "group reaper disabled: frontend pid %d is not its process-group leader (pgrp %d)",
+            os.getpid(),
+            os.getpgrp(),
+        )
+        return
+
     source = (
-        "import os,signal,time\n"
+        "import os,signal,sys,time\n"
         "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
         "watched = int(os.environ['_UNIRL_REAPER_WATCH_PID'])\n"
         "while os.getppid() == watched:\n"
         "    time.sleep(2.0)\n"
         "group = os.getpgrp()\n"
+        "print(f'reward group reaper: frontend {watched} gone, sweeping pgid {group}', file=sys.stderr, flush=True)\n"
         "try:\n"
         "    os.killpg(group, signal.SIGTERM)\n"
         "except ProcessLookupError:\n"
@@ -376,7 +392,9 @@ def _spawn_group_reaper() -> None:
         env=env,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        # The parent already routes this frontend's stderr into the per-child
+        # log; a sweep that vaporizes the group must leave a trace there.
+        stderr=None,
         close_fds=True,
     )
 

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -1,0 +1,301 @@
+"""Single-scorer loopback server for rank-affine managed image rewards."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import ctypes
+import hashlib
+import importlib
+import json
+import math
+import os
+import signal
+import socket
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+
+from reward_service.logging_utils import get_logger
+from reward_service.schemas import RewardIdentity, ScoreRequest, ScoreResponse
+from reward_service.scorers.registry import SCORER_MODULES, get_scorer_cls
+from reward_service.wire import request_to_item
+
+logger = get_logger(__name__)
+
+_PR_SET_PDEATHSIG = 1
+
+
+def _arm_parent_death_signal() -> None:
+    parent_pid = int(os.environ.get("UNIRL_REWARD_PARENT_PID", "0") or 0)
+    if parent_pid <= 0:
+        return
+    libc = ctypes.CDLL(None, use_errno=True)
+    prctl = libc.prctl
+    prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
+    prctl.restype = ctypes.c_int
+    if prctl(_PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0) != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+    if os.getppid() != parent_pid:
+        raise SystemExit("reward parent exited before child initialization")
+
+
+def _normalize_score(
+    result: Any,
+    *,
+    required_metrics: tuple[str, ...],
+) -> tuple[dict[str, float], str | None]:
+    if not isinstance(result, Mapping):
+        return {}, f"scorer returned {type(result).__name__}, expected a metric mapping"
+    missing = sorted(set(required_metrics) - set(result))
+    if not result or missing:
+        return {}, f"scorer omitted required metrics: {missing or list(required_metrics)}"
+    normalized: dict[str, float] = {}
+    invalid: list[str] = []
+    for name, value in result.items():
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            invalid.append(str(name))
+            continue
+        if not math.isfinite(numeric):
+            invalid.append(str(name))
+            continue
+        normalized[str(name)] = numeric
+    if invalid:
+        return {}, f"non-finite or non-numeric metrics: {sorted(invalid)}"
+    return normalized, None
+
+
+def _request_fingerprint(request: Any) -> str:
+    payload = request.model_dump(mode="json", exclude={"idempotency_key"})
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _cache_put(
+    cache: OrderedDict,
+    key: str,
+    value: tuple[str, dict[str, float], str | None],
+    limit: int,
+) -> None:
+    cache[key] = value
+    cache.move_to_end(key)
+    while len(cache) > limit:
+        cache.popitem(last=False)
+
+
+def create_direct_app(
+    scorer_name: str,
+    params: dict[str, Any],
+    *,
+    input_kind: str = "image",
+    cache_size: int = 1024,
+) -> FastAPI:
+    if input_kind not in {"image", "image_edit"}:
+        raise ValueError(f"direct managed scorer supports image/image_edit only, got {input_kind!r}")
+    if cache_size < 1:
+        raise ValueError(f"cache_size must be positive, got {cache_size}")
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        module_path = SCORER_MODULES.get(scorer_name)
+        if module_path:
+            importlib.import_module(module_path)
+        scorer_cls = get_scorer_cls(scorer_name)
+        scorer_input_kind = str(getattr(scorer_cls, "input_kind", "image"))
+        if scorer_input_kind != "image":
+            raise ValueError(
+                f"managed image server requires scorer input_kind='image'; "
+                f"{scorer_name!r} declares {scorer_input_kind!r}"
+            )
+        logger.info("direct scorer loading name=%s params=%s", scorer_name, params)
+        scorer = await asyncio.to_thread(scorer_cls, **params)
+        if not tuple(scorer.sub_metric_names):
+            raise ValueError(f"managed scorer {scorer_name!r} declares no sub_metric_names")
+        app.state.scorer = scorer
+        app.state.score_lock = asyncio.Lock()
+        app.state.result_cache = OrderedDict()
+        app.state.lifecycle_state = "resident"
+        logger.info("direct scorer ready name=%s version=%s", scorer_name, scorer.version)
+        try:
+            yield
+        finally:
+            if app.state.lifecycle_state != "stopping":
+                await asyncio.to_thread(scorer.close)
+
+    app = FastAPI(title=f"Direct Reward Service ({scorer_name})", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health() -> dict:
+        scorer = app.state.scorer
+        return {
+            "status": "ok",
+            "state": app.state.lifecycle_state,
+            "scorer": scorer.health(),
+            "rewards": {scorer_name: [app.state.lifecycle_state]},
+        }
+
+    @app.get("/rewards")
+    async def rewards() -> dict:
+        return {"rewards": [scorer_name]}
+
+    @app.post("/score", response_model=ScoreResponse)
+    async def score(body: ScoreRequest) -> ScoreResponse:
+        if body.protocol_version != "1":
+            raise HTTPException(status_code=400, detail=f"unsupported protocol_version={body.protocol_version!r}")
+        if not body.requests:
+            return ScoreResponse(results=[], errors=[], identities=[])
+        for request in body.requests:
+            unknown = [name for name in request.required_rewards if name != scorer_name]
+            if unknown:
+                raise HTTPException(status_code=400, detail=f"unknown rewards for this worker: {unknown}")
+
+        async with app.state.score_lock:
+            if app.state.lifecycle_state != "resident":
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"scorer is not resident (state={app.state.lifecycle_state})",
+                )
+            results: list[dict[str, dict[str, float]]] = [{} for _ in body.requests]
+            errors: list[dict[str, str]] = [{} for _ in body.requests]
+            identities: list[RewardIdentity] = [
+                request.identity(actual_scorer_version=app.state.scorer.version) for request in body.requests
+            ]
+            uncached_items = []
+            uncached_indices: list[int] = []
+            pending_fingerprints: dict[str, str] = {}
+            pending_key_indices: dict[str, int] = {}
+            duplicate_indices: dict[int, int] = {}
+            for index, request in enumerate(body.requests):
+                key = request.idempotency_key
+                fingerprint = _request_fingerprint(request)
+                if key:
+                    prior = pending_fingerprints.setdefault(key, fingerprint)
+                    if prior != fingerprint:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=f"idempotency key {key!r} was reused for different payloads in one batch",
+                        )
+                cached = app.state.result_cache.get(key) if key else None
+                if cached is not None:
+                    fingerprint, normalized, error = cached
+                    if fingerprint != pending_fingerprints[key]:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=f"idempotency key {key!r} was reused for a different payload",
+                        )
+                    results[index] = {scorer_name: dict(normalized)} if error is None else {}
+                    errors[index] = {} if error is None else {scorer_name: error}
+                    app.state.result_cache.move_to_end(key)
+                    continue
+                if key and key in pending_key_indices:
+                    duplicate_indices[index] = pending_key_indices[key]
+                    continue
+                if key:
+                    pending_key_indices[key] = index
+                uncached_items.append(request_to_item(request, allow_video=False))
+                uncached_indices.append(index)
+
+            if uncached_items:
+                try:
+                    scores = await asyncio.to_thread(app.state.scorer.score, uncached_items)
+                except Exception as exc:
+                    logger.exception("direct scorer failed: %s", exc)
+                    error = repr(exc)
+                    for index in uncached_indices:
+                        errors[index] = {scorer_name: error}
+                else:
+                    if len(scores) != len(uncached_items):
+                        raise RuntimeError(
+                            f"direct scorer returned {len(scores)} results for {len(uncached_items)} items"
+                        )
+                    for index, scorer_result in zip(uncached_indices, scores, strict=True):
+                        normalized, error = _normalize_score(
+                            scorer_result,
+                            required_metrics=tuple(app.state.scorer.sub_metric_names),
+                        )
+                        results[index] = {scorer_name: normalized} if error is None else {}
+                        errors[index] = {} if error is None else {scorer_name: error}
+                        key = body.requests[index].idempotency_key
+                        if key:
+                            _cache_put(
+                                app.state.result_cache,
+                                key,
+                                (_request_fingerprint(body.requests[index]), normalized, error),
+                                cache_size,
+                            )
+            for index, source_index in duplicate_indices.items():
+                results[index] = dict(results[source_index])
+                errors[index] = dict(errors[source_index])
+
+        return ScoreResponse(results=results, errors=errors, identities=identities)
+
+    @app.post("/lifecycle/{action}")
+    async def lifecycle(action: str) -> dict:
+        if action not in {"load", "health", "onload", "offload", "drain", "shutdown"}:
+            raise HTTPException(status_code=404, detail=f"unknown lifecycle action {action!r}")
+        if action == "health":
+            return await health()
+        async with app.state.score_lock:
+            scorer = app.state.scorer
+            if app.state.lifecycle_state == "stopping" and action != "shutdown":
+                raise HTTPException(status_code=409, detail="scorer is stopping")
+            if action in {"load", "onload"}:
+                await asyncio.to_thread(scorer.onload)
+                app.state.lifecycle_state = "resident"
+            elif action == "offload":
+                if not scorer.supports_offload:
+                    raise HTTPException(status_code=409, detail=f"scorer {scorer_name!r} does not support offload")
+                app.state.lifecycle_state = "draining"
+                await asyncio.to_thread(scorer.drain)
+                await asyncio.to_thread(scorer.offload)
+                app.state.lifecycle_state = "offloaded"
+            elif action == "drain":
+                app.state.lifecycle_state = "draining"
+                await asyncio.to_thread(scorer.drain)
+                app.state.lifecycle_state = "resident"
+            else:
+                app.state.lifecycle_state = "stopping"
+                await asyncio.to_thread(scorer.drain)
+                await asyncio.to_thread(scorer.close)
+            return {"status": "ok", "state": app.state.lifecycle_state}
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scorer", required=True)
+    parser.add_argument("--params-json", required=True)
+    parser.add_argument("--input-kind", default="image")
+    parser.add_argument("--cache-size", type=int, default=1024)
+    parser.add_argument("--fd", type=int)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--log-level", default="info")
+    args = parser.parse_args()
+
+    _arm_parent_death_signal()
+    params = json.loads(args.params_json)
+    if not isinstance(params, dict):
+        raise TypeError("--params-json must decode to an object")
+    app = create_direct_app(args.scorer, params, input_kind=args.input_kind, cache_size=args.cache_size)
+
+    import uvicorn
+
+    config = uvicorn.Config(app, host=args.host, port=args.port, log_level=args.log_level)
+    server = uvicorn.Server(config)
+    if args.fd is None:
+        server.run()
+        return
+    with socket.socket(fileno=args.fd) as listener:
+        server.run(sockets=[listener])
+
+
+if __name__ == "__main__":
+    main()

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -317,8 +317,23 @@ def create_direct_app(
             if app.state.lifecycle_state == "stopping" and action != "shutdown":
                 raise HTTPException(status_code=409, detail="scorer is stopping")
             if action in {"load", "onload"}:
-                await asyncio.to_thread(scorer.onload)
-                app.state.lifecycle_state = "resident"
+                if app.state.lifecycle_state != "resident":
+                    app.state.lifecycle_state = "loading"
+                    try:
+                        await asyncio.to_thread(scorer.onload)
+                    except Exception:
+                        if scorer.supports_offload:
+                            try:
+                                await asyncio.to_thread(scorer.offload)
+                            except Exception:
+                                app.state.lifecycle_state = "error"
+                                logger.exception("failed to roll back scorer after onload error")
+                            else:
+                                app.state.lifecycle_state = "offloaded"
+                        else:
+                            app.state.lifecycle_state = "error"
+                        raise
+                    app.state.lifecycle_state = "resident"
             elif action == "offload":
                 if not scorer.supports_offload:
                     raise HTTPException(status_code=409, detail=f"scorer {scorer_name!r} does not support offload")
@@ -327,9 +342,10 @@ def create_direct_app(
                 await asyncio.to_thread(scorer.offload)
                 app.state.lifecycle_state = "offloaded"
             elif action == "drain":
+                previous_state = app.state.lifecycle_state
                 app.state.lifecycle_state = "draining"
                 await asyncio.to_thread(scorer.drain)
-                app.state.lifecycle_state = "resident"
+                app.state.lifecycle_state = previous_state
             else:
                 app.state.lifecycle_state = "stopping"
                 await asyncio.to_thread(scorer.drain)

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -12,6 +12,8 @@ import math
 import os
 import signal
 import socket
+import threading
+import time
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -95,6 +97,7 @@ def create_direct_app(
     *,
     input_kind: str = "image",
     cache_size: int = 1024,
+    boot_offloaded: bool = False,
 ) -> FastAPI:
     if input_kind not in {"image", "image_edit"}:
         raise ValueError(f"direct managed scorer supports image/image_edit only, got {input_kind!r}")
@@ -120,8 +123,29 @@ def create_direct_app(
         app.state.scorer = scorer
         app.state.score_lock = asyncio.Lock()
         app.state.result_cache = OrderedDict()
-        app.state.lifecycle_state = "resident"
-        logger.info("direct scorer ready name=%s version=%s", scorer_name, scorer.version)
+        if boot_offloaded:
+            # per_call boot protocol: leave the GPU BEFORE the parent can see us
+            # ready. Waiting for the parent's first /lifecycle/offload would keep
+            # the scorer resident next to whatever the trainer already holds for
+            # the whole readiness poll — exactly the window that OOMs a colocated
+            # boot. Scorers that honor UNIRL_SCORER_BOOT_OFFLOADED construct on
+            # CPU and make this offload a no-op; engine-backed scorers at least
+            # shrink the window to construction itself.
+            if not scorer.supports_offload:
+                raise ValueError(
+                    f"--boot-offloaded requires scorer {scorer_name!r} to support offload "
+                    "(needed for lifecycle='per_call')"
+                )
+            await asyncio.to_thread(scorer.offload)
+            app.state.lifecycle_state = "offloaded"
+        else:
+            app.state.lifecycle_state = "resident"
+        logger.info(
+            "direct scorer ready name=%s version=%s state=%s",
+            scorer_name,
+            scorer.version,
+            app.state.lifecycle_state,
+        )
         try:
             yield
         finally:
@@ -280,12 +304,62 @@ def create_direct_app(
     return app
 
 
+def _spawn_group_reaper() -> None:
+    """Sweep the process group if this frontend dies without running cleanup.
+
+    PDEATHSIG covers parent->frontend only: when the frontend itself is
+    SIGKILLed (ray worker teardown at driver exit, an external kill), engine
+    subprocesses spawned by the scorer — e.g. a vLLM EngineCore — survive
+    re-parented to init and keep their GPU memory. Observed repeatedly with
+    both sleeping and resident engines whose own frontend-liveness watchdog
+    never fired. The parent's _stop_child() killpg covers the graceful path;
+    this sibling covers every path where nobody calls it: it shares this
+    process group, watches this PID, and sweeps the group (TERM, 5s grace,
+    KILL) the moment the frontend is gone. On a normal exit the group by then
+    holds only the reaper itself, so the sweep is a self-kill.
+    """
+    import subprocess
+    import sys
+
+    source = (
+        "import os,signal,time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "watched = int(os.environ['_UNIRL_REAPER_WATCH_PID'])\n"
+        "while os.getppid() == watched:\n"
+        "    time.sleep(2.0)\n"
+        "group = os.getpgrp()\n"
+        "try:\n"
+        "    os.killpg(group, signal.SIGTERM)\n"
+        "except ProcessLookupError:\n"
+        "    pass\n"
+        "time.sleep(5.0)\n"
+        "try:\n"
+        "    os.killpg(group, signal.SIGKILL)\n"
+        "except ProcessLookupError:\n"
+        "    pass\n"
+    )
+    env = dict(os.environ, _UNIRL_REAPER_WATCH_PID=str(os.getpid()))
+    subprocess.Popen(
+        [sys.executable, "-c", source],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--scorer", required=True)
     parser.add_argument("--params-json", required=True)
     parser.add_argument("--input-kind", default="image")
     parser.add_argument("--cache-size", type=int, default=1024)
+    parser.add_argument(
+        "--boot-offloaded",
+        action="store_true",
+        help="offload the scorer before first reporting ready (per_call boot protocol)",
+    )
     parser.add_argument("--fd", type=int)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=0)
@@ -293,10 +367,17 @@ def main() -> None:
     args = parser.parse_args()
 
     _arm_parent_death_signal()
+    _spawn_group_reaper()
     params = json.loads(args.params_json)
     if not isinstance(params, dict):
         raise TypeError("--params-json must decode to an object")
-    app = create_direct_app(args.scorer, params, input_kind=args.input_kind, cache_size=args.cache_size)
+    app = create_direct_app(
+        args.scorer,
+        params,
+        input_kind=args.input_kind,
+        cache_size=args.cache_size,
+        boot_offloaded=args.boot_offloaded,
+    )
 
     import uvicorn
 

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -155,6 +155,12 @@ def create_direct_app(
             if unknown:
                 raise HTTPException(status_code=400, detail=f"unknown rewards for this worker: {unknown}")
 
+        # Fingerprinting (and the decode below) is CPU work proportional to the b64
+        # media in the chunk. Run on the event loop it stalls /health and the
+        # lifecycle endpoints for the whole walk, so the parent sees a live child
+        # as unavailable mid-scoring.
+        fingerprints = await asyncio.to_thread(lambda: [_request_fingerprint(request) for request in body.requests])
+
         async with app.state.score_lock:
             if app.state.lifecycle_state != "resident":
                 raise HTTPException(
@@ -166,14 +172,17 @@ def create_direct_app(
             identities: list[RewardIdentity] = [
                 request.identity(actual_scorer_version=app.state.scorer.version) for request in body.requests
             ]
-            uncached_items = []
+            # One in-flight chunk must never evict its own rows, or a retry after a
+            # lost response recomputes exactly what the cache exists to deduplicate.
+            cache_limit = max(cache_size, len(body.requests))
+            uncached_requests = []
             uncached_indices: list[int] = []
             pending_fingerprints: dict[str, str] = {}
             pending_key_indices: dict[str, int] = {}
             duplicate_indices: dict[int, int] = {}
             for index, request in enumerate(body.requests):
                 key = request.idempotency_key
-                fingerprint = _request_fingerprint(request)
+                fingerprint = fingerprints[index]
                 if key:
                     prior = pending_fingerprints.setdefault(key, fingerprint)
                     if prior != fingerprint:
@@ -198,10 +207,13 @@ def create_direct_app(
                     continue
                 if key:
                     pending_key_indices[key] = index
-                uncached_items.append(request_to_item(request, allow_video=False))
+                uncached_requests.append(request)
                 uncached_indices.append(index)
 
-            if uncached_items:
+            if uncached_requests:
+                uncached_items = await asyncio.to_thread(
+                    lambda: [request_to_item(request, allow_video=False) for request in uncached_requests]
+                )
                 try:
                     scores = await asyncio.to_thread(app.state.scorer.score, uncached_items)
                 except Exception as exc:
@@ -226,8 +238,8 @@ def create_direct_app(
                             _cache_put(
                                 app.state.result_cache,
                                 key,
-                                (_request_fingerprint(body.requests[index]), normalized, error),
-                                cache_size,
+                                (fingerprints[index], normalized, error),
+                                cache_limit,
                             )
             for index, source_index in duplicate_indices.items():
                 results[index] = dict(results[source_index])

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -153,7 +153,7 @@ def create_direct_app(
             # misconfiguration must not pay a full model load (possibly onto the
             # exact GPU the protocol protects) just to be told no.
             raise ValueError(
-                f"--boot-offloaded requires scorer {scorer_name!r} to support offload (needed for lifecycle='per_call')"
+                f"--boot-offloaded requires scorer {scorer_name!r} to support offload (needed for gpu_residency='per_call')"
             )
         logger.info("direct scorer loading name=%s params=%s", scorer_name, params)
         scorer = await asyncio.to_thread(scorer_cls, **params)

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -44,6 +44,38 @@ def _arm_parent_death_signal() -> None:
         raise OSError(errno, os.strerror(errno))
     if os.getppid() != parent_pid:
         raise SystemExit("reward parent exited before child initialization")
+    _start_orphan_reaper(parent_pid)
+
+
+def _start_orphan_reaper(parent_pid: int, grace_seconds: float = 20.0) -> None:
+    """Guarantee no scorer subprocess outlives an orphaned server.
+
+    PDEATHSIG only covers this process: an engine-backed scorer (e.g. a vLLM
+    judge) spawns its own workers, and when this server dies by signal those
+    grandchildren reparent to init still holding GPU memory — engine-side
+    parent monitors have been observed not to fire, an idle/slept engine in
+    particular. This daemon thread watches for reparenting and, after a grace
+    period for the SIGTERM-driven graceful shutdown to finish, SIGKILLs the
+    server's own process group (the parent starts us with start_new_session,
+    so the group is exactly this server plus everything it spawned).
+    """
+
+    def _watch() -> None:
+        while True:
+            if os.getppid() != parent_pid:
+                time.sleep(grace_seconds)
+                # Only nuke the group when we lead it (start_new_session in the
+                # managed parent). Under a debug shell the group is the user's
+                # session — exit alone instead of killing their terminal.
+                if os.getpgid(0) == os.getpid():
+                    try:
+                        os.killpg(os.getpgid(0), signal.SIGKILL)
+                    except OSError:
+                        pass
+                os._exit(1)
+            time.sleep(1.0)
+
+    threading.Thread(target=_watch, name="orphan-reaper", daemon=True).start()
 
 
 def _normalize_score(

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -22,7 +22,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 
 from reward_service.logging_utils import get_logger
-from reward_service.schemas import RewardIdentity, ScoreRequest, ScoreResponse
+from reward_service.schemas import PROTOCOL_VERSION, RewardIdentity, ScoreRequest, ScoreResponse
 from reward_service.scorers.registry import SCORER_MODULES, get_scorer_cls
 from reward_service.wire import request_to_item
 
@@ -127,12 +127,12 @@ def create_direct_app(
     scorer_name: str,
     params: dict[str, Any],
     *,
-    input_kind: str = "image",
+    history_kind: str = "image",
     cache_size: int = 1024,
     boot_offloaded: bool = False,
 ) -> FastAPI:
-    if input_kind not in {"image", "image_edit"}:
-        raise ValueError(f"direct managed scorer supports image/image_edit only, got {input_kind!r}")
+    if history_kind not in {"image", "image_edit"}:
+        raise ValueError(f"history_kind must be image or image_edit, got {history_kind!r}")
     if cache_size < 1:
         raise ValueError(f"cache_size must be positive, got {cache_size}")
 
@@ -153,8 +153,7 @@ def create_direct_app(
             # misconfiguration must not pay a full model load (possibly onto the
             # exact GPU the protocol protects) just to be told no.
             raise ValueError(
-                f"--boot-offloaded requires scorer {scorer_name!r} to support offload "
-                "(needed for lifecycle='per_call')"
+                f"--boot-offloaded requires scorer {scorer_name!r} to support offload (needed for lifecycle='per_call')"
             )
         logger.info("direct scorer loading name=%s params=%s", scorer_name, params)
         scorer = await asyncio.to_thread(scorer_cls, **params)
@@ -205,7 +204,7 @@ def create_direct_app(
 
     @app.post("/score", response_model=ScoreResponse)
     async def score(body: ScoreRequest) -> ScoreResponse:
-        if body.protocol_version != "1":
+        if body.protocol_version != PROTOCOL_VERSION:
             raise HTTPException(status_code=400, detail=f"unsupported protocol_version={body.protocol_version!r}")
         if not body.requests:
             return ScoreResponse(results=[], errors=[], identities=[])
@@ -213,6 +212,8 @@ def create_direct_app(
             unknown = [name for name in request.required_rewards if name != scorer_name]
             if unknown:
                 raise HTTPException(status_code=400, detail=f"unknown rewards for this worker: {unknown}")
+            if history_kind == "image_edit" and len(request.history) < 2:
+                raise HTTPException(status_code=400, detail="image_edit requests require source and edited turns")
 
         # Fingerprinting (and the decode below) is CPU work proportional to the b64
         # media in the chunk. Run on the event loop it stalls /health and the
@@ -308,21 +309,23 @@ def create_direct_app(
 
     @app.post("/lifecycle/{action}")
     async def lifecycle(action: str) -> dict:
-        if action not in {"load", "health", "onload", "offload", "drain", "shutdown"}:
+        if action not in {"onload", "offload", "drain", "shutdown"}:
             raise HTTPException(status_code=404, detail=f"unknown lifecycle action {action!r}")
-        if action == "health":
-            return await health()
         async with app.state.score_lock:
             scorer = app.state.scorer
             if app.state.lifecycle_state == "stopping" and action != "shutdown":
                 raise HTTPException(status_code=409, detail="scorer is stopping")
-            if action in {"load", "onload"}:
-                if app.state.lifecycle_state != "resident":
+            if action == "onload":
+                if app.state.lifecycle_state == "resident":
+                    pass
+                else:
                     app.state.lifecycle_state = "loading"
                     try:
                         await asyncio.to_thread(scorer.onload)
                     except Exception:
-                        if scorer.supports_offload:
+                        if not scorer.supports_offload:
+                            app.state.lifecycle_state = "error"
+                        else:
                             try:
                                 await asyncio.to_thread(scorer.offload)
                             except Exception:
@@ -330,17 +333,20 @@ def create_direct_app(
                                 logger.exception("failed to roll back scorer after onload error")
                             else:
                                 app.state.lifecycle_state = "offloaded"
-                        else:
-                            app.state.lifecycle_state = "error"
                         raise
                     app.state.lifecycle_state = "resident"
             elif action == "offload":
                 if not scorer.supports_offload:
                     raise HTTPException(status_code=409, detail=f"scorer {scorer_name!r} does not support offload")
-                app.state.lifecycle_state = "draining"
-                await asyncio.to_thread(scorer.drain)
-                await asyncio.to_thread(scorer.offload)
-                app.state.lifecycle_state = "offloaded"
+                if app.state.lifecycle_state != "offloaded":
+                    app.state.lifecycle_state = "draining"
+                    try:
+                        await asyncio.to_thread(scorer.drain)
+                        await asyncio.to_thread(scorer.offload)
+                    except Exception:
+                        app.state.lifecycle_state = "error"
+                        raise
+                    app.state.lifecycle_state = "offloaded"
             elif action == "drain":
                 previous_state = app.state.lifecycle_state
                 app.state.lifecycle_state = "draining"
@@ -419,7 +425,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--scorer", required=True)
     parser.add_argument("--params-json", required=True)
-    parser.add_argument("--input-kind", default="image")
+    parser.add_argument("--history-kind", default="image")
     parser.add_argument("--cache-size", type=int, default=1024)
     parser.add_argument(
         "--boot-offloaded",
@@ -440,7 +446,7 @@ def main() -> None:
     app = create_direct_app(
         args.scorer,
         params,
-        input_kind=args.input_kind,
+        history_kind=args.history_kind,
         cache_size=args.cache_size,
         boot_offloaded=args.boot_offloaded,
     )

--- a/unirl-reward-service/reward_service/schemas.py
+++ b/unirl-reward-service/reward_service/schemas.py
@@ -21,6 +21,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
+PROTOCOL_VERSION = "1"
+
 
 class HistoryTurn(BaseModel):
     """One ``(text, media)`` pair in a conversation history.
@@ -50,9 +52,7 @@ class HistoryTurn(BaseModel):
         if self.video_b64 is not None and self.video_path is not None:
             raise ValueError("video_b64 and video_path are mutually exclusive")
         if self.image_b64 is None and self.video_b64 is None and self.video_path is None:
-            raise ValueError(
-                "HistoryTurn must include at least one of image_b64, video_b64, or video_path"
-            )
+            raise ValueError("HistoryTurn must include at least one of image_b64, video_b64, or video_path")
         return self
 
 
@@ -62,11 +62,42 @@ class RewardRequest(BaseModel):
     history: list[HistoryTurn]
     required_rewards: list[str]
     metadata: dict[str, Any] | None = None
+    request_id: str | None = None
+    sample_id: str | None = None
+    group_id: str | None = None
+    source_rank: int | None = None
+    policy_version: int | None = None
+    scorer_version: str | None = None
+    idempotency_key: str | None = None
+
+    def identity(self, *, actual_scorer_version: str | None = None) -> "RewardIdentity":
+        return RewardIdentity(
+            request_id=self.request_id,
+            sample_id=self.sample_id,
+            group_id=self.group_id,
+            source_rank=self.source_rank,
+            policy_version=self.policy_version,
+            scorer_version=actual_scorer_version,
+            idempotency_key=self.idempotency_key,
+        )
+
+
+class RewardIdentity(BaseModel):
+    """Optional item identity echoed across chunked/retried score calls."""
+
+    request_id: str | None = None
+    sample_id: str | None = None
+    group_id: str | None = None
+    source_rank: int | None = None
+    policy_version: int | None = None
+    scorer_version: str | None = None
+    idempotency_key: str | None = None
 
 
 class ScoreRequest(BaseModel):
     """Top-level HTTP body: a batch of RewardRequest."""
 
+    protocol_version: str = PROTOCOL_VERSION
     requests: list[RewardRequest]
 
 
@@ -81,3 +112,5 @@ class ScoreResponse(BaseModel):
 
     results: list[dict[str, dict[str, float]]]
     errors: list[dict[str, str]] = Field(default_factory=list)
+    identities: list[RewardIdentity] = Field(default_factory=list)
+    protocol_version: str = PROTOCOL_VERSION

--- a/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
+++ b/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
@@ -280,5 +280,5 @@ class EditRewardInferencer:
 
     def reward(self, prompts, image_src, image_paths):
         batch = self.prepare_batch(image_src, image_paths, prompts)
-        rewards = self.model(return_dict=True, **batch)["logits"]
-        return rewards
+        output = self.model(return_dict=True, **batch)
+        return output["logits"] if isinstance(output, Mapping) else output

--- a/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
+++ b/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
@@ -163,6 +163,11 @@ class EditRewardInferencer:
         self.use_special_tokens = model_config.use_special_tokens
         self.reward_dim = reward_dim
         self.rm_head_type = model_config.rm_head_type
+        # Surfaced for the scorer: these decide what reward()'s columns MEAN
+        # (per-head scores vs pooled [reward, log-sigma]).
+        self.output_dim = int(model_config.output_dim)
+        self.pooling_strategy = model_config.pooling_strategy
+        self.loss_type = str(getattr(model_config, "loss_type", "regular"))
 
         # Load checkpoint
         full_ckpt = os.path.join(checkpoint_path, "model.pth")

--- a/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
+++ b/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
@@ -163,11 +163,6 @@ class EditRewardInferencer:
         self.use_special_tokens = model_config.use_special_tokens
         self.reward_dim = reward_dim
         self.rm_head_type = model_config.rm_head_type
-        # Surfaced for the scorer: these decide what reward()'s columns MEAN
-        # (per-head scores vs pooled [reward, log-sigma]).
-        self.output_dim = int(model_config.output_dim)
-        self.pooling_strategy = model_config.pooling_strategy
-        self.loss_type = str(getattr(model_config, "loss_type", "regular"))
 
         # Load checkpoint
         full_ckpt = os.path.join(checkpoint_path, "model.pth")

--- a/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
+++ b/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
@@ -252,7 +252,11 @@ class EditRewardInferencer:
             batch = self._prepare_inputs(batch)
             return batch, image_inputs
 
-        if self.rm_head_type == "ranknet_multi_head":
+        if self.rm_head_type in {
+            "ranknet_multi_head",
+            "ranknet_multi_head_regression",
+            "ranknet_share_head",
+        }:
             batch_dim1, image_inputs_1 = _build_batch(prompts, image_src, image_paths, reward_dim="dim1")
             batch_dim2, image_inputs_2 = _build_batch(prompts, image_src, image_paths, reward_dim="dim2")
             return {

--- a/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
+++ b/unirl-reward-service/reward_service/scorers/_editreward/inferencer.py
@@ -6,29 +6,29 @@ Uses the vendored configs, model, prompts, and vision_process modules.
 
 from __future__ import annotations
 
+import importlib
 import os
 from collections.abc import Mapping
 from pathlib import Path
 
 import torch
-import safetensors
 
-from reward_service.scorers._editreward.vision_process import process_vision_info
-from reward_service.scorers._editreward.prompts import (
-    INSTRUCTION_EDIT_FOLLOWING,
-    INSTRUCTION_EDIT_QUALITY,
-    INSTRUCTION_EDIT_OVERALL,
-    INSTRUCTION_EDIT_OVERALL_DETAILED,
-    PROMPT_WITH_SPECIAL_TOKEN,
-    PROMPT_WITHOUT_SPECIAL_TOKEN,
-)
 from reward_service.scorers._editreward.configs import (
+    DataConfig,
     ModelConfig,
     PEFTLoraConfig,
     TrainingConfig,
-    DataConfig,
     parse_args_with_yaml,
 )
+from reward_service.scorers._editreward.prompts import (
+    INSTRUCTION_EDIT_FOLLOWING,
+    INSTRUCTION_EDIT_OVERALL,
+    INSTRUCTION_EDIT_OVERALL_DETAILED,
+    INSTRUCTION_EDIT_QUALITY,
+    PROMPT_WITH_SPECIAL_TOKEN,
+    PROMPT_WITHOUT_SPECIAL_TOKEN,
+)
+from reward_service.scorers._editreward.vision_process import process_vision_info
 
 _MODEL_CONFIG_PATH = Path(__file__).parent / "config"
 _DEFAULT_CONFIG_FILENAME = "EditReward-Qwen2.5-7B-VL.yaml"
@@ -47,15 +47,13 @@ def _resolve_config_path(config_path):
         if candidate.is_file():
             return str(candidate)
 
-    raise FileNotFoundError(
-        f"Config not found: {config_path}. "
-        f"Checked {[str(path) for path in candidate_paths]}"
-    )
+    raise FileNotFoundError(f"Config not found: {config_path}. Checked {[str(path) for path in candidate_paths]}")
 
 
 def _create_model_and_processor(model_config, peft_lora_config, training_args, differentiable=False):
     """Create model and processor for inference (no LoRA, no quantization)."""
     from transformers import AutoProcessor
+
     from reward_service.scorers._editreward.model import Qwen2_5_VLRewardModelBT_MultiHead
 
     torch_dtype = (
@@ -64,20 +62,16 @@ def _create_model_and_processor(model_config, peft_lora_config, training_args, d
         else getattr(torch, model_config.torch_dtype)
     )
 
-    processor = AutoProcessor.from_pretrained(
-        model_config.model_name_or_path, padding_side="right"
-    )
+    processor = AutoProcessor.from_pretrained(model_config.model_name_or_path, padding_side="right")
 
     special_token_ids = None
     if model_config.use_special_tokens:
         special_tokens = ["<|Reward|>"]
-        processor.tokenizer.add_special_tokens(
-            {"additional_special_tokens": special_tokens}
-        )
+        processor.tokenizer.add_special_tokens({"additional_special_tokens": special_tokens})
         special_token_ids = processor.tokenizer.convert_tokens_to_ids(special_tokens)
 
     try:
-        import flash_attn
+        importlib.import_module("flash_attn")
         attn_impl = "flash_attention_2"
     except ImportError:
         attn_impl = "sdpa"
@@ -125,6 +119,8 @@ class EditRewardInferencer:
         self,
         config_path=None,
         checkpoint_path=None,
+        model_name_or_path=None,
+        dtype=None,
         device="cuda",
         differentiable=False,
         reward_dim="dim1",
@@ -132,15 +128,29 @@ class EditRewardInferencer:
     ):
         config_path = _resolve_config_path(config_path)
 
-        (data_config, training_args, model_config, peft_lora_config), config_path = (
-            parse_args_with_yaml(
-                (DataConfig, TrainingConfig, ModelConfig, PEFTLoraConfig),
-                config_path,
-                is_train=False,
-            )
+        (data_config, training_args, model_config, peft_lora_config), config_path = parse_args_with_yaml(
+            (DataConfig, TrainingConfig, ModelConfig, PEFTLoraConfig),
+            config_path,
+            is_train=False,
         )
+        if model_name_or_path:
+            model_config.model_name_or_path = str(model_name_or_path)
+        if dtype:
+            dtype_name = {
+                "bf16": "bfloat16",
+                "fp16": "float16",
+                "fp32": "float32",
+            }.get(str(dtype), str(dtype))
+            allowed_dtypes = {"auto", "bfloat16", "float16", "float32"}
+            if dtype_name not in allowed_dtypes:
+                raise ValueError(f"Unsupported EditReward dtype {dtype!r}; expected one of {sorted(allowed_dtypes)}")
+            model_config.torch_dtype = dtype_name
+            if dtype_name != "auto":
+                training_args.bf16 = dtype_name == "bfloat16"
+                training_args.fp16 = dtype_name == "float16"
+        model_config.rm_head_type = str(rm_head_type)
         output_root = training_args.output_dir or "/tmp/editreward_output"
-        training_args.output_dir = os.path.join(output_root, config_path.split("/")[-1].split(".")[0])
+        training_args.output_dir = os.path.join(output_root, Path(config_path).stem)
 
         model, processor, _ = _create_model_and_processor(
             model_config=model_config,
@@ -152,7 +162,7 @@ class EditRewardInferencer:
         self.device = device
         self.use_special_tokens = model_config.use_special_tokens
         self.reward_dim = reward_dim
-        self.rm_head_type = rm_head_type
+        self.rm_head_type = model_config.rm_head_type
 
         # Load checkpoint
         full_ckpt = os.path.join(checkpoint_path, "model.pth")
@@ -162,6 +172,7 @@ class EditRewardInferencer:
             state_dict = torch.load(full_ckpt, map_location="cpu")
         elif os.path.exists(full_ckpt_safetensors):
             import safetensors.torch
+
             state_dict = safetensors.torch.load_file(full_ckpt_safetensors, device="cpu")
         else:
             raise ValueError(f"Checkpoint not found at {checkpoint_path}")
@@ -232,9 +243,7 @@ class EditRewardInferencer:
             messages = _build_messages(prompts, image_src, image_paths, reward_dim)
             image_inputs, _ = process_vision_info(messages)
             batch = self.processor(
-                text=self.processor.apply_chat_template(
-                    messages, tokenize=False, add_generation_prompt=True
-                ),
+                text=self.processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True),
                 images=image_inputs,
                 padding=True,
                 return_tensors="pt",

--- a/unirl-reward-service/reward_service/scorers/base.py
+++ b/unirl-reward-service/reward_service/scorers/base.py
@@ -60,6 +60,9 @@ class BaseScorer(ABC):
     """
 
     name: str = ""
+    version: str = "1"
+    input_kind: str = "image"
+    supports_offload: bool = False
     sub_metric_names: tuple[str, ...] = ()
 
     @abstractmethod
@@ -85,3 +88,20 @@ class BaseScorer(ABC):
 
     def close(self) -> None:
         """Release heavy resources (model, vLLM engine). Default is a no-op."""
+
+    def onload(self) -> None:
+        """Optionally restore model device state before scoring."""
+
+    def offload(self) -> None:
+        """Optionally release model device state after draining."""
+
+    def drain(self) -> None:
+        """Optionally flush scorer-internal asynchronous work."""
+
+    def health(self) -> dict:
+        return {
+            "name": self.name,
+            "version": self.version,
+            "input_kind": self.input_kind,
+            "supports_offload": self.supports_offload,
+        }

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -4,6 +4,16 @@ Wraps the EditRewardInferencer (Qwen2.5-VL-7B based) from the EditReward
 package. Evaluates how well an edited image follows the editing instruction
 (dim1: instruction following) and visual quality (dim2: visual quality).
 
+Column semantics depend on the pinned model config. With the official
+EditReward-MiMo-VL-7B-SFT-2508 config (``pooling_strategy: mean``,
+``output_dim: 2``, ``loss_type: uncertainty``) the two heads are pooled
+INSIDE the model and the returned columns are ``[reward mean, log-sigma]``
+— NOT two semantic scores. The sub-metric names below are historical wire
+identifiers; under such configs ``edit_following`` carries the reward and
+``edit_quality`` carries the heteroscedastic log-uncertainty, which is a
+diagnostic, not a training signal. Consume the score channel only
+(``sub_metric_reduce: first`` in recipes); never average the two.
+
 Input convention:
     history[0] = (prompt, source_image)   — source image before editing
     history[1] = (prompt, edited_image)   — edited image after editing

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -23,15 +23,10 @@ The text prompt (editing instruction) is taken from history[0][0].
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import torch
 
 from reward_service.scorers.base import BaseScorer, ScoreItem
 from reward_service.scorers.registry import register
-
-if TYPE_CHECKING:
-    pass
 
 
 class EditRewardScorer(BaseScorer):
@@ -86,6 +81,20 @@ class EditRewardScorer(BaseScorer):
             reward_dim="dim1",
             rm_head_type=rm_head_type,
         )
+
+        # Column semantics come from the pinned model config, not this wrapper.
+        # With in-model head pooling and the uncertainty loss, reward() returns
+        # [pooled reward, pooled log-sigma] — NOT two semantic scores; naming
+        # the second column "edit_quality" would log (and, under
+        # sub_metric_reduce: mean, optimize) the critic's own spread as a score.
+        # Per-head score pairs keep the semantic names.
+        if (
+            self._rm_head_type == "ranknet_multi_head"
+            and self.inferencer.pooling_strategy is not None
+            and self.inferencer.output_dim == 2
+            and self.inferencer.loss_type == "uncertainty"
+        ):
+            self.sub_metric_names = ("reward", "log_sigma")
 
     @torch.inference_mode()
     def score(self, items: list[ScoreItem]) -> list[dict[str, float]]:
@@ -144,28 +153,29 @@ class EditRewardScorer(BaseScorer):
         return results
 
     def _shape_reward(self, rewards, row: int) -> dict[str, float]:
-        """Map row ``row`` of a batched ``reward()`` output to the sub-metric dict.
+        """Map row ``row`` of a ``reward()`` output to the sub-metric dict.
 
-        Mirrors :meth:`_score_single`'s shaping exactly, indexed by batch row, so
-        the single batched forward produces the same per-item values the
-        one-at-a-time path produced.
+        The single shaping path for both the batched forward and the
+        one-at-a-time fallback (``_score_single`` calls this with row 0), keyed
+        by the instance's ``sub_metric_names``.
         """
+        first, second = self.sub_metric_names
         if self._rm_head_type == "ranknet_multi_head":
             if isinstance(rewards, torch.Tensor):
                 if rewards.dim() >= 2 and rewards.shape[-1] >= 2:
                     return {
-                        "edit_following": float(rewards[row, 0].item()),
-                        "edit_quality": float(rewards[row, 1].item()),
+                        first: float(rewards[row, 0].item()),
+                        second: float(rewards[row, 1].item()),
                     }
                 return {
-                    "edit_following": float(rewards[row].item()),
-                    "edit_quality": float("nan"),
+                    first: float(rewards[row].item()),
+                    second: float("nan"),
                 }
             if isinstance(rewards, (list, tuple)):
                 scores = [float(r[row].item()) if torch.is_tensor(r) else float(r) for r in rewards]
                 return {
-                    "edit_following": scores[0] if len(scores) > 0 else float("nan"),
-                    "edit_quality": scores[1] if len(scores) > 1 else float("nan"),
+                    first: scores[0] if len(scores) > 0 else float("nan"),
+                    second: scores[1] if len(scores) > 1 else float("nan"),
                 }
         else:
             if isinstance(rewards, torch.Tensor):
@@ -173,8 +183,8 @@ class EditRewardScorer(BaseScorer):
             else:
                 val = float(rewards[row])
             return {
-                "edit_following": val,
-                "edit_quality": float("nan"),
+                first: val,
+                second: float("nan"),
             }
         return {k: float("nan") for k in self.sub_metric_names}
 
@@ -201,41 +211,7 @@ class EditRewardScorer(BaseScorer):
             image_src=[source_image],
             image_paths=[edited_image],
         )
-
-        # rewards shape depends on rm_head_type:
-        # ranknet_multi_head: tensor of shape (batch, num_heads) or list of tensors
-        if self._rm_head_type == "ranknet_multi_head":
-            # Multi-head returns scores for both dims
-            if isinstance(rewards, torch.Tensor):
-                if rewards.dim() >= 2 and rewards.shape[-1] >= 2:
-                    return {
-                        "edit_following": float(rewards[0, 0].item()),
-                        "edit_quality": float(rewards[0, 1].item()),
-                    }
-                else:
-                    return {
-                        "edit_following": float(rewards[0].item()),
-                        "edit_quality": float("nan"),
-                    }
-            elif isinstance(rewards, (list, tuple)):
-                scores = [float(r[0].item()) if torch.is_tensor(r) else float(r) for r in rewards]
-                return {
-                    "edit_following": scores[0] if len(scores) > 0 else float("nan"),
-                    "edit_quality": scores[1] if len(scores) > 1 else float("nan"),
-                }
-        else:
-            # Single-head: only one score
-            if isinstance(rewards, torch.Tensor):
-                val = float(rewards[0, 0].item()) if rewards.dim() >= 2 else float(rewards[0].item())
-            else:
-                val = float(rewards[0])
-            return {
-                "edit_following": val,
-                "edit_quality": float("nan"),
-            }
-
-        # Fallback
-        return {k: float("nan") for k in self.sub_metric_names}
+        return self._shape_reward(rewards, 0)
 
     def onload(self) -> None:
         self.inferencer.model.to(self._target_device)

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -21,40 +21,50 @@ from reward_service.scorers.base import BaseScorer, ScoreItem
 from reward_service.scorers.registry import register
 
 if TYPE_CHECKING:
-    from PIL import Image
+    pass
 
 
 class EditRewardScorer(BaseScorer):
     """Multi-head edit reward scorer backed by EditRewardInferencer."""
 
     name = "editreward"
+    version = "1"
+    input_kind = "image"
+    supports_offload = True
     sub_metric_names = ("edit_following", "edit_quality")
 
     def __init__(
         self,
         checkpoint_path: str,
         config_path: str | None = None,
+        model_name_or_path: str | None = None,
         device: str = "cuda",
         dtype: str = "bfloat16",
         rm_head_type: str = "ranknet_multi_head",
+        offload_between_calls: bool = False,
     ) -> None:
         import os
 
         from reward_service.scorers._editreward import EditRewardInferencer
 
-        self._device = device if torch.cuda.is_available() else "cpu"
+        self._target_device = device if torch.cuda.is_available() else "cpu"
+        self._offload_between_calls = bool(offload_between_calls and self._target_device != "cpu")
+        initial_device = "cpu" if self._offload_between_calls else self._target_device
         self._rm_head_type = rm_head_type
 
         # If checkpoint_path looks like a HF repo ID (not a local dir),
         # download it via huggingface_hub first.
         if not os.path.isdir(checkpoint_path) and "/" in checkpoint_path:
             from huggingface_hub import snapshot_download
+
             checkpoint_path = snapshot_download(repo_id=checkpoint_path)
 
         self.inferencer = EditRewardInferencer(
             config_path=config_path,
             checkpoint_path=checkpoint_path,
-            device=self._device,
+            model_name_or_path=model_name_or_path,
+            dtype=dtype,
+            device=initial_device,
             reward_dim="dim1",
             rm_head_type=rm_head_type,
         )
@@ -64,6 +74,15 @@ class EditRewardScorer(BaseScorer):
         if not items:
             return []
 
+        try:
+            if self._offload_between_calls:
+                self.onload()
+            return self._score_batch(items)
+        finally:
+            if self._offload_between_calls:
+                self.offload()
+
+    def _score_batch(self, items: list[ScoreItem]) -> list[dict[str, float]]:
         # Score ALL valid items in ONE batched inferencer.reward() call. The
         # previous loop ran the 7B VLM once PER item (a batch of 1), so a
         # rollout's worth of scoring was N sequential forwards (~2h at 896
@@ -78,9 +97,7 @@ class EditRewardScorer(BaseScorer):
         for i, item in enumerate(items):
             try:
                 if len(item.history) < 2:
-                    raise ValueError(
-                        f"EditReward requires 2 history turns (source + edited), got {len(item.history)}"
-                    )
+                    raise ValueError(f"EditReward requires 2 history turns (source + edited), got {len(item.history)}")
                 prompt, source_image = item.history[0]
                 _, edited_image = item.history[1]
                 if source_image is None or edited_image is None:
@@ -151,9 +168,7 @@ class EditRewardScorer(BaseScorer):
             history[1] = (prompt, edited_image)
         """
         if len(item.history) < 2:
-            raise ValueError(
-                f"EditReward requires 2 history turns (source + edited), got {len(item.history)}"
-            )
+            raise ValueError(f"EditReward requires 2 history turns (source + edited), got {len(item.history)}")
 
         prompt, source_image = item.history[0]
         _, edited_image = item.history[1]
@@ -203,6 +218,16 @@ class EditRewardScorer(BaseScorer):
 
         # Fallback
         return {k: float("nan") for k in self.sub_metric_names}
+
+    def onload(self) -> None:
+        self.inferencer.model.to(self._target_device)
+        self.inferencer.device = self._target_device
+
+    def offload(self) -> None:
+        self.inferencer.model.to("cpu")
+        self.inferencer.device = "cpu"
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def close(self) -> None:
         if hasattr(self, "inferencer"):

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -49,7 +49,15 @@ class EditRewardScorer(BaseScorer):
 
         self._target_device = device if torch.cuda.is_available() else "cpu"
         self._offload_between_calls = bool(offload_between_calls and self._target_device != "cpu")
-        initial_device = "cpu" if self._offload_between_calls else self._target_device
+        # UNIRL_SCORER_BOOT_OFFLOADED is the managed parent's per_call boot hint:
+        # construct on CPU so the child never touches the GPU before it reports
+        # ready (the server's boot offload then finds nothing to move). Unlike
+        # offload_between_calls this does not change per-score behavior — the
+        # parent drives onload/offload through the lifecycle endpoints.
+        boot_offloaded = os.environ.get("UNIRL_SCORER_BOOT_OFFLOADED") == "1"
+        initial_device = (
+            "cpu" if (self._offload_between_calls or boot_offloaded) else self._target_device
+        )
         self._rm_head_type = rm_head_type
 
         # If checkpoint_path looks like a HF repo ID (not a local dir),

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -82,20 +82,6 @@ class EditRewardScorer(BaseScorer):
             rm_head_type=rm_head_type,
         )
 
-        # Column semantics come from the pinned model config, not this wrapper.
-        # With in-model head pooling and the uncertainty loss, reward() returns
-        # [pooled reward, pooled log-sigma] — NOT two semantic scores; naming
-        # the second column "edit_quality" would log (and, under
-        # sub_metric_reduce: mean, optimize) the critic's own spread as a score.
-        # Per-head score pairs keep the semantic names.
-        if (
-            self._rm_head_type == "ranknet_multi_head"
-            and self.inferencer.pooling_strategy is not None
-            and self.inferencer.output_dim == 2
-            and self.inferencer.loss_type == "uncertainty"
-        ):
-            self.sub_metric_names = ("reward", "log_sigma")
-
     @torch.inference_mode()
     def score(self, items: list[ScoreItem]) -> list[dict[str, float]]:
         if not items:

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -1,8 +1,8 @@
 """EditReward scorer — multi-dimensional reward for instruction-guided image editing.
 
 Wraps the EditRewardInferencer (Qwen2.5-VL-7B based) from the EditReward
-package. Evaluates how well an edited image follows the editing instruction
-(dim1: instruction following) and visual quality (dim2: visual quality).
+package. The model evaluates instruction following and visual quality before
+the configured head-pooling strategy produces the returned columns.
 
 Column semantics depend on the pinned model config. With the official
 EditReward-MiMo-VL-7B-SFT-2508 config (``pooling_strategy: mean``,
@@ -25,8 +25,11 @@ from __future__ import annotations
 
 import torch
 
+from reward_service.logging_utils import get_logger
 from reward_service.scorers.base import BaseScorer, ScoreItem
 from reward_service.scorers.registry import register
+
+logger = get_logger(__name__)
 
 
 class EditRewardScorer(BaseScorer):
@@ -60,9 +63,7 @@ class EditRewardScorer(BaseScorer):
         # offload_between_calls this does not change per-score behavior — the
         # parent drives onload/offload through the lifecycle endpoints.
         boot_offloaded = os.environ.get("UNIRL_SCORER_BOOT_OFFLOADED") == "1"
-        initial_device = (
-            "cpu" if (self._offload_between_calls or boot_offloaded) else self._target_device
-        )
+        initial_device = "cpu" if (self._offload_between_calls or boot_offloaded) else self._target_device
 
         # If checkpoint_path looks like a HF repo ID (not a local dir),
         # download it via huggingface_hub first.
@@ -108,12 +109,7 @@ class EditRewardScorer(BaseScorer):
         edits: list = []
         for i, item in enumerate(items):
             try:
-                if len(item.history) < 2:
-                    raise ValueError(f"EditReward requires 2 history turns (source + edited), got {len(item.history)}")
-                prompt, source_image = item.history[0]
-                _, edited_image = item.history[1]
-                if source_image is None or edited_image is None:
-                    raise ValueError("Both source and edited images must be provided")
+                prompt, source_image, edited_image = self._unpack_item(item)
                 rows.append(i)
                 prompts.append(prompt)
                 srcs.append(source_image)
@@ -126,9 +122,12 @@ class EditRewardScorer(BaseScorer):
                 rewards = self.inferencer.reward(prompts=prompts, image_src=srcs, image_paths=edits)
                 for row, i in enumerate(rows):
                     results[i] = self._shape_reward(rewards, row)
+            except torch.cuda.OutOfMemoryError:
+                raise
             except Exception:
                 # A single bad item must not nan the whole batch — fall back to
                 # the one-at-a-time path only on the error case.
+                logger.exception("EditReward batch scoring failed; retrying items individually")
                 for i in rows:
                     try:
                         results[i] = self._score_single(items[i])
@@ -167,7 +166,17 @@ class EditRewardScorer(BaseScorer):
                 first: scores[0] if scores else float("nan"),
                 second: scores[1] if len(scores) > 1 else float("nan"),
             }
-        return {k: float("nan") for k in self.sub_metric_names}
+        raise TypeError(f"unsupported EditReward reward output: {type(rewards).__name__}")
+
+    @staticmethod
+    def _unpack_item(item: ScoreItem):
+        if len(item.history) < 2:
+            raise ValueError(f"EditReward requires 2 history turns (source + edited), got {len(item.history)}")
+        prompt, source_image = item.history[0]
+        _, edited_image = item.history[1]
+        if source_image is None or edited_image is None:
+            raise ValueError("Both source and edited images must be provided")
+        return prompt, source_image, edited_image
 
     def _score_single(self, item: ScoreItem) -> dict[str, float]:
         """Score a single item.
@@ -176,14 +185,7 @@ class EditRewardScorer(BaseScorer):
             history[0] = (prompt, source_image)
             history[1] = (prompt, edited_image)
         """
-        if len(item.history) < 2:
-            raise ValueError(f"EditReward requires 2 history turns (source + edited), got {len(item.history)}")
-
-        prompt, source_image = item.history[0]
-        _, edited_image = item.history[1]
-
-        if source_image is None or edited_image is None:
-            raise ValueError("Both source and edited images must be provided")
+        prompt, source_image, edited_image = self._unpack_item(item)
 
         # EditRewardInferencer.reward() accepts paths or PIL images
         # (process_vision_info handles PIL.Image directly)

--- a/unirl-reward-service/reward_service/scorers/editreward.py
+++ b/unirl-reward-service/reward_service/scorers/editreward.py
@@ -63,7 +63,6 @@ class EditRewardScorer(BaseScorer):
         initial_device = (
             "cpu" if (self._offload_between_calls or boot_offloaded) else self._target_device
         )
-        self._rm_head_type = rm_head_type
 
         # If checkpoint_path looks like a HF repo ID (not a local dir),
         # download it via huggingface_hub first.
@@ -146,31 +145,27 @@ class EditRewardScorer(BaseScorer):
         by the instance's ``sub_metric_names``.
         """
         first, second = self.sub_metric_names
-        if self._rm_head_type == "ranknet_multi_head":
-            if isinstance(rewards, torch.Tensor):
-                if rewards.dim() >= 2 and rewards.shape[-1] >= 2:
-                    return {
-                        first: float(rewards[row, 0].item()),
-                        second: float(rewards[row, 1].item()),
-                    }
+        if isinstance(rewards, torch.Tensor):
+            if rewards.dim() >= 2 and rewards.shape[-1] >= 2:
                 return {
-                    first: float(rewards[row].item()),
-                    second: float("nan"),
+                    first: float(rewards[row, 0].item()),
+                    second: float(rewards[row, 1].item()),
                 }
-            if isinstance(rewards, (list, tuple)):
-                scores = [float(r[row].item()) if torch.is_tensor(r) else float(r) for r in rewards]
-                return {
-                    first: scores[0] if len(scores) > 0 else float("nan"),
-                    second: scores[1] if len(scores) > 1 else float("nan"),
-                }
-        else:
-            if isinstance(rewards, torch.Tensor):
-                val = float(rewards[row, 0].item()) if rewards.dim() >= 2 else float(rewards[row].item())
-            else:
-                val = float(rewards[row])
             return {
-                first: val,
+                first: float(rewards[row].item()),
                 second: float("nan"),
+            }
+        if isinstance(rewards, (list, tuple)):
+            scores = []
+            for reward in rewards:
+                if torch.is_tensor(reward):
+                    value = reward[row]
+                    scores.append(float(value.reshape(-1)[0].item()))
+                else:
+                    scores.append(float(reward))
+            return {
+                first: scores[0] if scores else float("nan"),
+                second: scores[1] if len(scores) > 1 else float("nan"),
             }
         return {k: float("nan") for k in self.sub_metric_names}
 

--- a/unirl-reward-service/reward_service/server.py
+++ b/unirl-reward-service/reward_service/server.py
@@ -14,81 +14,19 @@ return scores. The per-reward deadline is `server.score_timeout_s`.
 from __future__ import annotations
 
 import asyncio
-import base64
-import io
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from PIL import Image
 
 from reward_service.config import ServiceCfg
 from reward_service.logging_utils import get_logger
-from reward_service.schemas import HistoryTurn, RewardRequest, ScoreRequest, ScoreResponse
+from reward_service.schemas import RewardRequest, ScoreRequest, ScoreResponse
 from reward_service.scorers import ScoreItem
+from reward_service.wire import request_to_item
 from reward_service.workers.pool import WorkerPool
 
 logger = get_logger(__name__)
-
-
-def _decode_image(b64: str) -> Image.Image:
-    try:
-        raw = base64.b64decode(b64)
-        return Image.open(io.BytesIO(raw)).convert("RGB")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"invalid image_b64: {e}") from e
-
-
-def _resolve_video(turn: HistoryTurn) -> bytes | str | None:
-    """Return the video source for a turn, in the form scorers expect.
-
-    Three branches, kept zero-copy when possible:
-
-    * ``video_path`` set → return the path string after a stat check.
-      The scorer (e.g. videoalign / decord) opens it directly on the
-      shared filesystem, no bytes round-trip.
-    * ``video_b64`` set → base64-decode and return the raw bytes; the
-      scorer is responsible for spilling to a tempfile if its decoder
-      needs a path.
-    * Neither set → ``None`` (turn has no video, e.g. an image-only
-      request that happens to ride alongside a video request in the
-      same batch).
-    """
-    if turn.video_path is not None:
-        p = Path(turn.video_path)
-        if not p.is_file():
-            raise HTTPException(
-                status_code=400,
-                detail=f"video_path does not exist or is not a regular file: {turn.video_path}",
-            )
-        return str(p)
-    if turn.video_b64 is not None:
-        try:
-            return base64.b64decode(turn.video_b64)
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=f"invalid video_b64: {e}") from e
-    return None
-
-
-def _request_to_item(req: RewardRequest) -> ScoreItem:
-    if not req.history:
-        raise HTTPException(status_code=400, detail="history must not be empty")
-    history: list[tuple[str, Image.Image | None]] = []
-    videos: list[bytes | str | None] = []
-    any_video = False
-    for turn in req.history:
-        image = _decode_image(turn.image_b64) if turn.image_b64 is not None else None
-        history.append((turn.text, image))
-        video = _resolve_video(turn)
-        if video is not None:
-            any_video = True
-        videos.append(video)
-    return ScoreItem(
-        history=history,
-        videos=tuple(videos) if any_video else None,
-        metadata=req.metadata,
-    )
 
 
 def _bucket_by_reward(
@@ -172,23 +110,18 @@ def create_app(cfg: ServiceCfg) -> FastAPI:
     @app.post("/score", response_model=ScoreResponse)
     async def score(body: ScoreRequest) -> ScoreResponse:
         pool: WorkerPool = app.state.pool
+        if body.protocol_version != "1":
+            raise HTTPException(status_code=400, detail=f"unsupported protocol_version={body.protocol_version!r}")
         if not body.requests:
             return ScoreResponse(results=[], errors=[])
 
-        items = await asyncio.to_thread(
-            lambda: [_request_to_item(r) for r in body.requests]
-        )
+        items = await asyncio.to_thread(lambda: [request_to_item(r) for r in body.requests])
         buckets = _bucket_by_reward(body.requests, items, pool)
 
         timeout_s = cfg.server.score_timeout_s
-        name_to_ref = {
-            name: pool.dispatch(name, bucket_items)
-            for name, (_, bucket_items) in buckets.items()
-        }
+        name_to_ref = {name: pool.dispatch(name, bucket_items) for name, (_, bucket_items) in buckets.items()}
         gathered = dict(
-            await asyncio.gather(
-                *(_await_ref(pool, name, ref, timeout_s) for name, ref in name_to_ref.items())
-            )
+            await asyncio.gather(*(_await_ref(pool, name, ref, timeout_s) for name, ref in name_to_ref.items()))
         )
 
         results: list[dict[str, dict[str, float]]] = [dict() for _ in body.requests]
@@ -202,6 +135,10 @@ def create_app(cfg: ServiceCfg) -> FastAPI:
                 continue
             for i, sub_metrics in zip(indices, bucket_scores):
                 results[i][name] = sub_metrics
-        return ScoreResponse(results=results, errors=errors)
+        return ScoreResponse(
+            results=results,
+            errors=errors,
+            identities=[request.identity() for request in body.requests],
+        )
 
     return app

--- a/unirl-reward-service/reward_service/server.py
+++ b/unirl-reward-service/reward_service/server.py
@@ -21,7 +21,7 @@ from fastapi import FastAPI, HTTPException
 
 from reward_service.config import ServiceCfg
 from reward_service.logging_utils import get_logger
-from reward_service.schemas import RewardRequest, ScoreRequest, ScoreResponse
+from reward_service.schemas import PROTOCOL_VERSION, RewardRequest, ScoreRequest, ScoreResponse
 from reward_service.scorers import ScoreItem
 from reward_service.wire import request_to_item
 from reward_service.workers.pool import WorkerPool
@@ -110,7 +110,7 @@ def create_app(cfg: ServiceCfg) -> FastAPI:
     @app.post("/score", response_model=ScoreResponse)
     async def score(body: ScoreRequest) -> ScoreResponse:
         pool: WorkerPool = app.state.pool
-        if body.protocol_version != "1":
+        if body.protocol_version != PROTOCOL_VERSION:
             raise HTTPException(status_code=400, detail=f"unsupported protocol_version={body.protocol_version!r}")
         if any(request.scorer_version is not None for request in body.requests):
             # One gateway request may name several rewards and the pool reports no
@@ -121,7 +121,8 @@ def create_app(cfg: ServiceCfg) -> FastAPI:
                 status_code=400,
                 detail=(
                     "scorer_version pinning is not supported by the multi-reward gateway; "
-                    "drop expected_scorer_version or point the client at a managed single-scorer child"
+                    "omit the scorer_version pin (expected_scorer_version in RemoteRewardSpec) "
+                    "or point the client at a managed single-scorer child"
                 ),
             )
         if not body.requests:

--- a/unirl-reward-service/reward_service/server.py
+++ b/unirl-reward-service/reward_service/server.py
@@ -112,6 +112,18 @@ def create_app(cfg: ServiceCfg) -> FastAPI:
         pool: WorkerPool = app.state.pool
         if body.protocol_version != "1":
             raise HTTPException(status_code=400, detail=f"unsupported protocol_version={body.protocol_version!r}")
+        if any(request.scorer_version is not None for request in body.requests):
+            # One gateway request may name several rewards and the pool reports no
+            # per-scorer version, so this identity field can never be filled in
+            # truthfully here. Say so instead of echoing None and making the client
+            # reject every response as a version mismatch.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "scorer_version pinning is not supported by the multi-reward gateway; "
+                    "drop expected_scorer_version or point the client at a managed single-scorer child"
+                ),
+            )
         if not body.requests:
             return ScoreResponse(results=[], errors=[])
 

--- a/unirl-reward-service/reward_service/wire.py
+++ b/unirl-reward-service/reward_service/wire.py
@@ -1,0 +1,62 @@
+"""Reward HTTP wire decoding shared by the full and direct servers."""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+
+from fastapi import HTTPException
+from PIL import Image
+
+from reward_service.schemas import HistoryTurn, RewardRequest
+from reward_service.scorers import ScoreItem
+
+
+def decode_image(image_b64: str) -> Image.Image:
+    try:
+        raw = base64.b64decode(image_b64)
+        return Image.open(io.BytesIO(raw)).convert("RGB")
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"invalid image_b64: {exc}") from exc
+
+
+def resolve_video(turn: HistoryTurn) -> bytes | str | None:
+    if turn.video_path is not None:
+        path = Path(turn.video_path)
+        if not path.is_file():
+            raise HTTPException(
+                status_code=400,
+                detail=f"video_path does not exist or is not a regular file: {turn.video_path}",
+            )
+        return str(path)
+    if turn.video_b64 is not None:
+        try:
+            return base64.b64decode(turn.video_b64)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"invalid video_b64: {exc}") from exc
+    return None
+
+
+def request_to_item(request: RewardRequest, *, allow_video: bool = True) -> ScoreItem:
+    if not request.history:
+        raise HTTPException(status_code=400, detail="history must not be empty")
+    history: list[tuple[str, Image.Image | None]] = []
+    videos: list[bytes | str | None] = []
+    any_video = False
+    for turn in request.history:
+        image = decode_image(turn.image_b64) if turn.image_b64 is not None else None
+        history.append((turn.text, image))
+        video = resolve_video(turn)
+        if video is not None and not allow_video:
+            raise HTTPException(status_code=400, detail="this scorer server does not accept video inputs")
+        any_video = any_video or video is not None
+        videos.append(video)
+    return ScoreItem(
+        history=history,
+        videos=tuple(videos) if any_video else None,
+        metadata=request.metadata,
+    )
+
+
+__all__ = ["decode_image", "request_to_item", "resolve_video"]

--- a/unirl/reward/README.md
+++ b/unirl/reward/README.md
@@ -56,9 +56,48 @@ never mutates the input Sample — it returns a fresh one. Per call it:
 
 A backend is just `compute_rewards(request) -> RewardResponse`. Local scorers
 (`local/`) subclass `LocalRewardBackend` and implement `_compute_model_rewards`;
-the remote backend (`remote.py`) sends one `POST /score` per scoring call, packing
-the whole batch and multiplexing every requested reward in one round trip, and
-derives success from the response.
+the remote backend (`remote.py`) sends one or more bounded `POST /score` calls,
+multiplexes every requested reward in each item, and derives success from the
+merged response.
+
+### Managed image scorers
+
+`ManagedScorerProcessBackend` is the environment-isolated, rank-affine middle
+ground between local and externally deployed rewards. Each reward worker launches
+one scorer child with an explicit Python executable; the child inherits that
+worker's single visible GPU and serves only its local prompt-tree shard over
+loopback HTTP. The initial capability is deliberately limited to image and
+image-edit histories.
+
+Its config separates process ownership, scorer construction, and remote-client
+semantics:
+
+```yaml
+backend:
+  _target_: unirl.reward.managed_process.ManagedScorerProcessBackend
+  base_device: cpu
+  config:
+    _target_: unirl.reward.managed_process.ManagedScorerProcessSpec
+    process:
+      _target_: unirl.reward.managed_process.ManagedProcessConfig
+      python_executable: /venvs/reward/bin/python
+      service_root: /workspace/UniRL/unirl-reward-service
+    scorer:
+      _target_: unirl.reward.managed_process.ManagedScorerConfig
+      name: editreward
+      input_kind: image_edit
+      params: {device: cuda, checkpoint_path: /models/EditReward}
+    client:
+      _target_: unirl.reward.remote.RemoteRewardSpec
+      base_url: managed://rank-affine
+      required_rewards: [editreward]
+      input_kind: image
+      request_batch_size: 8
+```
+
+`request_batch_size` bounds transport/scorer calls independently from the DP
+shard size. Identity echo is required for managed children, and lifecycle calls
+map to explicit child `onload`/`offload`/`drain` endpoints.
 
 **Extending it:** a new local scorer is usually a file in `local/` subclassing
 `LocalRewardBackend` (set `canonical_model_name`, implement `_load_model` +

--- a/unirl/reward/README.md
+++ b/unirl/reward/README.md
@@ -85,7 +85,7 @@ backend:
     scorer:
       _target_: unirl.reward.managed_process.ManagedScorerConfig
       name: editreward
-      input_kind: image_edit
+      history_kind: image_edit
       params: {device: cuda, checkpoint_path: /models/EditReward}
     client:
       _target_: unirl.reward.remote.RemoteRewardSpec
@@ -93,11 +93,13 @@ backend:
       required_rewards: [editreward]
       input_kind: image
       request_batch_size: 8
+    gpu_residency: resident
 ```
 
 `request_batch_size` bounds transport/scorer calls independently from the DP
-shard size. Identity echo is required for managed children, and lifecycle calls
-map to explicit child `onload`/`offload`/`drain` endpoints.
+shard size. Identity echo is required for managed children. The parent manages
+GPU residency through the child's `onload`, `offload`, and `shutdown` endpoints;
+`drain` remains available for explicit synchronization.
 
 **Extending it:** a new local scorer is usually a file in `local/` subclassing
 `LocalRewardBackend` (set `canonical_model_name`, implement `_load_model` +

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -266,8 +266,9 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             response = self._session.post(f"{self.base_url}/lifecycle/{action}", timeout=timeout)
             response.raise_for_status()
             return True
-        except requests.RequestException:
+        except requests.RequestException as exc:
             if tolerate_failure:
+                logger.warning("managed scorer lifecycle %s failed during cleanup: %s", action, exc)
                 return False
             raise
 
@@ -275,15 +276,20 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         if self.process_config.lifecycle != "per_call":
             return super().compute_rewards(request)
         with self._lifecycle_lock:
-            self.onload()
             try:
+                self.onload()
                 response = super().compute_rewards(request)
             except BaseException:
-                # A child that crashed mid-score fails this offload too; that
-                # lifecycle error must not replace the real scoring failure.
+                # A failed onload or score can also make cleanup fail; preserve
+                # the operation that caused the request to fail.
                 self._lifecycle("offload", tolerate_failure=True)
                 raise
-            self.offload()
+            if all(response.successes):
+                self.offload()
+            else:
+                # The direct server reports scorer failures as HTTP 200 with
+                # per-item errors. Preserve those details if cleanup also fails.
+                self._lifecycle("offload", tolerate_failure=True)
             return response
 
     def is_available(self) -> bool:

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -122,12 +122,11 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             )
             super().__init__(config=remote_spec, base_device=base_device)
             # per_call means "on GPU only while scoring" — including BEFORE the
-            # first score call. The child boots resident (model loaded to CUDA),
-            # so without this initial offload it holds its full footprint through
-            # the whole first generation phase and can OOM a colocated rollout
-            # before any scoring ever happens.
-            if self.process_config.lifecycle == "per_call":
-                self.offload()
+            # first score call and before the child is even ready. The child is
+            # started with --boot-offloaded, so it leaves the GPU (or, for
+            # scorers honoring UNIRL_SCORER_BOOT_OFFLOADED, never touches it)
+            # BEFORE _start_child sees it ready; a parent-side offload here
+            # would reopen the bootstrap window it is meant to close.
         except Exception:
             self._stop_child()
             raise
@@ -147,6 +146,11 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             env["TRANSFORMERS_OFFLINE"] = "1"
         env.pop("RAY_ADDRESS", None)
         env["UNIRL_REWARD_PARENT_PID"] = str(os.getpid())
+        if cfg.lifecycle == "per_call":
+            # Construction-time hint: scorers that can build on CPU (e.g.
+            # EditReward) read this and never touch the GPU during boot, closing
+            # the bootstrap window entirely instead of merely shrinking it.
+            env["UNIRL_SCORER_BOOT_OFFLOADED"] = "1"
         device = str(cfg.scorer.params.get("device", "cuda"))
         _validate_visible_device(
             env,
@@ -185,6 +189,8 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                 "--params-json",
                 json.dumps(cfg.scorer.params, separators=(",", ":")),
             ]
+            if cfg.lifecycle == "per_call":
+                command.append("--boot-offloaded")
             logger.info(
                 "starting managed reward child scorer=%s port=%d cuda_visible=%s python=%s log=%s",
                 cfg.scorer.name,
@@ -206,6 +212,10 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         base_url = f"http://127.0.0.1:{port}"
         session = requests.Session()
         session.trust_env = False
+        # A per_call child boots offloaded (--boot-offloaded): the scorer must be
+        # off the GPU by the time it first reports ready, so that is the ready
+        # state to wait for. Resident children report "resident" as before.
+        expected_state = "offloaded" if cfg.lifecycle == "per_call" else "resident"
         deadline = time.monotonic() + float(cfg.process.startup_timeout)
         try:
             while time.monotonic() < deadline:
@@ -219,8 +229,22 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                         body = response.json()
                         scorer = body.get("scorer") or {}
                         if (
-                            cfg.scorer.name in dict(body.get("rewards") or {})
+                            expected_state == "offloaded"
                             and body.get("state") == "resident"
+                            and cfg.scorer.name in dict(body.get("rewards") or {})
+                        ):
+                            # An up-to-date child never reports resident before a
+                            # per_call parent has seen it offloaded — this is an
+                            # old server that ignored --boot-offloaded. Fail now
+                            # instead of burning the whole startup_timeout.
+                            raise RuntimeError(
+                                "reward child came up resident despite --boot-offloaded; "
+                                f"unirl-reward-service at {cfg.process.service_root!r} predates "
+                                f"the per_call boot protocol; log={log_path}"
+                            )
+                        if (
+                            cfg.scorer.name in dict(body.get("rewards") or {})
+                            and body.get("state") == expected_state
                             and scorer.get("input_kind") == "image"
                         ):
                             if cfg.lifecycle == "per_call" and not scorer.get("supports_offload"):

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -121,6 +121,13 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                 expected_scorer_version=config.scorer.version,
             )
             super().__init__(config=remote_spec, base_device=base_device)
+            # per_call means "on GPU only while scoring" — including BEFORE the
+            # first score call. The child boots resident (model loaded to CUDA),
+            # so without this initial offload it holds its full footprint through
+            # the whole first generation phase and can OOM a colocated rollout
+            # before any scoring ever happens.
+            if self.process_config.lifecycle == "per_call":
+                self.offload()
         except Exception:
             self._stop_child()
             raise

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -258,9 +258,14 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         with self._lifecycle_lock:
             self.onload()
             try:
-                return super().compute_rewards(request)
-            finally:
-                self.offload()
+                response = super().compute_rewards(request)
+            except BaseException:
+                # A child that crashed mid-score fails this offload too; that
+                # lifecycle error must not replace the real scoring failure.
+                self._lifecycle("offload", tolerate_failure=True)
+                raise
+            self.offload()
+            return response
 
     def is_available(self) -> bool:
         if self._process is None or self._process.poll() is not None:

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -40,7 +40,7 @@ class ManagedProcessConfig:
 @dataclass
 class ManagedScorerConfig:
     name: str = ""
-    input_kind: str = "image"
+    history_kind: str = "image"
     params: dict[str, Any] = field(default_factory=dict)
     version: str | None = None
 
@@ -55,7 +55,7 @@ class ManagedScorerProcessSpec(BaseRewardComponentSpec):
             required_rewards=("placeholder",),
         )
     )
-    lifecycle: str = "resident"
+    gpu_residency: str = "resident"
     idempotency_cache_size: int = 1024
 
     def __post_init__(self) -> None:
@@ -70,8 +70,8 @@ class ManagedScorerProcessSpec(BaseRewardComponentSpec):
         require(Path(self.process.service_root).is_dir(), f"reward service root not found: {self.process.service_root}")
         require(bool(self.scorer.name.strip()), "managed scorer name must be non-empty")
         require(
-            self.scorer.input_kind in {"image", "image_edit"},
-            f"managed scorer initial scope is image/image_edit; got {self.scorer.input_kind!r}",
+            self.scorer.history_kind in {"image", "image_edit"},
+            f"managed scorer history_kind must be image or image_edit; got {self.scorer.history_kind!r}",
         )
         require(
             tuple(self.client.required_rewards) == (self.scorer.name,),
@@ -81,7 +81,7 @@ class ManagedScorerProcessSpec(BaseRewardComponentSpec):
             self.client.input_kind == "image",
             f"managed image scorer requires client.input_kind='image'; got {self.client.input_kind!r}",
         )
-        require(self.lifecycle in {"resident", "per_call"}, "lifecycle must be resident or per_call")
+        require(self.gpu_residency in {"resident", "per_call"}, "gpu_residency must be resident or per_call")
         require(self.process.startup_timeout > 0, "startup_timeout must be positive")
         require(self.process.shutdown_timeout > 0, "shutdown_timeout must be positive")
         require(self.idempotency_cache_size > 0, "idempotency_cache_size must be positive")
@@ -104,12 +104,12 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
     """Own one persistent loopback scorer child on this reward worker's GPU."""
 
     def __init__(self, *, config: ManagedScorerProcessSpec, base_device: str) -> None:
-        self.process_config = config
+        self.spec = config
         self._process: subprocess.Popen[bytes] | None = None
         self._process_log: BinaryIO | None = None
         self._disposed = False
         self._atexit_registered = False
-        self._lifecycle_lock = threading.RLock()
+        self._residency_lock = threading.RLock()
         try:
             base_url = self._start_child()
             remote_spec = replace(
@@ -134,7 +134,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         self._atexit_registered = True
 
     def _child_env(self) -> dict[str, str]:
-        cfg = self.process_config
+        cfg = self.spec
         env = dict(os.environ)
         existing_pythonpath = env.get("PYTHONPATH")
         env["PYTHONPATH"] = cfg.process.service_root + (
@@ -146,7 +146,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             env["TRANSFORMERS_OFFLINE"] = "1"
         env.pop("RAY_ADDRESS", None)
         env["UNIRL_REWARD_PARENT_PID"] = str(os.getpid())
-        if cfg.lifecycle == "per_call":
+        if cfg.gpu_residency == "per_call":
             # Construction-time hint: scorers that can build on CPU (e.g.
             # EditReward) read this and never touch the GPU during boot, closing
             # the bootstrap window entirely instead of merely shrinking it.
@@ -160,7 +160,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         return env
 
     def _start_child(self) -> str:
-        cfg = self.process_config
+        cfg = self.spec
         env = self._child_env()
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
             listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -182,14 +182,14 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                 str(listener.fileno()),
                 "--scorer",
                 cfg.scorer.name,
-                "--input-kind",
-                cfg.scorer.input_kind,
+                "--history-kind",
+                cfg.scorer.history_kind,
                 "--cache-size",
                 str(cfg.idempotency_cache_size),
                 "--params-json",
                 json.dumps(cfg.scorer.params, separators=(",", ":")),
             ]
-            if cfg.lifecycle == "per_call":
+            if cfg.gpu_residency == "per_call":
                 command.append("--boot-offloaded")
             logger.info(
                 "starting managed reward child scorer=%s port=%d cuda_visible=%s python=%s log=%s",
@@ -215,7 +215,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         # A per_call child boots offloaded (--boot-offloaded): the scorer must be
         # off the GPU by the time it first reports ready, so that is the ready
         # state to wait for. Resident children report "resident" as before.
-        expected_state = "offloaded" if cfg.lifecycle == "per_call" else "resident"
+        expected_state = "offloaded" if cfg.gpu_residency == "per_call" else "resident"
         deadline = time.monotonic() + float(cfg.process.startup_timeout)
         try:
             while time.monotonic() < deadline:
@@ -226,7 +226,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                         " (an 'unrecognized arguments: --boot-offloaded' log means "
                         f"unirl-reward-service at {cfg.process.service_root!r} predates "
                         "the per_call boot protocol)"
-                        if cfg.lifecycle == "per_call"
+                        if cfg.gpu_residency == "per_call"
                         else ""
                     )
                     raise RuntimeError(
@@ -242,9 +242,9 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                             and body.get("state") == expected_state
                             and scorer.get("input_kind") == "image"
                         ):
-                            if cfg.lifecycle == "per_call" and not scorer.get("supports_offload"):
+                            if cfg.gpu_residency == "per_call" and not scorer.get("supports_offload"):
                                 raise RuntimeError(
-                                    f"managed scorer {cfg.scorer.name!r} does not support lifecycle='per_call'"
+                                    f"managed scorer {cfg.scorer.name!r} does not support gpu_residency='per_call'"
                                 )
                             if cfg.scorer.version is not None and scorer.get("version") != cfg.scorer.version:
                                 raise RuntimeError(
@@ -261,7 +261,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         self._stop_child()
         raise TimeoutError(f"reward child did not become ready within {cfg.process.startup_timeout}s; log={log_path}")
 
-    def _lifecycle(self, action: str, *, timeout: float = 30.0, tolerate_failure: bool = False) -> bool:
+    def _post_lifecycle(self, action: str, *, timeout: float = 30.0, tolerate_failure: bool = False) -> bool:
         try:
             response = self._session.post(f"{self.base_url}/lifecycle/{action}", timeout=timeout)
             response.raise_for_status()
@@ -273,23 +273,20 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             raise
 
     def compute_rewards(self, request: RewardRequest) -> RewardResponse:
-        if self.process_config.lifecycle != "per_call":
+        if self.spec.gpu_residency != "per_call":
             return super().compute_rewards(request)
-        with self._lifecycle_lock:
+        with self._residency_lock:
             try:
-                self.onload()
+                self._post_lifecycle("onload")
                 response = super().compute_rewards(request)
             except BaseException:
                 # A failed onload or score can also make cleanup fail; preserve
                 # the operation that caused the request to fail.
-                self._lifecycle("offload", tolerate_failure=True)
+                self._post_lifecycle("offload", tolerate_failure=True)
                 raise
-            if all(response.successes):
-                self.offload()
-            else:
-                # The direct server reports scorer failures as HTTP 200 with
-                # per-item errors. Preserve those details if cleanup also fails.
-                self._lifecycle("offload", tolerate_failure=True)
+            # The direct server reports scorer failures as HTTP 200 with
+            # per-item errors. Preserve those details if cleanup also fails.
+            self._post_lifecycle("offload", tolerate_failure=not all(response.successes))
             return response
 
     def is_available(self) -> bool:
@@ -298,15 +295,15 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         return super().is_available()
 
     def offload(self) -> None:
-        with self._lifecycle_lock:
-            self._lifecycle("offload")
+        with self._residency_lock:
+            self._post_lifecycle("offload")
 
     def onload(self) -> None:
-        with self._lifecycle_lock:
-            self._lifecycle("onload")
+        with self._residency_lock:
+            self._post_lifecycle("onload")
 
     def dispose(self) -> None:
-        with self._lifecycle_lock:
+        with self._residency_lock:
             if self._disposed:
                 return
             self._disposed = True
@@ -314,13 +311,12 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                 atexit.unregister(self._stop_child)
                 self._atexit_registered = False
             try:
-                if hasattr(self, "_session"):
-                    self._lifecycle(
-                        "shutdown",
-                        timeout=float(self.process_config.process.shutdown_timeout),
-                        tolerate_failure=True,
-                    )
-                    super().dispose()
+                self._post_lifecycle(
+                    "shutdown",
+                    timeout=float(self.spec.process.shutdown_timeout),
+                    tolerate_failure=True,
+                )
+                super().dispose()
             finally:
                 self._stop_child()
 
@@ -333,7 +329,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             except ProcessLookupError:
                 pass
             try:
-                process.wait(timeout=float(self.process_config.process.shutdown_timeout))
+                process.wait(timeout=float(self.spec.process.shutdown_timeout))
             except subprocess.TimeoutExpired:
                 try:
                     os.killpg(process.pid, signal.SIGKILL)
@@ -343,12 +339,6 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         if self._process_log is not None:
             self._process_log.close()
             self._process_log = None
-
-    def __del__(self) -> None:
-        try:
-            self._stop_child()
-        except Exception:
-            pass
 
 
 __all__ = [

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -1,0 +1,322 @@
+"""Rank-affine managed image scorer in an explicit child Python environment."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import signal
+import socket
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, BinaryIO
+
+import requests
+from omegaconf import DictConfig, OmegaConf
+
+from unirl.config.require import require
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.remote import RemoteRewardBackend, RemoteRewardSpec
+from unirl.types.reward import RewardRequest, RewardResponse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ManagedProcessConfig:
+    python_executable: str = ""
+    service_root: str = ""
+    startup_timeout: float = 1200.0
+    shutdown_timeout: float = 30.0
+    log_dir: str = "/tmp"
+    offline: bool = True
+    allow_multiple_visible_devices: bool = False
+
+
+@dataclass
+class ManagedScorerConfig:
+    name: str = ""
+    input_kind: str = "image"
+    params: dict[str, Any] = field(default_factory=dict)
+    version: str | None = None
+
+
+@dataclass
+class ManagedScorerProcessSpec(BaseRewardComponentSpec):
+    process: ManagedProcessConfig = field(default_factory=ManagedProcessConfig)
+    scorer: ManagedScorerConfig = field(default_factory=ManagedScorerConfig)
+    client: RemoteRewardSpec = field(
+        default_factory=lambda: RemoteRewardSpec(
+            base_url="managed://rank-affine",
+            required_rewards=("placeholder",),
+        )
+    )
+    lifecycle: str = "resident"
+    idempotency_cache_size: int = 1024
+
+    def __post_init__(self) -> None:
+        if isinstance(self.scorer.params, DictConfig):
+            resolved = OmegaConf.to_container(self.scorer.params, resolve=True)
+            require(isinstance(resolved, dict), "managed scorer params must resolve to a mapping")
+            self.scorer.params = dict(resolved)
+        require(
+            Path(self.process.python_executable).is_file(),
+            f"reward python not found: {self.process.python_executable}",
+        )
+        require(Path(self.process.service_root).is_dir(), f"reward service root not found: {self.process.service_root}")
+        require(bool(self.scorer.name.strip()), "managed scorer name must be non-empty")
+        require(
+            self.scorer.input_kind in {"image", "image_edit"},
+            f"managed scorer initial scope is image/image_edit; got {self.scorer.input_kind!r}",
+        )
+        require(
+            tuple(self.client.required_rewards) == (self.scorer.name,),
+            "managed single-scorer client.required_rewards must equal (scorer.name,)",
+        )
+        require(
+            self.client.input_kind == "image",
+            f"managed image scorer requires client.input_kind='image'; got {self.client.input_kind!r}",
+        )
+        require(self.lifecycle in {"resident", "per_call"}, "lifecycle must be resident or per_call")
+        require(self.process.startup_timeout > 0, "startup_timeout must be positive")
+        require(self.process.shutdown_timeout > 0, "shutdown_timeout must be positive")
+        require(self.idempotency_cache_size > 0, "idempotency_cache_size must be positive")
+
+
+def _validate_visible_device(env: dict[str, str], *, allow_multiple: bool, device: str) -> None:
+    if not str(device).startswith("cuda"):
+        return
+    visible = [item.strip() for item in env.get("CUDA_VISIBLE_DEVICES", "").split(",") if item.strip()]
+    if not visible:
+        raise RuntimeError("managed CUDA scorer requires CUDA_VISIBLE_DEVICES to identify its rank-local device")
+    if len(visible) != 1 and not allow_multiple:
+        raise RuntimeError(
+            f"managed scorer expected exactly one visible GPU, got CUDA_VISIBLE_DEVICES={visible!r}; "
+            "set allow_multiple_visible_devices=true only for an intentional multi-GPU scorer"
+        )
+
+
+class ManagedScorerProcessBackend(RemoteRewardBackend):
+    """Own one persistent loopback scorer child on this reward worker's GPU."""
+
+    def __init__(self, *, config: ManagedScorerProcessSpec, base_device: str) -> None:
+        self.process_config = config
+        self._process: subprocess.Popen[bytes] | None = None
+        self._process_log: BinaryIO | None = None
+        self._disposed = False
+        self._atexit_registered = False
+        self._lifecycle_lock = threading.RLock()
+        try:
+            base_url = self._start_child()
+            remote_spec = replace(
+                config.client,
+                base_url=base_url,
+                required_rewards=(config.scorer.name,),
+                input_kind="image",
+                require_identity_echo=True,
+                expected_scorer_version=config.scorer.version,
+            )
+            super().__init__(config=remote_spec, base_device=base_device)
+        except Exception:
+            self._stop_child()
+            raise
+        atexit.register(self._stop_child)
+        self._atexit_registered = True
+
+    def _child_env(self) -> dict[str, str]:
+        cfg = self.process_config
+        env = dict(os.environ)
+        existing_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = cfg.process.service_root + (
+            f"{os.pathsep}{existing_pythonpath}" if existing_pythonpath else ""
+        )
+        env["TOKENIZERS_PARALLELISM"] = "false"
+        if cfg.process.offline:
+            env["HF_HUB_OFFLINE"] = "1"
+            env["TRANSFORMERS_OFFLINE"] = "1"
+        env.pop("RAY_ADDRESS", None)
+        env["UNIRL_REWARD_PARENT_PID"] = str(os.getpid())
+        device = str(cfg.scorer.params.get("device", "cuda"))
+        _validate_visible_device(
+            env,
+            allow_multiple=cfg.process.allow_multiple_visible_devices,
+            device=device,
+        )
+        return env
+
+    def _start_child(self) -> str:
+        cfg = self.process_config
+        env = self._child_env()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(128)
+            listener.set_inheritable(True)
+            port = int(listener.getsockname()[1])
+
+            log_dir = Path(cfg.process.log_dir)
+            log_dir.mkdir(parents=True, exist_ok=True)
+            log_path = log_dir / f"{cfg.scorer.name}-child-{os.getpid()}-{port}.log"
+            self._process_log = log_path.open("ab", buffering=0)
+
+            command = [
+                cfg.process.python_executable,
+                "-m",
+                "reward_service.direct_server",
+                "--fd",
+                str(listener.fileno()),
+                "--scorer",
+                cfg.scorer.name,
+                "--input-kind",
+                cfg.scorer.input_kind,
+                "--cache-size",
+                str(cfg.idempotency_cache_size),
+                "--params-json",
+                json.dumps(cfg.scorer.params, separators=(",", ":")),
+            ]
+            logger.info(
+                "starting managed reward child scorer=%s port=%d cuda_visible=%s python=%s log=%s",
+                cfg.scorer.name,
+                port,
+                env.get("CUDA_VISIBLE_DEVICES", "<unset>"),
+                cfg.process.python_executable,
+                log_path,
+            )
+            self._process = subprocess.Popen(
+                command,
+                env=env,
+                pass_fds=(listener.fileno(),),
+                stdout=self._process_log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+
+        base_url = f"http://127.0.0.1:{port}"
+        session = requests.Session()
+        session.trust_env = False
+        deadline = time.monotonic() + float(cfg.process.startup_timeout)
+        try:
+            while time.monotonic() < deadline:
+                if self._process.poll() is not None:
+                    raise RuntimeError(
+                        f"reward child exited during startup with code {self._process.returncode}; log={log_path}"
+                    )
+                try:
+                    response = session.get(f"{base_url}/health", timeout=2.0)
+                    if response.status_code == 200:
+                        body = response.json()
+                        scorer = body.get("scorer") or {}
+                        if (
+                            cfg.scorer.name in dict(body.get("rewards") or {})
+                            and body.get("state") == "resident"
+                            and scorer.get("input_kind") == "image"
+                        ):
+                            if cfg.lifecycle == "per_call" and not scorer.get("supports_offload"):
+                                raise RuntimeError(
+                                    f"managed scorer {cfg.scorer.name!r} does not support lifecycle='per_call'"
+                                )
+                            if cfg.scorer.version is not None and scorer.get("version") != cfg.scorer.version:
+                                raise RuntimeError(
+                                    f"reward child scorer version {scorer.get('version')!r} "
+                                    f"!= expected {cfg.scorer.version!r}"
+                                )
+                            logger.info("managed reward child ready at %s", base_url)
+                            return base_url
+                except requests.RequestException:
+                    pass
+                time.sleep(1.0)
+        finally:
+            session.close()
+        self._stop_child()
+        raise TimeoutError(f"reward child did not become ready within {cfg.process.startup_timeout}s; log={log_path}")
+
+    def _lifecycle(self, action: str, *, timeout: float = 30.0, tolerate_failure: bool = False) -> bool:
+        try:
+            response = self._session.post(f"{self.base_url}/lifecycle/{action}", timeout=timeout)
+            response.raise_for_status()
+            return True
+        except requests.RequestException:
+            if tolerate_failure:
+                return False
+            raise
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        if self.process_config.lifecycle != "per_call":
+            return super().compute_rewards(request)
+        with self._lifecycle_lock:
+            self.onload()
+            try:
+                return super().compute_rewards(request)
+            finally:
+                self.offload()
+
+    def is_available(self) -> bool:
+        if self._process is None or self._process.poll() is not None:
+            return False
+        return super().is_available()
+
+    def offload(self) -> None:
+        with self._lifecycle_lock:
+            self._lifecycle("offload")
+
+    def onload(self) -> None:
+        with self._lifecycle_lock:
+            self._lifecycle("onload")
+
+    def dispose(self) -> None:
+        with self._lifecycle_lock:
+            if self._disposed:
+                return
+            self._disposed = True
+            if self._atexit_registered:
+                atexit.unregister(self._stop_child)
+                self._atexit_registered = False
+            try:
+                if hasattr(self, "_session"):
+                    self._lifecycle(
+                        "shutdown",
+                        timeout=float(self.process_config.process.shutdown_timeout),
+                        tolerate_failure=True,
+                    )
+                    super().dispose()
+            finally:
+                self._stop_child()
+
+    def _stop_child(self) -> None:
+        process = self._process
+        self._process = None
+        if process is not None and process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=float(self.process_config.process.shutdown_timeout))
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait(timeout=5)
+        if self._process_log is not None:
+            self._process_log.close()
+            self._process_log = None
+
+    def __del__(self) -> None:
+        try:
+            self._stop_child()
+        except Exception:
+            pass
+
+
+__all__ = [
+    "ManagedProcessConfig",
+    "ManagedScorerConfig",
+    "ManagedScorerProcessBackend",
+    "ManagedScorerProcessSpec",
+]

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -220,28 +220,23 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         try:
             while time.monotonic() < deadline:
                 if self._process.poll() is not None:
+                    # A service tree predating --boot-offloaded exits at argparse
+                    # ("unrecognized arguments") before ever binding the socket.
+                    hint = (
+                        " (an 'unrecognized arguments: --boot-offloaded' log means "
+                        f"unirl-reward-service at {cfg.process.service_root!r} predates "
+                        "the per_call boot protocol)"
+                        if cfg.lifecycle == "per_call"
+                        else ""
+                    )
                     raise RuntimeError(
-                        f"reward child exited during startup with code {self._process.returncode}; log={log_path}"
+                        f"reward child exited during startup with code {self._process.returncode}; log={log_path}{hint}"
                     )
                 try:
                     response = session.get(f"{base_url}/health", timeout=2.0)
                     if response.status_code == 200:
                         body = response.json()
                         scorer = body.get("scorer") or {}
-                        if (
-                            expected_state == "offloaded"
-                            and body.get("state") == "resident"
-                            and cfg.scorer.name in dict(body.get("rewards") or {})
-                        ):
-                            # An up-to-date child never reports resident before a
-                            # per_call parent has seen it offloaded — this is an
-                            # old server that ignored --boot-offloaded. Fail now
-                            # instead of burning the whole startup_timeout.
-                            raise RuntimeError(
-                                "reward child came up resident despite --boot-offloaded; "
-                                f"unirl-reward-service at {cfg.process.service_root!r} predates "
-                                f"the per_call boot protocol; log={log_path}"
-                            )
                         if (
                             cfg.scorer.name in dict(body.get("rewards") or {})
                             and body.get("state") == expected_state

--- a/unirl/reward/remote.py
+++ b/unirl/reward/remote.py
@@ -386,11 +386,10 @@ class RemoteRewardBackend(RewardBackend):
 
     def _post_score_requests(self, wire_requests: List[Dict[str, Any]]) -> Dict[str, Any]:
         if not wire_requests:
-            return {"protocol_version": "1", "results": [], "errors": [], "identities": []}
+            return {"protocol_version": "1", "results": [], "errors": []}
         request_batch_size = self.request_batch_size or len(wire_requests)
         merged_results: List[Dict[str, Dict[str, float]]] = []
         merged_errors: List[Dict[str, str]] = []
-        merged_identities: List[Dict[str, Any]] = []
 
         for start in range(0, len(wire_requests), request_batch_size):
             chunk = wire_requests[start : start + request_batch_size]
@@ -418,32 +417,14 @@ class RemoteRewardBackend(RewardBackend):
                     self._validate_identity_echo(expected, actual)
             elif self.require_identity_echo:
                 raise ValueError("RewardService response omitted required item identities")
-            else:
-                identities = [
-                    {
-                        key: request.get(key)
-                        for key in (
-                            "request_id",
-                            "sample_id",
-                            "group_id",
-                            "source_rank",
-                            "policy_version",
-                            "scorer_version",
-                            "idempotency_key",
-                        )
-                    }
-                    for request in chunk
-                ]
 
             merged_results.extend(results)
             merged_errors.extend(errors)
-            merged_identities.extend(identities)
 
         return {
             "protocol_version": "1",
             "results": merged_results,
             "errors": merged_errors,
-            "identities": merged_identities,
         }
 
     def _validate_identity_echo(self, expected: Dict[str, Any], actual: Dict[str, Any]) -> None:
@@ -477,6 +458,9 @@ class RemoteRewardBackend(RewardBackend):
                     self.max_retries,
                 )
             except http_requests.exceptions.RequestException as e:
+                response = getattr(e, "response", None)
+                if response is not None and 400 <= response.status_code < 500 and response.status_code != 429:
+                    raise
                 last_exc = e
                 logger.warning(
                     "RemoteRewardBackend: %s (attempt %d/%d)",

--- a/unirl/reward/remote.py
+++ b/unirl/reward/remote.py
@@ -611,6 +611,7 @@ class RemoteRewardSpec(BaseRewardComponentSpec):
     # None preserves the legacy one-POST-per-DP-shard behavior.
     request_batch_size: Optional[int] = None
     require_identity_echo: bool = False
+    # Managed/direct single-scorer servers only; the multi-reward gateway rejects a pin.
     expected_scorer_version: Optional[str] = None
     sub_metric_reduce: str = "first"
     aggregation_method: str = "weighted_sum"

--- a/unirl/reward/remote.py
+++ b/unirl/reward/remote.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import io
+import json
 import logging
 import math
+import os
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -93,6 +97,62 @@ def _encode_video_b64(
     return base64.b64encode(video_bytes).decode("ascii")
 
 
+def _optional_rank() -> Optional[int]:
+    raw = os.environ.get("RANK")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _payload_fingerprint(*, media_fingerprint: str, prompt: str, metadata: Any) -> str:
+    digest = hashlib.sha256()
+    digest.update(media_fingerprint.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(prompt.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(json.dumps(metadata, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _wire_identity(
+    request: RewardRequest,
+    index: int,
+    *,
+    required_rewards: List[str],
+    expected_scorer_version: Optional[str],
+    payload_fingerprint: str,
+) -> Dict[str, Any]:
+    sample_id = request.sample_ids[index] if request.sample_ids and index < len(request.sample_ids) else None
+    group_id = request.group_ids[index] if request.group_ids and index < len(request.group_ids) else None
+    metadata = request.metadata[index] if request.metadata and index < len(request.metadata) else None
+    policy_version = metadata.get("policy_version") if isinstance(metadata, dict) else None
+    request_id = str(sample_id or uuid.uuid4())
+    digest_input = json.dumps(
+        {
+            "protocol": "1",
+            "request_id": request_id,
+            "required_rewards": required_rewards,
+            "policy_version": policy_version,
+            "scorer_version": expected_scorer_version,
+            "payload_fingerprint": payload_fingerprint,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return {
+        "request_id": request_id,
+        "sample_id": sample_id,
+        "group_id": group_id,
+        "source_rank": _optional_rank(),
+        "policy_version": policy_version if isinstance(policy_version, int) else None,
+        "scorer_version": expected_scorer_version,
+        "idempotency_key": hashlib.sha256(digest_input.encode("utf-8")).hexdigest(),
+    }
+
+
 class RemoteRewardBackend(RewardBackend):
     """HTTP client backend for the remote RewardService ``POST /score`` endpoint."""
 
@@ -111,6 +171,9 @@ class RemoteRewardBackend(RewardBackend):
         self.reward_weights = dict(config.reward_weights or {})
         self.max_retries = config.max_retries
         self.retry_delay = config.retry_delay
+        self.request_batch_size = config.request_batch_size
+        self.require_identity_echo = config.require_identity_echo
+        self.expected_scorer_version = config.expected_scorer_version
         self.sub_metric_reduce = config.sub_metric_reduce
         self.image_format = config.image_format
         self.image_quality = config.image_quality
@@ -133,7 +196,7 @@ class RemoteRewardBackend(RewardBackend):
         bs = request.batch_size
         try:
             payload = self._build_score_payload(request)
-            raw = self._post_score(payload)
+            raw = self._post_score_requests(payload["requests"])
             return self._parse_score_response(raw, bs, time.time() - start)
         except Exception:
             if self.raise_on_failure:
@@ -228,18 +291,32 @@ class RemoteRewardBackend(RewardBackend):
                     {"text": prompt, "image_b64": condition_b64},
                     {"text": prompt, "image_b64": image_b64},
                 ]
+                media_fingerprint = hashlib.sha256(f"{condition_b64}:{image_b64}".encode("ascii")).hexdigest()
             else:
                 history = [{"text": prompt, "image_b64": image_b64}]
+                media_fingerprint = hashlib.sha256(image_b64.encode("ascii")).hexdigest()
 
+            identity = _wire_identity(
+                request,
+                idx,
+                required_rewards=self.required_rewards,
+                expected_scorer_version=self.expected_scorer_version,
+                payload_fingerprint=_payload_fingerprint(
+                    media_fingerprint=media_fingerprint,
+                    prompt=prompt,
+                    metadata=sample_metadata,
+                ),
+            )
             wire_requests.append(
                 {
                     "history": history,
                     "required_rewards": list(self.required_rewards),
                     "metadata": sample_metadata,
+                    **identity,
                 }
             )
 
-        return {"requests": wire_requests}
+        return {"protocol_version": "1", "requests": wire_requests}
 
     def _get_condition_images(self, request: RewardRequest) -> Optional[List[Union[Image.Image, torch.Tensor]]]:
         """Extract per-sample condition images from request primitives."""
@@ -259,7 +336,7 @@ class RemoteRewardBackend(RewardBackend):
         bs = request.batch_size
         try:
             payload = self._build_video_score_payload(request)
-            raw = self._post_score(payload)
+            raw = self._post_score_requests(payload["requests"])
             return self._parse_score_response(raw, bs, time.time() - start)
         except Exception:
             if self.raise_on_failure:
@@ -285,15 +362,102 @@ class RemoteRewardBackend(RewardBackend):
             sample_metadata = None
             if metadata_list is not None and idx < len(metadata_list):
                 sample_metadata = metadata_list[idx]
+            identity = _wire_identity(
+                request,
+                idx,
+                required_rewards=self.required_rewards,
+                expected_scorer_version=self.expected_scorer_version,
+                payload_fingerprint=_payload_fingerprint(
+                    media_fingerprint=hashlib.sha256(video_b64.encode("ascii")).hexdigest(),
+                    prompt=prompt,
+                    metadata=sample_metadata,
+                ),
+            )
             wire_requests.append(
                 {
                     "history": [{"text": prompt, "video_b64": video_b64}],
                     "required_rewards": list(self.required_rewards),
                     "metadata": sample_metadata,
+                    **identity,
                 }
             )
 
-        return {"requests": wire_requests}
+        return {"protocol_version": "1", "requests": wire_requests}
+
+    def _post_score_requests(self, wire_requests: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not wire_requests:
+            return {"protocol_version": "1", "results": [], "errors": [], "identities": []}
+        request_batch_size = self.request_batch_size or len(wire_requests)
+        merged_results: List[Dict[str, Dict[str, float]]] = []
+        merged_errors: List[Dict[str, str]] = []
+        merged_identities: List[Dict[str, Any]] = []
+
+        for start in range(0, len(wire_requests), request_batch_size):
+            chunk = wire_requests[start : start + request_batch_size]
+            raw = self._post_score({"protocol_version": "1", "requests": chunk})
+            response_version = raw.get("protocol_version")
+            if response_version is not None and response_version != "1":
+                raise ValueError(f"RewardService protocol_version={response_version!r}, expected '1'")
+            results = list(raw.get("results") or [])
+            errors = list(raw.get("errors") or [])
+            identities = list(raw.get("identities") or [])
+            if len(results) > len(chunk) or len(errors) > len(chunk):
+                raise ValueError(
+                    f"RewardService returned more rows than requested for chunk {start}: "
+                    f"results={len(results)} errors={len(errors)} requested={len(chunk)}"
+                )
+            results.extend({} for _ in range(len(chunk) - len(results)))
+            errors.extend({} for _ in range(len(chunk) - len(errors)))
+
+            if identities:
+                if len(identities) != len(chunk):
+                    raise ValueError(
+                        f"RewardService identity count {len(identities)} != requested chunk size {len(chunk)}"
+                    )
+                for expected, actual in zip(chunk, identities, strict=True):
+                    self._validate_identity_echo(expected, actual)
+            elif self.require_identity_echo:
+                raise ValueError("RewardService response omitted required item identities")
+            else:
+                identities = [
+                    {
+                        key: request.get(key)
+                        for key in (
+                            "request_id",
+                            "sample_id",
+                            "group_id",
+                            "source_rank",
+                            "policy_version",
+                            "scorer_version",
+                            "idempotency_key",
+                        )
+                    }
+                    for request in chunk
+                ]
+
+            merged_results.extend(results)
+            merged_errors.extend(errors)
+            merged_identities.extend(identities)
+
+        return {
+            "protocol_version": "1",
+            "results": merged_results,
+            "errors": merged_errors,
+            "identities": merged_identities,
+        }
+
+    def _validate_identity_echo(self, expected: Dict[str, Any], actual: Dict[str, Any]) -> None:
+        for key in ("request_id", "sample_id", "group_id", "source_rank", "policy_version", "idempotency_key"):
+            if actual.get(key) != expected.get(key):
+                raise ValueError(
+                    f"RewardService identity mismatch for {key}: expected {expected.get(key)!r}, "
+                    f"got {actual.get(key)!r}"
+                )
+        if self.expected_scorer_version is not None and actual.get("scorer_version") != self.expected_scorer_version:
+            raise ValueError(
+                f"RewardService scorer_version={actual.get('scorer_version')!r} "
+                f"!= expected {self.expected_scorer_version!r}"
+            )
 
     def _post_score(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """POST to ``/score`` with retry logic."""
@@ -423,7 +587,7 @@ class RemoteRewardBackend(RewardBackend):
     def _reduce_sub_metrics(self, sub_metrics: Dict[str, float]) -> float:
         """Collapse a reward's sub-metric dict into a single float."""
         if not sub_metrics:
-            return 0.0
+            raise ValueError("RewardService returned an empty sub-metric mapping")
         values = list(sub_metrics.values())
         if self.sub_metric_reduce == "first":
             return float(values[0])
@@ -443,6 +607,11 @@ class RemoteRewardSpec(BaseRewardComponentSpec):
     timeout: float = 300.0
     max_retries: int = 3
     retry_delay: float = 1.0
+    # Transport chunking is independent from scorer/model micro-batching.
+    # None preserves the legacy one-POST-per-DP-shard behavior.
+    request_batch_size: Optional[int] = None
+    require_identity_echo: bool = False
+    expected_scorer_version: Optional[str] = None
     sub_metric_reduce: str = "first"
     aggregation_method: str = "weighted_sum"
     image_format: str = "JPEG"
@@ -467,6 +636,10 @@ class RemoteRewardSpec(BaseRewardComponentSpec):
         require(
             self.retry_delay >= 0,
             f"RemoteRewardSpec.retry_delay must be >= 0; got {self.retry_delay!r}",
+        )
+        require(
+            self.request_batch_size is None or self.request_batch_size >= 1,
+            f"RemoteRewardSpec.request_batch_size must be None or >= 1; got {self.request_batch_size!r}",
         )
         require(
             self.sub_metric_reduce in {"first", "mean", "max"},

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -157,6 +157,12 @@ class RewardService(Remote):
     def dispose(self) -> None:
         self.backend.dispose()
 
+    def shutdown(self) -> None:
+        """Worker teardown hook: release backend sessions and managed children."""
+        self.dispose()
+
+    close = shutdown
+
 
 __all__ = [
     "RewardService",

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -161,8 +161,6 @@ class RewardService(Remote):
         """Worker teardown hook: release backend sessions and managed children."""
         self.dispose()
 
-    close = shutdown
-
 
 __all__ = [
     "RewardService",


### PR DESCRIPTION
## Summary

- Add `ManagedScorerProcessBackend`, which launches one scorer child per reward rank with an explicit Python executable and inherited rank-local GPU visibility.
- Serve one image/image-edit scorer over an inherited loopback socket without creating a nested Ray GPU allocation.
- Add bounded request chunking, stable identity/version echo, deterministic idempotency, protocol validation, and graceful lifecycle endpoints.
- Support `resident` and `per_call` GPU residency, and make EditReward model path, dtype, head type, batching, and device movement explicit.

## Related Issue

N/A

## Test Plan

- `uvx --from pre-commit pre-commit run --from-ref origin/main --to-ref HEAD`
- `python -m compileall -q unirl/reward unirl-reward-service/reward_service`
- `python lint/check_recipe_targets.py` (`2,408` recipe `_target_` paths resolved on this tree).
- Latest-upstream Hydra compose for the managed BAGEL recipe.
- End-to-end smoke on 8x NVIDIA H20 96GB using eight rank-affine EditReward children in `/root/venvs/editreward`, each scoring its local one-prompt/eight-image shard.
- Result: all eight children started and served the complete rollout/reward/advantage/train step; reward `-1.0735`, no OOM/traceback/actor crash, exit code 0, clean child and GPU teardown.
- No standalone test files are added; the managed child, wire path, lifecycle, and cleanup were exercised by the real DP8 run.

## Compatibility / Risk

- Existing local and externally hosted `RemoteRewardBackend` paths remain available and keep their defaults.
- Managed mode initially supports only `image` and `image_edit`; text/video/audio carriers are deliberately rejected.
- The child must be given an explicit compatible Python environment and exactly one visible GPU unless multi-GPU use is intentionally enabled.
- `resident` keeps scorer weights on GPU; `per_call` performs blocking CPU/GPU model movement and should be used only when memory requires it.
- Wire additions are versioned/additive; strict identity echo is enabled only for managed children.

## Reviewer Notes

- Rebased onto current `main` (includes #302, #316 one-line docstrings, and #366 `PrimitiveValue`). The branch merges cleanly.
- Review `unirl/reward/*` + `unirl-reward-service/*`. #304 is the BAGEL it2i consumer and production recipe; it must use `history_kind` / `gpu_residency`.
- Implementation was AI-assisted and manually reviewed; commits contain no coauthor trailers or generated test artifacts.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.