### PR TITLE
fix(lint): scope no-commit-to-branch to the pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,13 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
       - id: requirements-txt-fixer
+      # Inspects the *checked-out* branch, so it only means anything at commit time.
+      # Left on the default stages it also runs at pre-push, where it ignores the refs
+      # actually being pushed and instead fails any push issued from a worktree that
+      # happens to sit on main — while still not preventing main itself from being
+      # pushed from elsewhere. Scope it to the stage it can actually enforce.
       - id: no-commit-to-branch
+        stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.1


### PR DESCRIPTION
## Summary

`no-commit-to-branch` inspects the **checked-out branch**, so it only carries meaning at commit time. It currently has no `stages:` of its own and therefore inherits `default_stages: [pre-commit, pre-push, manual]`, which also runs it at pre-push.

At the pre-push stage the hook is both wrong and ineffective:

- **Wrong**: it ignores the refs actually being pushed and looks at whatever branch the working tree happens to be on. Pushing a feature branch from a worktree that sits on `main` fails with `don't commit to branch`, even though nothing is being pushed to `main`.
- **Ineffective**: it does not stop `main` from being pushed, since a push of `main` issued from a different checkout leaves the current branch untouched.

This scopes it to `stages: [pre-commit]`, the one stage where it can enforce what it claims to.

## Test plan

Verified with the branch checked out on `main`, so the false failure is reproducible:

- [x] Before: `pre-commit run no-commit-to-branch --hook-stage pre-push` → `Failed` (false positive, nothing was being pushed to `main`)
- [x] After: same command → `No hook with id 'no-commit-to-branch' in stage 'pre-push'`
- [x] After: `pre-commit run no-commit-to-branch --hook-stage pre-commit` → still `Failed` on `main`, so the actual guard is intact
- [x] `pre-commit run --all-files --hook-stage pre-push` → all 16 hooks pass
- [x] A real `git push` of this branch ran the pre-push suite clean