### PR TITLE
refactor(fastvideo): integrate upstream through runtime patches

### DIFF
--- a/examples/diffusion/wan21/wan21_t2v_dancegrpo_fastvideo.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_dancegrpo_fastvideo.yaml
@@ -17,9 +17,9 @@
 #      weights and pushes the merged full model (FastVideo serves merged weights;
 #      it has no separate adapter path here).
 #
-# FastVideo dependency: https://github.com/Zcchill/FastVideo at or after
-# 7fe1d7db9a0b8aebb46679e7924f597431f23665. Set $FASTVIDEO_PATH to that
-# checkout; FastVideo is lazy-imported by the rollout engine only.
+# FastVideo dependency: install UniRL's `fastvideo` extra. pyproject.toml pins
+# the unmodified hao-ai-lab/FastVideo source snapshot validated by UniRL's
+# fail-closed runtime patches. FASTVIDEO_PATH remains a development override.
 #
 # This recipe defaults to replay log-probs. Native mode is enabled by setting
 # rollout.config.native_logprob=true and algorithm.old_logp_source=rollout;

--- a/examples/diffusion/wan21/wan21_t2v_fastvideo_replay.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_fastvideo_replay.yaml
@@ -1,0 +1,176 @@
+# @package _global_
+# wan21_t2v.yaml (FlowGRPO trainside baseline) with ONLY the rollout engine
+# swapped trainside -> FastVideo VideoGenerator, in REPLAY log-prob mode.
+#
+# Purpose: head-to-head against the wan21_t2v.yaml trainside baseline under
+# IDENTICAL hyperparams (FlowSDEStrategy, shift=5, 720p/5-frame, video_pickscore,
+# LoRA targets, sampling schedule, num_updates=2). The intended experiment
+# isolates the rollout-engine effect. Replay mode recomputes both old and new
+# log-probs in the trainer; the adapter separately verifies the worker-echoed
+# sigma schedule so ratio==1 cannot hide rollout/replay schedule drift.
+#
+# Structural deltas the swap forces (mirrors wan21_t2v_dancegrpo_fastvideo.yaml):
+#   1. model_config + strategy lifted to shared top-level nodes (a dedicated
+#      engine needs them injected).
+#   2. A dedicated engine needs a sync: block (CheckpointWeightSync, lora_merged).
+
+num_devices: 8
+batch_size: 48
+adv_use_global_std: true
+num_rollouts: 1000
+weight_sync_interval: 1
+
+# Shared nodes (lifted from wan21_t2v.yaml inline bundle.config / pipeline.strategy).
+model_config:
+  _target_: unirl.models.wan21.config.WAN21PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.1-T2V-1.3B-Diffusers}
+  model_precision: bf16
+  shift: 5.0
+  max_sequence_length: 512
+
+strategy:
+  _target_: unirl.sde.kernels.FlowSDEStrategy
+
+bundle:
+  _target_: unirl.models.wan21.bundle.WAN21Bundle.from_config
+  config: ${model_config}
+
+pipeline:
+  _target_: unirl.models.wan21.pipeline.WAN21Pipeline
+  shift: 5.0
+  autocast_precision: bf16
+  trajectory_precision: fp16
+  logprob_precision: fp32
+  max_sequence_length: 512
+  strategy: ${strategy}
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["WanTransformerBlock"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    use_torch_compile: false
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: 1000
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 64
+    alpha: 128
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn1.to_q
+      - attn1.to_k
+      - attn1.to_v
+      - attn1.to_out.0
+      - attn2.to_q
+      - attn2.to_k
+      - attn2.to_v
+      - attn2.to_out.0
+
+# Rollout swapped: trainside -> FastVideo VideoGenerator (dedicated, colocate).
+rollout:
+  _target_: unirl.rollout.engine.fastvideo.engine.FastVideoRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.fastvideo.config.FastVideoEngineConfig
+    model_family: wan2.1
+    native_logprob: false
+    init_same_noise: ${sampling.init_same_noise}
+    num_gpus: 1
+    tp_size: 1
+    sp_size: 1
+    local_mode: true
+    forward_batch_size: 4
+    fastvideo_path: ${oc.env:FASTVIDEO_PATH,null}
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+    base_device: cuda
+    config:
+      _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+      batch_size: 8
+      device: auto
+      processor_id: laion/CLIP-ViT-H-14-laion2B-s32B-b79K
+      model_id: yuvalkirstain/PickScore_v1
+
+algorithm:
+  _target_: unirl.algorithms.flowgrpo.FlowGRPO
+  stage_attr: diffusion
+  clip_range: 1.0e-4
+  clip_schedule: constant
+  old_logp_source: replay
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.wan21.conditions.WAN21Conditions
+  params: ${sampling}
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 2
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 14
+  guidance_scale: 1.0
+  height: 720
+  width: 1280
+  num_frames: 5
+  eta: 0.7
+  samples_per_prompt: 16
+  seed: 42
+  init_same_noise: false
+  scheduler:
+    _target_: unirl.utils.scheduler_utils.AllSDEScheduler
+    num_timesteps: ${..num_inference_steps}
+    timestep_fraction: [0.0, 0.5]
+    num_sde_steps: null
+
+sync:
+  _target_: unirl.distributed.weight_sync.full.checkpoint.CheckpointWeightSync
+  lora_merged: true
+  sync_dir: ${oc.env:WEIGHT_SYNC_DIR,/tmp/unirl_fastvideo_weight_sync}
+  flush_cache: true
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-grpo-t2v}
+  run_name: ${oc.env:WANDB_RUN_NAME,wan21_t2v_fastvideo_replay}
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: ["wan21", "t2v", "grpo", "video", "pickscore", "fastvideo", "replay", "v2"]
+  log_media: false
+  media_max_items: 8
+  media_log_interval: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ vllm = [
   "torchvision==0.26.0+cu129 ; sys_platform == 'linux'",
   "torchaudio==2.11.0+cu129 ; sys_platform == 'linux'",
 ]
+# Exact upstream source snapshot that the fail-closed FastVideo patch package is
+# verified against. This is hao-ai-lab/FastVideo PR #1222's source commit, not
+# Zcchill/FastVideo's UniRL-modified fork; UniRL re-hosts the required RL
+# contracts under unirl/rollout/engine/fastvideo/_patches.
+fastvideo = [
+  "fastvideo @ git+https://github.com/hao-ai-lab/FastVideo.git@2095477eac7e289c7a7ab13acb367ca60687c304 ; sys_platform == 'linux'",
+]
 train = [
   "wandb>=0.16,<0.20",
   "aiohttp>=3.9",

--- a/tests/test_fastvideo_runtime_patches.py
+++ b/tests/test_fastvideo_runtime_patches.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import importlib.util
+import pickle
+import sys
+import types
+from dataclasses import dataclass, fields
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def _load_patch_module(name: str):
+    path = Path(__file__).parents[1] / "unirl" / "rollout" / "engine" / "fastvideo" / "_patches" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_test_fastvideo_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_conditions = _load_patch_module("conditions")
+_denoising = _load_patch_module("denoising")
+_ForwardResultPipe = _conditions._ForwardResultPipe
+_CONTEXT = _denoising._CONTEXT
+_TransitionContext = _denoising._TransitionContext
+_sde_step_with_logprob = _denoising._sde_step_with_logprob
+
+
+class _Scheduler:
+    def __init__(self) -> None:
+        self.sigmas = torch.tensor([1.0, 0.8, 0.4, 0.0])
+
+    def index_for_timestep(self, timestep: float) -> int:
+        values = [1.0, 0.8, 0.4]
+        return min(range(len(values)), key=lambda index: abs(values[index] - float(timestep)))
+
+
+def test_dance_transition_uses_explicit_eta() -> None:
+    scheduler = _Scheduler()
+    sample = torch.ones(1, 1, 1, 1, 1)
+    model_output = torch.zeros_like(sample)
+    prev_sample = torch.ones_like(sample)
+
+    _, log_prob, _, transition_std = _sde_step_with_logprob(
+        scheduler,
+        model_output,
+        torch.tensor(0.8),
+        sample,
+        prev_sample=prev_sample,
+        eta=0.25,
+        sde_type="dance",
+    )
+
+    assert torch.allclose(transition_std.flatten(), torch.tensor([0.25 * (0.4**0.5)]))
+    assert torch.isfinite(log_prob).all()
+
+
+def test_flow_first_step_uses_second_sigma_as_guard() -> None:
+    scheduler = _Scheduler()
+    sample = torch.ones(1, 1, 1, 1, 1)
+    model_output = torch.zeros_like(sample)
+
+    _, _, _, transition_std = _sde_step_with_logprob(
+        scheduler,
+        model_output,
+        torch.tensor(1.0),
+        sample,
+        prev_sample=torch.ones_like(sample),
+        eta=0.3,
+        sde_type="flow",
+    )
+
+    expected = (1.0 / (1.0 - 0.8)) ** 0.5 * 0.3 * (0.2**0.5)
+    assert torch.allclose(transition_std.flatten(), torch.tensor([expected]), rtol=1e-5, atol=1e-6)
+
+
+def test_transition_context_makes_tail_deterministic() -> None:
+    scheduler = _Scheduler()
+    sample = torch.ones(1, 1, 1, 1, 1)
+    model_output = torch.full_like(sample, 2.0)
+    token = _CONTEXT.set(
+        _TransitionContext(
+            eta=0.3,
+            sde_type="dance",
+            sde_step_indices=frozenset({0}),
+            collect_kl=False,
+            timestep_dtype="long",
+            generator=None,
+        )
+    )
+    try:
+        result, log_prob, mean, transition_std = _sde_step_with_logprob(
+            scheduler,
+            model_output,
+            torch.tensor(0.8),
+            sample,
+        )
+    finally:
+        _CONTEXT.reset(token)
+
+    expected = sample + (0.4 - 0.8) * model_output
+    assert torch.equal(result, expected)
+    assert torch.equal(mean, expected)
+    assert torch.count_nonzero(log_prob) == 0
+    assert torch.count_nonzero(transition_std) == 0
+
+
+def test_contract_patch_is_idempotent() -> None:
+    @dataclass
+    class RLData:
+        enabled: bool = False
+        collect_log_probs: bool = True
+        store_trajectory: bool = True
+        keep_trajectory_on_cpu: bool = False
+
+    class ForwardBatch:
+        pass
+
+    ForwardBatch.RLData = RLData
+    module = types.ModuleType("fastvideo.pipelines.pipeline_batch_info")
+    RLData.__module__ = module.__name__
+    ForwardBatch.__module__ = module.__name__
+    module.ForwardBatch = ForwardBatch
+    names = ("fastvideo", "fastvideo.pipelines", "fastvideo.pipelines.pipeline_batch_info")
+    previous = {name: sys.modules.get(name) for name in names}
+    try:
+        sys.modules["fastvideo"] = types.ModuleType("fastvideo")
+        sys.modules["fastvideo.pipelines"] = types.ModuleType("fastvideo.pipelines")
+        sys.modules["fastvideo.pipelines.pipeline_batch_info"] = module
+
+        contracts = _load_patch_module("contracts")
+        contracts.patch_contracts()
+        patched = ForwardBatch.RLData
+        contracts.patch_contracts()
+
+        assert ForwardBatch.RLData is patched
+        assert {"sde_step_indices", "sde_type"} <= {field.name for field in fields(patched)}
+        assert patched(sde_step_indices=[0, 1], sde_type="flow").sde_type == "flow"
+        restored = pickle.loads(pickle.dumps(patched(sde_step_indices=[0], sde_type="dance")))
+        assert restored.sde_step_indices == [0]
+    finally:
+        for name, old_module in previous.items():
+            if old_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old_module
+
+
+def test_forward_pipe_carries_exact_conditions_to_cpu() -> None:
+    sent = []
+
+    class Connection:
+        def send(self, payload):
+            sent.append(payload)
+
+    output = types.SimpleNamespace(
+        rl_data=types.SimpleNamespace(log_probs=torch.ones(1)),
+        trajectory_latents=torch.ones(1),
+        trajectory_timesteps=torch.ones(1),
+        prompt_embeds=[torch.ones(1)],
+        negative_prompt_embeds=None,
+        prompt_attention_mask=[torch.ones(1)],
+        negative_attention_mask=None,
+    )
+    wrapper = types.SimpleNamespace(_unirl_last_forward_batch=output)
+    owner = types.SimpleNamespace(worker=wrapper)
+    pipe = _ForwardResultPipe(Connection(), owner)
+
+    pipe.send({"output_batch": torch.zeros(1)})
+
+    assert torch.equal(sent[0]["prompt_embeds"][0], torch.ones(1))
+    assert torch.equal(sent[0]["rl_data"].log_probs, torch.ones(1))
+    assert owner.worker._unirl_last_forward_batch is None
+
+
+def test_timestep_patch_scopes_numpy_sigmas_to_forward_call() -> None:
+    observed = []
+
+    class TimestepPreparationStage:
+        def __init__(self):
+            self.scheduler = types.SimpleNamespace(
+                sigmas=torch.tensor([1.0, 0.5005, 0.0]),
+                timesteps=torch.tensor([1000, 500]),
+                config=types.SimpleNamespace(num_train_timesteps=1000),
+            )
+
+        def forward(self, batch, fastvideo_args):
+            observed.append(batch.sigmas)
+            batch.timesteps = self.scheduler.timesteps
+            return batch
+
+    module_name = "fastvideo.pipelines.stages.timestep_preparation"
+    module = types.ModuleType(module_name)
+    module.TimestepPreparationStage = TimestepPreparationStage
+    previous = sys.modules.get(module_name)
+    try:
+        sys.modules[module_name] = module
+        timesteps = _load_patch_module("timesteps")
+        timesteps.patch_timesteps()
+        batch = types.SimpleNamespace(sigmas=[1.0, 0.5])
+        args = types.SimpleNamespace(_unirl_custom_sigmas_dtype="float32")
+        stage = TimestepPreparationStage()
+        stage.forward(batch, args)
+        assert isinstance(observed[0], np.ndarray)
+        assert observed[0].dtype == np.float32
+        assert batch.sigmas == [1.0, 0.5]
+        assert torch.allclose(batch.timesteps, torch.tensor([1000.0, 500.5]))
+        assert torch.equal(stage.scheduler.timesteps, batch.timesteps)
+    finally:
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
+
+
+def test_multiproc_executor_retries_address_collision() -> None:
+    multiproc = _load_patch_module("multiproc")
+    attempts = []
+
+    def original_init(executor):
+        attempts.append(executor.fastvideo_args.master_port)
+        if len(attempts) == 1:
+            raise RuntimeError("TCPStore failed to bind: EADDRINUSE")
+
+    previous = multiproc._ORIGINAL_INIT_EXECUTOR
+    try:
+        multiproc._ORIGINAL_INIT_EXECUTOR = original_init
+        executor = types.SimpleNamespace(fastvideo_args=types.SimpleNamespace(master_port=29500))
+        multiproc._patched_init_executor(executor)
+    finally:
+        multiproc._ORIGINAL_INIT_EXECUTOR = previous
+
+    assert attempts == [29500, None]

--- a/unirl/rollout/engine/fastvideo/_patches/__init__.py
+++ b/unirl/rollout/engine/fastvideo/_patches/__init__.py
@@ -1,0 +1,5 @@
+"""UniRL runtime patches for FastVideo's RL rollout seams."""
+
+from unirl.rollout.engine.fastvideo._patches.hijack import FastVideoHijack
+
+__all__ = ["FastVideoHijack"]

--- a/unirl/rollout/engine/fastvideo/_patches/compat.py
+++ b/unirl/rollout/engine/fastvideo/_patches/compat.py
@@ -1,0 +1,180 @@
+"""Fail-closed compatibility checks for the FastVideo runtime patch suite."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import subprocess
+from dataclasses import fields, is_dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+_ALLOWED_COMMITS = {
+    # hao-ai-lab/FastVideo PR #1222 source snapshot pinned by pyproject.toml.
+    "2095477eac7e289c7a7ab13acb367ca60687c304",
+    # Temporary migration compatibility for Zcchill/FastVideo PR #1-#3 main.
+    "e7fafe6d4cfcb6a34735a8d6b767b27b8de09465",
+}
+
+
+class FastVideoCompatibilityError(RuntimeError):
+    """Raised when the installed FastVideo cannot be patched safely."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise FastVideoCompatibilityError(message)
+
+
+def _require_parameters(callable_obj: Any, *, symbol: str, names: set[str]) -> None:
+    try:
+        actual = set(inspect.signature(callable_obj).parameters)
+    except (TypeError, ValueError) as exc:
+        raise FastVideoCompatibilityError(f"cannot inspect FastVideo symbol {symbol}: {exc}") from exc
+    missing = names - actual
+    _require(not missing, f"incompatible FastVideo {symbol}: missing parameters {sorted(missing)}")
+
+
+def _installed_commit() -> str | None:
+    """Resolve VCS provenance from PEP 610 metadata or a source checkout."""
+
+    try:
+        direct_url = metadata.distribution("fastvideo").read_text("direct_url.json")
+    except metadata.PackageNotFoundError:
+        direct_url = None
+    if direct_url:
+        payload = json.loads(direct_url)
+        commit = (payload.get("vcs_info") or {}).get("commit_id")
+        if commit:
+            return str(commit).lower()
+
+    import fastvideo
+
+    package_file = Path(fastvideo.__file__).resolve()
+    for parent in package_file.parents:
+        if (parent / ".git").exists():
+            result = subprocess.run(
+                ["git", "-C", str(parent), "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return result.stdout.strip().lower()
+    return None
+
+
+def verify_fastvideo_compatibility() -> None:
+    """Verify the narrow upstream seams used by UniRL before patching.
+
+    FastVideo does not currently expose a stable plugin API or a reliable
+    package version for these RL seams. We therefore validate symbols,
+    dataclass fields, signatures, and the denoising source markers that the
+    around-patch relies on. Any mismatch aborts engine boot.
+    """
+
+    commit = _installed_commit()
+    _require(
+        commit in _ALLOWED_COMMITS,
+        "FastVideo provenance is not in UniRL's verified allowlist: "
+        f"commit={commit!r}, allowed={sorted(_ALLOWED_COMMITS)}. "
+        "Install the `fastvideo` extra or use an explicitly verified checkout.",
+    )
+
+    from fastvideo.entrypoints.video_generator import VideoGenerator
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+    from fastvideo.pipelines.stages import denoising
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor, WorkerMultiprocProc
+
+    _require(is_dataclass(ForwardBatch), "incompatible FastVideo ForwardBatch: expected dataclass")
+    _require(is_dataclass(ForwardBatch.RLData), "incompatible FastVideo ForwardBatch.RLData: expected dataclass")
+    rl_fields = {field.name for field in fields(ForwardBatch.RLData)}
+    _require(
+        {"enabled", "collect_log_probs", "store_trajectory", "keep_trajectory_on_cpu"} <= rl_fields,
+        f"incompatible FastVideo RLData fields: {sorted(rl_fields)}",
+    )
+
+    _require_parameters(
+        denoising.sde_step_with_logprob,
+        symbol="denoising.sde_step_with_logprob",
+        names={"scheduler", "model_output", "timestep", "sample"},
+    )
+    _require_parameters(
+        denoising.DenoisingStage.forward,
+        symbol="DenoisingStage.forward",
+        names={"self", "batch", "fastvideo_args"},
+    )
+    try:
+        forward_source = inspect.getsource(denoising.DenoisingStage.forward)
+    except (OSError, TypeError) as exc:
+        raise FastVideoCompatibilityError(f"cannot inspect FastVideo DenoisingStage.forward: {exc}") from exc
+    for marker in ("rl_data", "sde_step_with_logprob", "scheduler.step"):
+        _require(
+            marker in forward_source,
+            f"incompatible FastVideo DenoisingStage.forward: required source marker {marker!r} is absent",
+        )
+
+    _require_parameters(
+        MultiprocExecutor.execute_forward,
+        symbol="MultiprocExecutor.execute_forward",
+        names={"self", "forward_batch", "fastvideo_args"},
+    )
+    _require_parameters(
+        WorkerMultiprocProc.make_worker_process,
+        symbol="WorkerMultiprocProc.make_worker_process",
+        names={"fastvideo_args", "local_rank", "rank", "distributed_init_method"},
+    )
+    _require(
+        callable(getattr(VideoGenerator, "from_fastvideo_args", None)), "FastVideo VideoGenerator boot API is absent"
+    )
+
+
+def verify_fastvideo_capabilities() -> None:
+    """Assert every correctness-critical UniRL capability is installed."""
+
+    from fastvideo.entrypoints.video_generator import VideoGenerator
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+    from fastvideo.pipelines.stages import denoising
+    from fastvideo.pipelines.stages.timestep_preparation import TimestepPreparationStage
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor, WorkerMultiprocProc
+
+    rl_fields = {field.name for field in fields(ForwardBatch.RLData)}
+    _require(
+        {"sde_step_indices", "sde_type"} <= rl_fields,
+        f"FastVideo RLData patch incomplete: fields are {sorted(rl_fields)}",
+    )
+    _require(
+        bool(getattr(denoising.sde_step_with_logprob, "_unirl_fastvideo_sde", False)),
+        "FastVideo denoising SDE patch was not installed",
+    )
+    _require(
+        bool(getattr(denoising.DenoisingStage.forward, "_unirl_fastvideo_denoising", False)),
+        "FastVideo denoising context patch was not installed",
+    )
+    _require(
+        bool(getattr(TimestepPreparationStage.forward, "_unirl_fastvideo_timesteps", False)),
+        "FastVideo custom-sigma timestep patch was not installed",
+    )
+    _require(
+        bool(getattr(MultiprocExecutor.execute_forward, "_unirl_fastvideo_conditions", False)),
+        "FastVideo worker response patch was not installed",
+    )
+    _require(
+        callable(getattr(VideoGenerator, "update_transformer_weights_from_path", None)),
+        "FastVideo full-weight update entrypoint is absent",
+    )
+    _require(
+        bool(getattr(WorkerMultiprocProc.worker_main, "_unirl_fastvideo_spawn", False)),
+        "FastVideo spawn propagation patch was not installed",
+    )
+    _require(
+        bool(getattr(MultiprocExecutor._init_executor, "_unirl_fastvideo_port_retry", False)),
+        "FastVideo TCPStore startup retry patch was not installed",
+    )
+
+
+__all__ = [
+    "FastVideoCompatibilityError",
+    "verify_fastvideo_capabilities",
+    "verify_fastvideo_compatibility",
+]

--- a/unirl/rollout/engine/fastvideo/_patches/conditions.py
+++ b/unirl/rollout/engine/fastvideo/_patches/conditions.py
@@ -1,0 +1,125 @@
+"""Carry RL trajectories and exact text conditions across FastVideo worker pipes."""
+
+from __future__ import annotations
+
+from copy import copy
+from dataclasses import fields, is_dataclass
+from functools import wraps
+from typing import Any
+
+import torch
+
+
+def _cpu_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {key: _cpu_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_cpu_value(item) for item in value]
+    if torch.is_tensor(value):
+        return value.detach().cpu()
+    if is_dataclass(value) and not isinstance(value, type):
+        result = copy(value)
+        for field in fields(value):
+            setattr(result, field.name, _cpu_value(getattr(value, field.name)))
+        return result
+    return value
+
+
+class _ForwardResultPipe:
+    """Connection proxy that enriches only ``execute_forward`` responses."""
+
+    def __init__(self, connection: Any, owner: Any) -> None:
+        self._connection = connection
+        self._owner = owner
+
+    def send(self, payload: Any) -> None:
+        output_batch = getattr(self._owner.worker, "_unirl_last_forward_batch", None)
+        if isinstance(payload, dict) and "output_batch" in payload and output_batch is not None:
+            payload.setdefault("rl_data", _cpu_value(getattr(output_batch, "rl_data", None)))
+            payload.setdefault("trajectory_latents", _cpu_value(getattr(output_batch, "trajectory_latents", None)))
+            payload.setdefault("trajectory_timesteps", _cpu_value(getattr(output_batch, "trajectory_timesteps", None)))
+            payload.setdefault("prompt_embeds", _cpu_value(getattr(output_batch, "prompt_embeds", None)))
+            payload.setdefault(
+                "negative_prompt_embeds", _cpu_value(getattr(output_batch, "negative_prompt_embeds", None))
+            )
+            payload.setdefault(
+                "prompt_attention_mask", _cpu_value(getattr(output_batch, "prompt_attention_mask", None))
+            )
+            payload.setdefault(
+                "negative_attention_mask", _cpu_value(getattr(output_batch, "negative_attention_mask", None))
+            )
+            self._owner.worker._unirl_last_forward_batch = None
+        self._connection.send(payload)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._connection, name)
+
+
+def patch_conditions() -> None:
+    """Patch the narrow worker and driver seams without replacing busy loops."""
+
+    import fastvideo.envs as envs
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor, WorkerMultiprocProc
+    from fastvideo.worker.worker_base import WorkerWrapperBase
+
+    if not getattr(WorkerWrapperBase, "_unirl_fastvideo_forward_cache", False):
+
+        def execute_forward(self, forward_batch, fastvideo_args):
+            if self.worker is None:
+                raise RuntimeError("FastVideo worker is not initialized")
+            output_batch = self.worker.execute_forward(forward_batch, fastvideo_args)
+            self._unirl_last_forward_batch = output_batch
+            return output_batch
+
+        WorkerWrapperBase.execute_forward = execute_forward
+        setattr(WorkerWrapperBase, "_unirl_fastvideo_forward_cache", True)
+
+    original_init = WorkerMultiprocProc.__init__
+    if not getattr(original_init, "_unirl_fastvideo_conditions", False):
+
+        @wraps(original_init)
+        def init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            if not isinstance(self.pipe, _ForwardResultPipe):
+                self.pipe = _ForwardResultPipe(self.pipe, self)
+
+        setattr(init, "_unirl_fastvideo_conditions", True)
+        WorkerMultiprocProc.__init__ = init
+
+    current_execute = MultiprocExecutor.execute_forward
+    if getattr(current_execute, "_unirl_fastvideo_conditions", False):
+        return
+
+    def execute_forward(self, forward_batch, fastvideo_args):
+        responses = self.collective_rpc(
+            "execute_forward",
+            kwargs={"forward_batch": forward_batch, "fastvideo_args": fastvideo_args},
+        )
+        if not responses or not isinstance(responses[0], dict):
+            raise RuntimeError(f"FastVideo execute_forward returned invalid worker responses: {responses!r}")
+        response = responses[0]
+        kwargs: dict[str, Any] = {
+            "data_type": forward_batch.data_type,
+            "output": response.get("output_batch"),
+            "logging_info": response.get("logging_info") if envs.FASTVIDEO_STAGE_LOGGING else None,
+            "extra": response.get("extra", {}),
+            "trajectory_latents": response.get("trajectory_latents"),
+            "trajectory_timesteps": response.get("trajectory_timesteps"),
+        }
+        if response.get("rl_data") is not None:
+            kwargs["rl_data"] = response["rl_data"]
+        result = ForwardBatch(**kwargs)
+        result.prompt_embeds = response.get("prompt_embeds") or []
+        result.negative_prompt_embeds = response.get("negative_prompt_embeds")
+        result.prompt_attention_mask = response.get("prompt_attention_mask")
+        result.negative_attention_mask = response.get("negative_attention_mask")
+        return result
+
+    setattr(execute_forward, "_unirl_fastvideo_conditions", True)
+    MultiprocExecutor.execute_forward = execute_forward
+
+
+__all__ = ["patch_conditions"]

--- a/unirl/rollout/engine/fastvideo/_patches/contracts.py
+++ b/unirl/rollout/engine/fastvideo/_patches/contracts.py
@@ -1,0 +1,38 @@
+"""FastVideo request/response contract extensions required by UniRL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+
+def patch_contracts() -> None:
+    """Add the SDE-window fields to ``ForwardBatch.RLData`` idempotently."""
+
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+    original = ForwardBatch.RLData
+    existing = {field.name for field in fields(original)}
+    required = {"sde_step_indices", "sde_type"}
+    if required <= existing:
+        setattr(original, "_unirl_fastvideo_contract", True)
+        return
+
+    missing_base = {"enabled", "collect_log_probs", "store_trajectory"} - existing
+    if missing_base:
+        raise RuntimeError(f"FastVideo RLData is incompatible; missing base fields {sorted(missing_base)}")
+
+    @dataclass
+    class UniRLFastVideoRLData(original):
+        """Stock FastVideo RLData plus UniRL's resolved transition contract."""
+
+        sde_step_indices: list[int] | None = None
+        sde_type: str = "dance"
+
+    UniRLFastVideoRLData.__name__ = "RLData"
+    UniRLFastVideoRLData.__qualname__ = "ForwardBatch.RLData"
+    UniRLFastVideoRLData.__module__ = original.__module__
+    setattr(UniRLFastVideoRLData, "_unirl_fastvideo_contract", True)
+    ForwardBatch.RLData = UniRLFastVideoRLData
+
+
+__all__ = ["patch_contracts"]

--- a/unirl/rollout/engine/fastvideo/_patches/denoising.py
+++ b/unirl/rollout/engine/fastvideo/_patches/denoising.py
@@ -1,0 +1,202 @@
+"""UniRL-owned Flow/Dance transition math for FastVideo RL rollouts."""
+
+from __future__ import annotations
+
+import math
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class _TransitionContext:
+    eta: float
+    sde_type: str
+    sde_step_indices: frozenset[int] | None
+    collect_kl: bool
+    timestep_dtype: str | None
+    generator: Any
+
+
+_CONTEXT: ContextVar[_TransitionContext | None] = ContextVar("unirl_fastvideo_transition", default=None)
+
+
+def _step_indices(scheduler: Any, timestep: float | torch.Tensor) -> list[int]:
+    if isinstance(timestep, torch.Tensor):
+        values = timestep.reshape(-1).tolist()
+    else:
+        values = [timestep]
+    return [int(scheduler.index_for_timestep(value)) for value in values]
+
+
+def _sde_step_with_logprob(
+    scheduler: Any,
+    model_output: torch.Tensor,
+    timestep: float | torch.Tensor,
+    sample: torch.Tensor,
+    prev_sample: torch.Tensor | None = None,
+    generator: torch.Generator | list[torch.Generator] | None = None,
+    deterministic: bool = False,
+    return_pixel_log_prob: bool = False,
+    return_dt_and_std_dev_t: bool = False,
+    eta: float | None = None,
+    sde_type: str | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Apply the same Gaussian transition used by UniRL trainer replay."""
+
+    if return_pixel_log_prob:
+        raise NotImplementedError("FastVideo UniRL patch does not expose pixel-level log probabilities")
+    if prev_sample is not None and generator is not None:
+        raise ValueError("prev_sample and generator are mutually exclusive")
+
+    context = _CONTEXT.get()
+    if generator is None and prev_sample is None and context is not None:
+        generator = context.generator
+    resolved_eta = float(eta if eta is not None else (context.eta if context is not None else 0.3))
+    kernel = str(sde_type or (context.sde_type if context is not None else "dance")).strip().lower()
+    indices = _step_indices(scheduler, timestep)
+
+    sigmas = scheduler.sigmas.to(device=sample.device, dtype=sample.dtype)
+    sigma = sigmas[indices].reshape(-1, *([1] * (sample.ndim - 1)))
+    sigma_next = sigmas[[index + 1 for index in indices]].reshape(-1, *([1] * (sample.ndim - 1)))
+    dsigma = sigma_next - sigma
+    delta_t = sigma - sigma_next
+
+    is_sde_step = (
+        context is None
+        or context.sde_step_indices is None
+        or all(index in context.sde_step_indices for index in indices)
+    )
+    if deterministic or not is_sde_step:
+        if context is not None and context.collect_kl and not is_sde_step:
+            raise RuntimeError("FastVideo collect_kl is unsupported on deterministic tail transitions")
+        deterministic_sample = sample + dsigma * model_output
+        zeros = torch.zeros(sample.shape[0], device=sample.device, dtype=sample.dtype)
+        transition_std = torch.zeros_like(sigma)
+        sqrt_dt = torch.sqrt(torch.clamp(delta_t, min=0))
+        result = (deterministic_sample, zeros, deterministic_sample, transition_std)
+        return (*result, sqrt_dt) if return_dt_and_std_dev_t else result
+
+    if kernel == "flow":
+        sigma_max = sigmas[1].reshape(1, *([1] * (sample.ndim - 1)))
+        sigma_for_denom = torch.where(sigma == 1, sigma_max, sigma)
+        diffusion_coeff = torch.sqrt(sigma / (1 - sigma_for_denom)) * resolved_eta
+    elif kernel == "dance":
+        diffusion_coeff = torch.full_like(sigma, resolved_eta)
+    else:
+        raise ValueError(f"FastVideo UniRL patch supports sde_type 'flow' or 'dance'; got {kernel!r}")
+
+    prev_sample_mean = (
+        sample * (1 + diffusion_coeff.square() / (2 * sigma) * dsigma)
+        + model_output * (1 + diffusion_coeff.square() * (1 - sigma) / (2 * sigma)) * dsigma
+    )
+    sqrt_dt = torch.sqrt(delta_t)
+    transition_std = diffusion_coeff * sqrt_dt
+
+    if prev_sample is None:
+        from fastvideo.pipelines.stages.denoising import randn_tensor
+
+        variance_noise = randn_tensor(
+            model_output.shape,
+            generator=generator,
+            device=model_output.device,
+            dtype=model_output.dtype,
+        )
+        prev_sample = prev_sample_mean + transition_std * variance_noise
+
+    log_prob = (
+        -((prev_sample.detach() - prev_sample_mean).square()) / (2 * transition_std.square())
+        - torch.log(transition_std + 1e-8)
+        - math.log(math.sqrt(2 * math.pi))
+    )
+    log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+    result = (prev_sample, log_prob, prev_sample_mean, transition_std)
+    return (*result, sqrt_dt) if return_dt_and_std_dev_t else result
+
+
+setattr(_sde_step_with_logprob, "_unirl_fastvideo_sde", True)
+
+
+def patch_denoising() -> None:
+    """Install transition math and pass request-local SDE context to stock loops."""
+
+    from fastvideo.pipelines.stages import denoising
+
+    denoising.sde_step_with_logprob = _sde_step_with_logprob
+
+    original_forward = denoising.DenoisingStage.forward
+    if getattr(original_forward, "_unirl_fastvideo_denoising", False):
+        return
+
+    @wraps(original_forward)
+    def forward(self, batch, fastvideo_args):
+        rl_data = batch.rl_data if batch.rl_data is not None and batch.rl_data.enabled else None
+        if rl_data is None:
+            return original_forward(self, batch, fastvideo_args)
+
+        raw_indices = getattr(rl_data, "sde_step_indices", None)
+        indices = None if raw_indices is None else frozenset(int(index) for index in raw_indices)
+        collect_log_probs = bool(rl_data.collect_log_probs)
+        guidance_scale = batch.guidance_scale
+        guidance_scale_2 = getattr(batch, "guidance_scale_2", None)
+        if getattr(fastvideo_args, "_unirl_cfg_combine_dtype", None) == "float32":
+            device = batch.latents.device
+            batch.guidance_scale = torch.as_tensor(guidance_scale, dtype=torch.float32, device=device)
+            if guidance_scale_2 is not None:
+                batch.guidance_scale_2 = torch.as_tensor(guidance_scale_2, dtype=torch.float32, device=device)
+        # The pinned stock loop gates the SDE transition itself on this flag.
+        # Force that branch for replay too, then discard the unrequested logp.
+        rl_data.collect_log_probs = True
+        token = _CONTEXT.set(
+            _TransitionContext(
+                eta=float(batch.eta),
+                sde_type=str(getattr(rl_data, "sde_type", "dance")),
+                sde_step_indices=indices,
+                collect_kl=bool(getattr(rl_data, "collect_kl", False)),
+                timestep_dtype=getattr(fastvideo_args, "_unirl_timestep_dtype", None),
+                generator=batch.generator,
+            )
+        )
+        try:
+            result = original_forward(self, batch, fastvideo_args)
+            if not collect_log_probs and result.rl_data is not None:
+                result.rl_data.log_probs = None
+            return result
+        finally:
+            rl_data.collect_log_probs = collect_log_probs
+            batch.guidance_scale = guidance_scale
+            if guidance_scale_2 is not None:
+                batch.guidance_scale_2 = guidance_scale_2
+            _CONTEXT.reset(token)
+
+    setattr(forward, "_unirl_fastvideo_denoising", True)
+    denoising.DenoisingStage.forward = forward
+
+    # Wan consumes integer diffusion timesteps during UniRL replay. Keep this
+    # request-local and adapter-controlled instead of using a process-global
+    # environment variable in FastVideo's shared DenoisingStage.
+    from fastvideo.models.dits.wanvideo import WanTransformer3DModel
+
+    transformer_forward = WanTransformer3DModel.forward
+    if not getattr(transformer_forward, "_unirl_fastvideo_timestep", False):
+
+        @wraps(transformer_forward)
+        def wan_forward(self, *args, **kwargs):
+            context = _CONTEXT.get()
+            if context is not None and context.timestep_dtype == "long":
+                args = list(args)
+                if "timestep" in kwargs and torch.is_tensor(kwargs["timestep"]):
+                    kwargs["timestep"] = kwargs["timestep"].to(torch.long)
+                elif len(args) >= 3 and torch.is_tensor(args[2]):
+                    args[2] = args[2].to(torch.long)
+                args = tuple(args)
+            return transformer_forward(self, *args, **kwargs)
+
+        setattr(wan_forward, "_unirl_fastvideo_timestep", True)
+        WanTransformer3DModel.forward = wan_forward
+
+
+__all__ = ["patch_denoising"]

--- a/unirl/rollout/engine/fastvideo/_patches/hijack.py
+++ b/unirl/rollout/engine/fastvideo/_patches/hijack.py
@@ -1,0 +1,49 @@
+"""Fail-closed runtime patch installer for FastVideo."""
+
+from __future__ import annotations
+
+import threading
+
+
+class FastVideoHijack:
+    """Install UniRL's FastVideo integration exactly once per interpreter."""
+
+    _installed = False
+    _lock = threading.RLock()
+
+    @classmethod
+    def hijack(cls) -> None:
+        from unirl.rollout.engine.fastvideo._patches.compat import (
+            verify_fastvideo_capabilities,
+            verify_fastvideo_compatibility,
+        )
+
+        with cls._lock:
+            if cls._installed:
+                verify_fastvideo_capabilities()
+                return
+
+            verify_fastvideo_compatibility()
+
+            from unirl.rollout.engine.fastvideo._patches.conditions import patch_conditions
+            from unirl.rollout.engine.fastvideo._patches.contracts import patch_contracts
+            from unirl.rollout.engine.fastvideo._patches.denoising import patch_denoising
+            from unirl.rollout.engine.fastvideo._patches.multiproc import patch_multiproc
+            from unirl.rollout.engine.fastvideo._patches.timesteps import patch_timesteps
+            from unirl.rollout.engine.fastvideo._patches.weights import patch_weights
+
+            # Contract first: later patches and worker serialization refer to
+            # the extended RLData class. Spawn target is installed last, after
+            # every patch it will re-install has been validated in the parent.
+            patch_contracts()
+            patch_timesteps()
+            patch_denoising()
+            patch_conditions()
+            patch_weights()
+            patch_multiproc()
+
+            verify_fastvideo_capabilities()
+            cls._installed = True
+
+
+__all__ = ["FastVideoHijack"]

--- a/unirl/rollout/engine/fastvideo/_patches/multiproc.py
+++ b/unirl/rollout/engine/fastvideo/_patches/multiproc.py
@@ -1,0 +1,117 @@
+"""Propagate patches into workers and recover TCPStore startup collisions."""
+
+from __future__ import annotations
+
+import contextlib
+import faulthandler
+import logging
+import signal
+from typing import Any, Callable
+
+_MAX_PORT_ATTEMPTS = 5
+_ORIGINAL_INIT_EXECUTOR: Callable[..., Any] | None = None
+
+
+def _patched_worker_main(*args: Any, **kwargs: Any) -> Any:
+    from unirl.rollout.engine.fastvideo._patches.hijack import FastVideoHijack
+
+    FastVideoHijack.hijack()
+
+    import psutil
+    from fastvideo.worker import multiproc_executor as module
+
+    log_queue = kwargs.pop("log_queue", None)
+    if log_queue is not None:
+        handler = module._make_queue_log_handler(log_queue)
+        logging.getLogger("fastvideo").addHandler(handler)
+        kwargs["_initial_log_handler"] = handler
+
+    shutdown_requested = False
+
+    def signal_handler(signum, frame):
+        del signum, frame
+        nonlocal shutdown_requested
+        if not shutdown_requested:
+            shutdown_requested = True
+            raise SystemExit()
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    module.kill_itself_when_parent_died()
+    faulthandler.enable()
+    parent_process = psutil.Process().parent()
+
+    worker = None
+    ready_pipe = kwargs.pop("ready_pipe")
+    rank = kwargs.get("rank")
+    try:
+        worker = module.WorkerMultiprocProc(*args, **kwargs)
+        ready_pipe.send({"status": module.WorkerMultiprocProc.READY_STR})
+        ready_pipe.close()
+        ready_pipe = None
+        worker.worker_busy_loop()
+    except Exception as exc:  # noqa: BLE001
+        if ready_pipe is not None:
+            module.logger.exception("WorkerMultiprocProc failed to start.")
+            with contextlib.suppress(Exception):
+                ready_pipe.send(
+                    {
+                        "status": "ERROR",
+                        "error": str(exc),
+                        "traceback": module.get_exception_traceback(),
+                        "rank": rank,
+                    }
+                )
+        else:
+            module.logger.exception("WorkerMultiprocProc failed.")
+            if parent_process:
+                parent_process.send_signal(signal.SIGQUIT)
+        shutdown_requested = True
+        module.logger.error("Worker %s hit an exception: %s", rank, module.get_exception_traceback())
+    finally:
+        if ready_pipe is not None:
+            ready_pipe.close()
+        if worker is not None:
+            worker.shutdown()
+
+
+setattr(_patched_worker_main, "_unirl_fastvideo_spawn", True)
+
+
+def _patched_init_executor(self) -> None:
+    if _ORIGINAL_INIT_EXECUTOR is None or _ORIGINAL_INIT_EXECUTOR is _patched_init_executor:
+        raise RuntimeError("FastVideo executor retry patch could not resolve stock _init_executor")
+
+    for attempt in range(1, _MAX_PORT_ATTEMPTS + 1):
+        try:
+            _ORIGINAL_INIT_EXECUTOR(self)
+            return
+        except Exception as exc:  # noqa: BLE001
+            message = str(exc).lower()
+            address_in_use = "eaddrinuse" in message or "address already in use" in message
+            if not address_in_use or attempt == _MAX_PORT_ATTEMPTS:
+                raise
+            self.fastvideo_args.master_port = None
+
+
+setattr(_patched_init_executor, "_unirl_fastvideo_port_retry", True)
+
+
+def patch_multiproc() -> None:
+    """Make spawn initialization errors recoverable and retry fresh ports."""
+
+    global _ORIGINAL_INIT_EXECUTOR
+
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor, WorkerMultiprocProc
+
+    current_worker_main = WorkerMultiprocProc.worker_main
+    if not getattr(current_worker_main, "_unirl_fastvideo_spawn", False):
+        WorkerMultiprocProc.worker_main = staticmethod(_patched_worker_main)
+
+    current_init = MultiprocExecutor._init_executor
+    if not getattr(current_init, "_unirl_fastvideo_port_retry", False):
+        _ORIGINAL_INIT_EXECUTOR = current_init
+        MultiprocExecutor._init_executor = _patched_init_executor
+
+
+__all__ = ["patch_multiproc"]

--- a/unirl/rollout/engine/fastvideo/_patches/timesteps.py
+++ b/unirl/rollout/engine/fastvideo/_patches/timesteps.py
@@ -1,0 +1,48 @@
+"""Model-scoped custom-sigma adaptation for FastVideo schedulers."""
+
+from __future__ import annotations
+
+from functools import wraps
+
+import numpy as np
+import torch
+
+
+def patch_timesteps() -> None:
+    """Convert UniRL custom sigmas only when the selected adapter requests it."""
+
+    from fastvideo.pipelines.stages.timestep_preparation import TimestepPreparationStage
+
+    original_forward = TimestepPreparationStage.forward
+    if getattr(original_forward, "_unirl_fastvideo_timesteps", False):
+        return
+
+    @wraps(original_forward)
+    def forward(self, batch, fastvideo_args):
+        original_sigmas = batch.sigmas
+        dtype = getattr(fastvideo_args, "_unirl_custom_sigmas_dtype", None)
+        if original_sigmas is not None and dtype == "float32":
+            batch.sigmas = np.asarray(original_sigmas, dtype=np.float32)
+        try:
+            result = original_forward(self, batch, fastvideo_args)
+            if original_sigmas is not None and dtype == "float32":
+                # FlowUniPC stores custom sigmas exactly but truncates their
+                # corresponding model timesteps to int64. Keep the scheduler
+                # and denoising loop on exact float timesteps; the Wan-scoped
+                # transformer wrapper casts only the model input to long.
+                timesteps = self.scheduler.sigmas[:-1].to(
+                    device=result.timesteps.device,
+                    dtype=torch.float32,
+                )
+                timesteps = timesteps * float(self.scheduler.config.num_train_timesteps)
+                self.scheduler.timesteps = timesteps
+                result.timesteps = timesteps
+            return result
+        finally:
+            batch.sigmas = original_sigmas
+
+    setattr(forward, "_unirl_fastvideo_timesteps", True)
+    TimestepPreparationStage.forward = forward
+
+
+__all__ = ["patch_timesteps"]

--- a/unirl/rollout/engine/fastvideo/_patches/weights.py
+++ b/unirl/rollout/engine/fastvideo/_patches/weights.py
@@ -1,0 +1,109 @@
+"""Strict full-parameter checkpoint hot-swap for FastVideo workers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+def _strip_training_prefix(name: str) -> str:
+    for prefix in ("base_model.model.", "module.", "transformer."):
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+    return name
+
+
+def _worker_update_transformer_weights(self, state_dict: dict[str, torch.Tensor]) -> dict[str, Any]:
+    transformer = self.pipeline.modules.get("transformer")
+    if transformer is None:
+        raise RuntimeError("FastVideo worker has no transformer module")
+
+    target_state = transformer.state_dict()
+    target_device = next((parameter.device for parameter in transformer.parameters()), self.device)
+    target_dtype = next((parameter.dtype for parameter in transformer.parameters()), None)
+    stripped: dict[str, torch.Tensor] = {}
+    for raw_name, tensor in state_dict.items():
+        if not torch.is_tensor(tensor):
+            continue
+        name = _strip_training_prefix(str(raw_name))
+        if target_dtype is not None and tensor.is_floating_point():
+            tensor = tensor.to(dtype=target_dtype)
+        stripped[name] = tensor.to(target_device, non_blocking=True)
+
+    if not stripped:
+        raise RuntimeError("FastVideo weight update received no tensor entries")
+
+    mapping_dict = getattr(transformer, "param_names_mapping", None)
+    if mapping_dict:
+        from fastvideo.models.loader.utils import get_param_names_mapping, hf_to_custom_state_dict
+
+        mapping_fn = get_param_names_mapping(mapping_dict)
+        mapped, _ = hf_to_custom_state_dict(stripped, mapping_fn)
+    else:
+        mapped = stripped
+
+    target_names = set(target_state)
+    mapped_names = set(mapped)
+    matched = target_names & mapped_names
+    coverage = len(matched) / max(1, len(target_names))
+    unexpected_before_load = sorted(mapped_names - target_names)
+    if coverage < 0.99 or unexpected_before_load:
+        raise RuntimeError(
+            "FastVideo transformer key mapping failed closed: "
+            f"coverage={coverage:.2%}, matched={len(matched)}/{len(target_names)}, "
+            f"unexpected={unexpected_before_load[:10]}"
+        )
+
+    missing, unexpected = transformer.load_state_dict(mapped, strict=False, assign=False)
+    if missing or unexpected:
+        raise RuntimeError(
+            "FastVideo transformer load was incomplete: "
+            f"missing={list(missing)[:10]}, unexpected={list(unexpected)[:10]}"
+        )
+    return {
+        "status": "transformer_weights_updated",
+        "loaded": len(matched),
+        "target": len(target_names),
+        "coverage": coverage,
+    }
+
+
+setattr(_worker_update_transformer_weights, "_unirl_fastvideo_weights", True)
+
+
+def patch_weights() -> None:
+    """Install additive full-weight APIs on worker, executor, and generator."""
+
+    from fastvideo.entrypoints.video_generator import VideoGenerator
+    from fastvideo.worker.gpu_worker import Worker
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor
+
+    Worker.update_transformer_weights = _worker_update_transformer_weights
+
+    def executor_update(self, state_dict):
+        responses = self.collective_rpc("update_transformer_weights", kwargs={"state_dict": state_dict})
+        if len(responses) != int(self.world_size):
+            raise RuntimeError(
+                f"FastVideo weight update returned {len(responses)} responses for world_size={self.world_size}"
+            )
+        for rank, response in enumerate(responses):
+            if not isinstance(response, dict) or response.get("status") != "transformer_weights_updated":
+                raise RuntimeError(f"FastVideo worker {rank} weight update failed: {response!r}")
+            if float(response.get("coverage", 0.0)) < 0.99:
+                raise RuntimeError(f"FastVideo worker {rank} reported incomplete weight coverage: {response!r}")
+
+    setattr(executor_update, "_unirl_fastvideo_weights", True)
+    MultiprocExecutor.update_transformer_weights = executor_update
+
+    def update_from_path(self, checkpoint_path: str) -> None:
+        state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        if not isinstance(state_dict, dict):
+            raise TypeError(f"FastVideo checkpoint must contain a state-dict mapping; got {type(state_dict).__name__}")
+        self.executor.update_transformer_weights(state_dict)
+
+    setattr(update_from_path, "_unirl_fastvideo_weights", True)
+    VideoGenerator.update_transformer_weights_from_path = update_from_path
+
+
+__all__ = ["patch_weights"]

--- a/unirl/rollout/engine/fastvideo/adapters/__init__.py
+++ b/unirl/rollout/engine/fastvideo/adapters/__init__.py
@@ -1,0 +1,15 @@
+"""FastVideo model adapters."""
+
+from unirl.rollout.engine.fastvideo.adapters.base import (
+    FastVideoModelAdapter,
+    get_adapter,
+    registered_adapters,
+)
+from unirl.rollout.engine.fastvideo.adapters.wan21 import Wan21FastVideoAdapter
+
+__all__ = [
+    "FastVideoModelAdapter",
+    "Wan21FastVideoAdapter",
+    "get_adapter",
+    "registered_adapters",
+]

--- a/unirl/rollout/engine/fastvideo/adapters/base.py
+++ b/unirl/rollout/engine/fastvideo/adapters/base.py
@@ -1,0 +1,105 @@
+"""Model-specific boundary for the FastVideo rollout engine."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Tuple
+
+from unirl.config.require import require
+from unirl.sde.noise import _derive_group_seed
+
+_REGISTRY: Dict[str, type["FastVideoModelAdapter"]] = {}
+
+
+def register_adapter(*keys: str):
+    normalized = tuple(str(key).strip().lower() for key in keys)
+
+    def decorator(cls: type["FastVideoModelAdapter"]) -> type["FastVideoModelAdapter"]:
+        for key in normalized:
+            require(key and key not in _REGISTRY, f"FastVideo adapter key {key!r} is already registered")
+            _REGISTRY[key] = cls
+        cls.model_families = normalized
+        return cls
+
+    return decorator
+
+
+def get_adapter(key: str) -> type["FastVideoModelAdapter"]:
+    normalized = str(key).strip().lower()
+    require(normalized in _REGISTRY, f"unknown FastVideo model_family {key!r}; registered: {sorted(_REGISTRY)}")
+    return _REGISTRY[normalized]
+
+
+def registered_adapters() -> Tuple[str, ...]:
+    return tuple(sorted(_REGISTRY))
+
+
+class FastVideoModelAdapter(ABC):
+    """Own every model-specific schedule, shape, and response assumption."""
+
+    model_families: Tuple[str, ...] = ()
+
+    def __init__(self, config: Any, model_config: Any, *, strategy: Any = None) -> None:
+        self.cfg = config
+        self.model_config = model_config
+        self.strategy = strategy
+        self.validate()
+
+    def validate(self) -> None:
+        require(
+            self.model_config is not None and bool(getattr(self.model_config, "pretrained_model_ckpt_path", None)),
+            f"{type(self).__name__} requires model_config.pretrained_model_ckpt_path",
+        )
+
+    def schedule_policy(self) -> Any:
+        from unirl.sde.runtime import FlowMatchSchedulePolicy
+
+        return FlowMatchSchedulePolicy.from_pretrained(
+            self.model_config.pretrained_model_ckpt_path,
+            shift=float(self.model_config.shift),
+            require_dynamic=bool(getattr(self.model_config, "use_dynamic_shifting", False)),
+            dynamic_overrides=getattr(self.model_config, "dynamic_shift_overrides", None),
+        )
+
+    def per_sample_seeds(self, req: Any, params: Any) -> List[int]:
+        batch_size = int(req.batch_size)
+        base_seed = int(params.seed)
+        keys = getattr(req, "init_noise_group_ids", None)
+        if not (isinstance(keys, (list, tuple)) and len(keys) == batch_size):
+            same = bool(getattr(params, "init_same_noise", False))
+            keys = list(req.group_ids) if same else list(req.sample_ids)
+        if not (isinstance(keys, (list, tuple)) and len(keys) == batch_size):
+            return [base_seed] * batch_size
+        return [_derive_group_seed(base_seed, str(key)) for key in keys]
+
+    @abstractmethod
+    def align_runtime_args(self, fastvideo_args: Any) -> None:
+        """Validate and apply model-specific FastVideo boot configuration."""
+
+    @abstractmethod
+    def build_forward_batch(
+        self,
+        *,
+        prompt: str,
+        seed: int,
+        params: Any,
+        sigmas: Any,
+        fastvideo_args: Any,
+    ) -> Any:
+        """Build one FastVideo ``ForwardBatch`` without importing it in engine.py."""
+
+    @abstractmethod
+    def collect_output(self, output: Any) -> Dict[str, Any]:
+        """Normalize one FastVideo output into CPU-side adapter data."""
+
+    @abstractmethod
+    def build_response(self, req: Any, params: Any, samples: List[Dict[str, Any]]) -> Any:
+        """Build the typed UniRL response for a list of per-sample outputs."""
+
+
+__all__ = [
+    "FastVideoModelAdapter",
+    "get_adapter",
+    "register_adapter",
+    "registered_adapters",
+]

--- a/unirl/rollout/engine/fastvideo/adapters/wan21.py
+++ b/unirl/rollout/engine/fastvideo/adapters/wan21.py
@@ -1,0 +1,237 @@
+"""Wan2.1 adapter for FastVideo rollout."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from unirl.config.require import require
+from unirl.rollout.engine.fastvideo.adapters.base import FastVideoModelAdapter, register_adapter
+from unirl.rollout.engine.sigma_verify import verify_engine_used_sigmas
+from unirl.types.conditions import TextEmbedCondition
+from unirl.types.primitives import Video, Videos
+from unirl.types.rollout_resp import RolloutResp, RolloutTrack
+from unirl.types.segments.latent import make_video_segment
+
+
+@register_adapter("wan2.1", "wan21")
+class Wan21FastVideoAdapter(FastVideoModelAdapter):
+    """Isolate every Wan schedule/shape/condition assumption from the engine."""
+
+    def validate(self) -> None:
+        super().validate()
+        require(hasattr(self.model_config, "shift"), "Wan2.1 FastVideo adapter requires model_config.shift")
+
+    def align_runtime_args(self, fastvideo_args: Any) -> None:
+        target_shift = float(self.model_config.shift)
+        pipeline_config = fastvideo_args.pipeline_config
+        pipeline_config.flow_shift = target_shift
+        # Consumed by the request-local transformer wrapper in patch_denoising.
+        fastvideo_args._unirl_timestep_dtype = "long"
+        fastvideo_args._unirl_cfg_combine_dtype = "float32"
+        fastvideo_args._unirl_custom_sigmas_dtype = "float32"
+
+    def build_forward_batch(
+        self,
+        *,
+        prompt: str,
+        seed: int,
+        params: Any,
+        sigmas: torch.Tensor,
+        fastvideo_args: Any,
+    ) -> Any:
+        from fastvideo.configs.sample.base import SamplingParam
+        from fastvideo.pipelines import ForwardBatch
+        from fastvideo.utils import shallow_asdict
+
+        sampling = SamplingParam()
+        sampling.prompt = prompt
+        sampling.height = int(params.height)
+        sampling.width = int(params.width)
+        sampling.num_frames = int(params.num_frames)
+        sampling.num_inference_steps = int(params.num_inference_steps)
+        sampling.guidance_scale = float(params.guidance_scale)
+        sampling.seed = int(seed)
+        sampling.num_videos_per_prompt = 1
+        sampling.save_video = False
+        sampling.return_frames = False
+        sampling.return_trajectory_latents = True
+        sampling.return_trajectory_decoded = False
+
+        # FastVideo's scheduler re-applies flow_shift to custom sigmas. Supply
+        # the Wan FlowMatch inverse so the actual worker schedule equals the
+        # already-shifted UniRL schedule; verify_engine_used_sigmas checks the
+        # round trip on every result.
+        flow_shift = float(fastvideo_args.pipeline_config.flow_shift)
+        schedule = sigmas.detach().cpu().double()
+        denominator = flow_shift - schedule * (flow_shift - 1.0)
+        require(bool(torch.all(denominator != 0)), "Wan2.1 FastVideo sigma pre-image has a zero denominator")
+        preimage = schedule / denominator
+        # Keep the public ForwardBatch contract as a list. The Wan-scoped
+        # timestep patch converts it after FastVideo input validation and
+        # immediately before the upstream scheduler call.
+        sampling.sigmas = preimage.tolist()[:-1]
+
+        raw_indices = getattr(params, "sde_indices", None)
+        sde_indices = [int(index) for index in raw_indices] if raw_indices else None
+        latent_frames = (sampling.num_frames - 1) // 4 + 1
+        n_tokens = latent_frames * (sampling.height // 8) * (sampling.width // 8)
+        sampling_dict = shallow_asdict(deepcopy(sampling))
+        sampling_dict.pop("eta", None)
+        return ForwardBatch(
+            **sampling_dict,
+            eta=float(params.eta),
+            n_tokens=n_tokens,
+            VSA_sparsity=fastvideo_args.VSA_sparsity,
+            rl_data=ForwardBatch.RLData(
+                enabled=True,
+                collect_log_probs=bool(self.cfg.native_logprob),
+                store_trajectory=True,
+                keep_trajectory_on_cpu=True,
+                sde_step_indices=sde_indices,
+                sde_type=str(getattr(self.strategy, "canonical_name", "flow")),
+            ),
+        )
+
+    def collect_output(self, output: Any) -> Dict[str, Any]:
+        rl_data = output.rl_data
+        trajectory = getattr(rl_data, "trajectory_latents", None) if rl_data is not None else None
+        if trajectory is None:
+            trajectory = output.trajectory_latents
+        require(torch.is_tensor(trajectory), "FastVideo returned no trajectory tensor")
+        if trajectory.dim() == 5:
+            trajectory = trajectory.unsqueeze(0)
+
+        decoded = getattr(output, "output", None)
+        require(torch.is_tensor(decoded), "FastVideo returned no decoded output")
+        if decoded.dim() == 4:
+            decoded = decoded.unsqueeze(0)
+
+        prompt_embeds = output.prompt_embeds
+        require(
+            isinstance(prompt_embeds, (list, tuple)) and len(prompt_embeds) > 0 and torch.is_tensor(prompt_embeds[0]),
+            "FastVideo returned no Wan UMT5 prompt embedding",
+        )
+        text_embed = prompt_embeds[0]
+        if text_embed.dim() == 2:
+            text_embed = text_embed.unsqueeze(0)
+
+        prompt_mask = output.prompt_attention_mask
+        text_mask = (
+            prompt_mask[0]
+            if isinstance(prompt_mask, (list, tuple)) and prompt_mask and torch.is_tensor(prompt_mask[0])
+            else None
+        )
+
+        negative_embed = None
+        negative_mask = None
+        raw_negative = output.negative_prompt_embeds
+        if isinstance(raw_negative, (list, tuple)) and raw_negative and torch.is_tensor(raw_negative[0]):
+            negative_embed = raw_negative[0]
+            if negative_embed.dim() == 2:
+                negative_embed = negative_embed.unsqueeze(0)
+            raw_negative_mask = output.negative_attention_mask
+            if (
+                isinstance(raw_negative_mask, (list, tuple))
+                and raw_negative_mask
+                and torch.is_tensor(raw_negative_mask[0])
+            ):
+                negative_mask = raw_negative_mask[0]
+
+        actual_timesteps = getattr(rl_data, "trajectory_timesteps", None) if rl_data is not None else None
+        if actual_timesteps is None:
+            actual_timesteps = output.trajectory_timesteps
+        log_probs = getattr(rl_data, "log_probs", None) if rl_data is not None else None
+        return {
+            "trajectory": trajectory.detach().cpu(),
+            "decoded": decoded.detach().cpu().float(),
+            "actual_timesteps": None if actual_timesteps is None else actual_timesteps.detach().cpu(),
+            "log_probs": None if log_probs is None else log_probs.detach().cpu(),
+            "text_embed": text_embed.detach().cpu().float(),
+            "text_mask": None if text_mask is None else text_mask.detach().cpu(),
+            "negative_embed": None if negative_embed is None else negative_embed.detach().cpu().float(),
+            "negative_mask": None if negative_mask is None else negative_mask.detach().cpu(),
+        }
+
+    @staticmethod
+    def _condition(
+        samples: List[Dict[str, Any]],
+        *,
+        embed_key: str,
+        mask_key: str,
+    ) -> Optional[TextEmbedCondition]:
+        if any(sample[embed_key] is None for sample in samples):
+            return None
+        return TextEmbedCondition.concat(
+            [
+                TextEmbedCondition(
+                    embeds=sample[embed_key],
+                    pooled=None,
+                    attn_mask=sample[mask_key],
+                )
+                for sample in samples
+            ]
+        )
+
+    def build_response(self, req: Any, params: Any, samples: List[Dict[str, Any]]) -> RolloutResp:
+        require(len(samples) == int(req.batch_size), "FastVideo returned the wrong number of Wan samples")
+        expected_sigmas = req.sigmas.detach().cpu()
+        for sample in samples:
+            actual = sample["actual_timesteps"]
+            if torch.is_tensor(actual) and actual.numel() + 1 == expected_sigmas.numel():
+                actual = torch.cat([actual.reshape(-1), actual.new_zeros(1)])
+            verify_engine_used_sigmas(actual, expected=expected_sigmas, engine_name="fastvideo/wan2.1")
+
+        trajectory = torch.cat([sample["trajectory"] for sample in samples], dim=0)
+        decoded = torch.cat([sample["decoded"] for sample in samples], dim=0)
+        transitions = int(trajectory.shape[1]) - 1
+        sde_steps = sorted(int(index) for index in (getattr(params, "sde_indices", None) or []))
+        if not sde_steps:
+            sde_steps = list(range(transitions))
+        sde_indices = torch.tensor(sde_steps, dtype=torch.long)
+
+        log_prob_parts = [sample["log_probs"] for sample in samples]
+        sde_logp = None
+        if all(torch.is_tensor(part) for part in log_prob_parts):
+            log_probs = torch.cat(log_prob_parts, dim=0)
+            if log_probs.shape[1] == transitions and len(sde_steps) < transitions:
+                log_probs = log_probs[:, sde_steps]
+            require(
+                log_probs.shape[1] == len(sde_steps),
+                f"FastVideo native log-prob columns {log_probs.shape[1]} do not match SDE steps {len(sde_steps)}",
+            )
+            sde_logp = log_probs.contiguous()
+
+        segment = make_video_segment(
+            latents=trajectory,
+            sigmas=req.sigmas,
+            indices=torch.arange(trajectory.shape[1], dtype=torch.long),
+            sde_logp=sde_logp,
+            sde_indices=sde_indices,
+        )
+        text = self._condition(samples, embed_key="text_embed", mask_key="text_mask")
+        require(text is not None, "FastVideo returned no Wan text conditions")
+        conditions: Dict[str, Any] = {"text": text}
+        negative = self._condition(samples, embed_key="negative_embed", mask_key="negative_mask")
+        if negative is not None:
+            conditions["negative_text"] = negative
+
+        videos = Videos.from_list(
+            [Video(frames=decoded[index].permute(1, 0, 2, 3).contiguous()) for index in range(int(decoded.shape[0]))]
+        )
+        return RolloutResp(
+            tracks={
+                "video": RolloutTrack(
+                    sample_ids=list(req.sample_ids),
+                    parent_ids=list(req.group_ids),
+                    conditions=conditions,
+                    segment=segment,
+                    decoded=videos,
+                )
+            }
+        )
+
+
+__all__ = ["Wan21FastVideoAdapter"]

--- a/unirl/rollout/engine/fastvideo/backends/__init__.py
+++ b/unirl/rollout/engine/fastvideo/backends/__init__.py
@@ -1,0 +1,5 @@
+"""FastVideo runtime backends."""
+
+from unirl.rollout.engine.fastvideo.backends.native import FastVideoBackend
+
+__all__ = ["FastVideoBackend"]

--- a/unirl/rollout/engine/fastvideo/backends/native.py
+++ b/unirl/rollout/engine/fastvideo/backends/native.py
@@ -1,0 +1,97 @@
+"""Lazy native FastVideo runtime boundary."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+
+def _import_fastvideo_runtime() -> Dict[str, Any]:
+    """Install UniRL patches before importing objects that spawn workers."""
+
+    from unirl.rollout.engine.fastvideo._patches import FastVideoHijack
+
+    FastVideoHijack.hijack()
+
+    from fastvideo import VideoGenerator
+    from fastvideo.fastvideo_args import FastVideoArgs
+
+    return {"VideoGenerator": VideoGenerator, "FastVideoArgs": FastVideoArgs}
+
+
+class FastVideoBackend:
+    """Own FastVideo imports, worker boot, execution, and lifecycle."""
+
+    def __init__(self, generator: Any, fastvideo_args: Any, runtime: Dict[str, Any]) -> None:
+        self._generator = generator
+        self.fastvideo_args = fastvideo_args
+        self._runtime = runtime
+
+    @classmethod
+    def boot(
+        cls,
+        kwargs: Dict[str, Any],
+        *,
+        configure_args: Callable[[Any], None],
+        reserve_port: Callable[[], int],
+        max_port_attempts: int = 5,
+    ) -> "FastVideoBackend":
+        runtime = _import_fastvideo_runtime()
+        fastvideo_args = runtime["FastVideoArgs"].from_kwargs(**kwargs)
+        configure_args(fastvideo_args)
+        generator = cls._start_generator(
+            runtime,
+            fastvideo_args,
+            reserve_port=reserve_port,
+            max_port_attempts=max_port_attempts,
+        )
+        return cls(generator, fastvideo_args, runtime)
+
+    @staticmethod
+    def _start_generator(
+        runtime: Dict[str, Any],
+        fastvideo_args: Any,
+        *,
+        reserve_port: Callable[[], int],
+        max_port_attempts: int,
+    ) -> Any:
+        for attempt in range(1, max_port_attempts + 1):
+            try:
+                return runtime["VideoGenerator"].from_fastvideo_args(fastvideo_args)
+            except Exception as exc:  # noqa: BLE001
+                port_in_use = "eaddrinuse" in str(exc).lower() or "address already in use" in str(exc).lower()
+                if not port_in_use or attempt == max_port_attempts:
+                    raise
+                fastvideo_args.master_port = int(reserve_port())
+        raise RuntimeError("unreachable")
+
+    def execute(self, forward_batch: Any) -> Any:
+        if self._generator is None:
+            raise RuntimeError("FastVideo backend is offloaded")
+        return self._generator.executor.execute_forward(forward_batch, self.fastvideo_args)
+
+    def update_weights_from_path(self, checkpoint_path: str) -> None:
+        if self._generator is None:
+            raise RuntimeError("FastVideo backend is offloaded")
+        self._generator.update_transformer_weights_from_path(checkpoint_path)
+
+    def sleep(self) -> None:
+        if self._generator is not None:
+            self._generator.shutdown()
+            self._generator = None
+
+    def wake(self, *, reserve_port: Callable[[], int], max_port_attempts: int = 5) -> None:
+        if self._generator is not None:
+            return
+        self.fastvideo_args.master_port = int(reserve_port())
+        self._generator = self._start_generator(
+            self._runtime,
+            self.fastvideo_args,
+            reserve_port=reserve_port,
+            max_port_attempts=max_port_attempts,
+        )
+
+    def shutdown(self) -> None:
+        self.sleep()
+
+
+__all__ = ["FastVideoBackend"]

--- a/unirl/rollout/engine/fastvideo/config.py
+++ b/unirl/rollout/engine/fastvideo/config.py
@@ -83,12 +83,15 @@ class FastVideoEngineConfig(BaseEngineConfig):
     engine_kwargs: Optional[Dict[str, Any]] = dc_field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        from unirl.rollout.engine.fastvideo.adapters import registered_adapters
+
         if self.engine_kwargs is None:
             self.engine_kwargs = {}
         self.model_family = str(self.model_family or "").strip().lower()
         require(
-            self.model_family in {"wan2.1", "wan21"},
-            f"FastVideoEngineConfig.model_family currently supports only 'wan2.1'; got {self.model_family!r}",
+            self.model_family in registered_adapters(),
+            f"FastVideoEngineConfig.model_family={self.model_family!r} is not registered; "
+            f"available: {list(registered_adapters())}",
         )
         require(self.num_gpus >= 1, f"num_gpus must be >= 1; got {self.num_gpus!r}")
         require(

--- a/unirl/rollout/engine/fastvideo/engine.py
+++ b/unirl/rollout/engine/fastvideo/engine.py
@@ -5,10 +5,10 @@ Mirrors the ``TrainsideRolloutEngine`` / ``SGLangDiffusionRolloutEngine`` shells
 optionally chunks by ``forward_batch_size``, and packs one ``RolloutResp`` track
 with a ``LatentSegment`` (trajectory + native per-step log-probs).
 
-The FastVideo-driving logic (VideoGenerator boot, PR #1222 ``ForwardBatch.RLData``
-native-logprob path, transformer hot-swap, sleep/wake) is ported from the proven
-DiffusionRL FastVideo engine; only the typed boundary (RolloutReq/RolloutResp/
-LatentSegment, σ SSOT) is new.
+FastVideo remains an exact upstream snapshot. UniRL installs its RL contracts,
+transition math, worker response fields, and weight hot-swap at runtime before
+FastVideo spawns workers. Model-specific schedule/shape/condition behavior lives
+behind an adapter rather than in this engine shell.
 
 Validated scope:
   * Replay and native modes use the same resolved SDE window; native mode also
@@ -33,20 +33,19 @@ import torch
 from unirl.config.require import require
 from unirl.distributed.group.dispatch import Dispatch, distributed
 from unirl.rollout.engine.base import BaseRolloutEngine
+from unirl.rollout.engine.fastvideo.adapters import get_adapter
+from unirl.rollout.engine.fastvideo.backends import FastVideoBackend
 from unirl.rollout.engine.fastvideo.config import FastVideoEngineConfig, FastVideoPorts
-from unirl.sde.noise import _derive_group_seed
-from unirl.sde.runtime import FlowMatchSchedulePolicy, ensure_req_sigmas
-from unirl.types.conditions import TextEmbedCondition
-from unirl.types.primitives import Texts, Video, Videos
+from unirl.sde.runtime import ensure_req_sigmas
+from unirl.types.primitives import Texts
 from unirl.types.rollout_req import RolloutReq
-from unirl.types.rollout_resp import RolloutResp, RolloutTrack
-from unirl.types.segments.latent import make_video_segment
+from unirl.types.rollout_resp import RolloutResp
 
 logger = logging.getLogger(__name__)
 
 
 class FastVideoRolloutEngine(BaseRolloutEngine):
-    """Rollout engine backed by FastVideo ``VideoGenerator`` (RL fork, PR #1222)."""
+    """Rollout engine backed by a runtime-patched upstream ``VideoGenerator``."""
 
     _component_name = "fastvideo"
 
@@ -71,11 +70,12 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         self.cfg = config
         self.model_config = model_config
         self.strategy = strategy
+        self.adapter = get_adapter(config.model_family)(config, model_config, strategy=strategy)
+        self.schedule_policy = self.adapter.schedule_policy()
         self.rank = rank
         self._device = device if device is not None else torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._is_offloaded = False
-        self._generator: Any = None
-        self._fastvideo_args: Any = None
+        self._backend: FastVideoBackend | None = None
         # Last checkpoint pushed by the weight sync. ``VideoGenerator`` loads the
         # PRETRAINED weights from ``model_path`` on every (re)build, so a sleep/wake
         # would silently roll back to pretrained; we re-apply this on wake. None
@@ -87,21 +87,13 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         self._ports = ports
 
         self._ensure_fastvideo_importable()
-        self._build_generator()
+        self._build_backend()
 
-        # σ SSOT: same schedule policy the trainer/replay uses, so the engine can
-        # pin req.sigmas and FastVideo consumes that exact schedule.
-        self.schedule_policy = FlowMatchSchedulePolicy.from_pretrained(
-            model_config.pretrained_model_ckpt_path,
-            shift=float(model_config.shift),
-            require_dynamic=bool(getattr(model_config, "use_dynamic_shifting", False)),
-            dynamic_overrides=getattr(model_config, "dynamic_shift_overrides", None),
-        )
         logger.info(
             "Initialized fastvideo engine (rank=%s, native_logprob=%s, master_port=%s)",
             rank,
             config.native_logprob,
-            ports.master_port,
+            self._ports.master_port,
         )
 
     # ------------------------------------------------------------------ #
@@ -119,10 +111,7 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             sys.path.insert(0, str(Path(path).expanduser()))
         importlib.import_module("fastvideo")
 
-    def _build_generator(self) -> None:
-        from fastvideo import VideoGenerator
-        from fastvideo.fastvideo_args import FastVideoArgs
-
+    def _build_backend(self) -> None:
         ekw = dict(self.cfg.engine_kwargs or {})
         fv_kwargs: Dict[str, Any] = {
             "model_path": self.model_config.pretrained_model_ckpt_path,
@@ -140,37 +129,15 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             "master_port": int(self._ports.master_port),
         }
         fv_kwargs.update(ekw)
-        self._fastvideo_args = FastVideoArgs.from_kwargs(**fv_kwargs)
-        # WanT2V480PConfig (1.3B) defaults flow_shift=3.0. UniRL may train at
-        # model_config.shift=5.0 (baseline). FastVideo re-applies flow_shift inside
-        # set_timesteps even for custom sigmas, so pipeline_config.flow_shift MUST
-        # match model_config.shift or native old_logp and trainer replay diverge.
-        target_shift = float(self.model_config.shift)
-        pc = self._fastvideo_args.pipeline_config
-        if getattr(pc, "flow_shift", None) != target_shift:
-            logger.info(
-                "fastvideo engine: pipeline_config.flow_shift %s -> %s (model_config.shift)",
-                getattr(pc, "flow_shift", None),
-                target_shift,
-            )
-            pc.flow_shift = target_shift
-        max_port_attempts = 5
-        for attempt in range(1, max_port_attempts + 1):
-            try:
-                self._generator = VideoGenerator.from_fastvideo_args(self._fastvideo_args)
-                break
-            except Exception as exc:  # noqa: BLE001
-                port_in_use = "EADDRINUSE" in str(exc) or "address already in use" in str(exc).lower()
-                if not port_in_use or attempt == max_port_attempts:
-                    raise
-                self._ports = FastVideoPorts.reserve()
-                self._fastvideo_args.master_port = int(self._ports.master_port)
-                logger.warning(
-                    "fastvideo init: master port busy (attempt %d/%d); retrying with %s",
-                    attempt,
-                    max_port_attempts,
-                    self._ports.master_port,
-                )
+        self._backend = FastVideoBackend.boot(
+            fv_kwargs,
+            configure_args=self.adapter.align_runtime_args,
+            reserve_port=self._reserve_master_port,
+        )
+
+    def _reserve_master_port(self) -> int:
+        self._ports = FastVideoPorts.reserve()
+        return int(self._ports.master_port)
 
     # ------------------------------------------------------------------ #
     # Generation
@@ -221,33 +188,9 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             params is not None,
             "fastvideo engine requires req.sampling_params['diffusion']",
         )
-        seeds = self._per_sample_seeds(req, params)
+        seeds = self.adapter.per_sample_seeds(req, params)
         raw = self._drive_fastvideo(prompts, params, req.sigmas, seeds)
-        return self._build_resp(req, params, raw)
-
-    def _per_sample_seeds(self, req: RolloutReq, params: Any) -> List[int]:
-        """Per-sample seeds so sibling samples of one prompt diverge.
-
-        Without this every sample of a prompt shared ``params.seed`` → identical
-        video → identical reward → zero GRPO advantage → zero loss/grad. We key
-        the seed the same way the driver keys x_T (``_derive_group_seed``):
-        per-sample ids when ``init_same_noise`` is false (siblings differ),
-        per-group ids when true (siblings share). Prefer the driver's
-        ``init_noise_group_ids`` (carries rollout id + same/diff policy); fall
-        back to sample/group ids, then to the flat seed.
-        NOTE: this only decorrelates siblings; full driver-authoritative x_T SSOT
-        (byte-identical to other engines via ``regen_initial_noise``) is a
-        separate follow-up.
-        """
-        bs = int(req.batch_size)
-        base_seed = int(params.seed)
-        keys = getattr(req, "init_noise_group_ids", None)
-        if not (isinstance(keys, (list, tuple)) and len(keys) == bs):
-            same = bool(getattr(params, "init_same_noise", False))
-            keys = list(req.group_ids) if same else list(req.sample_ids)
-        if not (isinstance(keys, (list, tuple)) and len(keys) == bs):
-            return [base_seed] * bs
-        return [_derive_group_seed(base_seed, str(k)) for k in keys]
+        return self.adapter.build_response(req, params, raw)
 
     def _drive_fastvideo(
         self,
@@ -255,255 +198,27 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         params: Any,
         sigmas: torch.Tensor,
         seeds: List[int],
-    ) -> Dict[str, Any]:
-        """PR #1222 native-logprob path via executor.execute_forward + RLData.
-
-        Returns dict(trajectory=[B,T+1,...], log_probs=[B,T], samples=[B,...]).
-        """
-        from copy import deepcopy
-
-        from fastvideo.configs.sample.base import SamplingParam
-        from fastvideo.pipelines import ForwardBatch
-        from fastvideo.utils import shallow_asdict
-
-        sp = SamplingParam()
-        sp.height = int(params.height)
-        sp.width = int(params.width)
-        sp.num_frames = int(params.num_frames)
-        sp.num_inference_steps = int(params.num_inference_steps)
-        sp.guidance_scale = float(params.guidance_scale)
-        sp.seed = int(params.seed)  # per-sample override applied in the loop below
-        sp.num_videos_per_prompt = 1
-        sp.save_video = False
-        sp.return_frames = False
-        sp.return_trajectory_latents = True
-        sp.return_trajectory_decoded = False
-        # σ SSOT — AVOID the double-shift bug. ``req.sigmas`` is ALREADY the
-        # shift-applied flow-match schedule (σ = shift·t/(1+(shift-1)·t)), but
-        # FastVideo's FlowMatchEulerDiscreteScheduler.set_timesteps re-applies
-        # the SAME shift to whatever sigmas we hand it (no guard). Feeding
-        # req.sigmas directly makes FastVideo denoise on a *doubly*-shifted grid
-        # while the trainer replays on the single-shift grid — the trajectory's
-        # true noise level then mismatches the σ used to score its log-prob,
-        # corrupting the GRPO gradient. So hand FastVideo the shift PRE-IMAGE g,
-        # for which FastVideo's own shift reproduces req.sigmas exactly:
-        #     g = s / (shift - s·(shift-1))   ⇒   shift·g/(1+(shift-1)·g) == s
-        # (valid because FastVideo's WAN flow_shift == model_config.shift). Drop
-        # the terminal 0 — FastVideo appends its own endpoint.
-        _f = float(getattr(self._fastvideo_args.pipeline_config, "flow_shift", self.model_config.shift))
-        _s = sigmas.detach().cpu().double()
-        _g = _s / (_f - _s * (_f - 1.0))
-        sp.sigmas = [float(x) for x in _g.tolist()[:-1]]
-
-        # SDE window handed to FastVideo's denoiser so it injects exploration
-        # noise ONLY on the trainer's SDE steps and runs the rest as a
-        # deterministic Euler step (clean low-sigma tail). ``params.sde_indices``
-        # is stamped per rollout by the trainer (resolve_sde_indices); it matches
-        # the columns the trainer replays. Empty/None => every step is SDE.
-        _sde_idx = getattr(params, "sde_indices", None)
-        sde_step_indices = [int(x) for x in _sde_idx] if _sde_idx else None
-
-        all_log_probs: List[torch.Tensor] = []
-        all_traj: List[torch.Tensor] = []
-        all_samples: List[torch.Tensor] = []
-        all_decoded: List[torch.Tensor] = []
-        all_text_embeds: List[torch.Tensor] = []
-        all_text_masks: List[Optional[torch.Tensor]] = []
-        all_neg_embeds: List[torch.Tensor] = []
-        all_neg_masks: List[Optional[torch.Tensor]] = []
-
+    ) -> List[Dict[str, Any]]:
         require(
             len(seeds) == len(prompts),
             f"fastvideo engine expects one seed per prompt; got {len(seeds)} vs {len(prompts)}",
         )
+        require(self._backend is not None, "FastVideo backend is not initialized")
+        outputs: List[Dict[str, Any]] = []
         for prompt, seed in zip(prompts, seeds):
-            one = deepcopy(sp)
-            one.prompt = prompt
-            one.seed = int(seed)  # decorrelate sibling samples (see _per_sample_seeds)
-            latents_size = [(one.num_frames - 1) // 4 + 1, one.height // 8, one.width // 8]
-            n_tokens = latents_size[0] * latents_size[1] * latents_size[2]
-            sp_dict = shallow_asdict(one)
-            sp_dict.pop("eta", None)
-            batch = ForwardBatch(
-                **sp_dict,
-                eta=float(params.eta),
-                n_tokens=n_tokens,
-                VSA_sparsity=self._fastvideo_args.VSA_sparsity,
-                rl_data=ForwardBatch.RLData(
-                    enabled=True,
-                    collect_log_probs=bool(self.cfg.native_logprob),
-                    store_trajectory=True,
-                    keep_trajectory_on_cpu=True,
-                    sde_step_indices=sde_step_indices,
-                    sde_type=str(getattr(self.strategy, "canonical_name", "flow")),
-                ),
+            batch = self.adapter.build_forward_batch(
+                prompt=prompt,
+                seed=seed,
+                params=params,
+                sigmas=sigmas,
+                fastvideo_args=self._backend.fastvideo_args,
             )
-            out = self._generator.executor.execute_forward(batch, self._fastvideo_args)
-            rl = out.rl_data
-            traj = rl.trajectory_latents if rl is not None else None
-            if traj is None:
-                traj = out.trajectory_latents
-            require(torch.is_tensor(traj), "FastVideo returned no trajectory tensor")
-            if traj.dim() == 5:
-                traj = traj.unsqueeze(0)
-            all_traj.append(traj.detach().cpu())
-            samples = out.latents.cpu() if out.latents is not None else traj[:, -1].cpu()
-            all_samples.append(samples.detach().cpu())
-            # Decoded pixels: the FastVideo pipeline's DecodingStage writes the
-            # final video to batch.output as [B, C, T, H, W] in [0, 1] (float32,
-            # CPU). The reward path needs this as track.decoded (Videos).
-            dec = getattr(out, "output", None)
-            require(torch.is_tensor(dec), "FastVideo returned no decoded output (batch.output)")
-            if dec.dim() == 4:
-                dec = dec.unsqueeze(0)
-            all_decoded.append(dec.detach().cpu().float())
-
-            # Text conditioning: reuse the *exact* prompt embeddings FastVideo fed
-            # its transformer this rollout, so the trainer's replay forward yields
-            # an on-policy importance ratio (no re-encode drift). prompt_embeds is
-            # a per-encoder list; WAN uses a single UMT5 encoder -> index 0.
-            pe = out.prompt_embeds
-            require(
-                isinstance(pe, (list, tuple)) and len(pe) > 0 and torch.is_tensor(pe[0]),
-                "FastVideo returned no prompt_embeds for text conditioning",
-            )
-            te = pe[0]
-            if te.dim() == 2:
-                te = te.unsqueeze(0)
-            all_text_embeds.append(te.detach().cpu().float())
-            pm = out.prompt_attention_mask
-            tm = pm[0] if isinstance(pm, (list, tuple)) and len(pm) > 0 and torch.is_tensor(pm[0]) else None
-            all_text_masks.append(tm.detach().cpu() if tm is not None else None)
-
-            ne = out.negative_prompt_embeds
-            if isinstance(ne, (list, tuple)) and len(ne) > 0 and torch.is_tensor(ne[0]):
-                nte = ne[0]
-                if nte.dim() == 2:
-                    nte = nte.unsqueeze(0)
-                all_neg_embeds.append(nte.detach().cpu().float())
-                nm = out.negative_attention_mask
-                ntm = nm[0] if isinstance(nm, (list, tuple)) and len(nm) > 0 and torch.is_tensor(nm[0]) else None
-                all_neg_masks.append(ntm.detach().cpu() if ntm is not None else None)
-
-            if self.cfg.native_logprob:
-                lp = rl.log_probs if rl is not None else None
-                require(torch.is_tensor(lp), "FastVideo native rollout returned no log_probs")
-                all_log_probs.append(lp.detach().cpu())
-
-            # Per-video: outputs are already copied to CPU above, so drop this
-            # video's GPU tensors before the next iteration. This — not
-            # ``forward_batch_size`` — is what actually bounds peak GPU memory,
-            # since the forward runs one video at a time.
-            del out, rl, traj, samples, dec
+            output = self._backend.execute(batch)
+            outputs.append(self.adapter.collect_output(output))
+            del output
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
-
-        return {
-            "trajectory": torch.cat(all_traj, dim=0),
-            "samples": torch.cat(all_samples, dim=0),
-            "decoded": torch.cat(all_decoded, dim=0),
-            "log_probs": torch.cat(all_log_probs, dim=0) if all_log_probs else None,
-            "text_embeds": all_text_embeds,
-            "text_masks": all_text_masks,
-            "neg_embeds": all_neg_embeds,
-            "neg_masks": all_neg_masks,
-        }
-
-    def _build_resp(self, req: RolloutReq, params: Any, raw: Dict[str, Any]) -> RolloutResp:
-        segment = self._build_segment(req, params, raw)
-        decoded = self._build_decoded(raw)
-        conditions = self._build_conditions(raw)
-        return RolloutResp(
-            tracks={
-                "video": RolloutTrack(
-                    sample_ids=list(req.sample_ids),
-                    parent_ids=list(req.group_ids),
-                    conditions=conditions,
-                    segment=segment,
-                    decoded=decoded,
-                ),
-            }
-        )
-
-    def _build_conditions(self, raw: Dict[str, Any]) -> Dict[str, Any]:
-        """Assemble the WAN21 ``conditions`` dict the trainer replays against.
-
-        Packs the captured FastVideo prompt embeddings into ``TextEmbedCondition``s
-        (``text`` + optional CFG ``negative_text``), padding variable token lengths
-        with zeros via ``TextEmbedCondition.concat`` (WAN's zeroed-pad convention).
-        """
-        text_embeds: List[torch.Tensor] = raw.get("text_embeds") or []
-        require(len(text_embeds) > 0, "fastvideo engine produced no text embeddings")
-        text_masks: List[Optional[torch.Tensor]] = raw.get("text_masks") or [None] * len(text_embeds)
-
-        text = TextEmbedCondition.concat(
-            [
-                TextEmbedCondition(embeds=text_embeds[i], pooled=None, attn_mask=text_masks[i])
-                for i in range(len(text_embeds))
-            ]
-        )
-        conditions: Dict[str, Any] = {"text": text}
-
-        neg_embeds: List[torch.Tensor] = raw.get("neg_embeds") or []
-        if len(neg_embeds) == len(text_embeds) and len(neg_embeds) > 0:
-            neg_masks: List[Optional[torch.Tensor]] = raw.get("neg_masks") or [None] * len(neg_embeds)
-            conditions["negative_text"] = TextEmbedCondition.concat(
-                [
-                    TextEmbedCondition(embeds=neg_embeds[i], pooled=None, attn_mask=neg_masks[i])
-                    for i in range(len(neg_embeds))
-                ]
-            )
-        return conditions
-
-    def _build_decoded(self, raw: Dict[str, Any]) -> Videos:
-        """Pack FastVideo's decoded output [B, C, T, H, W] into a ``Videos``.
-
-        Mirrors WAN21VAEDecodeStage: permute each sample (C, T, H, W) →
-        (T, C, H, W) so Video.frames matches the canonical [T, C, H, W]
-        contract the reward path (video_pickscore) consumes.
-        """
-        frames = raw["decoded"]
-        require(
-            torch.is_tensor(frames) and frames.dim() == 5,
-            f"fastvideo decoded must be [B, C, T, H, W]; got "
-            f"{tuple(frames.shape) if torch.is_tensor(frames) else type(frames).__name__}",
-        )
-        videos = [Video(frames=frames[i].permute(1, 0, 2, 3).contiguous()) for i in range(int(frames.shape[0]))]
-        return Videos.from_list(videos)
-
-    def _build_segment(self, req: RolloutReq, params: Any, raw: Dict[str, Any]):
-        traj = raw["trajectory"]  # [B, T+1, C, T_lat, H, W]
-        device = traj.device
-        T = int(traj.shape[1]) - 1
-        indices = torch.arange(traj.shape[1], dtype=torch.long, device=device)
-
-        # sde_indices is ALWAYS populated (the trainer needs to know which steps
-        # to replay). Mirror the SGLang reference: when the caller didn't pin a
-        # subset, every transition is an SDE step (arange(num_steps)).
-        sde_set = sorted(int(i) for i in (params.sde_indices or []))
-        if not sde_set:
-            sde_set = list(range(T))
-        sde_indices = torch.tensor(sde_set, dtype=torch.long, device=device)
-
-        # sde_logp: native per-step log-prob [B, T] from FastVideo's RLData. Slice
-        # to the SDE columns when a strict subset was requested; otherwise the
-        # full [B, T] already matches the all-steps schedule.
-        sde_logp = None
-        lp = raw.get("log_probs")
-        if lp is not None:
-            if lp.shape[1] == T and len(sde_set) < T:
-                cols = [s for s in sde_set if 0 <= s < lp.shape[1]]
-                sde_logp = lp[:, cols].contiguous()
-            else:
-                sde_logp = lp.contiguous()
-
-        return make_video_segment(
-            latents=traj,
-            sigmas=req.sigmas,
-            indices=indices,
-            sde_logp=sde_logp,
-            sde_indices=sde_indices,
-        )
+        return outputs
 
     # ------------------------------------------------------------------ #
     # Lifecycle
@@ -512,43 +227,19 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
     def sleep(self) -> None:
         if self._is_offloaded:
             return
-        if self._generator is not None:
+        if self._backend is not None:
             try:
-                self._generator.shutdown()
+                self._backend.sleep()
             except Exception as exc:  # noqa: BLE001
                 logger.warning("fastvideo sleep/shutdown warning: %s", exc)
-            self._generator = None
         self._is_offloaded = True
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def wake_up(self) -> None:
         if not self._is_offloaded:
             return
-        from fastvideo import VideoGenerator
-
-        # MultiprocExecutor's TCPStore must bind a master port every time the
-        # generator is rebuilt. Reusing the constructor-time port after sleep
-        # can hit a lingering listener; its get_open_port() check also has a
-        # close-before-child-bind TOCTOU window when all DP actors wake
-        # concurrently. Refresh the hint for every attempt and self-heal the
-        # rare EADDRINUSE race instead of killing the Ray actor/run.
-        max_port_attempts = 5
-        for attempt in range(1, max_port_attempts + 1):
-            self._ports = FastVideoPorts.reserve()
-            self._fastvideo_args.master_port = int(self._ports.master_port)
-            try:
-                self._generator = VideoGenerator.from_fastvideo_args(self._fastvideo_args)
-                break
-            except Exception as exc:  # noqa: BLE001
-                port_in_use = "EADDRINUSE" in str(exc) or "address already in use" in str(exc).lower()
-                if not port_in_use or attempt == max_port_attempts:
-                    raise
-                logger.warning(
-                    "fastvideo wake_up: master_port=%s busy (attempt %d/%d); retrying",
-                    self._ports.master_port,
-                    attempt,
-                    max_port_attempts,
-                )
+        require(self._backend is not None, "FastVideo backend is not initialized")
+        self._backend.wake(reserve_port=self._reserve_master_port)
         self._is_offloaded = False
         # ``from_fastvideo_args`` reloads the PRETRAINED transformer from
         # ``model_path``; without this the engine would sample under pretrained
@@ -557,7 +248,7 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         # checkpoint so wake is weight-preserving, matching the other engines'
         # sleep/wake contract (sglang resume_memory keeps weights resident).
         if self._last_weights_path is not None:
-            self._generator.update_transformer_weights_from_path(self._last_weights_path)
+            self._backend.update_weights_from_path(self._last_weights_path)
             logger.info("fastvideo wake_up: re-applied synced weights from %s", self._last_weights_path)
 
     @property
@@ -569,9 +260,9 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         self.wake_up()
 
     def shutdown(self) -> None:
-        if self._generator is not None:
-            self._generator.shutdown()
-            self._generator = None
+        if self._backend is not None:
+            self._backend.shutdown()
+            self._backend = None
 
     # ------------------------------------------------------------------ #
     # Weight sync — checkpoint_path (full-param hot-swap). Reached per worker
@@ -580,8 +271,8 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
     def update_weights_from_path(self, checkpoint_path: str, *, track_prefix: str = "") -> None:
         del track_prefix
         require(bool(checkpoint_path), "update_weights_from_path requires a non-empty path")
-        require(self._generator is not None, "fastvideo engine is offloaded/not initialized")
-        self._generator.update_transformer_weights_from_path(checkpoint_path)
+        require(self._backend is not None and not self._is_offloaded, "fastvideo engine is offloaded/not initialized")
+        self._backend.update_weights_from_path(checkpoint_path)
         # Remember it so ``wake_up`` can re-apply after a rebuild (see wake_up).
         self._last_weights_path = checkpoint_path
         logger.info("fastvideo transformer weights updated from %s", checkpoint_path)


### PR DESCRIPTION
## Summary

Refactor the FastVideo rollout integration to run against a pinned, unmodified upstream FastVideo revision and install UniRL-specific behavior through fail-closed runtime patches.

This removes the runtime dependency on a separately maintained FastVideo fork and fixes the spawned-worker TCPStore failure path that previously caused otherwise healthy long-running jobs to terminate after repeated sleep/wake cycles.

## Motivation

Maintaining UniRL-specific behavior in a separate FastVideo repository made the effective runtime version difficult to identify and complicated reproduction, upgrades, and support for additional model families.

This change moves the integration boundary into UniRL:

- FastVideo is installed from a pinned upstream commit;
- UniRL validates the installed version, symbols, and signatures;
- runtime patches are installed idempotently in both parent and spawned workers;
- model-specific behavior is isolated behind adapters;
- unsupported versions and contracts fail closed.

## Design

### Runtime patch suite

The patch installer provides:

- RLData contract extensions for SDE metadata;
- custom sigma and timestep handling;
- Flow and Dance SDE transition math and SDE-index windows;
- trajectory, timestep, log-prob, and text-condition transport;
- strict full-parameter checkpoint hot-swaps;
- spawned-worker patch propagation;
- TCPStore address-collision recovery.

Compatibility and capability checks run before the FastVideo backend is exposed.

### Adapter and backend separation

The rollout engine is split into:

- a generic FastVideo backend responsible for lifecycle and execution;
- model adapters responsible for request construction, schedules, conditions, outputs, and responses;
- a Wan2.1 adapter containing the current Wan-specific assumptions.

This prevents Wan-specific scheduler, shape, and conditioning behavior from leaking into future FastVideo model integrations.

### Dependency model

The `fastvideo` optional dependency pins:

`hao-ai-lab/FastVideo@2095477eac7e289c7a7ab13acb367ca60687c304`

`FASTVIDEO_PATH` remains available as a development override. No FastVideo source file or installed `site-packages` file is modified on disk.

## Long-running stability

### Root cause

FastVideo recreates multiprocessing workers and their distributed process group after colocated sleep/wake cycles. Worker startup first selects an apparently free TCPStore port, but another process can claim it before the spawned worker binds the socket.

This time-of-check/time-of-use race produces `EADDRINUSE` in a child process. The original child failure path signals the parent process, causing the Ray rollout actor and training job to exit. Retrying only at the outer engine layer cannot reliably recover an exception originating asynchronously in the spawned worker.

### Fix

The multiprocessing runtime patch now:

- propagates UniRL patches into spawned workers;
- reports worker initialization failures through the ready pipe instead of terminating the parent;
- detects TCPStore address-collision failures;
- closes failed worker pipes and processes;
- reserves a new master port and retries worker startup;
- raises the original error when bounded recovery is exhausted.

The backend also retries initial generator boot with a newly reserved port.

### Validation

Formal long-running experiments encountered real TCPStore address collisions during repeated sleep/wake cycles. The patched workers recovered without terminating Ray or restarting the training jobs, and all four jobs continued completing later rollout and optimizer steps.

## Supported scope

This draft currently validates:

- Wan2.1 T2V 1.3B;
- Flow and Dance SDE strategies;
- replay old-log-prob mode;
- native rollout old-log-prob mode;
- single-node 8-GPU colocated rollout and training;
- full checkpoint-path weight synchronization.

Other model families require a dedicated adapter and are rejected instead of inheriting Wan-specific behavior.

## Validation

- 7 focused runtime-patch tests passed;
- all changed Python files passed compilation;
- Ruff check and format verification passed;
- 1,455 recipe target paths resolved;
- replay and native modes completed rollout, reward, backward, optimizer update, and 8/8 full-weight synchronization.

Formal 720p runs use `batch_size=48`, `samples_per_prompt=16`, 768 samples per rollout, two updates per batch, `forward_batch_size=4`, 14 denoising steps, and shift 5:

<img width="1874" height="1248" alt="Clipboard_Screenshot_1787044556" src="https://github.com/user-attachments/assets/cd42ca37-01b0-4fc7-95ea-932a438cdaa8" />

<img width="1762" height="1272" alt="Clipboard_Screenshot_1787044624" src="https://github.com/user-attachments/assets/e5039fbb-d3da-448f-8c41-f823700dc882" />


<img width="1890" height="1246" alt="Clipboard_Screenshot_1785751943" src="https://github.com/user-attachments/assets/6c6db43b-818a-432d-adaf-47517dadd45e" />

<img width="1766" height="1304" alt="Clipboard_Screenshot_1785751965" src="https://github.com/user-attachments/assets/87400854-061a-4d5a-ad3c-d8ff69d1aedc" />


## Draft status

This PR is opened as a draft for architecture and compatibility review.

Before marking it ready:

- finalize the supported FastVideo compatibility contract;
- review the patch surface for future non-Wan adapters;
- consolidate reproduction instructions and final validation evidence.