### PR TITLE
fix(bagel): initialize strategy schedule during replay

### DIFF
--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -529,6 +529,7 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
 
         schedule = segment.sigmas.to(device)
         sigma_max = schedule[1] if int(schedule.shape[0]) > 1 else schedule[0]
+        self.strategy.init_schedule(schedule)
 
         gen, cfg_text, cfg_img, image_shape = self._resolve_single(conditions)
         gi, gi_cfg_text, gi_cfg_img = self._build_generation_inputs(gen, cfg_text, cfg_img, image_shape, device=device)


### PR DESCRIPTION
## Summary

Bagel diffuse initializes the strategy with the sigma schedule before generating transitions. Bagel replay did not perform the corresponding initialization, so replay worked for the current stateless FlowSDEStrategy but could use stale or missing schedule state for a stateful strategy.

Replay now calls init_schedule(schedule) after moving the stored schedule to the model device and before evaluating replay transitions. This makes the replay lifecycle match diffuse and preserves the current no-op behavior for FlowSDEStrategy.

## Related Issue

Fixes #333.

## Test Plan

- Recording-strategy replay harness passed through the production Bagel stage/step path and confirmed schedule initialization occurs before replay evaluation.
- Strategy contract check passed.
- `python -m compileall -q unirl`
- `git diff --check abc05c1..HEAD`

## Compatibility / Risk

No change for the current FlowSDEStrategy. Custom strategies that depend on init_schedule now receive the schedule before replay, as required by the stage contract.

## Reviewer Notes

The review order is: compare Bagel diffuse ordering with replay ordering, then check that schedule initialization precedes the first replay step.

## Checklist

- [x] Reviewed the changed code and removed unrelated artifacts.
- [x] Updated validation coverage appropriate to the existing repository conventions.