### PR TITLE
fix(qwen_image_edit_plus): tile image_latent for batched-step replay

### DIFF
--- a/unirl/models/qwen_image_edit_plus/diffusion.py
+++ b/unirl/models/qwen_image_edit_plus/diffusion.py
@@ -36,6 +36,7 @@ from unirl.models.qwen_image.diffusion import (
     _pack_latents,
     _unpack_latents,
 )
+from unirl.types.conditions import ImageLatentCondition
 
 from .bundle import QwenImageEditPlusBundle
 from .conditions import QwenImageEditPlusConditions
@@ -179,9 +180,29 @@ class QwenImageEditPlusDiffusionStage(QwenImageDiffusionStage):
     all pick up the source-image concat automatically (verified delegation
     chain: ``step_with_logp`` → ``step`` → ``self.predict_noise``).
 
-    The type parameter widens to :class:`QwenImageEditPlusConditions`; no
-    body override is needed.
+    The type parameter widens to :class:`QwenImageEditPlusConditions`. One
+    override is needed: batched-step replay tiles the conditioning, and the base
+    tiler only knows the text fields.
     """
+
+    @staticmethod
+    def _tile_conditions(conditions: QwenImageEditPlusConditions, repeats: int) -> QwenImageEditPlusConditions:
+        """Tile the text fields via the base, then the source-image latent.
+
+        The base tiler builds a :class:`QwenImageConditions`, which has no
+        ``image_latent`` slot, so batched replay reached ``predict_noise`` with
+        the source image gone. Every ``repeats`` block replays the same ``B``
+        trajectories, so the latent repeats block-wise like the text fields.
+        """
+        base = QwenImageDiffusionStage._tile_conditions(conditions, repeats)
+        source = conditions.image_latent
+        tiled_source: Optional[ImageLatentCondition] = None
+        if source is not None:
+            latents = source.latents
+            tiled_source = ImageLatentCondition(
+                latents=latents.repeat(repeats, *([1] * (latents.dim() - 1))) if latents is not None else None
+            )
+        return QwenImageEditPlusConditions(text=base.text, negative_text=base.negative_text, image_latent=tiled_source)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Batched-step replay is broken for Qwen-Image-Edit-Plus. The batched path tiles
the conditioning through `QwenImageDiffusionStage._tile_conditions`, which builds
a `QwenImageConditions` — a type that has no `image_latent` slot.
`QwenImageEditPlusDiffusionStage` inherited that tiler unchanged, so an Edit-Plus
batched replay reaches `predict_noise` with the source image gone:

```
File "unirl/models/qwen_image_edit_plus/diffusion.py", line 93, in predict_noise
    image_latent_cond = conditions.image_latent
AttributeError: 'QwenImageConditions' object has no attribute 'image_latent'
```

The fix overrides the tiler on the Edit-Plus stage: delegate the text fields to
the base implementation and repeat the source latent block-wise alongside them,
returning `QwenImageEditPlusConditions`. Every one of the `S` blocks replays the
same `B` trajectories, so the source latent tiles exactly like the text fields.

The stage's docstring said no body override was needed. That was accurate when it
was written and stopped being true when the batched path arrived in #156, so it is
corrected here too.

**This is latent, not live.** `batch_replay_steps` defaults to `False` and no
Edit-Plus recipe enables it — the only recipe in the tree that turns it on is
`examples/pe/pe_trainside_pickscore.yaml`. So nothing in-tree hits this today; it
would bite the first Edit-Plus run that opts into batched replay. It also fails
loudly rather than silently dropping the source image and training on a quietly
wrong conditioning, which is the better failure mode — and is why it went
unnoticed.

## Related Issue

Found while verifying #288 on real weights, and independent of it: reproduces on
`main` (998f2f32) with `txt_seq_lens` untouched. Not folded into that PR because a
diffusers-compat fix is the wrong place for it.

## Test Plan

#156's replay harness on 1x H20 with real `Qwen-Image-Edit` transformer weights,
diffusers 0.37.0 (so the version question stays out of it — this branch is off
`main`, which still passes `txt_seq_lens`), `--mode correctness --model
qwen_image_edit_plus`, B=2, S=3, 384px, variable-length text masks.

| arm | before (this branch's parent) | after |
|---|---|---|
| Edit-Plus, no CFG | `AttributeError`, exit 1 | passes |
| Edit-Plus, CFG 4.5 | `AttributeError`, exit 1 | passes |

The property the tiler has to preserve is the harness's claim 1, batched replay
agreeing with serial replay. After the fix:

| arm | claim 1 batched==serial | claim 2 ratio anchor exactly 1 |
|---|---|---|
| Edit-Plus, no CFG | PASS, max rel `1.124e-07` | PASS, `0.000e+00` |
| Edit-Plus, CFG 4.5 | PASS, max rel `0.000e+00` | PASS, `0.000e+00` |

If the source latent were tiled wrongly — misaligned across the `S` blocks rather
than repeated — batched and serial would disagree per block, so claim 1 passing at
1e-7 (and exactly 0 with CFG) is what makes the tiling correct rather than merely
present.

Base stage unaffected, same harness on the same branch:

| arm | claim 1 | claim 2 | claim 3 grad |
|---|---|---|---|
| `qwen_image`, no CFG | PASS, max rel `2.130e-07` | PASS, `0.000e+00` | PASS |

That `2.130e-07` is the same value this harness produces on `main`, i.e. the base
path is untouched — expected, since the change only adds an override on the
subclass.

`pre-commit` passes (ruff check, ruff format, recipe `_target_` resolution,
experimental-tier boundaries).

## Compatibility / Risk

Low. One new `@staticmethod` on one stage subclass; no config, checkpoint, or
data-format change, no public API change, and no effect on any path that does not
enable `batch_replay_steps`. The serial path is untouched.

## Reviewer Notes

- Only `unirl/models/qwen_image_edit_plus/diffusion.py` changes: the override, one
  import, and the corrected docstring.
- The override delegates to `QwenImageDiffusionStage._tile_conditions` rather than
  re-implementing the text tiling, so the two cannot drift apart.
- `image_latent`-is-`None` is preserved rather than normalised away — Edit-Plus is
  edit-only and `predict_noise` already raises a specific `ValueError` for it, so
  the existing fail-fast message survives.
- No test file added: the repo has no test suite to extend. The harness used above
  is #156's, unmodified apart from a `qwen_image_edit_plus` entry (that model is
  not one of its built-in choices).
- Worth a separate look: whether the other stages carrying non-text conditioning
  have the same gap. `flux2_klein` tiles `image_latent`/`image_latent_ids` in its
  own `_tile_conditions`, so it is fine; I did not audit beyond the Qwen-Image
  family.
- AI-assisted.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
