### PR TITLE
fix(sglang): preserve unset diffusion seed semantics

### DIFF
--- a/unirl/rollout/engine/sglang_diffusion/adapters/image.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/image.py
@@ -159,21 +159,23 @@ class ImageAdapter(ModelAdapter):
         """Sampling scalars + the σ schedule slice.
 
         ``diffusion.sigmas`` is length T+1 (terminal 0 included); SGLang's
-        ``set_timesteps`` wants the interior T. Pass the seed even when
-        ``initial_noise`` pins x_T verbatim: SGLang derives per-step SDE noise
-        deterministically (its ``_make_step_generators``, keyed on
-        ``denoise_seeds``) only when seed is not None — a None seed silently
-        falls back to global RNG.
+        ``set_timesteps`` wants the interior T. When set, pass the seed even
+        when ``initial_noise`` pins x_T verbatim: SGLang derives per-step SDE
+        noise deterministically (its ``_make_step_generators``, keyed on
+        ``denoise_seeds``). When unset, omit the seed so SGLang keeps its global
+        RNG semantics.
         """
-        return {
+        kwargs = {
             "num_inference_steps": int(diffusion.num_inference_steps),
             "guidance_scale": float(diffusion.guidance_scale),
             "height": int(diffusion.height),
             "width": int(diffusion.width),
             "num_frames": int(diffusion.num_frames),
             "sigmas": diffusion.sigmas.detach().cpu().tolist()[:-1],
-            "seed": int(diffusion.seed) if diffusion.seed is not None else 0,
         }
+        if diffusion.seed is not None:
+            kwargs["seed"] = int(diffusion.seed)
+        return kwargs
 
     def build_response(self, sample: Sample, raw: List[RawResult]) -> Sample:
         require(bool(raw), "build_response: SGLang returned no results")


### PR DESCRIPTION
## Summary

An unset diffusion seed is a meaningful request: it lets the downstream SGLang engine use its global random-number generator. The shared image adapter previously converted seed=None to integer 0 before building the request. That silently changed an intentionally stochastic request into a deterministic one.

The adapter now omits the seed field when it is unset. Explicit seeds remain unchanged, including seed=0.

## Related Issue

Fixes #329.

## Test Plan

- Focused fake-engine boundary harness verified that seed=17 is forwarded unchanged and seed=None is omitted from the request.
- `python -m compileall -q unirl`
- `git diff --check abc05c1..HEAD`
- Focused Ruff validation passed.

## Compatibility / Risk

Explicit deterministic seeds keep their existing behavior. Only the previously incorrect None-to-zero conversion changes; no other rollout engine or sampling parameter changes.

## Reviewer Notes

The key contract is at the adapter boundary: absence of the seed must remain absence, while zero must remain an explicit seed.

## Checklist

- [x] Reviewed the changed code and removed unrelated artifacts.
- [x] Updated validation coverage appropriate to the existing repository conventions.