### PR TITLE
feat(train): add fsdp_mode=no_shard (DDP-equivalent FSDP2 mesh)

### DIFF
--- a/unirl/train/backend/fsdp/state.py
+++ b/unirl/train/backend/fsdp/state.py
@@ -118,12 +118,14 @@ def _global_clip_for_sharded_grads(
     CPU DTensor collectives missing under cpu_offload. Every grad here is a
     sharded DTensor: the root wrap claims all leftover params, and
     ``fsdp_wrap`` fails fast on trainable params outside every group when
-    ``root_wrap`` is disabled — so per-shard square sums SUM-reduce to the
-    exact global norm with no replicated double counting.
+    ``root_wrap`` is disabled. Reduce only over the DTensor shard dimension;
+    reducing over replicated mesh dimensions would count the same gradient
+    multiple times under HSDP / ``no_shard``.
     """
     import torch.distributed as dist
 
     grads: list[Tensor] = []
+    shard_group = None
     local_sq_sum = 0.0
     for param in params:
         grad = getattr(param, "grad", None)
@@ -131,6 +133,17 @@ def _global_clip_for_sharded_grads(
             continue
         local_grad = grad
         if hasattr(local_grad, "to_local") and callable(getattr(local_grad, "to_local")):
+            if shard_group is None:
+                mesh = getattr(local_grad, "device_mesh", None)
+                placements = getattr(local_grad, "placements", ())
+                shard_dims = [i for i, placement in enumerate(placements) if placement.is_shard()]
+                if mesh is not None and shard_dims:
+                    if len(shard_dims) != 1:
+                        raise RuntimeError(
+                            "clip_grad_norm fallback supports exactly one DTensor shard dimension; "
+                            f"got placements={placements!r}"
+                        )
+                    shard_group = mesh.get_group(shard_dims[0])
             local_grad = local_grad.to_local()
         if not isinstance(local_grad, Tensor):
             continue
@@ -146,7 +159,8 @@ def _global_clip_for_sharded_grads(
 
     total_sq = torch.tensor(local_sq_sum, device=reduce_device, dtype=torch.float32)
     if dist.is_available() and dist.is_initialized():
-        dist.all_reduce(total_sq, op=dist.ReduceOp.SUM)
+        if shard_group is None or dist.get_world_size(group=shard_group) > 1:
+            dist.all_reduce(total_sq, op=dist.ReduceOp.SUM, group=shard_group)
     global_norm = float(torch.sqrt(total_sq).item())
     clip_coef = float(max_grad_norm) / (global_norm + 1e-6)
     if clip_coef < 1.0:

--- a/unirl/train/backend/fsdp/wrap.py
+++ b/unirl/train/backend/fsdp/wrap.py
@@ -157,7 +157,7 @@ def fsdp_wrap(
             "ac=%s, compile=%s, dtype_casts=%d, master_dtype=%s, root_wrap=%s)",
             len(block_instances),
             tuple(block_class_names),
-            "HSDP" if mesh is not None else "FSDP2",
+            fsdp_mode,
             cpu_offload,
             mixed_precision,
             reshard_after_forward,
@@ -200,8 +200,25 @@ def _enumerate_block_instances(
     return tuple(m for _, m in model.named_modules() if type(m).__name__ in names)
 
 
+# Shard degree per fsdp_mode: how many ranks one parameter is split across.
+# ``None`` means the whole world, which is ``fully_shard``'s own default 1D mesh
+# (no explicit mesh needed).  ``no_shard`` is the degenerate end of the same
+# axis: a shard group of 1 leaves every rank holding the full parameter, so the
+# all-gather has no peer to gather from and only the replicate-dim all-reduce
+# syncs gradients (DDP semantics).  Parameters stay ``DTensor`` in every mode, so the
+# loss mesh, weight sync, checkpoint and grad-clip paths are unaffected.
+_SHARD_DEGREE: Dict[str, Optional[int]] = {"full": None, "hybrid": 8, "no_shard": 1}
+
+
 def _create_device_mesh(fsdp_mode: str) -> Optional[object]:
-    if str(fsdp_mode).strip().lower() != "hybrid":
+    mode = str(fsdp_mode).strip().lower()
+    require(
+        mode in _SHARD_DEGREE,
+        f"training.fsdp.fsdp_mode={fsdp_mode!r} is not one of {sorted(_SHARD_DEGREE)}; "
+        "an unrecognized mode would silently fall back to full sharding.",
+    )
+    shard_size = _SHARD_DEGREE[mode]
+    if shard_size is None:
         return None
 
     import torch.distributed as dist
@@ -210,7 +227,8 @@ def _create_device_mesh(fsdp_mode: str) -> Optional[object]:
         return None
 
     world_size = dist.get_world_size()
-    shard_size = 8
+    # A world that the shard degree cannot split (including single-rank
+    # ``no_shard``) already matches the default 1D mesh.
     if world_size <= shard_size or world_size % shard_size != 0:
         return None
 
@@ -222,7 +240,7 @@ def _create_device_mesh(fsdp_mode: str) -> Optional[object]:
         (replicate_size, shard_size),
         mesh_dim_names=("dp_replicate", "dp_shard"),
     )
-    logger.info("fsdp_wrap: HSDP mesh dp_replicate=%d x dp_shard=%d", replicate_size, shard_size)
+    logger.info("fsdp_wrap: %s mesh dp_replicate=%d x dp_shard=%d", mode, replicate_size, shard_size)
     return mesh
 
 

--- a/unirl/train/backend/fsdp/wrap.py
+++ b/unirl/train/backend/fsdp/wrap.py
@@ -200,13 +200,7 @@ def _enumerate_block_instances(
     return tuple(m for _, m in model.named_modules() if type(m).__name__ in names)
 
 
-# Shard degree per fsdp_mode: how many ranks one parameter is split across.
-# ``None`` means the whole world, which is ``fully_shard``'s own default 1D mesh
-# (no explicit mesh needed).  ``no_shard`` is the degenerate end of the same
-# axis: a shard group of 1 leaves every rank holding the full parameter, so the
-# all-gather has no peer to gather from and only the replicate-dim all-reduce
-# syncs gradients (DDP semantics).  Parameters stay ``DTensor`` in every mode, so the
-# loss mesh, weight sync, checkpoint and grad-clip paths are unaffected.
+# Parameter shard degree: full = world default, hybrid = 8 ranks, no_shard = 1 rank (DDP).
 _SHARD_DEGREE: Dict[str, Optional[int]] = {"full": None, "hybrid": 8, "no_shard": 1}
 
 

--- a/unirl/train/configs.py
+++ b/unirl/train/configs.py
@@ -49,6 +49,8 @@ class FSDPConfig:
     param_dtype: str = "bf16"
     cpu_offload: bool = False
     mixed_precision: bool = True
+    # Shard degree: full = the whole world, hybrid = one node (replicate across
+    # nodes), no_shard = nobody (DDP — every rank keeps the full model).
     fsdp_mode: str = "full"
     reshard_after_forward: bool = True
     activation_checkpointing: bool = False

--- a/unirl/train/configs.py
+++ b/unirl/train/configs.py
@@ -49,8 +49,7 @@ class FSDPConfig:
     param_dtype: str = "bf16"
     cpu_offload: bool = False
     mixed_precision: bool = True
-    # Shard degree: full = the whole world, hybrid = one node (replicate across
-    # nodes), no_shard = nobody (DDP — every rank keeps the full model).
+    # Shard degree: full = the whole world, hybrid = one node (replicate across nodes), no_shard = nobody (DDP — every rank keeps the full model).
     fsdp_mode: str = "full"
     reshard_after_forward: bool = True
     activation_checkpointing: bool = False

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -89,13 +89,14 @@ optimizer or LR schedule is a branch in `factories.py` plus fields on
   leak the stale accumulation into the next step's reduce-scatter).
 - **`fsdp_mode: no_shard` trades memory for the all-gather** — a `(world, 1)` mesh
   leaves the full model on every rank, so no parameter bytes cross ranks and only
-  gradients are all-reduced (DDP). Per-rank memory becomes the *whole* model +
-  grads + optimizer state, so it pays off for LoRA on a frozen base or small full
-  fine-tunes, not for a sharded-or-OOM model. Pair it with
-  `reshard_after_forward: false` (nothing to reshard; `true` still frees the
-  compute copy between forward and backward, which matters when `param_dtype`
-  upcasts) and `defer_grad_sync: true` (one all-reduce per optimizer step). VeOmni
-  only supports `full`.
+  gradients are all-reduced (DDP). It pays off where the re-gathered bytes dwarf the
+  gradient (LoRA on a frozen base re-gathers the whole backbone *every* micro-batch)
+  and the model still fits unsharded — per-rank memory becomes the whole model +
+  grads + optimizer state. `reshard_after_forward` is **not** a no-op here: `false`
+  keeps every block's unsharded compute copy resident, which is a second full copy of
+  the model whenever `param_dtype` upcasts (fp32 compute over a bf16 checkpoint), so
+  leave it `true` unless that copy is cheap. `defer_grad_sync: true` then gives one
+  all-reduce per optimizer step. VeOmni only supports `full`.
 
 ## Profiling → Perfetto
 

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -87,6 +87,15 @@ optimizer or LR schedule is a branch in `factories.py` plus fields on
   skips backward (an all-empty micro) while earlier ones ran, `TrainStack.train`
   raises instead of silently stepping on never-synced grads (which would also
   leak the stale accumulation into the next step's reduce-scatter).
+- **`fsdp_mode: no_shard` trades memory for the all-gather** — a `(world, 1)` mesh
+  leaves the full model on every rank, so no parameter bytes cross ranks and only
+  gradients are all-reduced (DDP). Per-rank memory becomes the *whole* model +
+  grads + optimizer state, so it pays off for LoRA on a frozen base or small full
+  fine-tunes, not for a sharded-or-OOM model. Pair it with
+  `reshard_after_forward: false` (nothing to reshard; `true` still frees the
+  compute copy between forward and backward, which matters when `param_dtype`
+  upcasts) and `defer_grad_sync: true` (one all-reduce per optimizer step). VeOmni
+  only supports `full`.
 
 ## Profiling → Perfetto
 


### PR DESCRIPTION
## Summary

`fsdp_mode` already selects a data-parallel **shard degree**: `full` splits a parameter across
the whole world, `hybrid` across one node (replicate across nodes). This adds the degenerate end
of the same axis, `no_shard`: a `(world, 1)` mesh, so the all-gather group holds a single rank,
every rank keeps the full parameter, and only the replicate-dim all-reduce syncs gradients —
**DDP semantics, expressed as FSDP2**.

Expressing it as a mesh rather than swapping in `nn.parallel.DistributedDataParallel` is what
keeps the change small: parameters stay `DTensor`, `mesh.size()` still equals the world size, and
the loss-reduction mesh, weight sync, DCP checkpoint and grad-clip paths are untouched. (Real DDP
would break all four, plus silently drop gradient sync for the stages that call submodules of the
wrapped module directly — `fully_shard` patches the module in place, DDP wraps it.)

Motivation: for LoRA on a frozen base, FSDP re-all-gathers the whole frozen backbone **every
micro-batch** to compute a gradient for a few adapter tensors. `no_shard` pays that in memory once
instead of in bandwidth per micro-batch.

Also: an unrecognized `fsdp_mode` used to fall through to full sharding silently. It now fails
closed — a typo like `no-shard` can no longer masquerade as a working recipe while quietly
running the exact configuration you were trying to turn off.

No behavior change for existing recipes: `full` and `hybrid` resolve exactly as before.

## Related Issue

N/A

## Test Plan

**Hardware:** 1 node x 8 H20 (95 GiB each), torch 2.7.1, NCCL. All commands run from this branch.

**1. Mesh + DDP semantics** (throwaway harness, not committed — `torchrun --nproc_per_node=8`,
tiny 4-block MLP, rank-distinct batches):

```
ok  full -> no explicit mesh (fully_shard default)
ok  unknown fsdp_mode raises instead of silently full-sharding
ok  every param stays a DTensor
ok  mesh dims ('dp_replicate', 'dp_shard')
ok  mesh shape (8, 1) == (8, 1)
ok  mesh.size() == world_size (loss reduction / grad averaging unchanged)
ok  every LOCAL shard is the FULL tensor (model not split)
ok  grads == mean of per-rank reference grads (max abs diff 0.00e+00)
ok  grads bit-identical on every rank (max spread 0.00e+00)
ok  full-shard grads match the same reference (max rel diff 1.05e-07)
ok  3 SGD steps match full sharding (max abs diff 7.45e-09)
ok  3 AdamW steps track full sharding (max abs diff 1.02e-04, <10% of one lr step)
ok  all-gather group has 1 rank (no cross-rank param traffic)
ALL CHECKS PASSED (world=8, torch=2.7.1)
```

The gradient check is the load-bearing one: under `no_shard` the reduced gradient is **bit-exact**
against a hand-computed mean of the per-rank unwrapped gradients, i.e. exactly DDP. Full sharding
reaches the same value at 1.05e-07 relative (reduce-scatter vs all-reduce ordering). SGD (linear in
the gradient) then tracks full sharding to 7.4e-09 over 3 steps; the larger AdamW figure is that
same fp32 reduce-order difference amplified by `1/(sqrt(v)+1e-8)` on a random-init net, not a
semantic gap.

**2. Parameter storage under each mesh** — real SD3.5-medium bundle + `FSDPBackend`
(LoRA r32), 8 GPUs, `torch.cuda.memory_allocated()` after the wrap:

| | local param bytes / rank | global | split factor | `memory_allocated` after wrap |
|---|---|---|---|---|
| `full` | 0.53 GiB | 4.21 GiB | **8.00x** | 11.55 GiB |
| `no_shard` | **4.21 GiB** | 4.21 GiB | **1.00x** | 15.26 GiB |

Exactly `world_size` vs 1: `no_shard` leaves every rank the whole model. The two figures are
self-consistent — `no_shard` costs 15.26 - 11.55 = 3.71 GiB more, matching the 4.21 - 0.53 =
3.68 GiB of parameters it declines to split. Both start from the same 15.23 GiB post-load
footprint; `full` drops to 11.55 GiB when the wrap shards and frees the full copies, `no_shard`
stays at 15.26 GiB because there is nothing to free.

**3. Two real recipes, paired** — identical geometry per pair, `full` vs `no_shard` the only
difference; 8 GPUs = 8 trainside actors (dp=8, 1 actor/GPU), PickScore reward.

SD3.5-medium LoRA GRPO (`examples/diffusion/sd3/sd3_trainside.yaml`, `samples_per_prompt=16`
→ 8 train micro-batches per optimizer step, so the per-micro all-gather is exercised):

```
python -m unirl.train_diffusion --config-name=diffusion/sd3/sd3_trainside \
  num_devices=8 batch_size=8 +num_rollouts=3 sampling.samples_per_prompt=16 \
  backend.fsdp_cfg.fsdp_mode={full|no_shard} backend.fsdp_cfg.reshard_after_forward=true
```

| | reward (rollout 1 / 2 / 3) | step time | GPU0 peak (`nvidia-smi`) |
|---|---|---|---|
| `full` | 0.7991 / 0.7226 / 0.7635 | 22.18s, 21.46s | 54445 MiB |
| `no_shard` | 0.7984 / 0.7224 / 0.7626 | **20.75s, 20.79s** | 54445 MiB |

Both completed (`EXIT=0`). Rewards track across all three rollouts; `ratio=1.0000±0.0000` in both.
Step time is consistently ~4.8% lower under `no_shard` (both measured steps beat both `full`
steps). The `nvidia-smi` peak is identical because it reports the caching allocator's *reserved*
pool, which here is dominated by the rollout (16-sample trajectory cache, VAE decode, text
encoders) and absorbs the parameter delta — hence the separate parameter-storage probe above.

FLUX.2-klein-base-9B LoRA GRPO (`examples/diffusion/flux2_klein/flux2_klein_trainside.yaml`,
`activation_checkpointing=true samples_per_prompt=2 forward_batch_size=2 num_updates_per_batch=1`):

| | reward (rollout 1 / 2) | step time | GPU0 peak |
|---|---|---|---|
| `full` | 0.7747 / 0.7188 | 13.0s | not sampled |
| `no_shard` | 0.7747 / 0.7198 | 13.0s | 46199 MiB (45.1 GiB) |

Both completed (`EXIT=0`). Rollout 1 reward is **identical** (same weights, deterministic rollout);
rollout 2 differs by 0.001 because it samples from weights updated through a different gradient
reduction path — the same fp32 ordering difference measured in (1), carried through AdamW. No
step-time difference at this geometry: with 2 samples/prompt the 10-step SDE rollout dominates and
there are too few train micro-batches for the removed all-gather to show — which is why the SD3.5
pair above uses 16.

**4. How far 9B scales unsharded** — same recipe, all `no_shard`, one lever at a time:

| | activation ckpt | samples/prompt | fwd batch | updates | result | GPU0 peak |
|---|---|---|---|---|---|---|
| A | **on** | 16 | 16 | 2 | **`EXIT=0`**, reward 0.7751 / 0.7187 | 80289 MiB (78.4 GiB) |
| B | off | 16 | 16 | 2 | OOM | ceiling |
| C | off | 4 | 4 | 2 | OOM | ceiling |

A is the recipe's own per-actor geometry (1 prompt x 16 samples, `forward_batch_size=16`, 2 PPO
updates) and it runs unsharded on one 95 GiB H20 with ~16 GiB spare — **a 9B LoRA actor per GPU is
comfortable, not marginal.**

The blocker is activation checkpointing, not the mesh. B and C peak within 144 MiB of each other
despite a 4x load difference, because with AC off and `micro_batch_size=1` the retained activations
of all 56 blocks are a fixed cost that shrinking the load cannot recover. Both fail at the same
allocation (`Tried to allocate 576.00 MiB`, ~90.2 GiB allocated) as the **`full`-mesh** baseline did
earlier — i.e. with AC off this recipe does not fit 95 GiB at *any* shard degree. The recipe ships
`activation_checkpointing: false` deliberately for speed and targets 4 nodes x 8 GPUs.

Not measured: multi-node, and `no_shard` under `defer_grad_sync`.

## Compatibility / Risk

- Config-only surface: one new accepted value for the existing `training.fsdp.fsdp_mode` string.
  `full` (the default) and `hybrid` are unchanged, so no existing recipe changes behavior.
- **Behavior change (intentional):** an unrecognized `fsdp_mode` now raises instead of silently
  full-sharding. No in-tree recipe uses anything but `full` / `hybrid`, so nothing in the repo is
  affected.
- `no_shard` is FSDPBackend-only. VeOmni already rejects any mode but `full` in
  `_validate_fsdp_cfg`, so it fails fast there with its existing message.
- Memory: `no_shard` puts the whole model + grads + optimizer state on every rank. It is a
  speed/memory trade, not a free win — see the readme gotcha and the measurements above.

## Reviewer Notes

- The interesting question is naming and where validation lives. `no_shard` follows FSDP1's
  `ShardingStrategy.NO_SHARD` and stays on the same axis as the existing `full` / `hybrid`
  (unlike `ddp`, which would name a different framework inside a field called `fsdp_mode`).
  The mode vocabulary lives in exactly one place, `_SHARD_DEGREE` in `wrap.py`, which is also
  where it is validated.
- `reshard_after_forward` is deliberately **not** forced or normalized under `no_shard`. It is not
  a no-op there: with `param_dtype` upcasting (as in the Klein recipe, `fp32`), `true` still frees
  the unsharded compute copy between forward and backward, and that is the difference between
  fitting and OOM at 9B — see the Test Plan.
- AI-assisted (Claude Code): design, implementation and the verification runs above. Checked open
  PRs for overlap on FSDP mesh / sharding mode — none.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
