### PR TITLE
chore(ci): drop @haonan3 from the CODEOWNERS fallback rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # Owners must have write access or GitHub silently skips them.
 
 # --- fallback ---------------------------------------------------------------
-*                                       @haonan3 @CjhHa1 @leviking98z-rgb @celve
+*                                       @CjhHa1 @leviking98z-rgb @celve
 
 # --- build, packaging, CI ---------------------------------------------------
 /pyproject.toml                         @CjhHa1 @celve


### PR DESCRIPTION
## Summary

Removes `@haonan3` from the catch-all `*` rule in `.github/CODEOWNERS`.

Because GitHub applies only the last matching pattern and never unions rules, the
fallback fires for every PR that touches a file no specific rule covers — which is
most PRs. That made `@haonan3` an automatic reviewer on the bulk of the repo's 279
PRs (65 currently carry a pending review request), and review requests are
"Participating" notifications, so they cannot be muted by unwatching the
repository. The fallback keeps three owners, still satisfying the two-owner
minimum documented at the top of the file once the author is excluded.

This only touches the fallback. `@haonan3` remains an explicit owner on 28 specific
rules (`/unirl/algorithms/`, `/unirl/train/`, `/unirl/models/`, `/unirl/reward/`,
docs, etc.), so ownership of the areas they actually maintain is unchanged.

## Related Issue

N/A

## Test Plan

- `pre-commit run --files .github/CODEOWNERS` — all applicable hooks passed
  (`check for merge conflicts`, `trim trailing whitespace`, `fix end of files`,
  `don't commit to branch`, `experimental-tier boundaries hold`; language-specific
  hooks skipped, no matching files).
- `gh api repos/Tencent-Hunyuan/UniRL/codeowners/errors?ref=chore/codeowners-drop-haonan3-fallback`
  — GitHub's own CODEOWNERS validator reports no errors on this branch.
- Self-check on this PR: it changes `.github/`, which is owned by
  `/.github/ @celve @haonan3`; with `@haonan3` as author GitHub requests `@celve`,
  confirming the specific rules still resolve.

## Compatibility / Risk

No code, config, checkpoint, or data-format impact. The only behavioral change is
reviewer routing: PRs that previously fell through to the fallback now request
`@CjhHa1`, `@leviking98z-rgb`, and `@celve` instead of those three plus `@haonan3`.

## Reviewer Notes

Requested by @haonan3 to cut notification volume; the remaining fallback owners
absorb the routing. AI-assisted (Claude Code); the diff is a single line and has
been reviewed. Duplicate-work check: no open PR or issue touching `CODEOWNERS`
(`gh api search/issues ... +is:open+CODEOWNERS` returned nothing).

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
