### PR TITLE
feat(rollout): add engine-neutral TP placement for SGLang and vLLM-Omni

### DIFF
--- a/examples/ar/qwen3_omni_audio_video_gspo_lora_vllm_omni_1x4.yaml
+++ b/examples/ar/qwen3_omni_audio_video_gspo_lora_vllm_omni_1x4.yaml
@@ -28,8 +28,6 @@ eval_num_prompts: -1
 eval_samples_per_prompt: 1
 eval_temperature: 1.0
 
-# The anchor must differ from rank 0 to avoid a synchronous self-call.
-rollout_anchor_device: 1
 # Manual colocate dance: FSDP2 owns sharding only; ARTrainer explicitly moves
 # the whole training model (including the frozen vision/audio encoders) between
 # CPU and GPU around rollout. This is intentionally separate from
@@ -123,6 +121,7 @@ rollout:
     _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
     model_path: ${oc.env:QWEN3_OMNI_PATH,/path/to/Qwen3-Omni-30B-A3B-Instruct}
     modality: qwen3_omni_thinker
+    tp_size: 4
     stage_yaml_override: qwen3_omni_thinker_only_rl_1x4.yaml   # TP=4 (audio tower 20 heads)
     enable_sleep_mode: true
     max_prompt_length: 16384
@@ -134,12 +133,11 @@ rollout:
       init_timeout: 1800
 
 sync:
-  _target_: unirl.distributed.weight_sync.lora.RemoteLoraWeightSync
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
   # vLLM-Omni's thinker mapper requires this prefix.
   param_prefix: "thinker."
   adapter_name: default
   verify: true
-  copy: true
 
 reward:
   _target_: unirl.reward.service.RewardService

--- a/examples/ar/qwen3_omni_audio_video_gspo_lora_vllm_omni_1x8.yaml
+++ b/examples/ar/qwen3_omni_audio_video_gspo_lora_vllm_omni_1x8.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 # Qwen3-Omni Thinker · GSPO + LoRA · Daily-Omni audio/video MCQA · vLLM-Omni.
 # TP=4 is required because TP must divide the audio tower's 20 attention heads.
+# DevicePool forms two TP=4 rollout replicas from the eight colocated workers.
 #
 # Launch from the repository root:
 #   QWEN3_OMNI_PATH=/path/to/Qwen3-Omni-30B-A3B-Instruct \
@@ -23,8 +24,6 @@ eval_num_prompts: -1
 eval_samples_per_prompt: 1
 eval_temperature: 1.0
 
-# The anchor must differ from rank 0 to avoid a synchronous self-call.
-rollout_anchor_device: 1
 # Offload training state while the colocated rollout engine is awake.
 enable_fsdp_offload: true
 
@@ -105,7 +104,7 @@ backend:
     # PEFT injects adapters by name even under frozen encoder modules.
     exclude_modules: ".*visual.*|.*audio_tower.*"
 
-# vLLM-Omni thinker rollout, TP=4.
+# vLLM-Omni thinker rollout, DP=2 x TP=4.
 rollout:
   _target_: unirl.rollout.engine.vllm_omni.engine.VLLMOmniRolloutEngine
   model_config: ${bundle.config}
@@ -113,6 +112,7 @@ rollout:
     _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
     model_path: ${oc.env:QWEN3_OMNI_PATH,/path/to/Qwen3-Omni-30B-A3B-Instruct}
     modality: qwen3_omni_thinker
+    tp_size: 4
     stage_yaml_override: qwen3_omni_thinker_only_rl_1x4.yaml   # TP=4 (audio tower 20 heads)
     enable_sleep_mode: true
     max_prompt_length: 16384
@@ -124,12 +124,11 @@ rollout:
       init_timeout: 1800
 
 sync:
-  _target_: unirl.distributed.weight_sync.lora.RemoteLoraWeightSync
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
   # vLLM-Omni's thinker mapper requires this prefix.
   param_prefix: "thinker."
   adapter_name: default
   verify: true
-  copy: true
 
 reward:
   _target_: unirl.reward.service.RewardService

--- a/examples/ar/qwen3_omni_video_r1_gspo_lora_vllm_omni_1x4.yaml
+++ b/examples/ar/qwen3_omni_video_r1_gspo_lora_vllm_omni_1x4.yaml
@@ -31,8 +31,6 @@ eval_num_prompts: 100
 eval_samples_per_prompt: 1
 eval_temperature: 1.0
 
-# The anchor must differ from rank 0 to avoid a synchronous self-call.
-rollout_anchor_device: 1
 # Manual colocate dance: FSDP2 owns sharding only; ARTrainer explicitly moves
 # the whole training model (including the frozen vision/audio encoders) between
 # CPU and GPU around rollout. This is intentionally separate from
@@ -122,6 +120,7 @@ rollout:
     _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
     model_path: ${oc.env:QWEN3_OMNI_PATH,/path/to/Qwen3-Omni-30B-A3B-Instruct}
     modality: qwen3_omni_thinker
+    tp_size: 4
     stage_yaml_override: qwen3_omni_thinker_only_rl_1x4.yaml   # TP=4 (audio tower 20 heads)
     enable_sleep_mode: true
     omni_extra:
@@ -129,12 +128,11 @@ rollout:
       init_timeout: 1800
 
 sync:
-  _target_: unirl.distributed.weight_sync.lora.RemoteLoraWeightSync
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
   # vLLM-Omni's thinker mapper requires this prefix.
   param_prefix: "thinker."
   adapter_name: default
   verify: true
-  copy: true
 
 reward:
   _target_: unirl.reward.service.RewardService

--- a/examples/ar/qwen3_omni_video_r1_gspo_lora_vllm_omni_1x8.yaml
+++ b/examples/ar/qwen3_omni_video_r1_gspo_lora_vllm_omni_1x8.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 # Qwen3-Omni Thinker · GSPO + LoRA · video MCQA · vLLM-Omni rollout.
 # TP=4 is required because TP must divide the audio tower's 20 attention heads.
+# DevicePool forms two TP=4 rollout replicas from the eight colocated workers.
 #
 # Launch from the repository root:
 #   QWEN3_OMNI_PATH=/path/to/Qwen3-Omni-30B-A3B-Instruct \
@@ -23,8 +24,6 @@ eval_num_prompts: 8
 eval_samples_per_prompt: 1
 eval_temperature: 1.0
 
-# The anchor must differ from rank 0 to avoid a synchronous self-call.
-rollout_anchor_device: 1
 # Offload training state while the colocated rollout engine is awake.
 enable_fsdp_offload: true
 
@@ -101,7 +100,7 @@ backend:
     # PEFT injects adapters by name even under frozen encoder modules.
     exclude_modules: ".*visual.*|.*audio_tower.*"
 
-# vLLM-Omni thinker rollout, TP=4.
+# vLLM-Omni thinker rollout, DP=2 x TP=4.
 rollout:
   _target_: unirl.rollout.engine.vllm_omni.engine.VLLMOmniRolloutEngine
   model_config: ${bundle.config}
@@ -109,6 +108,7 @@ rollout:
     _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
     model_path: ${oc.env:QWEN3_OMNI_PATH,/path/to/Qwen3-Omni-30B-A3B-Instruct}
     modality: qwen3_omni_thinker
+    tp_size: 4
     stage_yaml_override: qwen3_omni_thinker_only_rl_1x4.yaml   # TP=4 (audio tower 20 heads)
     enable_sleep_mode: true
     omni_extra:
@@ -116,12 +116,11 @@ rollout:
       init_timeout: 1800
 
 sync:
-  _target_: unirl.distributed.weight_sync.lora.RemoteLoraWeightSync
+  _target_: unirl.distributed.weight_sync.lora.LocalLoraWeightSync
   # vLLM-Omni's thinker mapper requires this prefix.
   param_prefix: "thinker."
   adapter_name: default
   verify: true
-  copy: true
 
 reward:
   _target_: unirl.reward.service.RewardService

--- a/unirl/distributed/README.md
+++ b/unirl/distributed/README.md
@@ -59,8 +59,11 @@ unmaintainable. This layer hides it behind two ideas:
 - **Placement** (`group/device_pool.py`, `group/placement.py`). A `DevicePool`
   reserves one Ray placement group per node (one GPU per "bundle"). A `placement(…)`
   scope claims a slab of devices and builds the workers in it — pure data-parallel by
-  default (`rank == dp_rank`); any TP/FSDP sharding is set up inside each role's
-  `initialize()`.
+  default (`rank == dp_rank`). Rollout engines may opt into Handle-owned TP: Handle
+  derives `(dp, tp, pp)` ranks, verifies each TP group is node-local, and injects a
+  `RolloutParallelContext` containing the scheduler-issued CUDA tokens. `tp_rank=0`
+  launches that group's backend process tree; peers remain SPMD shells for training
+  collectives. FSDP/SP sharding continues to be initialized by its owning role.
 - **The data plane — how rollout data reaches train** (`tensor/`). The subtle part,
   and the one most worth understanding:
   1. `generate` runs `DP_SCATTER` on the rollout workers. As each worker returns,
@@ -90,7 +93,11 @@ unmaintainable. This layer hides it behind two ideas:
 **Extending it:** a new dispatch mode is an enum entry + a `(dispatch, collect)` pair
 in `group/dispatch.py`; a new transport is a backend under `tensor/backend/`
 implementing the transport ABC and wired into the `build_transport()` kind-dispatch in `tensor/factory.py`; a new physical
-layout is a `placement(…)` wiring in the trainer (`trainer/diffusion.py`).
+layout is a `placement(…)` wiring in the trainer (`trainer/diffusion.py`). A rollout
+engine that launches a multi-GPU runtime sets
+`_accepts_rollout_parallel_context = True`, declares `tp_size` in its config, and
+consumes the injected context instead of deriving devices from global rank or a
+stage-specific anchor.
 
 ## Gotchas
 

--- a/unirl/distributed/group/handle.py
+++ b/unirl/distributed/group/handle.py
@@ -41,6 +41,7 @@ from unirl.distributed.group.dispatch import (
     Execute,
     resolve_backward_dispatch_mode,
 )
+from unirl.distributed.group.parallelism import RolloutParallelContext
 from unirl.distributed.group.remote import RankInfo, Remote
 from unirl.distributed.tensor import TensorRef, WorkerLocalTransport, map_tree
 from unirl.distributed.tensor.backend.gpu_store.handle import GPUTensorHandle
@@ -102,19 +103,15 @@ def _cfg_get(cfg: Any, key: str, default: int) -> int:
     return int(val or default)
 
 
-def _is_sglang_rollout_role(role_cls: Type[Remote]) -> bool:
-    """True if ``role_cls`` opts into per-rank rollout-TP kwargs.
+def _accepts_rollout_parallel_context(role_cls: Type[Remote]) -> bool:
+    """True when ``role_cls`` consumes Handle-owned rollout placement.
 
-    SGLangRolloutEngine sets ``_accepts_rollout_tp_kwargs = True`` so Handle
-    injects ``tp_rank``/``tp_size``/``tp_visible_devices``/``pp_rank``/``ep_size``
-    into its ``__init__``. Other roles (weight sync, reward, algorithms) do NOT
-    set this flag — they share the rollout Handle's layout via ``HandleRef``
-    but their ``__init__`` doesn't accept these kwargs, so injecting would
-    raise ``TypeError``. A class-attribute flag (vs a string name check) survives
-    rename and subclassing without silently dropping the injection.
+    Opted-in engines receive one :class:`RolloutParallelContext` instead of a
+    backend-specific bag of TP kwargs. Other roles inherit the same rank layout
+    through ``HandleRef`` but do not receive an extra constructor argument.
     """
     cls = _owning_class(role_cls)
-    return getattr(cls, "_accepts_rollout_tp_kwargs", False) is True
+    return getattr(cls, "_accepts_rollout_parallel_context", False) is True
 
 
 def _parallel_shape_from_init_kwargs(
@@ -125,10 +122,10 @@ def _parallel_shape_from_init_kwargs(
     """Resolve ``(sp, tp, pp, ep)`` layout hints for this handle.
 
     ``sp_size`` keeps the existing VeOmni/Ulysses inheritance behavior. Rollout
-    TP/PP/EP is only read from ``SGLangRolloutEngine`` config (or inherited from
-    a sibling ``HandleRef`` such as ``rollout=...`` on weight sync roles) so
-    diffusion engines with their own ``tp_size`` config do not accidentally adopt
-    the AR rollout layout.
+    TP/PP/EP is read only for engines that opt into the common placement contract
+    (or inherited from a sibling ``HandleRef`` such as ``rollout=...`` on a
+    weight-sync role). Diffusion configs with an unrelated ``tp_size`` therefore
+    do not accidentally change their Handle layout.
     """
     if not init_kwargs:
         return 1, 1, 1, 1
@@ -144,7 +141,7 @@ def _parallel_shape_from_init_kwargs(
     pp = int(init_kwargs.get("pp_size") or 1)
     ep = int(init_kwargs.get("ep_size") or 1)
 
-    if _is_sglang_rollout_role(role_cls):
+    if _accepts_rollout_parallel_context(role_cls):
         cfg = init_kwargs.get("config")
         if cfg is not None:
             tp = max(tp, _cfg_get(cfg, "tp_size", 1))
@@ -181,7 +178,7 @@ def _build_rank_infos(
 
     The default ``tp=pp=sp=1`` reproduces the flat one-rank-per-DP layout.
     Ulysses SP keeps its historical contiguous ``(dp, sp)`` layout. Rollout TP
-    uses ``(dp, pp, tp)`` with TP rank fastest so one SGLang engine owns a
+    uses ``(dp, pp, tp)`` with TP rank fastest so one rollout engine owns a
     contiguous ``tp_size`` block of workers.
     """
     if sp_size > 1:
@@ -230,9 +227,9 @@ def _build_tp_visible_device_map(
     MIG tokens instead of integers. Querying each Worker is therefore the only
     reliable source of the scheduler visibility list.
 
-    TP groups must be node-local because one SGLang engine spawns all of its TP
-    scheduler processes from the ``tp_rank==0`` Worker. Invalid topology fails
-    before any role is constructed or GPU process is started.
+    TP groups must be node-local because the ``tp_rank==0`` worker launches the
+    backend process tree for the whole group. Invalid topology fails before any
+    role is constructed or GPU process is started.
     """
     size = len(rank_infos)
     if len(node_ips) != size or len(cuda_visible_devices) != size:
@@ -258,24 +255,24 @@ def _build_tp_visible_device_map(
         group_nodes = [str(node_ips[index]).strip() for index in ordered]
         if any(not node for node in group_nodes) or len(set(group_nodes)) != 1:
             raise ValueError(
-                f"each SGLang TP group must be placed on a single node; group={group_key}, nodes={group_nodes}"
+                f"each rollout TP group must be placed on a single node; group={group_key}, nodes={group_nodes}"
             )
 
         tokens: List[str] = []
         for index in ordered:
             raw = str(cuda_visible_devices[index]).strip()
             if not raw:
-                raise ValueError(f"SGLang TP worker {index} has an empty CUDA_VISIBLE_DEVICES token")
+                raise ValueError(f"rollout TP worker {index} has an empty CUDA_VISIBLE_DEVICES token")
             split = [token.strip() for token in raw.split(",") if token.strip()]
             if len(split) != 1:
                 raise ValueError(
-                    "each SGLang TP Worker must expose exactly one CUDA_VISIBLE_DEVICES "
+                    "each rollout TP Worker must expose exactly one CUDA_VISIBLE_DEVICES "
                     f"token; worker={index}, value={raw!r}"
                 )
             tokens.append(split[0])
         if len(set(tokens)) != len(tokens):
             raise ValueError(
-                "CUDA_VISIBLE_DEVICES tokens within an SGLang TP group must be unique; "
+                "CUDA_VISIBLE_DEVICES tokens within a rollout TP group must be unique; "
                 f"group={group_key}, tokens={tokens}"
             )
 
@@ -419,9 +416,9 @@ class Handle:
             self.rank_infos[0].pp_size,
             self.rank_infos[0].ep_size,
         )
-        is_tp_engine = _is_sglang_rollout_role(role_cls)
+        accepts_parallel_context = _accepts_rollout_parallel_context(role_cls)
         tp_visible_device_map: Dict[int, List[str]] = {}
-        if is_tp_engine and any(rank_info.tp_size > 1 for rank_info in self.rank_infos):
+        if accepts_parallel_context and any(rank_info.tp_size > 1 for rank_info in self.rank_infos):
             node_ips = ray.get([worker.get_node_ip.remote() for worker in self.workers])
             cuda_visible_devices = ray.get([worker.get_cuda_visible_devices.remote() for worker in self.workers])
             tp_visible_device_map = _build_tp_visible_device_map(
@@ -436,20 +433,19 @@ class Handle:
         def _rank_init_kwargs(i: int) -> Dict[str, Any]:
             kwargs = dict(base_init_kwargs)
             ri = self.rank_infos[i]
-            if not is_tp_engine or (ri.tp_size <= 1 and ri.pp_size <= 1 and ri.ep_size <= 1):
+            if not accepts_parallel_context:
                 return kwargs
-            kwargs.update(
-                {
-                    "tp_rank": ri.tp_rank,
-                    "tp_size": ri.tp_size,
-                    "pp_rank": ri.pp_rank,
-                    "pp_size": ri.pp_size,
-                    "ep_rank": ri.ep_rank,
-                    "ep_size": ri.ep_size,
-                }
+            kwargs["rollout_parallel"] = RolloutParallelContext(
+                dp_rank=ri.dp_rank,
+                dp_size=ri.dp_size,
+                tp_rank=ri.tp_rank,
+                tp_size=ri.tp_size,
+                pp_rank=ri.pp_rank,
+                pp_size=ri.pp_size,
+                ep_rank=ri.ep_rank,
+                ep_size=ri.ep_size,
+                visible_devices=tuple(tp_visible_device_map.get(i, ())),
             )
-            if ri.tp_size > 1:
-                kwargs["tp_visible_devices"] = tp_visible_device_map[i]
             return kwargs
 
         ray.get(
@@ -500,12 +496,18 @@ class Handle:
 
     @property
     def tp_zero_workers(self) -> List[Any]:
-        """Worker actor handles that host a SGLang engine (tp_rank==0).
+        """Backward-compatible alias for :attr:`engine_launcher_workers`."""
+        return self.engine_launcher_workers
 
-        With rollout TP, one SGLang engine per TP group is hosted by its
-        tp_rank==0 worker; the others are no-op shells. Weight sync targets and
-        server-actor discovery must use this filtered list. ``tp_size==1``
-        returns every worker (identical to ``self.workers``)."""
+    @property
+    def engine_launcher_workers(self) -> List[Any]:
+        """Worker actors that launch one backend process tree (``tp_rank==0``).
+
+        With rollout TP, one engine per TP group is hosted by its launcher; the
+        remaining workers are no-op engine shells. Weight-sync targets and
+        server discovery must use this filtered list. For TP=1 this returns all
+        workers, identical to ``self.workers``.
+        """
         return [w for w, ri in zip(self.workers, self.rank_infos) if ri.tp_rank == 0]
 
     def initialize(self, *args, **kwargs) -> None:

--- a/unirl/distributed/group/parallelism.py
+++ b/unirl/distributed/group/parallelism.py
@@ -1,0 +1,44 @@
+"""Backend-neutral placement context for distributed rollout engines.
+
+``Handle`` owns the logical DP/TP/PP/EP layout and the physical GPU tokens.
+An engine that launches a multi-process runtime consumes this immutable value;
+it must not rediscover placement from global ranks or hard-coded device ids.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class RolloutParallelContext:
+    """One worker's coordinates and the device group owned by its engine.
+
+    Only ``tp_rank == 0`` launches the backend runtime for a TP group. The
+    remaining workers are SPMD shells: they still participate in trainer-side
+    collectives, while rollout dispatch/collect keeps the launcher's result.
+
+    ``visible_devices`` contains scheduler-issued CUDA tokens (ordinals, UUIDs,
+    or MIG ids), ordered by TP rank. It is intentionally empty for TP=1 so the
+    worker's existing Ray visibility remains authoritative.
+    """
+
+    dp_rank: int = 0
+    dp_size: int = 1
+    tp_rank: int = 0
+    tp_size: int = 1
+    pp_rank: int = 0
+    pp_size: int = 1
+    ep_rank: int = 0
+    ep_size: int = 1
+    visible_devices: Tuple[str, ...] = ()
+
+    @property
+    def is_engine_launcher(self) -> bool:
+        """Whether this worker owns the backend process tree for its TP group."""
+
+        return self.tp_rank == 0
+
+
+__all__ = ["RolloutParallelContext"]

--- a/unirl/distributed/weight_sync/README.md
+++ b/unirl/distributed/weight_sync/README.md
@@ -41,8 +41,9 @@ materialization.
   streams them in buckets.
 - **`sync()` is a train-mesh collective.** Extracting weights redistributes each
   FSDP `DTensor` shard to a full tensor — a collective every train rank must run —
-  so `sync()` is dispatched `BROADCAST`. Only the *push* is rank-0 (for NCCL and
-  Remote-LoRA); ranks ≥1 run the all-gather and discard.
+  so `sync()` is dispatched `BROADCAST`. Only the *push* is rank-0 for
+  separate-slab transports; colocated rollout TP pushes once from each TP group's
+  engine launcher. Other ranks run the all-gather and discard.
 - **Transports.** LoRA: `LocalLoraWeightSync` (colocate, in-process sibling) and
   `RemoteLoraWeightSync` (cross-slab rank-0 Ray push). Full: `NCCLWeightSync`
   (separate slabs, cross-node capable), `TensorWeightSync` (colocate serialized
@@ -63,7 +64,7 @@ matching receiver on the engine side (`../../rollout/engine/`).
 ## Gotchas
 
 - **`sync()` is a train-mesh collective** — the FSDP→full materialization runs on
-  *every* train rank; never gate it behind `if rank == 0`. Only the push is rank-0.
+  *every* train rank; never gate it behind `if rank == 0`. Only the push is filtered.
 - **`transfer_queue` is not weight sync** — that's the rollout→trainer data plane
   for bulky rollout outputs (segments, conditions, decoded media); weight sync is
   trainer→rollout. Don't conflate them.

--- a/unirl/distributed/weight_sync/full/nccl.py
+++ b/unirl/distributed/weight_sync/full/nccl.py
@@ -26,7 +26,7 @@ Driver wiring (in the trainer, once both slabs exist; engine workers alive)::
 
     addr, port = ws.pick_master()[0]
     tp = rollout.tp_size
-    targets = [w for w, ri in zip(rollout.workers, rollout.rank_infos) if ri.tp_rank == 0]
+    targets = rollout.engine_launcher_workers
     ws.set_rollout_targets(targets, rollout.role_name)
     ws.connect(master_addr=addr, master_port=port, num_rollout_gpus=len(targets)*tp, tp_size=tp)
     ...

--- a/unirl/distributed/weight_sync/lora/local.py
+++ b/unirl/distributed/weight_sync/lora/local.py
@@ -48,17 +48,51 @@ class LocalLoraWeightSync(LoraWeightSyncBase):
             track_prefix=track_prefix,
         )
         self._rollout = rollout
+        self._cached = None
+
+    def _is_engine_launcher(self) -> bool:
+        return self.rank_info is None or int(self.rank_info.tp_rank) == 0
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST)
+    def extract(self) -> None:
+        """Collectively extract LoRA; cache it on each rollout replica launcher."""
+
+        self._extract_to_cache()
+
+    @distributed(dispatch_mode=Dispatch.BROADCAST)
+    def push(self) -> None:
+        """Push the cached LoRA after the trainer has made room for rollout."""
+
+        self._push_from_cache()
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def sync(self) -> None:
         """Extract LoRA from the local FSDP model and load it into the engine.
 
         Runs on every Worker (``BROADCAST``); the extract is a train-mesh
-        collective that lines up because every rank runs together. The engine must
-        be awake (the caller wakes it before ``sync``); ``set_lora_from_tensors``
-        drops any existing adapter and loads the new one on every stage's workers.
+        collective that lines up because every rank runs together. Each TP group's
+        launcher keeps one CPU payload and pushes it to its sibling engine; shell
+        ranks discard theirs. The engine must be awake before the push.
         """
+        self._extract_to_cache()
+        self._push_from_cache()
+
+    def _extract_to_cache(self) -> None:
+        """Run the train-mesh collective and retain one CPU copy per TP group."""
+
         lora_tensors, peft_config = self._extract()
+        if self._is_engine_launcher():
+            self._cached = (lora_tensors, peft_config)
+
+    def _push_from_cache(self) -> None:
+        """Load the cached adapter into this launcher's sibling engine."""
+
+        if not self._is_engine_launcher():
+            return
+        if self._cached is None:
+            raise RuntimeError("LocalLoraWeightSync.push: call extract() (or sync()) first")
+        lora_tensors, peft_config = self._cached
+        self._cached = None
         self._rollout.set_lora_from_tensors(self._adapter_name, lora_tensors, peft_config=peft_config)
         rank = self.rank_info.rank if self.rank_info is not None else 0
         logger.info(

--- a/unirl/rollout/README.md
+++ b/unirl/rollout/README.md
@@ -63,6 +63,12 @@ wrong objective.
   ratio is 1 on the first update; *separate* — a dedicated engine on its own GPUs
   plus a `sync:` block; *colocate* — a dedicated engine sharing GPUs with train,
   plus offload/onload and `sync:`.
+- **Backend-neutral rollout TP.** SGLang and vLLM-Omni use the same
+  `RolloutParallelContext` supplied by the distributed `Handle`. `tp_size` declares
+  how many DevicePool workers one backend process tree owns; Handle derives the
+  remaining DP replicas, validates node-local placement, and passes scheduler GPU
+  tokens to the group launcher. Engine adapters and stage YAML describe model
+  execution, not physical cluster ownership.
 - **Driver-side async engines** (`engine/asynchronous.py`, the driver-side half next
   to `engine/synchronous.py`'s worker-side sync contracts). Both engines expose the
   same consumer verbs the async trainers program against: `poll` / `drain_freshest` /
@@ -78,7 +84,9 @@ wrong objective.
 `engine/<name>/engine.py` (subclass `SyncRolloutEngine`, implement
 synchronous generation over the whole-`Sample` contract — thread-safe for
 concurrent callers if it should serve as an agentic inner, else serialized
-internally — and dispatch `generate` with `DP_SCATTER`). A dedicated engine also
+internally — and dispatch `generate` with `DP_SCATTER`). A multi-GPU engine opts
+into the common parallel context rather than adding placement kwargs to Handle.
+A dedicated engine also
 implements its weight-receive method and a matching `sync:` handler in
 `../distributed/weight_sync`.
 

--- a/unirl/rollout/engine/sglang/engine.py
+++ b/unirl/rollout/engine/sglang/engine.py
@@ -28,6 +28,7 @@ import torch
 
 from unirl.config.require import require
 from unirl.distributed.group.dispatch import Dispatch, distributed
+from unirl.distributed.group.parallelism import RolloutParallelContext
 from unirl.rollout.engine.sglang.adapters import get_adapter
 from unirl.rollout.engine.sglang.backends import HTTPBackend, NativeBackend
 from unirl.rollout.engine.sglang.config import SGLangEngineConfig, SGLangPorts
@@ -44,7 +45,7 @@ class SGLangRolloutEngine(SyncRolloutEngine):
 
     _component_name = "sglang"
 
-    _accepts_rollout_tp_kwargs: bool = True
+    _accepts_rollout_parallel_context: bool = True
 
     def __init__(
         self,
@@ -55,14 +56,7 @@ class SGLangRolloutEngine(SyncRolloutEngine):
         rank: Optional[int] = None,
         model_config: Optional[Any] = None,
         ports: Optional[SGLangPorts] = None,
-        tp_rank: int = 0,
-        tp_size: int = 1,
-        tp_visible_devices: Optional[List[str]] = None,
-        tp_device_ids: Optional[List[int]] = None,
-        pp_rank: int = 0,
-        pp_size: int = 1,
-        ep_rank: int = 0,
-        ep_size: int = 1,
+        rollout_parallel: Optional[RolloutParallelContext] = None,
     ) -> None:
         require(
             isinstance(config, SGLangEngineConfig),
@@ -81,22 +75,27 @@ class SGLangRolloutEngine(SyncRolloutEngine):
         self._is_offloaded = False
         self._weights_onloaded_for_sync = False
 
-        self._tp_rank = int(tp_rank)
-        self._tp_size = int(tp_size)
-        self._pp_rank = int(pp_rank)
-        self._pp_size = int(pp_size)
-        self._ep_rank = int(ep_rank)
-        self._ep_size = int(ep_size)
-        if tp_visible_devices is not None and tp_device_ids is not None:
-            raise ValueError("set only one of tp_visible_devices or tp_device_ids")
-        if tp_visible_devices is not None:
-            self._tp_visible_devices = [str(token) for token in tp_visible_devices]
-        elif tp_device_ids is not None:
-            self._tp_visible_devices = [str(device_id) for device_id in tp_device_ids]
-        else:
-            self._tp_visible_devices = None
-        self._tp_device_ids = list(tp_device_ids) if tp_device_ids is not None else None
-        self._is_tp_zero = self._tp_rank == 0
+        self._parallel = rollout_parallel or RolloutParallelContext()
+        self._tp_rank = int(self._parallel.tp_rank)
+        self._tp_size = int(self._parallel.tp_size)
+        self._pp_rank = int(self._parallel.pp_rank)
+        self._pp_size = int(self._parallel.pp_size)
+        self._ep_rank = int(self._parallel.ep_rank)
+        self._ep_size = int(self._parallel.ep_size)
+        self._tp_visible_devices = list(self._parallel.visible_devices) or None
+        self._is_tp_zero = self._parallel.is_engine_launcher
+        expected_shape = (
+            int(config.tp_size or 1),
+            int(config.pp_size or 1),
+            int(config.ep_size or 1),
+        )
+        assigned_shape = (self._tp_size, self._pp_size, self._ep_size)
+        require(
+            expected_shape == assigned_shape,
+            "SGLangRolloutEngine placement mismatch: config declares "
+            f"(tp, pp, ep)={expected_shape}, but Handle assigned {assigned_shape}. "
+            "Construct parallel engines through a rollout Handle so DevicePool owns placement.",
+        )
 
         if not self._is_tp_zero:
             self.adapter = None

--- a/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py
@@ -477,7 +477,6 @@ class Qwen3OmniThinkerAdapter(ModelAdapter):
     needs_sigmas = False
     needs_driver_tokenizer = False
     ar_lora_passthrough = True
-    clear_cuda_visible = True
     lora_copy_transport = True
 
     def __init__(
@@ -489,6 +488,11 @@ class Qwen3OmniThinkerAdapter(ModelAdapter):
         tokenize_fn: Any = None,
     ) -> None:
         super().__init__(config, model_config, strategy=strategy, tokenize_fn=tokenize_fn)
+        require(
+            getattr(config, "tp_size", None) is not None,
+            "Qwen3OmniThinkerAdapter requires an explicit config.tp_size so Handle/DevicePool "
+            "owns the GPUs referenced by the stage YAML.",
+        )
 
         mc = model_config
         model_path = str(config.model_path)

--- a/unirl/rollout/engine/vllm_omni/backends/native.py
+++ b/unirl/rollout/engine/vllm_omni/backends/native.py
@@ -11,9 +11,10 @@ Boot sequence (load-bearing order — see each step's note):
    ``mp.Process`` wrap that re-installs them inside every spawn child.
 2. ``mp.set_start_method("spawn", force=True)`` — before any Omni mp object
    exists (fork-context SemLocks can't cross into spawn workers).
-3. ``CUDA_VISIBLE_DEVICES`` pop when the adapter's boot intent asks for it
-   (HI3 multi-GPU stages; the documented last-resort env override — vllm-omni
-   reads CVD for per-stage device pinning and has no arg for it).
+3. Apply a spawn-scoped ``CUDA_VISIBLE_DEVICES`` policy. Handle-owned rollout
+   TP supplies one scheduler-approved device group; legacy HI3 adapters may
+   still request an unscoped view. The Worker environment is restored after
+   the runtime has spawned.
 4. ``Omni(...)`` with the PRISTINE packaged stage YAML + ctor kwargs —
    ``enable_sleep_mode`` / ``master_port`` ride the runtime's own override
    channel (the ``base_engine_args`` merge + the dedicated sleep-mode
@@ -34,6 +35,7 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import contextmanager
 from pprint import pformat
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -157,6 +159,41 @@ def _assemble_omni_kwargs(intent: Dict[str, Any]) -> Dict[str, Any]:
     return omni_kwargs
 
 
+@contextmanager
+def _spawn_device_visibility(intent: Dict[str, Any]):
+    """Apply boot-only CUDA visibility and restore the Worker environment.
+
+    vLLM-Omni v0.20.0 interprets stage-YAML device ids as logical indices into
+    the current ``CUDA_VISIBLE_DEVICES`` list. A rollout TP group therefore
+    passes DevicePool/Ray-issued tokens here; clearing CVD would escape the
+    scheduler allocation and let independent replicas overlap physical GPUs.
+    """
+
+    requested = intent.get("cuda_visible_devices")
+    clear = bool(intent.get("clear_cuda_visible")) and requested is None
+    if requested is None and not clear:
+        yield
+        return
+
+    existed = "CUDA_VISIBLE_DEVICES" in os.environ
+    previous = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if requested is not None:
+        tokens = [str(token).strip() for token in requested if str(token).strip()]
+        if not tokens:
+            raise ValueError("cuda_visible_devices must contain at least one scheduler device token")
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(tokens)
+    else:
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
+    try:
+        yield
+    finally:
+        if existed:
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(previous)
+        else:
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
+
 class VLLMOmniBackend:
     """The native ``Backend`` impl over the ``Omni`` orchestrator."""
 
@@ -197,9 +234,6 @@ class VLLMOmniBackend:
 
         rt = _import_omni_runtime()
 
-        if intent.get("clear_cuda_visible"):
-            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-
         import fcntl
 
         # Release the trainer CUDA cache before spawning the engine process.
@@ -231,11 +265,12 @@ class VLLMOmniBackend:
             try:
                 if lock_file is not None:
                     fcntl.flock(lock_file, fcntl.LOCK_EX)
-                omni = rt["Omni"](
-                    model=str(intent["model_path"]),
-                    stage_configs_path=yaml_path,
-                    **omni_kwargs,
-                )
+                with _spawn_device_visibility(intent):
+                    omni = rt["Omni"](
+                        model=str(intent["model_path"]),
+                        stage_configs_path=yaml_path,
+                        **omni_kwargs,
+                    )
             finally:
                 if lock_file is not None:
                     fcntl.flock(lock_file, fcntl.LOCK_UN)

--- a/unirl/rollout/engine/vllm_omni/config.py
+++ b/unirl/rollout/engine/vllm_omni/config.py
@@ -61,6 +61,11 @@ class VLLMOmniEngineConfig(BaseEngineConfig):
     model_path: str = MISSING
     modality: str = "hi3_t2i"
 
+    # Physical devices allocated to one Omni orchestrator. Handle derives the
+    # number of DP replicas as world_size // tp_size; stage YAML device ids stay
+    # logical within each replica's visible-device group.
+    tp_size: Optional[int] = None
+
     enable_sleep_mode: bool = True
 
     stage_yaml_override: Optional[str] = None
@@ -75,6 +80,10 @@ class VLLMOmniEngineConfig(BaseEngineConfig):
 
     def __post_init__(self) -> None:
         self.modality = str(self.modality or "").strip().lower()
+        require(
+            self.tp_size is None or int(self.tp_size) >= 1,
+            f"VLLMOmniEngineConfig.tp_size must be >= 1 when set; got {self.tp_size!r}",
+        )
         from unirl.rollout.engine.vllm_omni.adapters import registered_adapters
 
         valid = registered_adapters()

--- a/unirl/rollout/engine/vllm_omni/engine.py
+++ b/unirl/rollout/engine/vllm_omni/engine.py
@@ -31,6 +31,7 @@ import torch
 
 from unirl.config.require import require
 from unirl.distributed.group.dispatch import Dispatch, distributed
+from unirl.distributed.group.parallelism import RolloutParallelContext
 from unirl.rollout.engine.synchronous import SyncRolloutEngine
 from unirl.rollout.engine.vllm_omni.adapters import get_adapter
 from unirl.rollout.engine.vllm_omni.backends import VLLMOmniBackend
@@ -46,6 +47,7 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
     """Rollout engine backed by vllm-omni's ``Omni`` orchestrator (v2 layout)."""
 
     _component_name = "vllm_omni"
+    _accepts_rollout_parallel_context: bool = True
 
     def __init__(
         self,
@@ -56,8 +58,11 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         rank: Optional[int] = None,
         model_config: Any = None,
         ports: Optional[VLLMOmniPorts] = None,
+        rollout_parallel: Optional[RolloutParallelContext] = None,
     ) -> None:
         self.cfg = config
+        self._parallel = rollout_parallel or RolloutParallelContext()
+        self._is_engine_launcher = self._parallel.is_engine_launcher
         self._weight_version = 0
         self._generate_lock = threading.Lock()
         self._shutdown_lock = threading.Lock()
@@ -68,12 +73,34 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         self.rank = rank
         self.model_config = model_config
         self._is_offloaded = False
+        self.adapter = None
+        self.schedule_policy = None
+        self._backend = None
+        self._weight_sync = None
         logger.info(
-            "VLLM-Omni engine config (complete typed config): %s; model_config_available=%s model_config=%s",
+            "VLLM-Omni engine config: %s; rollout_parallel=%s; model_config_available=%s model_config=%s",
             config,
+            self._parallel,
             model_config is not None,
             model_config,
         )
+
+        expected_group_size = int(config.tp_size or 1)
+        require(
+            expected_group_size == int(self._parallel.tp_size),
+            "VLLMOmniRolloutEngine placement mismatch: config.tp_size declares "
+            f"{expected_group_size}, but Handle assigned tp_size={self._parallel.tp_size}. "
+            "Construct TP engines through a rollout Handle so DevicePool owns placement.",
+        )
+        if not self._is_engine_launcher:
+            logger.info(
+                "VLLMOmniRolloutEngine: tp_rank=%d/%d is a no-op shell (rank=%s); "
+                "Omni orchestrator hosted by tp_rank=0 of this TP group",
+                self._parallel.tp_rank,
+                self._parallel.tp_size,
+                rank,
+            )
+            return
 
         self.adapter = get_adapter(config.modality)(
             config, model_config, strategy=strategy, tokenize_fn=self._tokenize_prompt
@@ -89,7 +116,21 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
             ports=ports,
             extra=self.adapter.boot_kwargs(),
         )
+        if self._parallel.visible_devices:
+            intent["cuda_visible_devices"] = list(self._parallel.visible_devices)
         self._backend = VLLMOmniBackend.boot(intent)
+
+        stage_tp = self._backend.tp_per_stage()
+        if config.tp_size is not None:
+            try:
+                require(
+                    bool(stage_tp) and max(stage_tp.values()) == expected_group_size,
+                    "VLLMOmniRolloutEngine TP declaration does not match the resolved "
+                    f"stage topology: config.tp_size={expected_group_size}, tp_per_stage={stage_tp}",
+                )
+            except BaseException:
+                self._backend.shutdown()
+                raise
 
         self._weight_sync = WeightSync(
             self._backend,
@@ -104,6 +145,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
     def generate(self, sample: Sample) -> Sample:
         """Generate one whole DP shard synchronously."""
+        if not self._is_engine_launcher:
+            return None
         return self._generate_locked(sample)
 
     def _generate_locked(self, sample: Sample) -> Sample:
@@ -141,6 +184,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def sleep(self) -> None:
         """Fan ``handle_sleep_task`` to every stage's workers (level 2)."""
+        if not self._is_engine_launcher:
+            return
         if self._is_offloaded:
             return
         self._backend.sleep_task()
@@ -150,6 +195,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def wake_up(self) -> None:
         """Fan ``handle_wake_task`` to every stage's workers + restore LoRA."""
+        if not self._is_engine_launcher:
+            return
         if not self._is_offloaded:
             return
         if torch.cuda.is_available():
@@ -167,10 +214,14 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         return bool(self._is_offloaded)
 
     def health_check(self) -> bool:
+        if not self._is_engine_launcher:
+            return True
         return self._backend.ping()
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def shutdown(self) -> None:
+        if not self._is_engine_launcher:
+            return
         shutdown_lock = getattr(self, "_shutdown_lock", None)
         if shutdown_lock is None:
             backend = getattr(self, "_backend", None)
@@ -201,6 +252,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         """``{stage_id: tensor_parallel_size}`` per stage (parsed from the
         stage YAML at boot). The IPC weight-sync handler needs this to skip
         orphan train ranks that exceed a stage's TP size."""
+        if not self._is_engine_launcher:
+            return {}
         return self._backend.tp_per_stage()
 
     def update_weights_from_ipc(
@@ -213,6 +266,10 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         track_prefix: str = "",
     ) -> None:
         del track_prefix
+        if not self._is_engine_launcher:
+            return
+        if replica_rank is None:
+            replica_rank = int(self._parallel.dp_rank)
         self._weight_sync.update_weights_from_ipc(
             peft_config=peft_config,
             base_sync_done=base_sync_done,
@@ -233,6 +290,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         track_prefix: str = "",
     ) -> None:
         del track_prefix
+        if not self._is_engine_launcher:
+            return
         self._weight_sync.init_weights_update_group(
             master_address=master_address,
             master_port=master_port,
@@ -254,6 +313,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         track_prefix: str = "",
     ) -> None:
         del track_prefix
+        if not self._is_engine_launcher:
+            return
         self._weight_sync.update_weights_from_distributed(
             names=names,
             dtypes=dtypes,
@@ -271,6 +332,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         track_prefix: str = "",
     ) -> None:
         del track_prefix
+        if not self._is_engine_launcher:
+            return
         self._weight_sync.destroy_weights_update_group(group_name=group_name)
 
     def update_weights_from_tensor(
@@ -283,6 +346,8 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         track_prefix: str = "",
     ) -> None:
         del track_prefix
+        if not self._is_engine_launcher:
+            return
         self._weight_sync.update_weights_from_tensor(
             serialized_named_tensors=serialized_named_tensors,
             target_modules=target_modules,
@@ -298,7 +363,12 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         *,
         peft_config: Optional[dict] = None,
     ) -> None:
-        self._weight_sync.set_lora_from_tensors(adapter_name, lora_tensors, peft_config=peft_config)
+        if not self._is_engine_launcher:
+            return
+        if self.adapter.lora_copy_transport:
+            self._weight_sync.set_lora_from_tensors_copy(adapter_name, lora_tensors, peft_config=peft_config)
+        else:
+            self._weight_sync.set_lora_from_tensors(adapter_name, lora_tensors, peft_config=peft_config)
 
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def set_lora_from_tensors_copy(
@@ -314,17 +384,25 @@ class VLLMOmniRolloutEngine(SyncRolloutEngine):
         ``RemoteLoraWeightSync(copy=True)`` reaches the disjoint-partition HI3
         engines through this entry point.
         """
+        if not self._is_engine_launcher:
+            return
         self._weight_sync.set_lora_from_tensors_copy(adapter_name, lora_tensors, peft_config=peft_config)
 
     def loaded_param_checksums(self, *, names: List[str]) -> dict:
+        if not self._is_engine_launcher:
+            return {}
         return self._weight_sync.loaded_param_checksums(names=names)
 
     def loaded_lora_checksums(self, *, adapter_id: int, names: Optional[List[str]] = None) -> dict:
+        if not self._is_engine_launcher:
+            return {}
         return self._weight_sync.loaded_lora_checksums(adapter_id=adapter_id, names=names)
 
     @property
     def lora_dirty(self) -> bool:
         """True when LoRA is in use but the adapter must be (re)pushed."""
+        if not self._is_engine_launcher:
+            return False
         return self._weight_sync.lora_dirty
 
 

--- a/unirl/rollout/engine/vllm_omni/patches/runtime.py
+++ b/unirl/rollout/engine/vllm_omni/patches/runtime.py
@@ -65,7 +65,7 @@ def install_fate_sharing(anchor_pid: int, *, arm_pdeathsig: bool) -> None:
     """Bind this process's lifetime to the root of its spawn chain.
 
     Without this the engine subprocess tree outlives the run. Measured on the
-    Qwen3-Omni anchored TP=4 topology: ``kill -TERM`` on the driver takes down
+    Qwen3-Omni TP=4 rollout topology: ``kill -TERM`` on the driver takes down
     the driver, the Ray actors and ``StageEngineCoreProc``, but the four
     ``Worker_TP*`` processes reparent to init and sit there holding ~7.3 GiB of
     device memory each until reaped by hand.

--- a/unirl/train_ar.py
+++ b/unirl/train_ar.py
@@ -55,7 +55,6 @@ def main(cfg: DictConfig) -> None:
             eval_batch_size=cfg.get("eval_batch_size", 8),
             eval_samples_per_prompt=cfg.get("eval_samples_per_prompt", 16),
             eval_temperature=cfg.get("eval_temperature", 1.0),
-            rollout_anchor_device=cfg.get("rollout_anchor_device", None),
             enable_fsdp_offload=cfg.get("enable_fsdp_offload", True),
         )
         guard.claim_signals()

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -2,8 +2,7 @@ import inspect
 import logging
 import math
 import time
-from contextlib import contextmanager, nullcontext
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 from hydra.utils import instantiate
@@ -64,7 +63,6 @@ class ARTrainer(BaseTrainer):
         eval_batch_size: int = 8,
         eval_samples_per_prompt: int = 16,
         eval_temperature: float = 1.0,
-        rollout_anchor_device: Optional[int] = None,
         enable_fsdp_offload: bool = True,
     ) -> None:
         validate_qwen3_5_training_contract(
@@ -88,12 +86,7 @@ class ARTrainer(BaseTrainer):
         self.eval_samples_per_prompt = int(eval_samples_per_prompt)
         self.eval_temperature = float(eval_temperature)
 
-        self._rollout_anchor_device: Optional[int] = (
-            int(rollout_anchor_device) if rollout_anchor_device is not None else None
-        )
         self._enable_fsdp_offload = bool(enable_fsdp_offload)
-        self._anchored_backend_offloaded: Optional[bool] = False
-        self._anchored_rollout_awake: Optional[bool] = None
 
         self.data_source = instantiate(data_source_cfg)
 
@@ -101,6 +94,7 @@ class ARTrainer(BaseTrainer):
 
         self.weight_sync = None
         self._supports_staged_wake = False
+        self._supports_split_sync = False
 
         with placement(self.pool, fraction=1.0, shared_workers=True):
             self.bundle = remote_hydra(bundle_cfg)
@@ -112,177 +106,57 @@ class ARTrainer(BaseTrainer):
             self.stack = remote_hydra(stack_cfg, fsdp_backend=self.backend, algorithm=self.algorithm)
 
             rollout_parsed = parse_hydra_cfg(rollout_cfg)
-            if self._rollout_anchor_device is None:
-                self._supports_staged_wake = "tags" in inspect.signature(rollout_parsed["role_cls"].wake_up).parameters
-                bootstrap_offload = sync_cfg is not None and self._enable_fsdp_offload
-                bootstrap_offloaded = False
-                rollout_boot_started = False
-                rollout_constructed = False
-                rollout_sleep_attempted = False
-                rollout_memory_released = False
-                try:
-                    if bootstrap_offload:
-                        try:
-                            self.backend.offload()
-                            bootstrap_offloaded = True
-                        except BaseException:
-                            self.backend.onload()
-                            raise
-
-                    rollout_boot_started = True
-                    if "pipeline" in inspect.signature(rollout_parsed["role_cls"]).parameters:
-                        self.rollout = remote(**rollout_parsed, pipeline=self.pipeline)
-                    else:
-                        self.rollout = remote(**rollout_parsed)
-                    rollout_constructed = True
-                    if sync_cfg is not None:
-                        self.weight_sync = remote_hydra(sync_cfg, backend=self.backend, rollout=self.rollout)
-
-                    if self.weight_sync is not None:
-                        rollout_sleep_attempted = True
-                        self.rollout.sleep()
-                        rollout_memory_released = True
-                    if bootstrap_offloaded:
+            self._supports_staged_wake = "tags" in inspect.signature(rollout_parsed["role_cls"].wake_up).parameters
+            bootstrap_offload = sync_cfg is not None and self._enable_fsdp_offload
+            bootstrap_offloaded = False
+            rollout_boot_started = False
+            rollout_constructed = False
+            rollout_sleep_attempted = False
+            rollout_memory_released = False
+            try:
+                if bootstrap_offload:
+                    try:
+                        self.backend.offload()
+                        bootstrap_offloaded = True
+                    except BaseException:
                         self.backend.onload()
-                except BaseException:
-                    if bootstrap_offloaded and not rollout_boot_started:
-                        self.backend.onload()
-                    elif bootstrap_offloaded and rollout_constructed and not rollout_sleep_attempted:
-                        try:
-                            self.rollout.sleep()
-                        except BaseException:
-                            logger.exception("Failed to release rollout memory after bootstrap failure")
-                        else:
-                            self.backend.onload()
-                    elif bootstrap_offloaded and rollout_memory_released:
-                        pass
-                    raise
-            else:
-                if sync_cfg is not None and self._rollout_anchor_device == 0:
-                    raise ValueError(
-                        "rollout_anchor_device=0 would colocate the TP engine with "
-                        "the rank-0 RemoteLoraWeightSync sender and self-deadlock; "
-                        "use a nonzero anchor device."
-                    )
-                if self._enable_fsdp_offload:
-                    self._anchored_backend_offloaded = None
-                    self.backend.offload()
-                    self._anchored_backend_offloaded = True
+                        raise
 
-                role_cls = rollout_parsed.pop("role_cls")
-                self.rollout = self.pool.create_remote(
-                    role_cls,
-                    device_ids=[self._rollout_anchor_device],
-                    init_kwargs=rollout_parsed,
-                )
-                self._anchored_rollout_awake = None
-                if self._enable_fsdp_offload:
-                    self.rollout.sleep()
-                    self._anchored_rollout_awake = False
+                rollout_boot_started = True
+                if "pipeline" in inspect.signature(rollout_parsed["role_cls"]).parameters:
+                    self.rollout = remote(**rollout_parsed, pipeline=self.pipeline)
                 else:
-                    self._anchored_rollout_awake = True
-
+                    self.rollout = remote(**rollout_parsed)
+                rollout_constructed = True
                 if sync_cfg is not None:
-                    self.weight_sync = remote_hydra(sync_cfg, backend=self.backend)
-                    self.weight_sync.set_rollout_targets([(self.rollout.role_name, self.rollout.workers)])
+                    self.weight_sync = remote_hydra(sync_cfg, backend=self.backend, rollout=self.rollout)
+                    self._supports_split_sync = all(hasattr(self.weight_sync, method) for method in ("extract", "push"))
 
-    def _ensure_anchored_backend_loaded(self) -> None:
-        if not self._enable_fsdp_offload or self._anchored_backend_offloaded is False:
-            return
-        self._anchored_backend_offloaded = None
-        self.backend.onload()
-        self._anchored_backend_offloaded = False
-
-    def _ensure_anchored_backend_offloaded(self) -> None:
-        if not self._enable_fsdp_offload or self._anchored_backend_offloaded is True:
-            return
-        self._anchored_backend_offloaded = None
-        self.backend.offload()
-        self._anchored_backend_offloaded = True
-
-    def _ensure_anchored_rollout_awake(self) -> None:
-        if not self._enable_fsdp_offload:
-            return
-        if self._anchored_rollout_awake is True:
-            return
-        self._anchored_rollout_awake = None
-        self.rollout.wake_up()
-        self._anchored_rollout_awake = True
-
-    def _ensure_anchored_rollout_asleep(self) -> None:
-        if not self._enable_fsdp_offload:
-            return  # resident colocate: never sleep the engine
-        if self._anchored_rollout_awake is False:
-            return
-        self._anchored_rollout_awake = None
-        self.rollout.sleep()
-        self._anchored_rollout_awake = False
-
-    @contextmanager
-    def _anchored_rollout_session(
-        self,
-        *,
-        sync_weights: bool,
-        restore_backend: bool = True,
-    ) -> Iterator[None]:
-        """Run one anchored rollout phase and restore the requested steady state.
-
-        ``enable_fsdp_offload`` controls the trainer's *manual* placement dance;
-        it is independent from FSDP's ``CPUOffloadPolicy`` (``fsdp_cfg.cpu_offload``).
-        Callers doing a backward pass request ``restore_backend=True``. Eval and
-        pre-backward reward processing keep the backend offloaded so only the
-        vLLM subprocess owns GPU memory.
-        """
-        original_error: Optional[BaseException] = None
-        try:
-            if sync_weights and self.weight_sync is not None:
-                self._ensure_anchored_backend_loaded()
-                self.weight_sync.extract()
-            self._ensure_anchored_backend_offloaded()
-            self._ensure_anchored_rollout_awake()
-            if sync_weights and self.weight_sync is not None:
-                self.weight_sync.push()
-            yield
-        except BaseException as exc:
-            original_error = exc
-            raise
-        finally:
-            cleanup_errors: list[tuple[str, BaseException]] = []
-            cleanup_ops = [("sleep rollout", self._ensure_anchored_rollout_asleep)]
-            if restore_backend:
-                cleanup_ops.append(("onload backend", self._ensure_anchored_backend_loaded))
-            for operation, cleanup in cleanup_ops:
-                try:
-                    cleanup()
-                except BaseException as exc:
-                    cleanup_errors.append((operation, exc))
-
-            if cleanup_errors:
-                if original_error is not None:
-                    for operation, cleanup_error in cleanup_errors:
-                        original_error.add_note(
-                            f"anchored cleanup failed while trying to {operation}: {cleanup_error!r}"
-                        )
-                        logger.error(
-                            "Anchored cleanup failed while trying to %s",
-                            operation,
-                            exc_info=(type(cleanup_error), cleanup_error, cleanup_error.__traceback__),
-                        )
-                else:
-                    operation, cleanup_error = cleanup_errors[0]
-                    for later_operation, later_error in cleanup_errors[1:]:
-                        cleanup_error.add_note(
-                            f"additional anchored cleanup failure while trying to {later_operation}: {later_error!r}"
-                        )
-                    cleanup_error.add_note(f"anchored cleanup operation: {operation}")
-                    raise cleanup_error
+                if self.weight_sync is not None:
+                    rollout_sleep_attempted = True
+                    self.rollout.sleep()
+                    rollout_memory_released = True
+                if bootstrap_offloaded:
+                    self.backend.onload()
+            except BaseException:
+                if bootstrap_offloaded and not rollout_boot_started:
+                    self.backend.onload()
+                elif bootstrap_offloaded and rollout_constructed and not rollout_sleep_attempted:
+                    try:
+                        self.rollout.sleep()
+                    except BaseException:
+                        logger.exception("Failed to release rollout memory after bootstrap failure")
+                    else:
+                        self.backend.onload()
+                elif bootstrap_offloaded and rollout_memory_released:
+                    pass
+                raise
 
     def _prepare_rollout(self, *, sync_weights: bool) -> bool:
         """Wake/sync the SPMD rollout and optionally offload train state.
 
         Returns whether the train state was offloaded and must be restored by
-        :meth:`_finish_rollout`. Anchored rollout uses
-        :meth:`_anchored_rollout_session` instead.
+        :meth:`_finish_rollout`.
         """
         do_offload = self._enable_fsdp_offload and self.weight_sync is not None
         do_sync = sync_weights and self.weight_sync is not None
@@ -298,6 +172,18 @@ class ARTrainer(BaseTrainer):
                 full_wake_after_train_offload_in_progress = True
                 self.rollout.wake_up()
                 full_wake_after_train_offload_in_progress = False
+            elif do_sync and do_offload and self._supports_split_sync:
+                # Runtimes without staged wake (notably vLLM-Omni) cannot have
+                # both the full FSDP model and the rollout engine resident while
+                # state_dict extraction runs. Split transport from extraction:
+                # gather to CPU, offload train, wake rollout, then push.
+                self.weight_sync.extract()
+                train_state_maybe_offloaded = True
+                self.backend.offload()
+                full_wake_after_train_offload_in_progress = True
+                self.rollout.wake_up()
+                full_wake_after_train_offload_in_progress = False
+                self.weight_sync.push()
             elif do_sync:
                 self.rollout.wake_up()
                 self.weight_sync.sync()
@@ -368,19 +254,11 @@ class ARTrainer(BaseTrainer):
         line. ``rollout_id`` only keys the wandb panels (see :meth:`UniRLWandBLogger.log_rollout_step`).
         """
         t0 = time.perf_counter()
-        anchored = self._rollout_anchor_device is not None
-        if not anchored:
-            train_state_offloaded = self._prepare_rollout(sync_weights=sync_weights)
-            try:
-                sample = self.rollout.generate(sample)
-            finally:
-                self._finish_rollout(train_state_offloaded=train_state_offloaded)
-        else:
-            with self._anchored_rollout_session(sync_weights=sync_weights, restore_backend=False):
-                sample = self.rollout.generate(sample)
-                from unirl.trainer.unified_model import deep_hydrate
-
-                sample = deep_hydrate(sample)
+        train_state_offloaded = self._prepare_rollout(sync_weights=sync_weights)
+        try:
+            sample = self.rollout.generate(sample)
+        finally:
+            self._finish_rollout(train_state_offloaded=train_state_offloaded)
 
         sample = self.reward.score_and_attach(sample)
 
@@ -403,13 +281,7 @@ class ARTrainer(BaseTrainer):
         train_part = sample.parts[-1]
         if self.balance_shards:
             train_part = train_part.balance_shards(int(self.num_devices))
-        if anchored:
-            self._ensure_anchored_backend_loaded()
-        try:
-            result = self.stack.train_track(train_part, training_progress=float(training_progress))
-        finally:
-            if anchored:
-                self._ensure_anchored_backend_offloaded()
+        result = self.stack.train_track(train_part, training_progress=float(training_progress))
         self.wandb_logger.log_rollout_step(
             rollout_id,
             result,
@@ -449,68 +321,47 @@ class ARTrainer(BaseTrainer):
         )
         reward_sum, reward_n, prompt_n, batch_n = 0.0, 0, 0, 0
 
-        anchored = self._rollout_anchor_device is not None
-
         logger.info(
-            "EVAL rollout %d starting: max_prompts=%s batch_size=%d samples_per_prompt=%d temperature=%s anchored=%s",
+            "EVAL rollout %d starting: max_prompts=%s batch_size=%d samples_per_prompt=%d temperature=%s",
             rollout_id + 1,
             "all" if self.eval_num_prompts < 0 else self.eval_num_prompts,
             self.eval_batch_size,
             self.eval_samples_per_prompt,
             self.eval_temperature,
-            anchored,
         )
-        train_state_offloaded = False
-        if not anchored:
-            train_state_offloaded = self._prepare_rollout(sync_weights=self.weight_sync is not None)
-        eval_session = (
-            self._anchored_rollout_session(
-                sync_weights=self.weight_sync is not None,
-                restore_backend=False,
-            )
-            if anchored
-            else nullcontext()
-        )
+        train_state_offloaded = self._prepare_rollout(sync_weights=self.weight_sync is not None)
         try:
-            with eval_session:
-                for eval_inputs in eval_batches:
-                    batch_n += 1
-                    real_prompt_n = eval_inputs.batch_size
-                    prompt_n += real_prompt_n
-                    dispatch_inputs = self._pad_eval_inputs(eval_inputs)
-                    sample = self._build_request_sample(dispatch_inputs, rollout_id, sampling=eval_sp)
-                    if anchored:
-                        generated = self.rollout.generate(sample)
-                        from unirl.trainer.unified_model import deep_hydrate
-
-                        generated = deep_hydrate(generated)
-                    else:
-                        generated = self.rollout.generate(sample)
-                    scored = self.reward.score_and_attach(generated)
-                    rewards = scored.parts[-1].rewards
-                    if rewards is not None:
-                        rewards = hydrate(rewards).to(torch.float32)
-                        fanout = total_samples_per_prompt(eval_sp)
-                        expected_total = dispatch_inputs.batch_size * fanout
-                        if int(rewards.numel()) != expected_total:
-                            raise RuntimeError(
-                                f"ARTrainer.evaluate: reward count {int(rewards.numel())} != "
-                                f"dispatch prompts {dispatch_inputs.batch_size} * fanout {fanout} "
-                                f"({expected_total})."
-                            )
-                        rewards = rewards[: real_prompt_n * fanout]
-                        reward_sum += float(rewards.sum().item())
-                        reward_n += int(rewards.numel())
-                    logger.info(
-                        "EVAL rollout %d progress: batch=%d prompts=%d samples=%d",
-                        rollout_id + 1,
-                        batch_n,
-                        prompt_n,
-                        reward_n,
-                    )
+            for eval_inputs in eval_batches:
+                batch_n += 1
+                real_prompt_n = eval_inputs.batch_size
+                prompt_n += real_prompt_n
+                dispatch_inputs = self._pad_eval_inputs(eval_inputs)
+                sample = self._build_request_sample(dispatch_inputs, rollout_id, sampling=eval_sp)
+                generated = self.rollout.generate(sample)
+                scored = self.reward.score_and_attach(generated)
+                rewards = scored.parts[-1].rewards
+                if rewards is not None:
+                    rewards = hydrate(rewards).to(torch.float32)
+                    fanout = total_samples_per_prompt(eval_sp)
+                    expected_total = dispatch_inputs.batch_size * fanout
+                    if int(rewards.numel()) != expected_total:
+                        raise RuntimeError(
+                            f"ARTrainer.evaluate: reward count {int(rewards.numel())} != "
+                            f"dispatch prompts {dispatch_inputs.batch_size} * fanout {fanout} "
+                            f"({expected_total})."
+                        )
+                    rewards = rewards[: real_prompt_n * fanout]
+                    reward_sum += float(rewards.sum().item())
+                    reward_n += int(rewards.numel())
+                logger.info(
+                    "EVAL rollout %d progress: batch=%d prompts=%d samples=%d",
+                    rollout_id + 1,
+                    batch_n,
+                    prompt_n,
+                    reward_n,
+                )
         finally:
-            if not anchored:
-                self._finish_rollout(train_state_offloaded=train_state_offloaded)
+            self._finish_rollout(train_state_offloaded=train_state_offloaded)
 
         acc = reward_sum / max(1, reward_n)
         logger.info(

--- a/unirl/trainer/async_ar.py
+++ b/unirl/trainer/async_ar.py
@@ -209,7 +209,7 @@ class AsyncARTrainer(ARTrainer):
         addr, port = self.weight_sync.pick_master()[0]
         tp_size = self.rollout.tp_size
         pp_size = self.rollout.pp_size
-        targets = self.rollout.tp_zero_workers
+        targets = self.rollout.engine_launcher_workers
         self.weight_sync.set_rollout_targets(targets, self.rollout.role_name)
         self.weight_sync.connect(
             master_addr=addr,

--- a/unirl/utils/graceful_shutdown.py
+++ b/unirl/utils/graceful_shutdown.py
@@ -2,7 +2,7 @@
 
 A training driver that dies on an unhandled ``SIGTERM`` never runs its
 ``finally`` blocks, so the rollout engine's subprocess tree is never asked to
-shut down. On the anchored vLLM-Omni topology that stranded four ``Worker_TP``
+shut down. On a vLLM-Omni TP=4 rollout group that stranded four ``Worker_TP``
 processes holding ~7.3 GiB of device memory each until they were reaped by
 hand.
 


### PR DESCRIPTION
## Summary

- promote rollout TP placement from SGLang-specific constructor kwargs into a backend-neutral `RolloutParallelContext` owned by `DevicePool` / `Handle`; Handle derives DP replicas, validates node-local TP groups, and carries Ray-issued CUDA tokens
- migrate SGLang to the shared context and add vLLM-Omni support with one backend launcher per TP group, no-op collective shells, spawn-scoped device visibility, and resolved stage-TP validation
- remove synchronous `ARTrainer`'s separate `rollout_anchor_device` lifecycle; split colocated LoRA extract/push around train offload through the standard lifecycle and migrate the four Qwen3-Omni 1x4/1x8 recipes (8 GPU now means DP=2 x TP=4)

## Related Issue

Refs #217 and #222. Builds on the SGLang topology merged in #226; this PR does not close the broader SGLang TP/EP and weight-sync RFC.

## Test Plan

- `python3 -m py_compile unirl/distributed/group/parallelism.py unirl/distributed/group/handle.py unirl/distributed/weight_sync/lora/local.py unirl/rollout/engine/sglang/engine.py unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py unirl/rollout/engine/vllm_omni/backends/native.py unirl/rollout/engine/vllm_omni/config.py unirl/rollout/engine/vllm_omni/engine.py unirl/train_ar.py unirl/trainer/ar.py unirl/trainer/async_ar.py`
- `pre-commit run --files <all 21 changed files>` (YAML, AST, Ruff, recipe target resolution, and experimental-boundary hooks passed)
- `git diff --check`
- one-off, uncommitted CPU harness (repository policy excludes a committed `tests/` tree): executed the exact AST-extracted Handle topology/device-map functions for world=8, TP=4, DP=2; checked cross-node rejection, HandleRef inheritance, CVD scope/restoration including exception cleanup, and parsed all four migrated recipes (`rollout TP harness: OK`)
- Not run: GPU rollout/training smoke. Target validation is Qwen3-Omni-30B-A3B-Instruct with the migrated video and audio-video recipes on 4 GPUs (DP=1 x TP=4) and 8 GPUs (DP=2 x TP=4); the checkpoint, datasets, and target GPU allocation are not available in this environment. Keep draft until this evidence is attached.

## Compatibility / Risk

- `ARTrainer.rollout_anchor_device` is removed. Qwen3-Omni vLLM-Omni recipes must declare `rollout.config.tp_size` and use the colocated `LocalLoraWeightSync` path.
- SGLang's internal per-rank TP constructor kwargs are replaced by the common context; normal Hydra/Handle construction is migrated and fails early if config and placement disagree.
- Eight-GPU Qwen recipes now launch two disjoint TP=4 replicas instead of one hidden TP=4 engine using GPUs selected by stage YAML.
- vLLM-Omni stage device ids are logical within the Handle-issued device group. The parent Worker's CUDA visibility is restored after spawn; the engine shuts down if its resolved stage topology disagrees with the declared TP size.
- GPU boot, sleep/wake, LoRA checksum verification, and multi-round memory behavior remain required before ready-for-review.

## Reviewer Notes

- Please review the ownership boundary first: `Handle` groups devices and injects `RolloutParallelContext`; adapters/stage YAML describe model execution and never choose cluster GPUs.
- The vLLM-Omni mapping follows pinned v0.20.0 `set_stage_devices`, which maps stage logical indices through the current visible-device list: https://github.com/vllm-project/vllm-omni/blob/v0.20.0/vllm_omni/entrypoints/stage_utils.py
- Duplicate-work check: #217/#222 cover the SGLang design and #226 supplied its first implementation; this PR generalizes that path rather than adding the AR-specific anchor/host design. #225 and #227 remain transport-specific work. #298 is complementary TP checksum readback. #306/#309 overlap the Qwen adapter/recipes and should rebase by adding explicit `tp_size` plus local split sync instead of reintroducing `rollout_anchor_device`.
- UnifiedModel's disjoint HI3 multi-engine placement is intentionally out of scope; this removes the duplicate synchronous AR/Qwen lifecycle, not every multi-track placement in the repository.
- AI assistance: implementation, code audit, and PR text were produced with Codex. No generated test or unrelated artifact is committed.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
