### PR TITLE
feat(bagel): add it2i vLLM-Omni managed reward recipe

### DIFF
--- a/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
@@ -1,0 +1,282 @@
+# @package _global_
+# BAGEL-7B-MoT image-EDIT GRPO — vLLM-Omni + managed EditReward DP8.
+#
+# The vllm_omni-rollout sibling of examples/diffusion/bagel/bagel_editreward.yaml:
+# identical model / precision / algorithm / data / reward, but generation runs in
+# eight colocated vLLM-Omni worker subprocesses (one per GPU, TP=1 → DP=8) instead
+# of the in-process TrainsideRolloutEngine, and the freshly-trained LoRA is pushed
+# into them each rollout. Train and one environment-isolated EditReward child per
+# rank remain resident; rollout residency is an explicit memory-policy choice.
+#
+# What it2i adds over bagel_vllmomni.yaml (all handled in unirl/{models,rollout}/bagel):
+#   - modality bagel_it2i — the adapter ships each sample's SOURCE image on the
+#     request (multi_modal_data["image"]) AND mirrors it onto the deferred
+#     conditions (input_images), because the trainer rebuilds the KV contexts at
+#     replay and must prefill the same source image the worker did.
+#   - RLBagelPipeline builds the three it2i KV contexts inside the worker with the
+#     vendored ImageTransform pair and injects them through vLLM-Omni's KV channel,
+#     so upstream's own img2img prefill never runs. That prefill would (a) override
+#     the output canvas with the resized SOURCE dims — breaking the driver-authored
+#     x_T shape — and (b) squash the source to a fixed 980x980 SigLIP square (~4x the
+#     ViT tokens, aspect ratio dropped) instead of the aspect-preserving navit
+#     transform the trainer replays with. A conditioning mismatch is NOT something
+#     replay can absorb: the reward would be earned under one conditioning while the
+#     gradient is taken under another, and no importance ratio corrects that.
+#   - bundle.enable_vit: true — the und ViT tower, needed on the TRAINER to rebuild
+#     the contexts at replay (the worker always builds its own).
+#   - packed rollout is off for it2i (upstream's grouped generate_image is cfg=1 t2i
+#     only), so every GRPO sibling is its own worker request.
+#
+# Deploy (one rank-affine child per train worker; no extra Ray GPU slot):
+#   export BAGEL_PATH=/path/to/BAGEL-7B-MoT
+#   export EDITREWARD_PYTHON=/path/to/editreward/venv/bin/python
+#   export EDITREWARD_CHECKPOINT=/path/to/EditReward-checkpoint
+#   export EDITREWARD_BASE_MODEL=/path/to/MiMo-VL-base
+#   export EDITREWARD_SERVICE_ROOT=$PWD/unirl-reward-service
+#   bash examples/run_experiment_single_node.sh diffusion/bagel/bagel_it2i_vllmomni
+#
+# Compose check (CPU):  python -m unirl.train_diffusion \
+#   --config-name diffusion/bagel/bagel_it2i_vllmomni --cfg job --resolve
+# Smoke first — it2i colocate is the tightest memory shape in the family (7B MoT +
+# ViT on the trainer AND a full BAGEL in each worker, plus source-image KV):
+#   override batch_size=8 num_rollouts=2 eval_interval=2 sampling.samples_per_prompt=2
+
+num_devices: 8
+batch_size: 8                  # prompts/rollout (x samples_per_prompt = images/rollout)
+adv_use_global_std: false      # per-group GRPO normalization
+num_rollouts: 10000            # intentionally large; stop manually
+
+# Periodic eval on the eval set (deterministic: eval_eta=0), logged under eval/*.
+# Eval prompts are chunked (eval_chunk_prompts) to stay within the it2i driver-memory
+# budget. Same values as the trainside editreward run.
+eval_interval: 25
+eval_num_prompts: 16
+eval_samples_per_prompt: 4
+eval_chunk_prompts: 8
+eval_cfg_text_scale: 1
+eval_eta: 0.0
+
+transport_kind: colocate_store
+workers_per_device: 1
+
+# LoRA weight-sync cadence (loop concern, read by DiffusionTrainer.train). Every N
+# rollouts the loop pushes the freshly-trained adapter into the vLLM-Omni engine.
+# 1 = on-policy; >1 lags rollout weights (off-policy drift).
+weight_sync_interval: 1
+# Safe default. Set false only after measuring the full training peak for the
+# exact model, reward, sampling geometry, and accelerator.
+enable_fsdp_offload: false
+offload_train_during_reward: false
+rollout_sleep_after_generate: true
+
+# NB: no `task_config.task: it2i` here. On the trainside recipe that pin is what
+# makes a source-image-less dataset fail loudly; on this path the modality does it —
+# BagelIt2iAdapter.validate_request rejects a Sample without image conditioning.
+
+logging:
+  report_to_wandb: true
+  project_name: ${oc.env:WANDB_PROJECT,bagel-editreward}
+  run_name: bagel_it2i_vllmomni_lora
+  # entity: set via the WANDB_ENTITY env var (wandb picks it up automatically)
+  tags: [bagel, it2i, edit, editreward, lora, vllmomni, fp32master]
+  log_media: true              # logs the source|edited side-by-side preview for it2i
+  media_max_items: 8
+  media_log_interval: 5
+
+bundle:
+  _target_: unirl.models.bagel.bundle.BagelBundle.from_config
+  config:
+    _target_: unirl.models.bagel.config.BagelPipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:BAGEL_PATH,ByteDance-Seed/BAGEL-7B-MoT}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: fp32   # keep diffuse<->replay bit-exact; do NOT lower
+    logprob_precision: fp32
+    shift: 3.0
+    use_lora: true               # read by the engine's WeightSync (uses_lora)
+    enable_vit: true             # EDIT: the und ViT the replay context rebuild needs
+
+pipeline:
+  _target_: unirl.models.bagel.pipeline.BagelPipeline
+  autocast_precision: bf16
+  trajectory_precision: fp32
+  logprob_precision: fp32
+  shift: 3.0
+  strategy:
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Qwen2MoTDecoderLayer"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16                  # COMPUTE dtype (FSDP all-gather + forward/backward)
+    master_dtype: fp32                 # load-bearing: fp32 LoRA master + Adam (reward-collapse fix)
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true     # 7B + multi-step replay: required
+    use_torch_compile: false
+    root_wrap: false                   # vendored BAGEL calls embed_tokens/lm_head outside a root forward
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 1.0e-4
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 100000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64                           # must be <= the stage YAML's max_lora_rank (64)
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:                    # = BAGEL_MOE_GEN_LORA_TARGETS (gen experts only; und/ViT frozen)
+      - self_attn.q_proj_moe_gen
+      - self_attn.k_proj_moe_gen
+      - self_attn.v_proj_moe_gen
+      - self_attn.o_proj_moe_gen
+      - mlp_moe_gen.gate_proj
+      - mlp_moe_gen.up_proj
+      - mlp_moe_gen.down_proj
+
+rollout:
+  _target_: unirl.rollout.engine.vllm_omni.engine.VLLMOmniRolloutEngine
+  # model_config carries the σ-schedule ``shift`` (read by the adapter's
+  # schedule_policy) and ``use_lora`` (read by WeightSync); point it at the bundle's
+  # config so train + rollout share one source.
+  model_config: ${bundle.config}
+  config:
+    _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
+    # Required; same checkpoint the bundle loads.
+    model_path: ${oc.env:BAGEL_PATH,ByteDance-Seed/BAGEL-7B-MoT}
+    # BAGEL single-stage editing modality (registers BagelIt2iAdapter + boots
+    # stage_configs/bagel_t2i_rl.yaml — one YAML serves both image-out modalities —
+    # with RLBagelPipeline).
+    modality: bagel_it2i
+    # Required for colocate: the trainer calls sleep()/wake_up() around the train
+    # phase, a no-op unless CuMemAllocator is enabled at vLLM-Omni init time.
+    enable_sleep_mode: true
+
+# One managed EditReward child per reward rank. The child uses an explicit Python
+# environment, inherits exactly that rank's GPU, and receives bounded source/edit
+# image batches over loopback HTTP.
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.managed_process.ManagedScorerProcessBackend
+    base_device: cpu
+    config:
+      _target_: unirl.reward.managed_process.ManagedScorerProcessSpec
+      process:
+        _target_: unirl.reward.managed_process.ManagedProcessConfig
+        python_executable: ${oc.env:EDITREWARD_PYTHON,/root/venvs/editreward/bin/python}
+        service_root: ${oc.env:EDITREWARD_SERVICE_ROOT,unirl-reward-service}
+        startup_timeout: 1200
+        shutdown_timeout: 30
+        log_dir: ${oc.env:EDITREWARD_CHILD_LOG_DIR,/tmp/unirl-reward}
+        offline: true
+      scorer:
+        _target_: unirl.reward.managed_process.ManagedScorerConfig
+        name: editreward
+        input_kind: image_edit
+        version: "1"
+        params:
+          checkpoint_path: ${oc.env:EDITREWARD_CHECKPOINT,TIGER-Lab/EditReward-MiMo-VL-7B-SFT-2508}
+          model_name_or_path: ${oc.env:EDITREWARD_BASE_MODEL,XiaomiMiMo/MiMo-VL-7B-SFT-2508}
+          config_path: config/EditReward-MiMo-VL-7B-SFT-2508.yaml
+          device: cuda
+          dtype: bfloat16
+          rm_head_type: ranknet_multi_head
+      client:
+        _target_: unirl.reward.remote.RemoteRewardSpec
+        base_url: managed://rank-affine
+        required_rewards: [editreward]
+        reward_weights: {editreward: 1.0}
+        batch_size: 8
+        request_batch_size: 8
+        timeout: 600.0
+        sub_metric_reduce: mean
+        aggregation_method: weighted_sum
+        input_kind: image
+      lifecycle: resident
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 5.0e-3
+  clip_schedule: constant
+  # replay, NOT rollout (which the t2i vllmomni recipe can afford). The worker now
+  # conditions on the SAME source pixels and token geometry as the trainer, but it
+  # still builds the KV context with vLLM's ViT / VAE / MoT kernels while replay uses
+  # the vendored ones — so the emitted rollout log-probs carry a systematic offset.
+  # Anchoring pi_old in the trainer's own forward keeps the ratio well-defined
+  # (== 1 on update 1) instead of starting off it.
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.bagel.conditions.BagelDiffusionConditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1                  # navit bs=1; BagelDiffusionConditions.single asserts it
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2             # 2 optimizer updates/rollout (disjoint mini-batches)
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      # Editing instruction + SOURCE image (role: condition -> the request's input image).
+      data_path: ${oc.env:EDIT_DATA_PATH,datasets/image_edit/train.jsonl}
+      eval_data_path: ${oc.env:EDIT_EVAL_DATA_PATH,datasets/image_edit/test.jsonl}
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+# BAGEL edit sampling (BagelDiffusionParams). Dual-CFG: cfg_text amplifies the
+# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when cfg_text_scale>1).
+sampling:
+  _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
+  num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); the adapter sends +1 to the worker
+  guidance_scale: 1.0
+  cfg_text_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
+  cfg_img_scale: 1.0                   # source<->diversity knob; only active when cfg_text_scale>1
+  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when cfg_text_scale>1
+  cfg_renorm_min: 0.0
+  cfg_renorm_type: text_channel        # CFG renorm; only active when cfg_text_scale>1
+  eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)
+  samples_per_prompt: 8                # GRPO group size; it2i sends one worker request per sample
+  height: 512                          # the OUTPUT canvas. Fixed square: the driver's x_T recipe carries ONE
+  width: 512                           # shape for the whole request, and the worker honors it via kv_metadata
+  seed: 42
+  init_same_noise: true                # siblings share x_T; in-group diversity comes from the SDE noise (eta>0)
+  trajectory_precision: fp32           # forwarded to the worker scheduler's SDE log-prob storage round-trip
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.WindowScheduler
+    num_timesteps: 7                   # SDE window drawn from the first half of the 14 inference steps
+    config:
+      _target_: unirl.utils.scheduler_utils.WindowConfig
+      strategy: random
+      window_size: 3                   # a random contiguous 3-step SDE window per rollout
+
+# LoRA weight sync → vLLM-Omni rollout. Instantiated as a LocalLoraWeightSync
+# (sibling of backend + rollout). The train loop drives cadence via
+# weight_sync_interval (top of file): every N rollouts it calls sync() to push the
+# freshly-trained LoRA (set_lora_from_tensors) into the engine just before generate.
+sync:
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
+  verify: true                         # checksum read-back asserts the synced LoRA landed; catches a wrong prefix
+  # Mirrors BagelPipelineConfig.weight_sync_param_name_prefix; must match the
+  # engine-side LoRA key naming (the trainable module is model.language_model).
+  param_prefix: "language_model."
+  adapter_name: default

--- a/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
@@ -187,7 +187,7 @@ reward:
       scorer:
         _target_: unirl.reward.managed_process.ManagedScorerConfig
         name: editreward
-        input_kind: image_edit
+        history_kind: image_edit
         version: "1"
         params:
           checkpoint_path: ${oc.env:EDITREWARD_CHECKPOINT,TIGER-Lab/EditReward-MiMo-VL-7B-SFT-2508}
@@ -208,7 +208,7 @@ reward:
         sub_metric_reduce: first
         aggregation_method: weighted_sum
         input_kind: image
-      lifecycle: resident
+      gpu_residency: resident
 
 algorithm:
   _target_: unirl.algorithms.flowgrpo.FlowGRPO

--- a/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
@@ -53,7 +53,6 @@ eval_interval: 25
 eval_num_prompts: 16
 eval_samples_per_prompt: 4
 eval_chunk_prompts: 8
-eval_cfg_text_scale: 1
 eval_eta: 0.0
 
 transport_kind: colocate_store
@@ -118,6 +117,7 @@ backend:
     fsdp_mode: full
     reshard_after_forward: true
     activation_checkpointing: true     # 7B + multi-step replay: required
+    ac_wrap_order: inside              # recompute re-enters FSDP hooks; the order this recipe's smoke validated
     use_torch_compile: false
     root_wrap: false                   # vendored BAGEL calls embed_tokens/lm_head outside a root forward
   optimizer_cfg:
@@ -204,13 +204,7 @@ reward:
         batch_size: 8
         request_batch_size: 8
         timeout: 600.0
-        # `first` == the scorer's first sub-metric == reward column 0. The pinned
-        # config above pools its two semantic heads INSIDE the model
-        # (pooling_strategy: mean) and emits output_dim=2 as [reward, log-sigma] —
-        # see the "sum" branch of the vendored model, which reads column 1 as
-        # exp()-able sigma. Those columns are not instruction-following and visual
-        # quality, so `mean` would spend half the training signal driving the reward
-        # model's own uncertainty. Column 1 stays visible as a logged sub-metric.
+        # EditReward's first column is reward; the second is log uncertainty, so do not average them.
         sub_metric_reduce: first
         aggregation_method: weighted_sum
         input_kind: image

--- a/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
@@ -204,7 +204,14 @@ reward:
         batch_size: 8
         request_batch_size: 8
         timeout: 600.0
-        sub_metric_reduce: mean
+        # `first` == the scorer's first sub-metric == reward column 0. The pinned
+        # config above pools its two semantic heads INSIDE the model
+        # (pooling_strategy: mean) and emits output_dim=2 as [reward, log-sigma] —
+        # see the "sum" branch of the vendored model, which reads column 1 as
+        # exp()-able sigma. Those columns are not instruction-following and visual
+        # quality, so `mean` would spend half the training signal driving the reward
+        # model's own uncertainty. Column 1 stays visible as a logged sub-metric.
+        sub_metric_reduce: first
         aggregation_method: weighted_sum
         input_kind: image
       lifecycle: resident

--- a/unirl/algorithms/bagel_flow_unigrpo.py
+++ b/unirl/algorithms/bagel_flow_unigrpo.py
@@ -165,7 +165,6 @@ class BagelFlowUniGRPO(FlowGRPO):
         typed_conds = typed_conditions(conditions, self.conditions_cls)
         device = next(self.stage.model.transformer.parameters()).device
         schedule = segment.sigmas.to(device)
-        forward_kwargs = self.stage.build_forward_kwargs(typed_conds, params=self.params, device=device)
         transformer = self.stage.model.transformer
         full_ft_ref = not self._has_lora(transformer)
         # Compute reference velocities before retaining trainable graphs to reduce peak memory.
@@ -182,17 +181,24 @@ class BagelFlowUniGRPO(FlowGRPO):
                         "stage.model.transformer. Train with a lora_cfg or full fine-tuning, "
                         "or set mse_weight=0."
                     )
+                # Rebuild reference conditioning only after policy weights are disabled.
+                ref_forward_kwargs = self.stage.build_forward_kwargs(
+                    typed_conds, params=self.params, device=device, force_rebuild=True
+                )
                 v_refs = [
                     self.stage.predict_velocity_at(
-                        forward_kwargs,
+                        ref_forward_kwargs,
                         sample=segment.latents_at(s)[0].to(device),
                         sigma=schedule[s],
                         params=self.params,
                     ).detach()
                     for s in target_steps
                 ]
+                del ref_forward_kwargs
         if full_ft_ref and torch.cuda.is_available():
             torch.cuda.empty_cache()
+        # Build policy contexts after freeing the reference contexts.
+        forward_kwargs = self.stage.build_forward_kwargs(typed_conds, params=self.params, device=device)
 
         mse_terms: List[torch.Tensor] = []
         for step_idx, v_ref in zip(target_steps, v_refs):

--- a/unirl/algorithms/bagel_flow_unigrpo.py
+++ b/unirl/algorithms/bagel_flow_unigrpo.py
@@ -183,7 +183,10 @@ class BagelFlowUniGRPO(FlowGRPO):
                     )
                 # Rebuild reference conditioning only after policy weights are disabled.
                 ref_forward_kwargs = self.stage.build_forward_kwargs(
-                    typed_conds, params=self.params, device=device, force_rebuild=True
+                    typed_conds,
+                    params=self.params,
+                    device=device,
+                    force_rebuild=bool(typed_conds.input_images),
                 )
                 v_refs = [
                     self.stage.predict_velocity_at(

--- a/unirl/models/bagel/bundle.py
+++ b/unirl/models/bagel/bundle.py
@@ -11,9 +11,9 @@ from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 from unirl.models.types.bundle import Bundle
 from unirl.utils.dtypes import parse_torch_dtype
 
+from . import rl_ops
 from .config import BagelPipelineConfig
 from .vendor.data.data_utils import add_special_tokens
-from .vendor.data.transforms import ImageTransform
 from .vendor.inferencer import InterleaveInferencer
 from .vendor.modeling.autoencoder import load_ae
 from .vendor.modeling.bagel import (
@@ -126,8 +126,11 @@ class BagelBundle(Bundle):
         tokenizer = Qwen2Tokenizer.from_pretrained(model_dir)
         tokenizer, new_token_ids, _ = add_special_tokens(tokenizer)
 
-        vae_transform = ImageTransform(512, 256, 8)
-        vit_transform = ImageTransform(490, 112, 14)
+        # Image transforms (image-conditioned paths only; pure T2I never exercises
+        # them, but the inferencer constructor requires both). The geometry lives in
+        # rl_ops so the vllm_omni worker's it2i prefill builds the SAME pair — see
+        # rl_ops.build_image_transforms for the sizes and the stride-14 rationale.
+        vae_transform, vit_transform = rl_ops.build_image_transforms()
 
         vae_model = vae_model.to(device=device, dtype=vae_dtype).eval()
         vae_model.requires_grad_(False)

--- a/unirl/models/bagel/conditions.py
+++ b/unirl/models/bagel/conditions.py
@@ -59,7 +59,7 @@ class BagelDiffusionConditions(Condition):
     cfg_text_contexts: List[Any] = concat_field(default_factory=list)
     cfg_img_contexts: List[Any] = concat_field(default_factory=list)
     prompts: List[Any] = concat_field(default_factory=list)
-    input_images: List[Any] = concat_field(default_factory=list)  # Raw source PILs for deferred it2i replay.
+    input_images: List[Any] = concat_field(default_factory=list)  # Raw it2i PILs retained for context rebuilds.
     image_shapes: List[Tuple[int, int]] = concat_field(default_factory=list)
 
     @property

--- a/unirl/models/bagel/conditions.py
+++ b/unirl/models/bagel/conditions.py
@@ -59,6 +59,7 @@ class BagelDiffusionConditions(Condition):
     cfg_text_contexts: List[Any] = concat_field(default_factory=list)
     cfg_img_contexts: List[Any] = concat_field(default_factory=list)
     prompts: List[Any] = concat_field(default_factory=list)
+    input_images: List[Any] = concat_field(default_factory=list)  # Raw source PILs for deferred it2i replay.
     image_shapes: List[Tuple[int, int]] = concat_field(default_factory=list)
 
     @property
@@ -114,8 +115,8 @@ class BagelDiffusionConditions(Condition):
         image_shape = tuple(self.image_shapes[0])
         return gen, cfg_text, cfg_img, image_shape
 
-    def single_prompt(self) -> Tuple[str, Tuple[int, int]]:
-        """Return ``(prompt, image_shape)`` for a 1-sample deferred-prompt batch."""
+    def single_prompt(self) -> Tuple[str, Optional[Any], Tuple[int, int]]:
+        """Return ``(prompt, input_image, image_shape)`` for a 1-sample deferred batch."""
         require(
             self.batch_size == 1,
             f"BagelDiffusionConditions.single_prompt: expected exactly 1 sample "
@@ -127,7 +128,8 @@ class BagelDiffusionConditions(Condition):
             "adapter must ship prompts for the deferred-rebuild path.",
         )
         image_shape = tuple(self.image_shapes[0])
-        return str(self.prompts[0]), image_shape
+        input_image = self.input_images[0] if self.input_images else None
+        return str(self.prompts[0]), input_image, image_shape
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "BagelDiffusionConditions":

--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -226,6 +226,13 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         force_rebuild: bool = False,
     ) -> Tuple[Any, Any, Any, Tuple[int, int]]:
         """Return ``(gen, cfg_text, cfg_img, image_shape)`` for a 1-sample batch."""
+        if force_rebuild:
+            require(
+                bool(conditions.input_images),
+                "_resolve_single(force_rebuild=True) requires image-conditioned "
+                "raw material; prompt-only stored contexts (t2i/t2ti) cannot be "
+                "reproduced from the bare prompt.",
+            )
         if differentiable and conditions.input_images:
             prompt, input_image, image_shape = conditions.single_prompt()
             gen, cfg_text, cfg_img = self._build_contexts_from_prompt(

--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
@@ -172,33 +173,74 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
             return torch.autocast("cuda", self.autocast_dtype)
         return nullcontext()
 
-    def _build_contexts_from_prompt(self, prompt: str) -> Tuple[Any, Any, Any]:
-        """Rebuild the three KV contexts (gen / cfg_text / cfg_img) from a prompt."""
-        from copy import deepcopy
+    def _build_contexts_from_prompt(
+        self,
+        prompt: str,
+        image: Optional[Any] = None,
+        *,
+        differentiable: bool = False,
+    ) -> Tuple[Any, Any, Any]:
+        """Rebuild the three KV contexts from raw prompt and optional source image."""
+        if image is not None and getattr(self.model.model, "vit_model", None) is None:
+            raise ValueError(
+                "BagelDiffusionStage: the conditions carry an it2i source image but the bundle "
+                "was built without the und ViT; set BagelPipelineConfig.enable_vit=true."
+            )
 
         inf = self.model.inferencer
         device = torch.device(self.model.device)
         clean_prompt = str(prompt).removeprefix("<|im_start|>").removesuffix("<|im_end|>")
         gen = inf.init_gen_context()
         cfg_img = deepcopy(gen)
-        mot = self.model.transformer
-        was_training = mot.training
-        mot.eval()
-        try:
-            with torch.no_grad(), self._autocast_ctx(device):
-                cfg_text = deepcopy(gen)
+        # Preserve inference dispatch while rebuilding frozen or differentiable it2i contexts.
+        grad_context = torch.enable_grad if differentiable else torch.no_grad
+        with (
+            rl_ops.inference_dispatch_scope(self.model.model),
+            grad_context(),
+            self._autocast_ctx(device),
+        ):
+            if image is not None:
+                resized = rl_ops.resize_input_image(self.model, image)
+                gen = rl_ops.update_context_image(
+                    self.model,
+                    resized,
+                    gen,
+                    vae=True,
+                    vit=True,
+                    differentiable=differentiable,
+                )
+            cfg_text = rl_ops.clone_context(gen) if differentiable else deepcopy(gen)
+            if differentiable:
+                gen = rl_ops.update_context_text(self.model, clean_prompt, gen, differentiable=True)
+                cfg_img = rl_ops.update_context_text(self.model, clean_prompt, cfg_img, differentiable=True)
+            else:
                 gen = inf.update_context_text(clean_prompt, gen)
                 cfg_img = inf.update_context_text(clean_prompt, cfg_img)
-        finally:
-            mot.train(was_training)
         return gen, cfg_text, cfg_img
 
-    def _resolve_single(self, conditions: BagelDiffusionConditions) -> Tuple[Any, Any, Any, Tuple[int, int]]:
+    def _resolve_single(
+        self,
+        conditions: BagelDiffusionConditions,
+        *,
+        differentiable: bool = False,
+    ) -> Tuple[Any, Any, Any, Tuple[int, int]]:
         """Return ``(gen, cfg_text, cfg_img, image_shape)`` for a 1-sample batch."""
+        if differentiable and conditions.input_images:
+            prompt, input_image, image_shape = conditions.single_prompt()
+            gen, cfg_text, cfg_img = self._build_contexts_from_prompt(
+                prompt,
+                input_image,
+                differentiable=True,
+            )
+            return gen, cfg_text, cfg_img, image_shape
         if conditions.has_contexts():
             return conditions.single()
-        prompt, image_shape = conditions.single_prompt()
-        gen, cfg_text, cfg_img = self._build_contexts_from_prompt(prompt)
+        prompt, input_image, image_shape = conditions.single_prompt()
+        gen, cfg_text, cfg_img = self._build_contexts_from_prompt(
+            prompt,
+            input_image,
+            differentiable=differentiable,
+        )
         return gen, cfg_text, cfg_img, image_shape
 
     def _build_generation_inputs(
@@ -382,7 +424,10 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         schedule = segment.sigmas.to(device)
         sigma_max = schedule[1] if int(schedule.shape[0]) > 1 else schedule[0]
 
-        gen, cfg_text, cfg_img, image_shape = self._resolve_single(conditions)
+        gen, cfg_text, cfg_img, image_shape = self._resolve_single(
+            conditions,
+            differentiable=torch.is_grad_enabled(),
+        )
         gi, gi_cfg_text, gi_cfg_img = self._build_generation_inputs(gen, cfg_text, cfg_img, image_shape, device=device)
         forward_kwargs = self._forward_kwargs(gen, cfg_text, cfg_img, gi, gi_cfg_text, gi_cfg_img, params)
 
@@ -428,7 +473,10 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         device: torch.device,
     ) -> Dict[str, Any]:
         """Rebuild the KV contexts → the step-invariant ``_forward_flow`` kwargs."""
-        gen, cfg_text, cfg_img, image_shape = self._resolve_single(conditions)
+        gen, cfg_text, cfg_img, image_shape = self._resolve_single(
+            conditions,
+            differentiable=torch.is_grad_enabled(),
+        )
         gi, gi_cfg_text, gi_cfg_img = self._build_generation_inputs(gen, cfg_text, cfg_img, image_shape, device=device)
         return self._forward_kwargs(gen, cfg_text, cfg_img, gi, gi_cfg_text, gi_cfg_img, params)
 

--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -223,6 +223,7 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         conditions: BagelDiffusionConditions,
         *,
         differentiable: bool = False,
+        force_rebuild: bool = False,
     ) -> Tuple[Any, Any, Any, Tuple[int, int]]:
         """Return ``(gen, cfg_text, cfg_img, image_shape)`` for a 1-sample batch."""
         if differentiable and conditions.input_images:
@@ -233,7 +234,7 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
                 differentiable=True,
             )
             return gen, cfg_text, cfg_img, image_shape
-        if conditions.has_contexts():
+        if conditions.has_contexts() and not force_rebuild:
             return conditions.single()
         prompt, input_image, image_shape = conditions.single_prompt()
         gen, cfg_text, cfg_img = self._build_contexts_from_prompt(
@@ -471,11 +472,13 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         *,
         params: BagelDiffusionParams,
         device: torch.device,
+        force_rebuild: bool = False,
     ) -> Dict[str, Any]:
         """Rebuild the KV contexts → the step-invariant ``_forward_flow`` kwargs."""
         gen, cfg_text, cfg_img, image_shape = self._resolve_single(
             conditions,
             differentiable=torch.is_grad_enabled(),
+            force_rebuild=force_rebuild,
         )
         gi, gi_cfg_text, gi_cfg_img = self._build_generation_inputs(gen, cfg_text, cfg_img, image_shape, device=device)
         return self._forward_kwargs(gen, cfg_text, cfg_img, gi, gi_cfg_text, gi_cfg_img, params)

--- a/unirl/models/bagel/pipeline.py
+++ b/unirl/models/bagel/pipeline.py
@@ -6,7 +6,6 @@ import logging
 from collections import OrderedDict
 from contextlib import nullcontext
 from copy import deepcopy
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import torch
@@ -21,10 +20,10 @@ from unirl.types.sampling import ARSamplingParams, DiffusionSamplingParams
 from unirl.types.segments.latent import LatentSegment
 from unirl.types.segments.text import TextSegment
 
+from . import rl_ops
 from .ar import BagelARStage
 from .conditions import BagelARConditions, BagelDiffusionConditions
 from .diffusion import BagelDiffusionParams, BagelDiffusionStage
-from .rl_ops import _to_device
 from .vae import BagelVAEDecodeStage, BagelVAEEncodeStage, bagel_latent_shape
 
 if TYPE_CHECKING:
@@ -132,12 +131,6 @@ class BagelPipeline(Pipeline):
             return torch.autocast("cuda", dtype)
         return nullcontext()
 
-    def _resize_input_image(self, image: Any) -> Any:
-        """Canonical input-image preproc (inferencer.py:249): rgb → aspect-preserving"""
-        from .vendor.data.data_utils import pil_img2rgb
-
-        return self.bundle.vae_transform.resize_transform(pil_img2rgb(image))
-
     def _extract_input_images(self, conditioning: List[Any], task: str, *, n_prompts: Optional[int]) -> List[Any]:
         """Validated per-sample input PILs for image-input tasks (it2i / i2t / it2t)."""
         images_prim = next((c for c in conditioning if isinstance(c, Images)), None)
@@ -157,59 +150,23 @@ class BagelPipeline(Pipeline):
             )
         return pil_images
 
-    def _update_context_image(self, image: Any, gen_context: Any, *, vae: bool, vit: bool) -> Any:
-        """Prefill one input image into a KV context (VAE and/or ViT branch)."""
-        bagel = self.bundle.model
-        device = torch.device(self.bundle.device)
-        ctx = gen_context
-        if vae:
-            gi, kv_lens, ropes = bagel.prepare_vae_images(
-                curr_kvlens=ctx["kv_lens"],
-                curr_rope=ctx["ropes"],
-                images=[image],
-                transforms=self.bundle.vae_transform,
-                new_token_ids=self.bundle.new_token_ids,
-            )
-            gi = _to_device(gi, device)
-            vae_mod, proj = self.bundle.vae, bagel.vae2llm
-
-            def _vae_encode(x: torch.Tensor) -> torch.Tensor:
-                return vae_mod.encode(x.to(dtype=next(vae_mod.parameters()).dtype)).to(
-                    dtype=next(proj.parameters()).dtype
-                )
-
-            past = bagel.forward_cache_update_vae(SimpleNamespace(encode=_vae_encode), ctx["past_key_values"], **gi)
-            ctx = {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
-        if vit:
-            gi, kv_lens, ropes = bagel.prepare_vit_images(
-                curr_kvlens=ctx["kv_lens"],
-                curr_rope=ctx["ropes"],
-                images=[image],
-                transforms=self.bundle.vit_transform,
-                new_token_ids=self.bundle.new_token_ids,
-            )
-            gi = _to_device(gi, device)
-            past = bagel.forward_cache_update_vit(ctx["past_key_values"], **gi)
-            ctx = {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
-        return ctx
-
     def _build_contexts(self, prompt: str, image: Optional[Any] = None) -> Tuple[Any, Any, Any]:
         """Build (gen, cfg_text, cfg_img) KV contexts for T2I or editing (it2i)."""
         inf = self.bundle.inferencer
         gen = inf.init_gen_context()
         cfg_img = deepcopy(gen)
-        mot = self.bundle.transformer
-        was_training = mot.training
-        mot.eval()
-        try:
-            with torch.no_grad(), self._autocast_ctx():
-                if image is not None:
-                    gen = self._update_context_image(self._resize_input_image(image), gen, vae=True, vit=True)
-                cfg_text = deepcopy(gen)
-                gen = inf.update_context_text(prompt, gen)
-                cfg_img = inf.update_context_text(prompt, cfg_img)
-        finally:
-            mot.train(was_training)
+        # Share image prefill with deferred vLLM-Omni replay while preserving inference dispatch.
+        with (
+            rl_ops.inference_dispatch_scope(self.bundle.model),
+            torch.no_grad(),
+            self._autocast_ctx(),
+        ):
+            if image is not None:
+                resized = rl_ops.resize_input_image(self.bundle, image)
+                gen = rl_ops.update_context_image(self.bundle, resized, gen, vae=True, vit=True)
+            cfg_text = deepcopy(gen)  # snapshot before the prompt text → drop-text branch
+            gen = inf.update_context_text(prompt, gen)
+            cfg_img = inf.update_context_text(prompt, cfg_img)
         return gen, cfg_text, cfg_img
 
     def _t2i_cache_enabled(self) -> bool:
@@ -354,6 +311,7 @@ class BagelPipeline(Pipeline):
             params=params,
             sample=sample,
             image_shape=image_shape,
+            input_images=pil_images,
         )
 
         filled = frontier.fill(segment=segment, primitives={"image": images}, conditions=conditions.to_dict())
@@ -367,8 +325,9 @@ class BagelPipeline(Pipeline):
         params: BagelDiffusionParams,
         sample: Sample,
         image_shape: Tuple[int, int],
+        input_images: Optional[List[Any]] = None,
     ) -> Tuple[LatentSegment, BagelDiffusionConditions, Images]:
-        """Diffuse per-sample over prebuilt ``(gen, cfg_text, cfg_img)`` contexts,"""
+        """Diffuse, batch, and decode per-sample prebuilt BAGEL contexts."""
         device = torch.device(self.bundle.device)
         schedule = params.sigmas.to(device)
         initial = NoiseRecipe.from_sample(sample).resolve(device=device, dtype=torch.float32)
@@ -400,6 +359,7 @@ class BagelPipeline(Pipeline):
             cfg_text_contexts=cfg_text_list,
             cfg_img_contexts=cfg_img_list,
             prompts=list(prompts),
+            input_images=list(input_images) if input_images is not None else [],
             image_shapes=shapes,
         )
         images = self.vae_decode.decode(segment, image_shape=image_shape)
@@ -452,7 +412,10 @@ class BagelPipeline(Pipeline):
         for i in range(n):
             splits: List[Dict[str, Any]] = []
             if pil_images is not None:
-                img = self._resize_input_image(pil_images[i])
+                # Understanding preproc chain (inferencer.py:249-250, vae=False):
+                # rgb → vae resize → vit_transform; store the FINAL pixels so
+                # rollout and replay consume byte-identical inputs.
+                img = rl_ops.resize_input_image(self.bundle, pil_images[i])
                 splits.append({"kind": "vit", "image": self.bundle.vit_transform(img)})
             if prompts is not None:
                 ids = [ntk["bos_token_id"]] + tokenizer.encode(prompts[i]) + [ntk["eos_token_id"]]

--- a/unirl/models/bagel/rl_ops.py
+++ b/unirl/models/bagel/rl_ops.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
@@ -10,17 +13,23 @@ import torch.nn.functional as F
 from torch.utils.checkpoint import checkpoint
 
 __all__ = [
+    "build_image_transforms",
+    "clone_context",
     "decode_text",
     "disable_inference_cache",
     "forward_flow",
     "init_und_context",
     "pack_und_forward_inputs",
+    "inference_dispatch_scope",
     "prefill_text_split",
     "prefill_vit_split",
     "require_inference_dispatch",
+    "resize_input_image",
     "score_response",
     "score_response_with_prompt",
     "und_replay_logits",
+    "update_context_image",
+    "update_context_text",
 ]
 
 
@@ -96,6 +105,187 @@ def _pack_text_ids(text_ids: torch.Tensor, *, kv_len: int, rope_start: int) -> D
 def _to_device(d: Dict[str, Any], device: torch.device) -> Dict[str, Any]:
     """Move every tensor value onto ``device`` (non-tensors pass through)."""
     return {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in d.items()}
+
+
+@contextmanager
+def inference_dispatch_scope(model: Any) -> Iterator[None]:
+    """Force the MoT into ``eval()`` for the duration of a packed-INFERENCE call.
+
+    Every navit module routes ``forward_train`` vs ``forward_inference`` on
+    ``self.training``, so the packed-inference call shape (the
+    ``forward_cache_update_*`` prefills) dies with ``TypeError: forward_train() got an
+    unexpected keyword argument 'packed_query_sequence'`` when the module is in train
+    mode. And it IS: ``TrainStack.train_track`` puts the model in train mode before
+    the optimizer step, so the vllm_omni deferred-context REBUILD — which runs inside
+    ``replay`` — has to force eval itself, exactly as :func:`forward_flow` already
+    does for the velocity call.
+
+    Unlike ``forward_flow`` this restores the previous mode unconditionally: the
+    rebuild runs under ``no_grad``, so no activation-checkpointing recompute can land
+    back inside this scope during a later ``backward()``.
+    """
+    lm = model.language_model
+    was_training = lm.training
+    if was_training:
+        lm.eval()
+    try:
+        yield
+    finally:
+        if was_training:
+            lm.train()
+
+
+# ---------------------------------------------------------------------------
+# Image-input context prefill (shared by rollout + replay)
+# ---------------------------------------------------------------------------
+
+#: Canonical BAGEL input-image transform geometry, ``(max_size, min_size, stride)``.
+#: Sizes follow the official inference setup (flow_grpo: vae 512/256, vit 490/112).
+#: NB: the ViT resize STRIDE must equal the SigLIP patch size (14) — ``patchify``
+#: asserts ``h % patch_size == 0``, so a stride that is not a multiple of 14 makes
+#: non-square image inputs crash. flow_grpo's stride 7 (half a patch) is that bug.
+BAGEL_VAE_TRANSFORM_GEOMETRY = (512, 256, 8)
+BAGEL_VIT_TRANSFORM_GEOMETRY = (490, 112, 14)
+
+
+def build_image_transforms() -> Tuple[Any, Any]:
+    """The ``(vae_transform, vit_transform)`` pair every BAGEL image path must use.
+
+    ONE definition for both sides of the RL loop: :class:`BagelBundle` builds the
+    trainer's pair from here, and the vllm_omni worker pipeline builds its own from
+    here too. Were these to drift apart, rollout and replay would prefill differently
+    resized source images — the exact failure :func:`update_context_image` exists to
+    prevent.
+    """
+    from .vendor.data.transforms import ImageTransform
+
+    return ImageTransform(*BAGEL_VAE_TRANSFORM_GEOMETRY), ImageTransform(*BAGEL_VIT_TRANSFORM_GEOMETRY)
+
+
+def resize_input_image(bundle: Any, image: Any) -> Any:
+    """Canonical input-image preproc (inferencer.py:249): rgb → aspect-preserving
+    stride-8 resize.
+
+    Every image-input task funnels through this before the VAE/ViT branches so the
+    chain has one home — and so the trainside rollout and the vllm_omni replay feed
+    :func:`update_context_image` byte-identical pixels.
+    """
+    from .vendor.data.data_utils import pil_img2rgb
+
+    return bundle.vae_transform.resize_transform(pil_img2rgb(image))
+
+
+def _encode_vae_posterior_mean(vae: Any, x: torch.Tensor) -> torch.Tensor:
+    """Encode with the deterministic posterior mean, never a Gaussian draw."""
+    reg = getattr(vae, "reg", None)
+    if reg is None or not hasattr(reg, "chunk_dim"):
+        raise RuntimeError("BAGEL VAE has no compatible diagonal-Gaussian regulator.")
+    encoded = vae.encoder(x)
+    mean, _ = torch.chunk(encoded, 2, dim=int(reg.chunk_dim))
+    return vae.scale_factor * (mean - vae.shift_factor)
+
+
+def clone_context(ctx: Dict[str, Any]) -> Dict[str, Any]:
+    """Copy a BAGEL KV context for copy-on-write cache updates."""
+    cache = ctx["past_key_values"]
+    cloned_cache = type(cache)(cache.num_layers)
+    cloned_cache.key_cache = dict(cache.key_cache)
+    cloned_cache.value_cache = dict(cache.value_cache)
+    return {
+        "kv_lens": list(ctx["kv_lens"]),
+        "ropes": list(ctx["ropes"]),
+        "past_key_values": cloned_cache,
+    }
+
+
+def update_context_text(
+    bundle: Any,
+    text: str,
+    ctx: Dict[str, Any],
+    *,
+    differentiable: bool = False,
+) -> Dict[str, Any]:
+    """Prefill text, optionally bypassing the vendor's inference-only decorator."""
+    bagel = bundle.model
+    generation_input, kv_lens, ropes = bagel.prepare_prompts(
+        curr_kvlens=ctx["kv_lens"],
+        curr_rope=ctx["ropes"],
+        prompts=[text],
+        tokenizer=bundle.tokenizer,
+        new_token_ids=bundle.new_token_ids,
+    )
+    generation_input = _to_device(generation_input, torch.device(bundle.device))
+    update = _raw(type(bagel).forward_cache_update_text) if differentiable else bagel.forward_cache_update_text
+    past = (
+        update(bagel, ctx["past_key_values"], **generation_input)
+        if differentiable
+        else update(ctx["past_key_values"], **generation_input)
+    )
+    return {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
+
+
+def update_context_image(
+    bundle: Any,
+    image: Any,
+    ctx: Dict[str, Any],
+    *,
+    vae: bool,
+    vit: bool,
+    differentiable: bool = False,
+) -> Dict[str, Any]:
+    """Prefill one input image into a KV context (VAE and/or ViT branch).
+
+    Mirrors the vendored ``InterleaveInferencer.update_context_image``
+    (vendor/inferencer.py:62-96) with explicit device pinning: the vendored
+    ``prepare_vae_images`` / ``prepare_vit_images`` build their tensors on CPU and
+    the bundle's VAE carries no accelerate hooks, so ``padded_images`` (and the
+    packed index tensors) must be moved before the cache update. ``image`` is
+    already :func:`resize_input_image`-ed. Caller owns no_grad + autocast.
+    """
+    bagel = bundle.model
+    device = torch.device(bundle.device)
+    if vae:
+        gi, kv_lens, ropes = bagel.prepare_vae_images(
+            curr_kvlens=ctx["kv_lens"],
+            curr_rope=ctx["ropes"],
+            images=[image],
+            transforms=bundle.vae_transform,
+            new_token_ids=bundle.new_token_ids,
+        )
+        gi = _to_device(gi, device)
+        # Sticky-fp32 VAE after decode; vendor only calls .encode then vae2llm.
+        vae_mod, proj = bundle.vae, bagel.vae2llm
+        vae_dtype = next(vae_mod.parameters()).dtype
+        projection_dtype = next(proj.parameters()).dtype
+
+        def _vae_encode(x: torch.Tensor) -> torch.Tensor:
+            return _encode_vae_posterior_mean(vae_mod, x.to(dtype=vae_dtype)).to(dtype=projection_dtype)
+
+        update_vae = _raw(type(bagel).forward_cache_update_vae) if differentiable else bagel.forward_cache_update_vae
+        vae_proxy = SimpleNamespace(encode=_vae_encode)
+        past = (
+            update_vae(bagel, vae_proxy, ctx["past_key_values"], **gi)
+            if differentiable
+            else update_vae(vae_proxy, ctx["past_key_values"], **gi)
+        )
+        ctx = {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
+    if vit:
+        gi, kv_lens, ropes = bagel.prepare_vit_images(
+            curr_kvlens=ctx["kv_lens"],
+            curr_rope=ctx["ropes"],
+            images=[image],
+            transforms=bundle.vit_transform,
+            new_token_ids=bundle.new_token_ids,
+        )
+        gi = _to_device(gi, device)
+        update_vit = _raw(type(bagel).forward_cache_update_vit) if differentiable else bagel.forward_cache_update_vit
+        past = (
+            update_vit(bagel, ctx["past_key_values"], **gi)
+            if differentiable
+            else update_vit(ctx["past_key_values"], **gi)
+        )
+        ctx = {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
+    return ctx
 
 
 def prefill_text_split(

--- a/unirl/models/bagel/rl_ops.py
+++ b/unirl/models/bagel/rl_ops.py
@@ -109,21 +109,7 @@ def _to_device(d: Dict[str, Any], device: torch.device) -> Dict[str, Any]:
 
 @contextmanager
 def inference_dispatch_scope(model: Any) -> Iterator[None]:
-    """Force the MoT into ``eval()`` for the duration of a packed-INFERENCE call.
-
-    Every navit module routes ``forward_train`` vs ``forward_inference`` on
-    ``self.training``, so the packed-inference call shape (the
-    ``forward_cache_update_*`` prefills) dies with ``TypeError: forward_train() got an
-    unexpected keyword argument 'packed_query_sequence'`` when the module is in train
-    mode. And it IS: ``TrainStack.train_track`` puts the model in train mode before
-    the optimizer step, so the vllm_omni deferred-context REBUILD — which runs inside
-    ``replay`` — has to force eval itself, exactly as :func:`forward_flow` already
-    does for the velocity call.
-
-    Unlike ``forward_flow`` this restores the previous mode unconditionally: the
-    rebuild runs under ``no_grad``, so no activation-checkpointing recompute can land
-    back inside this scope during a later ``backward()``.
-    """
+    """Temporarily force packed-inference dispatch through ``eval()``."""
     lm = model.language_model
     was_training = lm.training
     if was_training:
@@ -135,41 +121,19 @@ def inference_dispatch_scope(model: Any) -> Iterator[None]:
             lm.train()
 
 
-# ---------------------------------------------------------------------------
-# Image-input context prefill (shared by rollout + replay)
-# ---------------------------------------------------------------------------
-
-#: Canonical BAGEL input-image transform geometry, ``(max_size, min_size, stride)``.
-#: Sizes follow the official inference setup (flow_grpo: vae 512/256, vit 490/112).
-#: NB: the ViT resize STRIDE must equal the SigLIP patch size (14) — ``patchify``
-#: asserts ``h % patch_size == 0``, so a stride that is not a multiple of 14 makes
-#: non-square image inputs crash. flow_grpo's stride 7 (half a patch) is that bug.
-BAGEL_VAE_TRANSFORM_GEOMETRY = (512, 256, 8)
-BAGEL_VIT_TRANSFORM_GEOMETRY = (490, 112, 14)
+BAGEL_VAE_TRANSFORM_GEOMETRY = (512, 256, 8)  # (max_size, min_size, stride)
+BAGEL_VIT_TRANSFORM_GEOMETRY = (490, 112, 14)  # Stride matches the SigLIP patch size.
 
 
 def build_image_transforms() -> Tuple[Any, Any]:
-    """The ``(vae_transform, vit_transform)`` pair every BAGEL image path must use.
-
-    ONE definition for both sides of the RL loop: :class:`BagelBundle` builds the
-    trainer's pair from here, and the vllm_omni worker pipeline builds its own from
-    here too. Were these to drift apart, rollout and replay would prefill differently
-    resized source images — the exact failure :func:`update_context_image` exists to
-    prevent.
-    """
+    """Build the shared ``(vae_transform, vit_transform)`` pair."""
     from .vendor.data.transforms import ImageTransform
 
     return ImageTransform(*BAGEL_VAE_TRANSFORM_GEOMETRY), ImageTransform(*BAGEL_VIT_TRANSFORM_GEOMETRY)
 
 
 def resize_input_image(bundle: Any, image: Any) -> Any:
-    """Canonical input-image preproc (inferencer.py:249): rgb → aspect-preserving
-    stride-8 resize.
-
-    Every image-input task funnels through this before the VAE/ViT branches so the
-    chain has one home — and so the trainside rollout and the vllm_omni replay feed
-    :func:`update_context_image` byte-identical pixels.
-    """
+    """Convert to RGB and apply the canonical aspect-preserving VAE resize."""
     from .vendor.data.data_utils import pil_img2rgb
 
     return bundle.vae_transform.resize_transform(pil_img2rgb(image))
@@ -233,15 +197,7 @@ def update_context_image(
     vit: bool,
     differentiable: bool = False,
 ) -> Dict[str, Any]:
-    """Prefill one input image into a KV context (VAE and/or ViT branch).
-
-    Mirrors the vendored ``InterleaveInferencer.update_context_image``
-    (vendor/inferencer.py:62-96) with explicit device pinning: the vendored
-    ``prepare_vae_images`` / ``prepare_vit_images`` build their tensors on CPU and
-    the bundle's VAE carries no accelerate hooks, so ``padded_images`` (and the
-    packed index tensors) must be moved before the cache update. ``image`` is
-    already :func:`resize_input_image`-ed. Caller owns no_grad + autocast.
-    """
+    """Prefill a resized image into the VAE and/or ViT KV branches."""
     bagel = bundle.model
     device = torch.device(bundle.device)
     if vae:

--- a/unirl/rollout/engine/vllm_omni/adapters/__init__.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/__init__.py
@@ -1,7 +1,9 @@
-"""Adapter registry — importing this package registers all 10 modalities."""
+"""Adapter registry — importing this package registers all 12 modalities."""
 
 from unirl.rollout.engine.vllm_omni.adapters.bagel import (
+    BagelAdapter,
     BagelInputAdapter,
+    BagelIt2iAdapter,
     BagelOutputAdapter,
     BagelT2iAdapter,
 )
@@ -46,7 +48,9 @@ from unirl.rollout.engine.vllm_omni.adapters.sd3 import Sd3InputAdapter, Sd3Outp
 __all__ = [
     "DitInputAdapter",
     "DitOutputAdapter",
+    "BagelAdapter",
     "BagelInputAdapter",
+    "BagelIt2iAdapter",
     "BagelOutputAdapter",
     "BagelT2iAdapter",
     "Hi3ArRecaptionAdapter",

--- a/unirl/rollout/engine/vllm_omni/adapters/bagel.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/bagel.py
@@ -1,4 +1,4 @@
-"""BAGEL-7B-MoT family: input/output sub-adapters + the ``bagel_t2i`` modality class."""
+"""BAGEL-7B-MoT input/output adapters for the t2i and it2i modalities."""
 
 from __future__ import annotations
 
@@ -25,12 +25,48 @@ from unirl.rollout.engine.vllm_omni.utils import (
 from unirl.rollout.engine.vllm_omni.utils.noise import pack_initial_noise_extra_args
 from unirl.rollout.engine.vllm_omni.utils.sigmas import sigmas_list_from_diffusion
 from unirl.sde.runtime import FlowMatchSchedulePolicy
+from unirl.types.primitives import Images, Texts
 from unirl.types.sample import Sample
 from unirl.types.sampling import DiffusionSamplingParams
 
 
+def _conditioning_rows(
+    sample: Sample,
+    *,
+    image_input: bool,
+    caller: str,
+) -> tuple[List[str], List[Any]]:
+    """Return frontier-aligned prompt rows and optional source PIL images."""
+    conditioning = sample.conditioning()
+    text_batches = [value for value in conditioning if isinstance(value, Texts)]
+    if len(text_batches) != 1:
+        raise ValueError(f"{caller}: expected exactly one Texts conditioning batch, got {len(text_batches)}")
+
+    prompt_rows = list(text_batches[0].texts)
+    n_samples = len(sample.frontier_gen_part(DiffusionSamplingParams).sample_ids)
+    if len(prompt_rows) != n_samples:
+        raise RuntimeError(f"{caller}: prompt count {len(prompt_rows)} != diffusion sample count {n_samples}")
+
+    image_batches = [value for value in conditioning if isinstance(value, Images)]
+    if image_input:
+        if len(image_batches) != 1:
+            raise ValueError(f"{caller}: expected exactly one Images conditioning batch, got {len(image_batches)}")
+        image_rows = [image.to_pil() for image in image_batches[0].to_list()]
+        if len(image_rows) != n_samples:
+            raise RuntimeError(f"{caller}: image count {len(image_rows)} != diffusion sample count {n_samples}")
+    else:
+        if image_batches:
+            raise ValueError(f"{caller}: modality does not accept image conditioning")
+        image_rows = []
+    return prompt_rows, image_rows
+
+
 class BagelInputAdapter(DitInputAdapter):
-    """Request side: prompt dicts + the BAGEL diffusion-stage sampling intent."""
+    """Build BAGEL prompt dictionaries and diffusion-stage sampling intent."""
+
+    def __init__(self, modality: str, *, image_input: bool = False) -> None:
+        super().__init__(modality)
+        self.image_input = bool(image_input)
 
     def _spp(self, sample: Sample) -> int:
         """``samples_per_prompt`` — the GRPO group size; 1 disables packing."""
@@ -43,6 +79,8 @@ class BagelInputAdapter(DitInputAdapter):
 
     def _is_packable_t2i(self, sample: Sample) -> bool:
         """Collapse spp samples into one ``num_outputs_per_prompt=spp`` request."""
+        if self.image_input:
+            return False
         if self._spp(sample) <= 1:
             return False
         diff_params = sample.frontier_gen_part(DiffusionSamplingParams).sampling_params
@@ -50,12 +88,23 @@ class BagelInputAdapter(DitInputAdapter):
 
     def build_prompts(self, sample: Sample) -> List[Any]:
         """Plain ``{"prompt": text}`` dicts (no ``modalities`` → image path)."""
-        if sample.has_image_input():
-            raise ValueError(f"modality={self.modality!r} does not accept image conditioning")
+        caller = f"{self.modality}.build_prompts"
+        prompt_rows, pil_images = _conditioning_rows(
+            sample,
+            image_input=self.image_input,
+            caller=caller,
+        )
+        gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
+        n_samples = len(gen_part.sample_ids)
+        if self.image_input:
+            return [
+                {"prompt": text, "multi_modal_data": {"image": image}}
+                for text, image in zip(prompt_rows, pil_images, strict=True)
+            ]
         spp = self._spp(sample)
         grouped_texts, grouped_spp = _grouped_texts_from_sample(
             sample,
-            caller=f"{self.modality}.build_prompts",
+            caller=caller,
         )
         if grouped_spp != spp:
             raise RuntimeError(
@@ -63,16 +112,14 @@ class BagelInputAdapter(DitInputAdapter):
                 f"({grouped_spp} from grouping, {spp} from diffusion params)."
             )
 
-        gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
         pack = self._is_packable_t2i(sample)
         if pack:
             prompt_texts = grouped_texts
             num_outputs_per_prompt = spp
         else:
-            prompt_texts = list(sample.text_conditioning()[0].content.texts)
+            prompt_texts = prompt_rows
             num_outputs_per_prompt = 1
 
-        n_samples = len(gen_part.sample_ids)
         if len(prompt_texts) * num_outputs_per_prompt != n_samples:
             raise RuntimeError(
                 f"{self.modality}.build_prompts: prompt count {len(prompt_texts)} * "
@@ -83,21 +130,24 @@ class BagelInputAdapter(DitInputAdapter):
     def build_sampling(self, sample: Sample) -> List[StageSampling]:
         """One diffusion-stage intent with the BAGEL-specific kwargs."""
         spp = self._spp(sample)
-        grouped_texts, grouped_spp = _grouped_texts_from_sample(
-            sample,
-            caller=f"{self.modality}.build_sampling",
-        )
         gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
         diff_params = gen_part.sampling_params
-        if grouped_spp != spp:
-            raise RuntimeError(
-                f"{self.modality}.build_sampling: inconsistent samples_per_prompt "
-                f"({grouped_spp} from grouping, {spp} from diffusion params)."
-            )
         pack = self._is_packable_t2i(sample)
 
         n_samples = len(gen_part.sample_ids)
-        n_prompts = len(grouped_texts) if pack else n_samples
+        if self.image_input:
+            n_prompts = n_samples
+        else:
+            grouped_texts, grouped_spp = _grouped_texts_from_sample(
+                sample,
+                caller=f"{self.modality}.build_sampling",
+            )
+            if grouped_spp != spp:
+                raise RuntimeError(
+                    f"{self.modality}.build_sampling: inconsistent samples_per_prompt "
+                    f"({grouped_spp} from grouping, {spp} from diffusion params)."
+                )
+            n_prompts = len(grouped_texts) if pack else n_samples
         num_outputs_per_prompt = spp if pack else 1
         if n_prompts * num_outputs_per_prompt != n_samples:
             raise RuntimeError(
@@ -105,11 +155,12 @@ class BagelInputAdapter(DitInputAdapter):
                 f"num_outputs_per_prompt={num_outputs_per_prompt} != diffusion sample count {n_samples}."
             )
 
-        T = int(diff_params.num_inference_steps)
+        num_steps = int(diff_params.num_inference_steps)
         diff_kwargs: Dict[str, Any] = dict(
             height=int(diff_params.height),
             width=int(diff_params.width),
-            num_inference_steps=T + 1,
+            # +1: BAGEL builds linspace(1, 0, num_timesteps) and loops num_timesteps-1.
+            num_inference_steps=num_steps + 1,
             eta=float(diff_params.eta),
             return_trajectory_latents=True,
             return_trajectory_decoded=False,
@@ -119,7 +170,10 @@ class BagelInputAdapter(DitInputAdapter):
         if seed is not None:
             diff_kwargs["seed"] = int(seed)
 
-        _ = sigmas_list_from_diffusion(diff_params, T)
+        # σ contract self-check: the engine-pinned Part schedule for num_steps
+        # steps must have num_steps+1 points. We don't send sigmas (BAGEL ignores
+        # them), but assert the engine resolved the schedule the worker will loop.
+        sigmas_list_from_diffusion(diff_params, num_steps)
 
         extra_args: Dict[str, Any] = {
             "cfg_text_scale": float(getattr(diff_params, "cfg_text_scale", 1.0)),
@@ -129,7 +183,13 @@ class BagelInputAdapter(DitInputAdapter):
             "cfg_renorm_type": str(getattr(diff_params, "cfg_renorm_type", "global")),
         }
         sde_indices = getattr(diff_params, "sde_indices", None)
-        if sde_indices is not None:
+        # eta == 0 (deterministic eval) means no step is stochastic. Shipping a
+        # non-empty gate anyway makes the worker scheduler raise ("step_index=N is in
+        # the SDE gate but eta=0.0"); an absent gate is its documented pure-Euler
+        # path, and matches trainside, whose ``diffuse`` gates per-step eta on the same
+        # params.eta and simply records no log-probs. FlowSDEStrategy uses 1e-7
+        # as the deterministic cutoff; the wire gate must use the same threshold.
+        if sde_indices is not None and float(getattr(diff_params, "eta", 0.0)) >= 1e-7:
             extra_args["sde_indices"] = sorted({int(i) for i in sde_indices})
         if diff_params.sigmas is not None and int(diff_params.sigmas.shape[0]) > 1:
             extra_args["sigma_max"] = float(diff_params.sigmas[1].item())
@@ -144,7 +204,11 @@ class BagelInputAdapter(DitInputAdapter):
 
 
 class BagelOutputAdapter(DitOutputAdapter):
-    """Response side: one image generation Part with prompt-carrying conditions."""
+    """Build one image Part with deferred BAGEL replay conditions."""
+
+    def __init__(self, modality: str, *, image_input: bool = False) -> None:
+        super().__init__(modality)
+        self.image_input = bool(image_input)
 
     def build_segment(self, sample: Sample, per_request: List[List[OmniRawResult]]) -> Any:
         """The DiT trajectory segment (asserts the σ echo)."""
@@ -162,40 +226,36 @@ class BagelOutputAdapter(DitOutputAdapter):
         return pils_to_images(pil_images)
 
     def build_conditions(self, sample: Sample, per_request: List[List[OmniRawResult]]) -> Dict[str, Any]:
-        """Ship the PROMPTS (deferred conditions) for trainer-side KV rebuild."""
+        """Ship raw prompt, shape, and optional source image for trainer-side KV rebuild."""
         del per_request
-        turns = sample.text_conditioning()
-        if len(turns) != 1:
-            raise ValueError(f"{self.modality}.build_conditions: expected exactly one text turn, got {len(turns)}")
-        texts = turns[0].content
+        prompts, input_images = _conditioning_rows(
+            sample,
+            image_input=self.image_input,
+            caller=f"{self.modality}.build_conditions",
+        )
         gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
         diff_params = gen_part.sampling_params
         image_shape = (int(diff_params.height), int(diff_params.width))
-        prompts = list(texts.texts)
-        if len(prompts) != len(gen_part.sample_ids):
-            raise RuntimeError(
-                f"{self.modality}.build_conditions: prompt count {len(prompts)} "
-                f"!= diffusion sample count {len(gen_part.sample_ids)}"
-            )
         conditions = BagelDiffusionConditions(
             prompts=prompts,
+            input_images=input_images,
             image_shapes=[image_shape] * len(prompts),
         )
         return conditions.to_dict()
 
 
-@register_adapter("bagel_t2i")
-class BagelT2iAdapter(ModelAdapter):
-    """BAGEL-7B-MoT text → image (single diffusion stage, TP=1)."""
+class BagelAdapter(ModelAdapter):
+    """Bind BAGEL t2i and it2i to one single-stage DiT worker."""
 
     stage_yaml = "bagel_t2i_rl.yaml"
     omni_mode = "text-to-image"
     needs_driver_tokenizer = False
+    image_input: bool = False  # Whether the modality requires an edit-source image.
 
     def __init__(self, config: Any, model_config: Any, *, strategy: Any = None, tokenize_fn: Any = None) -> None:
         super().__init__(config, model_config, strategy=strategy, tokenize_fn=tokenize_fn)
-        self.input_adapter = BagelInputAdapter(self.modality)
-        self.output_adapter = BagelOutputAdapter(self.modality)
+        self.input_adapter = BagelInputAdapter(self.modality, image_input=self.image_input)
+        self.output_adapter = BagelOutputAdapter(self.modality, image_input=self.image_input)
 
     def schedule_policy(self) -> FlowMatchSchedulePolicy:
         """Static-shift FlowMatch σ policy (BAGEL uses no dynamic shifting)."""
@@ -203,9 +263,15 @@ class BagelT2iAdapter(ModelAdapter):
         return FlowMatchSchedulePolicy.static_only(shift)
 
     def validate_request(self, sample: Sample) -> None:
-        if sample.has_image_input():
+        has_image = sample.has_image_input()
+        if self.image_input and not has_image:
             raise ValueError(
-                f"modality={self.modality!r} rejects image-bearing requests; use an image-conditioned modality instead."
+                f"modality={self.modality!r} requires image conditioning (the edit source); "
+                "use modality='bagel_t2i' for prompt-only generation."
+            )
+        if not self.image_input and has_image:
+            raise ValueError(
+                f"modality={self.modality!r} rejects image-bearing requests; use modality='bagel_it2i' instead."
             )
 
     def build_inputs(self, sample: Sample) -> List[GenerateCall]:
@@ -215,4 +281,16 @@ class BagelT2iAdapter(ModelAdapter):
         return self.output_adapter.build(sample, per_request)
 
 
-__all__ = ["BagelInputAdapter", "BagelOutputAdapter", "BagelT2iAdapter"]
+@register_adapter("bagel_t2i")
+class BagelT2iAdapter(BagelAdapter):
+    """BAGEL-7B-MoT text → image."""
+
+
+@register_adapter("bagel_it2i")
+class BagelIt2iAdapter(BagelAdapter):
+    """BAGEL-7B-MoT text + source image → edited image (editing / it2i)."""
+
+    image_input = True
+
+
+__all__ = ["BagelAdapter", "BagelInputAdapter", "BagelIt2iAdapter", "BagelOutputAdapter", "BagelT2iAdapter"]

--- a/unirl/rollout/engine/vllm_omni/pipelines/bagel/pipeline.py
+++ b/unirl/rollout/engine/vllm_omni/pipelines/bagel/pipeline.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
+import copy
 import logging
-from typing import Any, Dict, Optional
+from types import SimpleNamespace
+from typing import Any, Dict, Optional, Tuple
 
+import PIL.Image
 import torch
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
+from vllm_omni.diffusion.models.bagel.bagel_transformer import NaiveCache
 from vllm_omni.diffusion.models.bagel.pipeline_bagel import BagelPipeline
 from vllm_omni.diffusion.request import OmniDiffusionRequest
 
+from unirl.models.bagel.rl_ops import (
+    build_image_transforms,
+    resize_input_image,
+    update_context_image,
+)
 from unirl.rollout.engine.vllm_omni.pipelines._shared.interception import (
     drain_trajectory_into,
     resolve_request_noise,
@@ -37,6 +46,8 @@ class RLBagelPipeline(BagelPipeline):
         self._pending_spp: int = 1
         self._pending_batched_latents: Optional[list] = None
         self._trajectory_dtype: torch.dtype = torch.float32
+        self._vae_transform: Optional[Any] = None
+        self._vit_transform: Optional[Any] = None
 
     def _install_sde_scheduler(self) -> None:
         """Point ``self.scheduler`` at the trajectory-capturing SDE scheduler — always installed, even at eta=0."""
@@ -191,6 +202,103 @@ class RLBagelPipeline(BagelPipeline):
         self.bagel.generate_image = generate_image_grouped  # type: ignore[assignment]
         self._generate_image_tap_installed = True
 
+    def _bundle_view(self) -> SimpleNamespace:
+        """Return a ``BagelBundle``-shaped worker view for shared image prefill."""
+        if self._vae_transform is None:
+            self._vae_transform, self._vit_transform = build_image_transforms()
+        return SimpleNamespace(
+            model=self.bagel,
+            vae=self.vae,
+            vae_transform=self._vae_transform,
+            vit_transform=self._vit_transform,
+            new_token_ids=self.new_token_ids,
+            device=self.device,
+        )
+
+    @staticmethod
+    def _prompt_text(req: OmniDiffusionRequest) -> str:
+        """The request's prompt string (upstream's own extraction, pipeline_bagel:327)."""
+        prompt = req.prompts[0]
+        return prompt if isinstance(prompt, str) else (prompt.get("prompt") or "")
+
+    @staticmethod
+    def _source_image(req: OmniDiffusionRequest) -> Optional[PIL.Image.Image]:
+        """The it2i source PIL off the prompt dict; ``None`` on the t2i path."""
+        prompt = req.prompts[0] if getattr(req, "prompts", None) else None
+        if not isinstance(prompt, dict):
+            return None
+        image = (prompt.get("multi_modal_data") or {}).get("image")
+        if image is None:
+            return None
+        if not isinstance(image, PIL.Image.Image):
+            raise TypeError(
+                "RLBagelPipeline: multi_modal_data['image'] must be ONE PIL image "
+                f"(BagelInputAdapter ships one per sample); got {type(image).__name__}."
+            )
+        return image
+
+    def _prefill_text(self, ctx: Dict[str, Any], prompt: str) -> Dict[str, Any]:
+        """Advance a KV context with the upstream text-prefill path."""
+        clean = str(prompt).removeprefix("<|im_start|>").removesuffix("<|im_end|>")
+        gi, kv_lens, ropes = self.bagel.prepare_prompts(
+            curr_kvlens=ctx["kv_lens"],
+            curr_rope=ctx["ropes"],
+            prompts=[clean],
+            tokenizer=self.tokenizer,
+            new_token_ids=self.new_token_ids,
+        )
+        gi = {k: (v.to(self.device) if torch.is_tensor(v) else v) for k, v in gi.items()}
+        past = self.bagel.forward_cache_update_text(ctx["past_key_values"], **gi)
+        return {"kv_lens": kv_lens, "ropes": ropes, "past_key_values": past}
+
+    def _build_it2i_contexts(
+        self, image: PIL.Image.Image, prompt: str
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+        """Build the gen, drop-text, and drop-image KV contexts for editing."""
+        bundle = self._bundle_view()
+        gen = {
+            "kv_lens": [0],
+            "ropes": [0],
+            "past_key_values": NaiveCache(self.bagel.config.llm_config.num_hidden_layers),
+        }
+        cfg_img = copy.deepcopy(gen)
+        autocast = torch.autocast(
+            device_type=self.device.type,
+            enabled=self.device.type != "cpu",
+            dtype=self.od_config.dtype,
+        )
+        with torch.no_grad(), autocast:
+            resized = resize_input_image(bundle, image)
+            gen = update_context_image(bundle, resized, gen, vae=True, vit=True)
+            cfg_text = copy.deepcopy(gen)  # snapshot before the prompt text
+            gen = self._prefill_text(gen, prompt)
+            cfg_img = self._prefill_text(cfg_img, prompt)
+        return gen, cfg_text, cfg_img
+
+    def _inject_it2i_contexts(self, req: OmniDiffusionRequest, image: PIL.Image.Image) -> None:
+        """Inject it2i KV contexts and requested canvas metadata into a copied request."""
+        sp = req.sampling_params
+        if sp.height is None or sp.width is None:
+            raise ValueError(
+                "RLBagelPipeline it2i: sampling_params must carry height/width (the "
+                "output canvas the driver's x_T recipe was authored for)."
+            )
+        image_shape = (int(sp.height), int(sp.width))
+        gen, cfg_text, cfg_img = self._build_it2i_contexts(image, self._prompt_text(req))
+
+        sp = copy.copy(sp)
+        sp.past_key_values = gen["past_key_values"]
+        sp.kv_metadata = {"ropes": gen["ropes"], "image_shape": image_shape}
+        sp.cfg_text_past_key_values = cfg_text["past_key_values"]
+        sp.cfg_text_kv_metadata = {"ropes": cfg_text["ropes"]}
+        sp.cfg_img_past_key_values = cfg_img["past_key_values"]
+        sp.cfg_img_kv_metadata = {"ropes": cfg_img["ropes"]}
+        req.sampling_params = sp
+
+    # ------------------------------------------------------------------ #
+    # arm — every request (stale-leak guards)
+    # ------------------------------------------------------------------ #
+
     def _arm_sde(self, req: OmniDiffusionRequest, image_token_sizes: Optional[list] = None) -> None:
         """This request's SDE strength + sparse step gate + σ_max + storage dtype."""
         sp = req.sampling_params
@@ -250,6 +358,12 @@ class RLBagelPipeline(BagelPipeline):
                     f"is disabled."
                 )
             return self._forward_batched(req, spp, **kwargs)
+
+        # it2i: build the conditioning ourselves (trainside-identical) and inject it,
+        # so upstream's own img2img prefill never runs. No-op for t2i.
+        image = self._source_image(req)
+        if image is not None:
+            self._inject_it2i_contexts(req, image)
 
         self._arm_sde(req)
         self._arm_initial_noise(req)

--- a/unirl/rollout/engine/vllm_omni/stage_configs/bagel_t2i_rl.yaml
+++ b/unirl/rollout/engine/vllm_omni/stage_configs/bagel_t2i_rl.yaml
@@ -1,8 +1,13 @@
-# Single-stage BAGEL-7B-MoT text-to-image config for RL rollout.
+# Single-stage BAGEL-7B-MoT image-out config for RL rollout.
 #
 # BAGEL is the single-stage topology where the DiT worker owns a full
 # Qwen2-MoT LLM + ViT + VAE + tokenizer and handles text2img end-to-end (no
-# separate AR/Thinker prelude — think mode is off for the T2I GRPO path).
+# separate AR/Thinker prelude — think mode is off for the GRPO path).
+#
+# Shared by BOTH image-out modalities — ``bagel_t2i`` and ``bagel_it2i``
+# (editing). The custom worker pipeline owns the ViT and editing prefill; the
+# source image travels on the request (``multi_modal_data["image"]``), not in this
+# config, so the two modalities need no stage-level difference.
 #
 # Diff vs upstream's bagel_single_stage deploy yaml:
 #   - custom_pipeline_args installs our RLBagelPipeline subclass. Unlike SD3/Qwen
@@ -62,7 +67,7 @@ stage_args:
       # Without ``enable_lora``, ``add_lora`` still registers the adapter (so
       # checksum probes pass) but no Linear consults it and the forward silently
       # runs base weights. ``max_lora_rank`` must be >= the recipe's LoRA rank
-      # (64 in bagel_trainside_lora); vllm's default of 16 silently rejects larger.
+      # (64 in the BAGEL LoRA recipes); vLLM's default of 16 rejects larger ranks.
       enable_lora: true
       max_lora_rank: 64
       parallel_config:

--- a/unirl/rollout/engine/vllm_omni/utils/noise.py
+++ b/unirl/rollout/engine/vllm_omni/utils/noise.py
@@ -28,8 +28,17 @@ def pack_initial_noise_extra_args(
             )
         extra_args["initial_noise_batch"] = initial_latents
     elif diff_params.init_noise_latent_shape:
-        share = bool(getattr(diff_params, "init_same_noise", False))
-        keys = gen_part.group_ids if share else list(gen_part.sample_ids)
+        explicit_keys = list(getattr(gen_part, "init_noise_group_ids", []) or [])
+        if explicit_keys:
+            if len(explicit_keys) != n_samples:
+                raise RuntimeError(
+                    f"{caller}: init_noise_group_ids count {len(explicit_keys)} "
+                    f"!= diffusion sample count {n_samples} after sharding."
+                )
+            keys = explicit_keys
+        else:
+            share = bool(getattr(diff_params, "init_same_noise", False))
+            keys = gen_part.group_ids if share else list(gen_part.sample_ids)
         extra_args["init_noise_group_ids"] = [str(k) for k in keys]
         extra_args["init_noise_latent_shape"] = [int(x) for x in diff_params.init_noise_latent_shape]
         extra_args["init_noise_seed"] = int(diff_params.seed) if getattr(diff_params, "seed", None) is not None else 0


### PR DESCRIPTION
## Summary

- Add a Sample/Part-native BAGEL `bagel_it2i` vLLM-Omni adapter that preserves source-image alignment for every GRPO sibling.
- Build worker and replay contexts from the same aspect-preserving VAE/ViT transforms, deterministic VAE posterior mean, fixed-noise keys, and matched SDE cutoff.
- Rebuild source contexts differentiably for LoRA replay while preserving upstream navit inference-mode guards and copy-on-write KV storage.
- Add the first end-to-end managed reward consumer recipe: BAGEL FSDP8 + vLLM-Omni DP8/TP1 + rank-affine EditReward DP8, with safe rollout sleep by default and measured all-resident opt-in.

## Related Issue

N/A

## Test Plan

- `uvx --from pre-commit pre-commit run --files <all changed PR3 files>`
- `python -m compileall -q unirl/models/bagel unirl/rollout/engine/vllm_omni`
- `python lint/check_recipe_targets.py` (`2,458` recipe `_target_` paths resolved on the top-stack tree).
- Hydra compose:
  `python -m unirl.train_diffusion --config-name=diffusion/bagel/bagel_it2i_vllmomni --cfg job --resolve rollout_sleep_after_generate=false offload_train_during_reward=false`
- End-to-end latest-upstream smoke on 8x NVIDIA H20 96GB with `ByteDance-Seed/BAGEL-7B-MoT`, `TIGER-Lab/EditReward-MiMo-VL-7B-SFT-2508`, `XiaomiMiMo/MiMo-VL-7B-SFT-2508`, OpenGPT image-edit data, FSDP8, vLLM-Omni DP8/TP1, LoRA rank 64, 8 prompts x 8 samples, and two optimizer updates.
- Result: one complete rollout/reward/advantage/train step, reward `-1.0735`, ratio `1.0000±0.0000`, grad norm `0.0001`, peak HBM `88,430–88,538 MiB/card`, exit code 0, and zero residual GPU memory after teardown.
- The 8xH20 smoke ran on the pre-refresh tree; the refresh since merged current main and adjusted the recipe (retired eval key dropped, ac_wrap_order pinned) — see the refresh comment for what was re-verified.
- No standalone test files are added; validation is pre-commit, compile/compose checks, and the real DP8 smoke above.

## Compatibility / Risk

- The new modality and recipe are additive; existing BAGEL T2I behavior remains available.
- The shared context-helper refactor retains upstream's load-bearing eval-mode guard for navit packed inference.
- It2i intentionally disables packed rollout because each request carries a distinct source image.
- `bundle.enable_vit=true` is required for trainer-side source-context replay.
- The recipe defaults to rollout sleep; all-resident mode must be explicitly enabled only after measuring full geometry memory.
- No checkpoint format change; conditions add raw source-image material required to rebuild cross-process replay contexts.

## Reviewer Notes

- Stacked on #302 and #303 and refreshed onto current main. Review the PR3 slice: `unirl/models/bagel/*`, `unirl/rollout/engine/vllm_omni/*`, `unirl/algorithms/bagel_flow_unigrpo.py`, and the recipe — `git diff <PR2-head>..HEAD`. Must not merge before both dependencies.
- The two upstream BAGEL conflicts were resolved semantically: upstream's eval-mode guard and this PR's differentiable source-context rebuild are both retained.
- Implementation was AI-assisted and manually reviewed; commits contain no coauthor trailers or generated test artifacts.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.