### PR TITLE
perf(reward): send only scoring payload across slabs

### DIFF
--- a/examples/diffusion/sd3/sd3_dancegrpo_reward_slab.yaml
+++ b/examples/diffusion/sd3/sd3_dancegrpo_reward_slab.yaml
@@ -11,8 +11,9 @@
 # shares — nor offload-thrashes — the policy's cards ("reward doesn't steal
 # cards"). The reward slab takes the tail of the pool, mirroring how
 # layout="separate" gives the rollout engine the tail. Cross-slab
-# reward.score_and_attach is DP_SCATTER-dispatched and pytree-merged back on the
-# driver, so the trainer is unchanged. To reproduce the 16-GPU scenario, set
+# RewardService.score dispatches only a row-aligned RewardRequest and merges the
+# scalar response on the driver; trajectory refs stay on their producing slab.
+# To reproduce the 16-GPU scenario, set
 # num_devices: 16 and reward_fraction: 0.125 (= 2 of 16 GPUs).
 #
 # NOTE: PickScore is tiny — dedicating whole cards to it is wasteful and this

--- a/experimental/refl/trainer.py
+++ b/experimental/refl/trainer.py
@@ -12,6 +12,7 @@ from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement
 from unirl.distributed.tensor.grad_context import enable_grad
+from unirl.reward.client import RewardClient
 from unirl.trainer.base import BaseTrainer, build_sampling_dict
 from unirl.trainer.hydra import remote_hydra
 from unirl.types.primitives import Images, Texts
@@ -79,7 +80,7 @@ class REFLTrainer(BaseTrainer):
 
         with placement(self.pool, fraction=1.0, shared_workers=True):
             self.actor = remote_hydra(cfg.actor)
-            self.reward = remote_hydra(cfg.reward)
+            self.reward = RewardClient(remote_hydra(cfg.reward))
         self.actor.initialize()
         self.backend = self.actor
 

--- a/unirl/README.md
+++ b/unirl/README.md
@@ -143,7 +143,7 @@ flows through them like this:
 2. The `<Domain>Trainer` (e.g. `trainer/diffusion.py`) acquires a Ray `DevicePool` and builds the rollout and train workers.
 3. The trainer builds a typed `Sample` lineage and dispatches it to the rollout engine.
 4. The engine returns the lineage with generated `Part`s filled with conditions, segments, primitive maps, and media previews.
-5. `RewardService.score_and_attach` attaches rewards; `Part.compute_advantages` z-scores them into advantages.
+5. Driver-side `RewardClient.score_and_attach` sends a minimal request to `RewardService.score` and attaches its response; `Part.compute_advantages` z-scores the rewards into advantages.
 6. `TrainStack.train_track(...)` shards the generated `Part` across train workers and runs the mini-batch optimizer loop.
 7. Each train worker owns a model `Bundle`, an `FSDPBackend`, and one loss algorithm.
 8. Dedicated-rollout modes (separate / colocate) sync trainer weights back to the rollout workers.

--- a/unirl/reward/README.md
+++ b/unirl/reward/README.md
@@ -6,10 +6,10 @@
 > Full map: [`../README.md`](../README.md).
 
 <div align="center">
-  <img src="../../assets/reward-flow-new.png" alt="UniRL reward: RewardService.score_and_attach turns the rollout output (decoded image or text) into a per-sample reward via exactly one backend — local is a single in-process scorer (PickScore, CLIP, HPS, OCR, GenEval2, …) while remote is an HTTP server that runs a panel of reward models (required_rewards) and weight-aggregates them (weighted_sum, mean, min, max) into one reward plus the per-model breakdown; the trainer then z-scores that reward into the advantage" width="100%">
+  <img src="../../assets/reward-flow-new.png" alt="UniRL reward: RewardClient projects the rollout Sample into a row-aligned RewardRequest, RewardService scores it through exactly one backend, and the client attaches the returned scalar rewards before the trainer computes advantages" width="100%">
 </div>
 
-*One `RewardService` wraps **one backend**: a single in-process scorer (local) or a remote HTTP server that runs and weight-aggregates a **panel** of reward models. The per-sample reward it attaches is what the trainer z-scores into the advantage.*
+*One `RewardService` wraps **one backend**: a single in-process scorer (local) or a remote HTTP server that runs and weight-aggregates a **panel** of reward models. `RewardClient` keeps the full training Sample on its producing slab and sends the service only the row-aligned request that backend consumes.*
 
 ## What it is
 
@@ -38,21 +38,25 @@ easy to get wrong — so this module owns both:
 
 ## How it works
 
-Everything goes through one method, `RewardService.score_and_attach(sample)`
-(`service.py`). It runs per DP shard (sharding the Sample by prompt-tree), so it
-never mutates the input Sample — it returns a fresh one. Per call it:
+The trainer-facing `RewardClient.score_and_attach(sample)` (`client.py`) is a
+driver-side adapter over the distributed `RewardService.score(request)`
+(`service.py`). It never mutates the input Sample — it returns a fresh one whose
+trajectory and condition refs are the original producer-owned objects. Per call it:
 
 1. **Refuses precomputed rewards** — raises if the frontier Part already has
    `rewards` (actor-side scoring is the only writer).
-2. **Pairs input with output** — the conditioning (`Sample.conditioning`) with the
-   media in the frontier Part's `primitive`, already row-aligned (no expansion).
-3. **Scores** — hands a typed `RewardRequest` to `backend.compute_rewards`, getting
-   back rewards, per-component rewards, and per-sample success flags.
-4. **Fails fast** — raises and names the sample if any failed.
+2. **Projects the wire payload** — pairs `Sample.conditioning()` with the frontier
+   primitives in a typed `RewardRequest`; segment tensors, encoded conditions,
+   previews, and existing training fields never enter the reward RPC.
+3. **DP-shards rows** — `RewardRequest` is a `Batch`, so each worker receives the
+   same frontier-row range that its backend scores independently.
+4. **Scores and fails fast** — the worker calls `backend.compute_rewards` and raises
+   before DP merge if any row failed.
 5. **Zeroes runaway AR traces** — when the scored Part is itself an AR generation,
    one that hit `max_new_tokens` (never terminated) gets reward 0, so training
    doesn't learn to ramble to the cap.
-6. **Attaches** `rewards` + `component_rewards` and returns the Sample.
+6. **Returns scalars only** — `RewardResponse` is merged on the driver, which
+   attaches float32 CPU `rewards` + `component_rewards` to a copy of the Sample.
 
 A backend is just `compute_rewards(request) -> RewardResponse`. Local scorers
 (`local/`) subclass `LocalRewardBackend` and implement `_compute_model_rewards`;
@@ -111,9 +115,12 @@ new remote reward needs no UniRL code — add it to the server and list its name
 
 - **A non-finite/missing reward fails the whole step, by design** — fix the scorer.
   `raise_on_failure=False` (remote only) does *not* let training continue on it: the
-  backend returns zeros with `successes=[False]`, and `score_and_attach`'s fail-fast
+  backend returns zeros with `successes=[False]`, and `RewardService.score`'s fail-fast
   then raises on those flags anyway. So it can't silently zero-poison a group; leave
   it `True`.
+- **Reward DP shards frontier rows, not the full Sample tree.** Conditioning has
+  already been projected onto those rows, and built-in backends score rows
+  independently. GRPO sibling aggregation remains a driver-side advantage concern.
 - **`input_kind` must match the media** (`image`/`video`/`text`) — it picks which
   decoded key the backend sees. Remote allows only `image`/`video`; local scorers
   may be `text`.

--- a/unirl/reward/client.py
+++ b/unirl/reward/client.py
@@ -1,0 +1,91 @@
+"""Driver-side reward adapter: build requests and attach scalar responses."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+import torch
+
+from unirl.types.primitives import PrimitiveValue, primitive_modality_key
+from unirl.types.reward import RewardRequest
+from unirl.types.sample import Sample, _part_with_field
+from unirl.types.sampling import ARSamplingParams
+
+if TYPE_CHECKING:
+    from unirl.distributed.group.handle import Handle
+
+
+def _build_reward_request(sample: Sample) -> RewardRequest:
+    """Project a Sample onto the row-aligned fields consumed by reward backends."""
+    frontier = sample.parts[-1]
+    primitives: Dict[str, PrimitiveValue] = {}
+    for primitive in sample.conditioning():
+        primitives[primitive_modality_key(primitive)] = primitive
+
+    generated = dict(frontier.primitives)
+    audio_sample_rate: Optional[int] = None
+    audio_metadata = frontier.primitive_metadata.get("audio", {})
+    if "audio" in generated and audio_metadata.get("sample_rate") is not None:
+        audio_sample_rate = int(audio_metadata["sample_rate"])
+
+    response_lengths: Optional[list[int]] = None
+    max_new_tokens: Optional[int] = None
+    sampling = frontier.sampling_params
+    if isinstance(sampling, ARSamplingParams) and frontier.segment is not None:
+        lengths = getattr(frontier.segment, "lengths", None)
+        if lengths is not None and lengths.numel() == frontier.batch_size:
+            response_lengths = [int(value) for value in lengths.tolist()]
+            max_new_tokens = int(sampling.max_new_tokens)
+
+    metadata = sample.root_metadata(-1)
+    return RewardRequest(
+        primitives=primitives,
+        generated=generated,
+        metadata=metadata if any(value is not None for value in metadata) else None,
+        prompt_ids=[str(sample_id) for sample_id in frontier.sample_ids],
+        sample_ids=list(frontier.sample_ids),
+        group_ids=list(frontier.group_ids),
+        response_lengths=response_lengths,
+        audio_sample_rate=audio_sample_rate,
+        max_new_tokens=max_new_tokens,
+    )
+
+
+class RewardClient:
+    """Driver-side reward API preserving the historical score-and-attach surface."""
+
+    def __init__(self, handle: "Handle") -> None:
+        self._handle = handle
+
+    @property
+    def dp_size(self) -> int:
+        return self._handle.dp_size
+
+    def score_and_attach(self, sample: Sample) -> Sample:
+        """Score the frontier and return a copy sharing every non-reward field."""
+        if not sample.parts:
+            raise ValueError("RewardClient.score_and_attach: Sample has no Parts.")
+        frontier = sample.parts[-1]
+        if frontier.rewards is not None:
+            raise RuntimeError("Actor-side reward compute does not accept precomputed rewards on the frontier Part.")
+        if not frontier.primitives:
+            raise ValueError("RewardClient.score_and_attach: frontier Part has no generated primitives to score.")
+
+        response = self._handle.score(_build_reward_request(sample))
+        rewards = torch.tensor(response.rewards, dtype=torch.float32)
+        component_rewards = {
+            str(name): torch.tensor(list(values or []), dtype=torch.float32)
+            for name, values in dict(response.component_rewards or {}).items()
+        }
+        scored = _part_with_field(frontier, "rewards", rewards)
+        scored = _part_with_field(scored, "component_rewards", component_rewards)
+        return sample.with_parts([*sample.parts[:-1], scored])
+
+    def score_differentiable(self, *args: Any, **kwargs: Any) -> Any:
+        return self._handle.score_differentiable(*args, **kwargs)
+
+    def get_memory_stats(self, *args: Any, **kwargs: Any) -> Any:
+        return self._handle.get_memory_stats(*args, **kwargs)
+
+
+__all__ = ["RewardClient"]

--- a/unirl/reward/local/per_domain.py
+++ b/unirl/reward/local/per_domain.py
@@ -4,47 +4,12 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
-import torch
-
-from unirl.distributed.tensor.batch import Batch
 from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
 from unirl.types.reward import RewardRequest, RewardResponse
 
 DOMAIN_KEY = "domain"
-
-
-def _select_rows(value: Any, indices: torch.Tensor) -> Any:
-    """Re-index one request field along the batch dim."""
-    if value is None:
-        return None
-    if isinstance(value, Batch):
-        return value.select(indices)
-    raise TypeError(
-        f"PerDomainRewardScorer: cannot row-select request field of type {type(value).__name__}; "
-        "expected a Batch primitive (Texts/Images/Videos/Audios)."
-    )
-
-
-def _select_request(request: RewardRequest, indices: List[int]) -> RewardRequest:
-    """A fresh ``RewardRequest`` holding only the given rows."""
-    idx = torch.tensor(indices, dtype=torch.long)
-
-    def _pick(x: Optional[List[Any]]) -> Optional[List[Any]]:
-        return None if x is None else [x[i] for i in indices]
-
-    return RewardRequest(
-        primitives={k: _select_rows(v, idx) for k, v in request.primitives.items()},
-        generated={k: _select_rows(v, idx) for k, v in request.generated.items()},
-        metadata=_pick(request.metadata),
-        prompt_ids=_pick(request.prompt_ids),
-        sample_ids=_pick(request.sample_ids),
-        group_ids=_pick(request.group_ids),
-        reward_types=list(request.reward_types),
-        return_components=request.return_components,
-        audio_sample_rate=request.audio_sample_rate,
-    )
 
 
 class PerDomainRewardScorer(RewardBackend):
@@ -85,7 +50,7 @@ class PerDomainRewardScorer(RewardBackend):
         component_rewards: Dict[str, List[float]] = {d: [float("nan")] * bs for d in self._scorers}
 
         for domain, indices in groups.items():
-            resp = self._scorers[domain].compute_rewards(_select_request(request, indices))
+            resp = self._scorers[domain].compute_rewards(request.select(indices))
             if len(resp.rewards) != len(indices):
                 raise RuntimeError(
                     f"PerDomainRewardScorer: scorer for domain {domain!r} returned "

--- a/unirl/reward/local/video_pickscore.py
+++ b/unirl/reward/local/video_pickscore.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, List
 
 import torch
@@ -80,15 +80,9 @@ class VideoPickScoreScorer(PickScoreRewardScorer):
 
             pil_frames = [self._extract_frame(v, self.frame_selection) for v in request.videos]
             frame_pixels = torch.stack([to_tensor(f) for f in pil_frames])
-            request = RewardRequest(
-                primitives=dict(request.primitives),
+            request = replace(
+                request,
                 generated={"image": Images.from_dense(frame_pixels)},
-                prompt_ids=request.prompt_ids,
-                sample_ids=request.sample_ids,
-                group_ids=request.group_ids,
-                metadata=request.metadata,
-                reward_types=request.reward_types,
-                return_components=request.return_components,
             )
         return super()._compute_model_rewards(request)
 

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -1,56 +1,24 @@
-"""Reward service: score a response :class:`~unirl.types.sample.Sample` in place."""
+"""Worker-side reward service: score a row-aligned request."""
 
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional
+from dataclasses import replace
+from typing import List, Optional
 
 import torch
 
 from unirl.distributed.group.dispatch import Dispatch, distributed
 from unirl.distributed.group.remote import Remote
-from unirl.types.primitives import PrimitiveValue, primitive_modality_key
 from unirl.types.reward import RewardRequest, RewardResponse
-from unirl.types.sample import Sample, _part_with_field
-from unirl.types.sampling import ARSamplingParams
 
 from .base import DifferentiableReward, RewardBackend
 
 logger = logging.getLogger(__name__)
 
 
-def _build_reward_request(sample: Sample, preferred_input_kind: str) -> RewardRequest:
-    """Assemble a :class:`RewardRequest` from a response ``Sample``."""
-    frontier = sample.parts[-1]
-    primitives: Dict[str, PrimitiveValue] = {}
-    for prim in sample.conditioning():
-        primitives[primitive_modality_key(prim)] = prim
-
-    if preferred_input_kind not in frontier.primitives:
-        raise ValueError(
-            f"Reward backend consumes {preferred_input_kind!r} but the frontier Part generated "
-            f"{sorted(frontier.primitives)!r}; check the recipe's reward/model pairing."
-        )
-
-    metadata = sample.root_metadata(-1)
-    generated = dict(frontier.primitives)
-    audio_sample_rate: Optional[int] = None
-    audio_metadata = frontier.primitive_metadata.get("audio", {})
-    if "audio" in generated and audio_metadata.get("sample_rate") is not None:
-        audio_sample_rate = int(audio_metadata["sample_rate"])
-    return RewardRequest(
-        primitives=primitives,
-        generated=generated,
-        audio_sample_rate=audio_sample_rate,
-        prompt_ids=[str(sid) for sid in frontier.sample_ids],
-        sample_ids=list(frontier.sample_ids),
-        group_ids=list(frontier.group_ids),
-        metadata=(metadata if any(m is not None for m in metadata) else None),
-    )
-
-
 class RewardService(Remote):
-    """Actor-side reward entry: one backend, scores a Sample's frontier Part in place."""
+    """Actor-side reward entry owning one backend and its shaping policy."""
 
     def __init__(
         self,
@@ -102,15 +70,14 @@ class RewardService(Remote):
         return self.backend.compute_rewards_differentiable(media_tensor, list(prompts), records=records)
 
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
-    def score_and_attach(self, sample: Sample) -> Sample:
-        """Score the frontier (last) Part's generated media and return the updated Sample."""
-        frontier = sample.parts[-1]
-        if frontier.rewards is not None:
-            raise RuntimeError("Actor-side reward compute does not accept precomputed rewards on the frontier Part.")
-        if not frontier.primitives:
-            raise ValueError("RewardService.score_and_attach: frontier Part has no generated primitives to score.")
-
-        request = _build_reward_request(sample, self.preferred_input_kind)
+    def score(self, request: RewardRequest) -> RewardResponse:
+        """Score one DP shard and return row-aligned scalar results."""
+        input_kind = self.preferred_input_kind
+        if input_kind not in request.generated:
+            raise ValueError(
+                f"Reward backend consumes {input_kind!r} but the request generated "
+                f"{sorted(request.generated)!r}; check the recipe's reward/model pairing."
+            )
         reward_response = self.compute_rewards(request)
 
         failed = [(i, e) for i, (ok, e) in enumerate(zip(reward_response.successes, reward_response.errors)) if not ok]
@@ -120,30 +87,27 @@ class RewardService(Remote):
                 f"sample(s) as failure. First few: {failed[:3]}"
             )
 
+        if len(reward_response.rewards) != request.batch_size:
+            raise RuntimeError(
+                f"Reward backend returned {len(reward_response.rewards)} rewards for {request.batch_size} request rows."
+            )
         rewards = torch.tensor(reward_response.rewards, dtype=torch.float32)
+        if self.truncated_reward != "keep" and request.response_lengths is not None:
+            if request.max_new_tokens is None or len(request.response_lengths) != rewards.numel():
+                raise ValueError(
+                    "RewardService.score requires response_lengths and max_new_tokens aligned with reward rows."
+                )
+            lengths = torch.tensor(request.response_lengths, dtype=torch.float32)
+            max_len = float(request.max_new_tokens)
+            if self.truncated_reward == "zero":
+                rewards = torch.where(lengths >= max_len, torch.zeros_like(rewards), rewards)
+            else:
+                buf = float(self.overlong_buffer_len)
+                exceed = lengths - (max_len - buf)
+                penalty = torch.clamp(-exceed / buf * self.overlong_penalty_factor, max=0.0)
+                rewards = rewards + penalty
 
-        sp = frontier.sampling_params
-        if self.truncated_reward != "keep" and isinstance(sp, ARSamplingParams) and frontier.segment is not None:
-            seg_lengths = getattr(frontier.segment, "lengths", None)
-            if seg_lengths is not None and seg_lengths.numel() == rewards.numel():
-                seg_lengths = seg_lengths.to(rewards.device).float()
-                max_len = float(int(sp.max_new_tokens))
-                if self.truncated_reward == "zero":
-                    truncated = seg_lengths >= max_len
-                    rewards = torch.where(truncated, torch.zeros_like(rewards), rewards)
-                else:
-                    buf = float(self.overlong_buffer_len)
-                    exceed = seg_lengths - (max_len - buf)
-                    penalty = torch.clamp(-exceed / buf * self.overlong_penalty_factor, max=0.0)
-                    rewards = rewards + penalty
-
-        component_rewards = {
-            str(name): torch.tensor(list(values or []), dtype=torch.float32)
-            for name, values in dict(reward_response.component_rewards or {}).items()
-        }
-        scored = _part_with_field(frontier, "rewards", rewards)
-        scored = _part_with_field(scored, "component_rewards", component_rewards)
-        return sample.with_parts([*sample.parts[:-1], scored])
+        return replace(reward_response, rewards=[float(value) for value in rewards.tolist()])
 
     def is_available(self) -> bool:
         return self.backend.is_available()

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -42,8 +42,9 @@ stay swappable by `_target_`.
   rollout per call: `wake_up` → (sync weights, if due) →
   `rollout.generate(sample)` → `reward.score_and_attach(sample)` →
   `part.compute_advantages(...)` → drop reward-only decoded media →
-  `stack.train_track(...)`. The driver builds a request `Sample` whose Parts
-  preserve prompt lineage and carry sampling parameters. A single-stage stack
+  `stack.train_track(...)`. The reward client projects only scoring inputs into a
+  `RewardRequest`; the original Sample keeps its trajectory refs. The driver builds
+  a rollout request `Sample` whose Parts preserve prompt lineage and carry sampling parameters. A single-stage stack
   receives the trainable frontier `Part`; `UnifiedModelTrainStack` receives the
   whole `Sample` so AR and image Parts are sharded by the same prompt trees.
   `AgenticTrainer` uses a manager to collect `List[Sample]` groups of

--- a/unirl/trainer/agentic.py
+++ b/unirl/trainer/agentic.py
@@ -13,7 +13,7 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
-from unirl.distributed.tensor import hydrate
+from unirl.reward.client import RewardClient
 from unirl.rollout.manager import RolloutManager, required_worker_concurrency, validate_worker_inflight
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import (
@@ -103,7 +103,7 @@ class AgenticTrainer(BaseTrainer):
                 self.bundle = remote_hydra(bundle_cfg)
                 self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
                 self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
-                self.reward = remote_hydra(reward_cfg)
+                self.reward = RewardClient(remote_hydra(reward_cfg))
                 self.algorithm = remote_hydra(algorithm_cfg, pipeline=self.pipeline)
                 self.stack = remote_hydra(stack_cfg, fsdp_backend=self.backend, algorithm=self.algorithm)
                 self._build_colocated_rollout(rollout_cfg, sync_cfg)
@@ -268,7 +268,7 @@ class AgenticTrainer(BaseTrainer):
         scored_rewards = scored.parts[-1].rewards
         if scored_rewards is None:
             raise RuntimeError("reward service returned no rewards")
-        values = hydrate(scored_rewards).to(torch.float32).flatten()
+        values = scored_rewards.to(torch.float32).flatten()
         if values.numel() != score_count + score_padding:
             raise RuntimeError(
                 f"reward service returned {values.numel()} rewards for {score_count + score_padding} scoring rows"

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -12,7 +12,7 @@ from hydra.utils import get_object, instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
-from unirl.distributed.tensor import hydrate
+from unirl.reward.client import RewardClient
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
 from unirl.trainer.hydra import parse_hydra_cfg, remote_hydra
@@ -125,7 +125,7 @@ class ARTrainer(BaseTrainer):
             self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
             self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
 
-            self.reward = remote_hydra(reward_cfg)
+            self.reward = RewardClient(remote_hydra(reward_cfg))
             self.algorithm = remote_hydra(algorithm_cfg, pipeline=self.pipeline)
             self.stack = remote_hydra(stack_cfg, fsdp_backend=self.backend, algorithm=self.algorithm)
 
@@ -379,9 +379,6 @@ class ARTrainer(BaseTrainer):
         part = sample.parts[-1]
         mean_reward = 0.0
         if part.rewards is not None:
-            part.rewards = hydrate(part.rewards)
-            if isinstance(part.component_rewards, dict):
-                part.component_rewards = {name: hydrate(value) for name, value in part.component_rewards.items()}
             mean_reward = float(part.rewards.to(torch.float32).mean().item())
             if self.advantage_mode == "grpo":
                 part = part.compute_advantages(
@@ -467,7 +464,7 @@ class ARTrainer(BaseTrainer):
                     scored = self.reward.score_and_attach(generated)
                     rewards = scored.parts[-1].rewards
                     if rewards is not None:
-                        rewards = hydrate(rewards).to(torch.float32)
+                        rewards = rewards.to(torch.float32)
                         fanout = total_samples_per_prompt(eval_sp)
                         expected_total = dispatch_inputs.batch_size * fanout
                         if int(rewards.numel()) != expected_total:

--- a/unirl/trainer/async_ar.py
+++ b/unirl/trainer/async_ar.py
@@ -9,7 +9,7 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
-from unirl.distributed.tensor import hydrate
+from unirl.reward.client import RewardClient
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.ar import ARTrainer, ar_preflight
 from unirl.trainer.async_rollout import (
@@ -137,7 +137,7 @@ class AsyncARTrainer(AsyncRolloutTrainerMixin, ARTrainer):
             self.bundle = remote_hydra(bundle_cfg)
             self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
             self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
-            self.reward = remote_hydra(reward_cfg)
+            self.reward = RewardClient(remote_hydra(reward_cfg))
             self.algorithm = remote_hydra(algorithm_cfg, pipeline=self.pipeline)
             self.stack = remote_hydra(stack_cfg, fsdp_backend=self.backend, algorithm=self.algorithm)
             if sync_cfg is not None:
@@ -196,7 +196,6 @@ class AsyncARTrainer(AsyncRolloutTrainerMixin, ARTrainer):
         part = sample.parts[-1]
         mean_reward = 0.0
         if part.rewards is not None:
-            part.rewards = hydrate(part.rewards)
             mean_reward = float(part.rewards.to(torch.float32).mean().item())
         if self.advantage_mode == "grpo":
             part = part.compute_advantages(

--- a/unirl/trainer/async_diffusion.py
+++ b/unirl/trainer/async_diffusion.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Optional, Tuple
 
 import torch
 
-from unirl.distributed.tensor import hydrate
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.async_rollout import (
     AsyncRolloutTrainerMixin,
@@ -100,9 +99,6 @@ class AsyncDiffusionTrainer(AsyncRolloutTrainerMixin, DiffusionTrainer):
         part = sample.parts[-1]
         mean_reward = 0.0
         if part.rewards is not None:
-            part.rewards = hydrate(part.rewards)
-            if isinstance(part.component_rewards, dict):
-                part.component_rewards = {name: hydrate(value) for name, value in part.component_rewards.items()}
             mean_reward = float(part.rewards.to(torch.float32).mean().item())
         part = part.compute_advantages(normalize=True, use_global_std=self._adv_use_global_std)
         sample = sample.replace_frontier(part)

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -12,7 +12,7 @@ from hydra.utils import get_class, get_object, instantiate
 from omegaconf import DictConfig, OmegaConf
 
 from unirl.distributed.group.placement import placement, remote
-from unirl.distributed.tensor import hydrate
+from unirl.reward.client import RewardClient
 from unirl.train.configs import FSDPConfig, resolve_fsdp_mesh_shape
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
@@ -48,15 +48,16 @@ def _validate_prompt_tree_dp_geometry(
     reward_dp_size: int,
     context: str,
 ) -> None:
-    roles = [("reward", reward_dp_size)]
-    if rollout_dp_size is not None:
-        roles.insert(0, ("rollout", rollout_dp_size))
-    for role, dp_size in roles:
-        if batch_size % dp_size:
-            raise ValueError(
-                f"{context}: {role} dp_size={dp_size} must divide batch_size={batch_size} "
-                "root prompt trees; DP_SCATTER preserves each prompt's whole subtree."
-            )
+    if rollout_dp_size is not None and batch_size % rollout_dp_size:
+        raise ValueError(
+            f"{context}: rollout dp_size={rollout_dp_size} must divide batch_size={batch_size} "
+            "root prompt trees; rollout DP_SCATTER preserves each prompt's whole subtree."
+        )
+    if batch_size % reward_dp_size:
+        raise ValueError(
+            f"{context}: reward dp_size={reward_dp_size} must divide batch_size={batch_size} "
+            "root prompts so its frontier-row RewardRequest shards keep prompt groups aligned."
+        )
 
 
 def _validate_dp_geometry(
@@ -453,7 +454,7 @@ class DiffusionTrainer(BaseTrainer):
 
         if reward_separate:
             with placement(self.pool, fraction=reward_fraction, shared_workers=True):
-                self.reward = remote_hydra(reward_cfg)
+                self.reward = RewardClient(remote_hydra(reward_cfg))
                 self._wire_eval_suites()
 
         self._validate_reward_config()
@@ -550,7 +551,7 @@ class DiffusionTrainer(BaseTrainer):
         self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
         self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
         if reward_cfg is not None:
-            self.reward = remote_hydra(reward_cfg)
+            self.reward = RewardClient(remote_hydra(reward_cfg))
             self._wire_eval_suites()
         algo_cls = get_class(str(algorithm_cfg.get("_target_", "")))
         self._uses_ema = getattr(algo_cls, "requires_ema_rollout", False)
@@ -774,9 +775,6 @@ class DiffusionTrainer(BaseTrainer):
         part = sample.parts[-1]
         mean_reward = 0.0
         if part.rewards is not None:
-            part.rewards = hydrate(part.rewards)
-            if isinstance(part.component_rewards, dict):
-                part.component_rewards = {name: hydrate(value) for name, value in part.component_rewards.items()}
             mean_reward = float(part.rewards.to(torch.float32).mean().item())
             if self._algo_requires_advantages:
                 part = part.compute_advantages(normalize=True, use_global_std=self._adv_use_global_std)
@@ -967,16 +965,13 @@ class DiffusionTrainer(BaseTrainer):
                     part = scored.parts[-1]
                     rewards = part.rewards
                     if rewards is not None:
-                        r = hydrate(rewards).to(torch.float32)
-                        if scored is first_scored:
-                            # Captions read part.rewards, which remote scoring returns dehydrated.
-                            part.rewards = r
+                        r = rewards.to(torch.float32)
                         sums[name] += float(r.sum().item())
                         counts[name] += int(r.numel())
                     components = part.component_rewards
                     if isinstance(components, dict):
                         for component_name, component_values in components.items():
-                            component = hydrate(component_values).to(torch.float32)
+                            component = component_values.to(torch.float32)
                             metric_name = f"{name}_{str(component_name).replace('/', '_')}"
                             sums.setdefault(metric_name, 0.0)
                             counts.setdefault(metric_name, 0)

--- a/unirl/trainer/eval_suites.py
+++ b/unirl/trainer/eval_suites.py
@@ -9,6 +9,7 @@ from typing import Any, List, Optional
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
+from unirl.reward.client import RewardClient
 from unirl.trainer.hydra import remote_hydra
 
 logger = logging.getLogger(__name__)
@@ -63,7 +64,7 @@ def build_eval_suites(
         suites.append(
             EvalRewardSuite(
                 name=name,
-                reward=remote_hydra(reward_cfg),
+                reward=RewardClient(remote_hydra(reward_cfg)),
                 data_source=suite_source,
                 num_prompts=None if entry.get("num_prompts") is None else int(entry.get("num_prompts")),
             )

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -16,8 +16,8 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
-from unirl.distributed.tensor import hydrate
 from unirl.models.pe.pipeline import PEPipeline
+from unirl.reward.client import RewardClient
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
 from unirl.trainer.eval_suites import build_eval_suites
@@ -118,7 +118,7 @@ class PETrainer(BaseTrainer):
                 self.pe_pipeline = None
                 self.rollout = remote(**rollout_parsed)
 
-            self.reward = remote_hydra(reward_cfg)
+            self.reward = RewardClient(remote_hydra(reward_cfg))
             self._eval_suites = build_eval_suites(
                 eval_rewards_cfg, data_source_cfg=data_source_cfg, enabled=self.eval_interval > 0
             )
@@ -202,18 +202,13 @@ class PETrainer(BaseTrainer):
         parts_by_name = {"ar": ar_idx, "diffusion": diff_idx}
 
         sample = self.reward.score_and_attach(sample)
-        diff_part = sample.parts[diff_idx]
-        if diff_part.rewards is not None:
-            diff_part.rewards = hydrate(diff_part.rewards)
-        if isinstance(diff_part.component_rewards, dict):
-            diff_part.component_rewards = {name: hydrate(value) for name, value in diff_part.component_rewards.items()}
 
         sample = sample.propagate_rewards(op="mean")
 
         mean_reward = 0.0
         di_rewards = sample.parts[diff_idx].rewards
         if di_rewards is not None:
-            mean_reward = float(hydrate(di_rewards).to(torch.float32).mean().item())
+            mean_reward = float(di_rewards.to(torch.float32).mean().item())
 
         new_parts = list(sample.parts)
         for name in self._train_tracks:
@@ -291,7 +286,7 @@ class PETrainer(BaseTrainer):
                 scored = reward.score_and_attach(generated)
                 rewards = scored.parts[-1].rewards
                 if rewards is not None:
-                    r = hydrate(rewards).to(torch.float32)
+                    r = rewards.to(torch.float32)
                     sums[name] += float(r.sum().item())
                     counts[name] += int(r.numel())
         return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -17,6 +17,7 @@ from omegaconf import DictConfig
 from unirl.distributed.group.placement import placement, remote
 from unirl.distributed.tensor import TensorRef, hydrate
 from unirl.distributed.tensor.batch import Batch
+from unirl.reward.client import RewardClient
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
 from unirl.trainer.eval_suites import build_eval_suites
@@ -109,7 +110,7 @@ class UnifiedModelTrainer(BaseTrainer):
             self.bundle = remote_hydra(bundle_cfg)
             self.pipeline = remote_hydra(pipeline_cfg, bundle=self.bundle)
             self.backend = remote_hydra(backend_cfg, bundle=self.bundle)
-            self.reward = remote_hydra(reward_cfg)
+            self.reward = RewardClient(remote_hydra(reward_cfg))
             self._eval_suites = build_eval_suites(
                 eval_rewards_cfg, data_source_cfg=data_source_cfg, enabled=self.eval_interval > 0
             )
@@ -354,18 +355,13 @@ class UnifiedModelTrainer(BaseTrainer):
         img_idx = sample.gen_part_index(DiffusionSamplingParams)
 
         sample = self.reward.score_and_attach(sample)
-        img_part = sample.parts[img_idx]
-        if img_part.rewards is not None:
-            img_part.rewards = hydrate(img_part.rewards)
-        if isinstance(img_part.component_rewards, dict):
-            img_part.component_rewards = {name: hydrate(value) for name, value in img_part.component_rewards.items()}
 
         sample = sample.propagate_rewards(op="mean")
 
         mean_reward = 0.0
         di_rewards = sample.parts[img_idx].rewards
         if di_rewards is not None:
-            mean_reward = float(hydrate(di_rewards).to(torch.float32).mean().item())
+            mean_reward = float(di_rewards.to(torch.float32).mean().item())
 
         if self.dump_dir:
             self._dump_rollout(self._dump_rollout_id, sample)
@@ -422,7 +418,7 @@ class UnifiedModelTrainer(BaseTrainer):
 
             rewards = None
             if image_part is not None and image_part.rewards is not None:
-                rewards = hydrate(image_part.rewards).to(torch.float32).tolist()
+                rewards = image_part.rewards.to(torch.float32).tolist()
 
             n_imgs = 0
             if isinstance(img_decoded, Images):
@@ -533,7 +529,7 @@ class UnifiedModelTrainer(BaseTrainer):
                 scored = reward.score_and_attach(generated)
                 rewards = scored.parts[-1].rewards
                 if rewards is not None:
-                    r = hydrate(rewards).to(torch.float32)
+                    r = rewards.to(torch.float32)
                     sums[name] += float(r.sum().item())
                     counts[name] += int(r.numel())
         return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}

--- a/unirl/types/reward.py
+++ b/unirl/types/reward.py
@@ -1,13 +1,13 @@
 """Shared reward data types."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import torch
 from PIL import Image
 
-from unirl.distributed.tensor.batch import Batch, concat_field, max_field
+from unirl.distributed.tensor.batch import Batch, concat_field, max_field, shared_field
 
 
 class RewardType(Enum):
@@ -19,18 +19,46 @@ class RewardType(Enum):
 
 
 @dataclass
-class RewardRequest:
-    """Request for reward computation."""
+class RewardRequest(Batch):
+    """Row-aligned, DP-shardable request for reward computation."""
 
-    primitives: Dict[str, Any] = field(default_factory=dict)
-    generated: Dict[str, Any] = field(default_factory=dict)
-    metadata: Optional[List[Optional[Dict[str, Any]]]] = None
-    prompt_ids: Optional[List[str]] = None
-    sample_ids: Optional[List[str]] = None
-    group_ids: Optional[List[str]] = None
-    reward_types: List[RewardType] = field(default_factory=lambda: [RewardType.IMAGE_TEXT_ALIGNMENT])
-    return_components: bool = False
-    audio_sample_rate: Optional[int] = None
+    primitives: Dict[str, Any] = concat_field(default_factory=dict)
+    generated: Dict[str, Any] = concat_field(default_factory=dict)
+    metadata: Optional[List[Optional[Dict[str, Any]]]] = concat_field(default=None)
+    prompt_ids: Optional[List[str]] = concat_field(default=None)
+    sample_ids: Optional[List[str]] = concat_field(default=None)
+    group_ids: Optional[List[str]] = concat_field(default=None)
+    response_lengths: Optional[List[int]] = concat_field(default=None)
+    reward_types: List[RewardType] = shared_field(default_factory=lambda: [RewardType.IMAGE_TEXT_ALIGNMENT])
+    return_components: bool = shared_field(default=False)
+    audio_sample_rate: Optional[int] = shared_field(default=None)
+    max_new_tokens: Optional[int] = shared_field(default=None)
+
+    def __post_init__(self) -> None:
+        batch_size = self.batch_size
+        named_values = [
+            *((f"generated[{key!r}]", value) for key, value in self.generated.items() if value is not None),
+            *((f"primitives[{key!r}]", value) for key, value in self.primitives.items() if value is not None),
+        ]
+        for name, value in named_values:
+            try:
+                size = len(value)
+            except TypeError:
+                raise TypeError(f"RewardRequest.{name} must be row-aligned and sized, got {type(value).__name__}.")
+            if size != batch_size:
+                raise ValueError(f"RewardRequest.{name} has {size} rows, expected {batch_size}.")
+
+        for name in ("metadata", "prompt_ids", "sample_ids", "group_ids", "response_lengths"):
+            value = getattr(self, name)
+            if value is not None and len(value) != batch_size:
+                raise ValueError(f"RewardRequest.{name} has {len(value)} rows, expected {batch_size}.")
+
+        if (self.response_lengths is None) != (self.max_new_tokens is None):
+            raise ValueError("RewardRequest.response_lengths and max_new_tokens must be provided together.")
+
+    def slice(self, start: int, end: int) -> "RewardRequest":
+        """Slice rows through select so packed TensorRefs remain zero-copy views."""
+        return self.select(range(int(start), int(end)))
 
     @property
     def prompts(self) -> List[str]:


### PR DESCRIPTION
## Summary

Replace the PR's generic `@distributed(reads=/skips=)` machinery with a reward-domain boundary that sends only what scoring consumes:

- `RewardRequest` is now a row-aligned `Batch`, so `DP_SCATTER` shards generated media, conditioning, metadata, IDs, and optional AR length metadata directly.
- `RewardService.score(RewardRequest) -> RewardResponse` runs on reward workers, retains input-kind validation, nested failure propagation, and zero/keep/soft truncation shaping, and returns scalar lists only.
- Driver-side `RewardClient.score_and_attach(sample)` preserves the existing trainer API and observability region while attaching float32 CPU rewards to a copy that shares the original trajectory/condition refs.
- All trainer, eval-suite, async, and ReFL reward handles are wrapped explicitly. Per-domain slicing uses `RewardRequest.select`, and VideoPickScore preserves request fields with `dataclasses.replace`.
- The final diff makes no changes under `unirl/distributed/**`.

This keeps the dedicated reward-slab benefit of the original PR while removing store-key masks, partial worker hydration, passthrough rebind/finalizer rules, same-object alias handling, and the partial-localization/autograd restriction.

## Measured result

Same-Sample A/B on a private 2-H20 topology (one policy/train GPU, one dedicated reward GPU), SD3.5 Medium DanceGRPO, 8 prompts x 16 samples:

- 5/5 full/request pairs produced exactly equal rewards and component rewards.
- Reward hop: `836,241,004 -> 402,653,184` bytes (`-51.85%`).
- Following train hop: `433,587,820 -> 0` bytes.
- Combined cross-slab traffic: `1,269,828,824 -> 402,653,184` bytes (`-68.29%`).
- Median reward call: `3.1819s -> 3.1646s` (`-0.54%`); wall time is diagnostic only, not a throughput claim.
- Reward-worker live allocation changed by only `+0.03125 GiB` across repeated probes.
- 3/3 candidate end-to-end rollouts completed with finite rewards/losses and zero train-localization bytes.

Shared experiment archive: `/apdcephfs_gz44/share_305110755/UniRL_group/aimicahchen/2026-09-10/unirl-reward-rpc-r014`.

## Test Plan

- Temporary focused harness: 11 tests passed, covering request chunk/select/concat with packed `TensorRef` views, row-alignment rejection, AR truncation modes, backend failure/size propagation, copy-on-write attachment, ref identity preservation, and adapter forwarding.
- Hydra composition passed for SD3 reward slab, Qwen3 AR, prompt enhancement, unified model, and agentic recipes.
- `pre-commit run --all-files` passed.
- Exact Taiji A/B and three-rollout smoke passed as reported above.

## Compatibility / Risk

- `RewardService`'s distributed Sample method becomes the narrower `score(request)` RPC. Every in-tree construction site now wraps the raw Handle in `RewardClient`, preserving `reward.score_and_attach(sample)`, `dp_size`, `score_differentiable`, and memory monitoring for trainers.
- `RewardRequest` now rejects misaligned row fields before dispatch instead of silently broadcasting them.
- Built-in backends score rows independently; GRPO grouping remains on the driver Sample. Existing prompt-count divisibility checks remain intentionally stricter so current shard grouping is preserved.
- This change intentionally does not retain the original PR's train-side `skips=` capability: shipped trainers already drop decoded media before `train_track`, so it did not establish a second bandwidth use case.

## Checklist

- [x] Final diff reviewed against current `upstream/main`.
- [x] No generic distributed-core changes or compatibility aliases.
- [x] Local checks, config construction, focused behavior tests, and GPU validation completed.