### PR TITLE
fix(config): surface LoRA model import failures

### DIFF
--- a/unirl/config/validation.py
+++ b/unirl/config/validation.py
@@ -229,8 +229,9 @@ def validate_lora_target_modules(cfg: DictConfig) -> None:
 
         model_cls = load_function(target_dotpath)
     except (ImportError, AttributeError, KeyError, ValueError) as exc:
-        logger.debug(
-            "Could not resolve model class %r for LoRA target lookup: %s",
+        logger.warning(
+            "Could not resolve model class %r for LoRA target lookup: %s; "
+            "falling back to None (SGLang will wrap every linear layer).",
             target_dotpath,
             exc,
         )


### PR DESCRIPTION
## Summary

When LoRA target modules are not configured explicitly, UniRL tries to import the configured model class so it can infer the correct linear-layer scope. If that import fails, the old code logged only at DEBUG level and returned with target modules still unset. SGLang then falls back to wrapping every linear layer, which can make rollout adapter coverage differ from the training configuration without an actionable signal.

This change promotes the diagnostic to WARNING and states the exact fallback behavior. The existing fallback remains non-raising so configurations that intentionally rely on downstream discovery keep their current control flow.

## Related Issue

Fixes #327.

## Test Plan

- Focused import-resolution harness: missing model import emitted one warning, preserved target_modules=None, and left the configuration unchanged.
- `python -m compileall -q unirl`
- `git diff --check abc05c1..HEAD`

## Compatibility / Risk

No API or configuration schema change. Import failures are now visible at WARNING level; the existing fallback behavior is unchanged.

## Reviewer Notes

The important review point is the distinction between reporting the unresolved model class and changing the existing fallback contract. This PR only makes the silent failure visible.

## Checklist

- [x] Reviewed the changed code and removed unrelated artifacts.
- [x] Updated validation coverage appropriate to the existing repository conventions.