### PR TITLE
fix(advantages): keep normalization finite for invalid rewards

### DIFF
--- a/unirl/algorithms/normalizers.py
+++ b/unirl/algorithms/normalizers.py
@@ -4,13 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import torch
 
-
-def _finite_stats(values: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    if values.numel() == 0:
-        return values.new_zeros(()), values.new_ones(())
-    mean = values.mean()
-    std = values.std(unbiased=False) if values.numel() > 1 else values.new_ones(())
-    return mean, std
+from unirl.types.advantages import _finite_stats
 
 
 def normalize_grouped(

--- a/unirl/algorithms/normalizers.py
+++ b/unirl/algorithms/normalizers.py
@@ -5,6 +5,14 @@ from typing import Any, Dict, List, Optional
 import torch
 
 
+def _finite_stats(values: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if values.numel() == 0:
+        return values.new_zeros(()), values.new_ones(())
+    mean = values.mean()
+    std = values.std(unbiased=False) if values.numel() > 1 else values.new_ones(())
+    return mean, std
+
+
 def normalize_grouped(
     rewards: torch.Tensor,
     group_indices: List[List[int]],
@@ -15,8 +23,9 @@ def normalize_grouped(
 ) -> torch.Tensor:
     """Unified grouped normalization - single implementation for all group-based strategies.
 
-    Normalizes rewards within specified groups, subtracting the group mean and
-    dividing by the group (or global) standard deviation.
+    Normalizes finite rewards within specified groups, subtracting the group mean
+    and dividing by the group (or global) standard deviation. Non-finite rewards
+    receive zero advantage.
 
     Args:
         rewards: Reward values [N]
@@ -30,28 +39,38 @@ def normalize_grouped(
         Advantages tensor [N] with per-group normalization
     """
     advantages = torch.zeros_like(rewards)
-    batch_std = rewards.std() + epsilon if use_global_std else None
+    finite_rewards = rewards[torch.isfinite(rewards)]
+    _, batch_std = _finite_stats(finite_rewards) if use_global_std else (None, None)
 
     for indices in group_indices:
         if not indices:
             continue
 
         group_rewards = rewards[indices]
+        group_finite = torch.isfinite(group_rewards)
+        finite_group_rewards = group_rewards[group_finite]
+        if finite_group_rewards.numel() == 0:
+            continue
 
-        if trim_outliers_ratio > 0 and len(indices) > 2:
-            sorted_rewards, _ = torch.sort(group_rewards)
+        if trim_outliers_ratio > 0 and finite_group_rewards.numel() > 2:
+            sorted_rewards, _ = torch.sort(finite_group_rewards)
             trim_size = int(len(sorted_rewards) * trim_outliers_ratio)
             if trim_size > 0 and trim_size * 2 < len(sorted_rewards):
                 trimmed = sorted_rewards[trim_size:-trim_size]
             else:
                 trimmed = sorted_rewards
-            group_mean = trimmed.mean()
-            group_std = batch_std if use_global_std else (trimmed.std() + epsilon)
+            group_mean, group_std = _finite_stats(trimmed)
         else:
-            group_mean = group_rewards.mean()
-            group_std = batch_std if use_global_std else (group_rewards.std() + epsilon)
+            group_mean, group_std = _finite_stats(finite_group_rewards)
 
-        advantages[indices] = (group_rewards - group_mean) / group_std
+        if use_global_std:
+            group_std = batch_std
+
+        advantages[indices] = torch.where(
+            group_finite,
+            (group_rewards - group_mean) / (group_std + epsilon),
+            torch.zeros_like(group_rewards),
+        )
 
     if clip_max is not None:
         advantages = torch.clamp(advantages, -clip_max, clip_max)
@@ -64,7 +83,7 @@ def normalize_global(
     epsilon: float = 1e-8,
     clip_max: Optional[float] = None,
 ) -> torch.Tensor:
-    """Global normalization across all samples.
+    """Global normalization across all finite samples.
 
     Args:
         rewards: Reward values [N]
@@ -72,11 +91,16 @@ def normalize_global(
         clip_max: If set, clip advantages to [-clip_max, clip_max]
 
     Returns:
-        Advantages tensor [N] with global normalization
+        Advantages tensor [N] with global normalization; non-finite rewards receive
+        zero advantage.
     """
-    mean = rewards.mean()
-    std = rewards.std() + epsilon
-    advantages = (rewards - mean) / std
+    finite = torch.isfinite(rewards)
+    mean, std = _finite_stats(rewards[finite])
+    advantages = torch.where(
+        finite,
+        (rewards - mean) / (std + epsilon),
+        torch.zeros_like(rewards),
+    )
 
     if clip_max is not None:
         advantages = torch.clamp(advantages, -clip_max, clip_max)

--- a/unirl/types/advantages.py
+++ b/unirl/types/advantages.py
@@ -12,6 +12,15 @@ from typing import Optional, Tuple
 import torch
 
 
+def _finite_stats(values: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Mean and population std over ``values``; empty → ``(0, 1)``, singleton → std ``1``."""
+    if values.numel() == 0:
+        return values.new_zeros(()), values.new_ones(())
+    mean = values.mean()
+    std = values.std(unbiased=False) if values.numel() > 1 else values.new_ones(())
+    return mean, std
+
+
 def compute_gae_advantages(
     rewards: torch.Tensor,
     values: torch.Tensor,

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -332,7 +332,7 @@ class Part(Batch):
         """GRPO per-group advantage ``(reward - group_mean) / (group_std + eps)``.
 
         ``scope`` picks the normalization mode: ``"group"`` (default) normalizes
-        per group; ``"global"`` z-scores the whole batch (unbiased std — the
+        per group; ``"global"`` z-scores the whole batch (population std — the
         historical convention) and ignores the grouping knobs. Under
         ``scope="group"``, ``group_layer`` picks the lineage layer whose ancestor
         id labels the groups (the id's first ``layer + 1`` segments): ``None``
@@ -340,7 +340,8 @@ class Part(Batch):
         degenerates to per-sample groups → advantage 0), ``0`` by the root prompt.
         Labels must be group-by-parent contiguous with uniform branching (``fork``
         guarantees this at every layer), so the reduce is one ``view``.
-        ``use_global_std`` keeps per-group means but one batch-wide std. Population
+        ``use_global_std`` keeps per-group means but one batch-wide std. Non-finite
+        rewards are excluded from statistics and receive zero advantage; population
         std (``unbiased=False``) makes ``branch=1`` degenerate to advantage 0.
         """
         if self.rewards is None:
@@ -353,10 +354,15 @@ class Part(Batch):
 
         if scope == "global":
             rewards_g = rewards_local.to(torch.float32)
+            finite = torch.isfinite(rewards_g)
+            finite_rewards = rewards_g[finite]
+            mean = finite_rewards.mean() if finite_rewards.numel() else rewards_g.new_zeros(())
+            centered = torch.where(finite, rewards_g - mean, torch.zeros_like(rewards_g))
             if normalize:
-                adv_g = (rewards_g - rewards_g.mean()) / (rewards_g.std() + eps)
+                std = finite_rewards.std(unbiased=False) if finite_rewards.numel() > 1 else rewards_g.new_ones(())
+                adv_g = centered / (std + eps)
             else:
-                adv_g = rewards_g - rewards_g.mean()
+                adv_g = centered
             return _part_with_field(self, "advantages", adv_g)
 
         layer = group_layer if group_layer is not None else max(self.sample_ids[0].count("/") - 1, 0)
@@ -379,15 +385,21 @@ class Part(Batch):
 
         rewards = rewards_local.to(torch.float32)
         reshaped = rewards.view(n_groups, branch)
-        mean = reshaped.mean(dim=1, keepdim=True)
+        finite = torch.isfinite(reshaped)
+        counts = finite.sum(dim=1, keepdim=True)
+        finite_values = torch.where(finite, reshaped, torch.zeros_like(reshaped))
+        mean = finite_values.sum(dim=1, keepdim=True) / counts.clamp_min(1)
+        centered = torch.where(finite, reshaped - mean, torch.zeros_like(reshaped))
         if normalize:
             if use_global_std:
-                std = rewards.std() + eps
+                finite_rewards = rewards[torch.isfinite(rewards)]
+                std = finite_rewards.std(unbiased=False) if finite_rewards.numel() > 1 else rewards.new_ones(())
             else:
-                std = (reshaped.var(dim=1, unbiased=False, keepdim=True) + eps).sqrt()
-            adv = (reshaped - mean) / std
+                variance = (centered * centered).sum(dim=1, keepdim=True) / counts.clamp_min(1)
+                std = torch.where(counts > 1, variance.sqrt(), torch.ones_like(variance))
+            adv = centered / (std + eps)
         else:
-            adv = reshaped - mean
+            adv = centered
         return _part_with_field(self, "advantages", adv.flatten())
 
     def compute_gae_advantages(

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -31,8 +31,13 @@ from unirl.distributed.tensor.batch import (
     shared_field,
 )
 from unirl.distributed.tensor.ref import hydrate
-from unirl.types.advantages import compute_gae_advantages as _compute_gae
-from unirl.types.advantages import scatter_terminal_rewards
+from unirl.types.advantages import (
+    _finite_stats,
+    scatter_terminal_rewards,
+)
+from unirl.types.advantages import (
+    compute_gae_advantages as _compute_gae,
+)
 from unirl.types.conditions import Condition
 from unirl.types.media import MediaRefs
 from unirl.types.media_preview import MediaPreview
@@ -355,11 +360,9 @@ class Part(Batch):
         if scope == "global":
             rewards_g = rewards_local.to(torch.float32)
             finite = torch.isfinite(rewards_g)
-            finite_rewards = rewards_g[finite]
-            mean = finite_rewards.mean() if finite_rewards.numel() else rewards_g.new_zeros(())
+            mean, std = _finite_stats(rewards_g[finite])
             centered = torch.where(finite, rewards_g - mean, torch.zeros_like(rewards_g))
             if normalize:
-                std = finite_rewards.std(unbiased=False) if finite_rewards.numel() > 1 else rewards_g.new_ones(())
                 adv_g = centered / (std + eps)
             else:
                 adv_g = centered
@@ -392,8 +395,7 @@ class Part(Batch):
         centered = torch.where(finite, reshaped - mean, torch.zeros_like(reshaped))
         if normalize:
             if use_global_std:
-                finite_rewards = rewards[torch.isfinite(rewards)]
-                std = finite_rewards.std(unbiased=False) if finite_rewards.numel() > 1 else rewards.new_ones(())
+                _, std = _finite_stats(rewards[torch.isfinite(rewards)])
             else:
                 variance = (centered * centered).sum(dim=1, keepdim=True) / counts.clamp_min(1)
                 std = torch.where(counts > 1, variance.sqrt(), torch.ones_like(variance))


### PR DESCRIPTION
## Summary
- Keep advantage normalization finite when rewards contain NaN/Inf or when a group/batch is a singleton: finite-only mean/std, invalid rows get advantage 0, singleton finite groups get advantage 0.
- Use population std (`unbiased=False`) consistently across `normalize_*` and `Part.compute_advantages`, matching the existing agentic path.
- Share `_finite_stats` from `unirl.types.advantages` so normalizers and `Part.compute_advantages` cannot drift apart (avoids importing `unirl.algorithms` from `sample`).

Supersedes / extends #335 (same finite-mask fix, plus shared helper). Fixes #330.

## Test plan
- [x] `[1.0, NaN, 3.0]` → `[-1.0, 0.0, 1.0]` via `normalize_global` and `Part.compute_advantages(scope="global")`
- [x] singleton `[1.0]` → `[0.0]`
- [x] cold import `unirl.types.sample` / `unirl.algorithms.normalizers` (no circular import)
- [ ] Existing GRPO training smoke if desired