### PR TITLE
feat(trainer): log eval media and decouple eval sampling from the RL rollout

### DIFF
--- a/unirl/train_async_diffusion.py
+++ b/unirl/train_async_diffusion.py
@@ -51,8 +51,10 @@ def main(cfg: DictConfig) -> None:
         eval_num_prompts=cfg.get("eval_num_prompts", 64),
         eval_samples_per_prompt=cfg.get("eval_samples_per_prompt", 4),
         eval_chunk_prompts=cfg.get("eval_chunk_prompts", 16),
-        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale", 4.0),
+        # Unset ⇒ eval inherits `sampling.guidance_scale` instead of a fixed default.
+        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale"),
         eval_eta=cfg.get("eval_eta", 0.0),
+        eval_sampling_cfg=cfg.get("eval_sampling"),
         eval_rewards_cfg=cfg.get("eval_rewards"),
         task_config=cfg.get("task_config"),
         max_inflight=int(cfg.get("max_inflight", 1)),

--- a/unirl/train_diffusion.py
+++ b/unirl/train_diffusion.py
@@ -62,8 +62,10 @@ def main(cfg: DictConfig) -> None:
         eval_num_prompts=cfg.get("eval_num_prompts", 64),
         eval_samples_per_prompt=cfg.get("eval_samples_per_prompt", 4),
         eval_chunk_prompts=cfg.get("eval_chunk_prompts", 16),
-        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale", 4.0),
+        # Unset ⇒ eval inherits `sampling.guidance_scale` instead of a fixed default.
+        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale"),
         eval_eta=cfg.get("eval_eta", 0.0),
+        eval_sampling_cfg=cfg.get("eval_sampling"),
         eval_rewards_cfg=cfg.get("eval_rewards"),
         task_config=_resolve_task_config(cfg),
     )

--- a/unirl/train_pe.py
+++ b/unirl/train_pe.py
@@ -36,8 +36,10 @@ def main(cfg: DictConfig) -> None:
         diffusion_group_scope=cfg.get("diffusion_group_scope", "rewrite"),
         eval_interval=int(cfg.get("eval_interval", 0)),
         eval_num_prompts=int(cfg.get("eval_num_prompts", cfg.batch_size)),
-        eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
+        # Unset ⇒ eval inherits `sampling.guidance_scale` instead of a fixed default.
+        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale"),
         eval_eta=float(cfg.get("eval_eta", 0.0)),
+        eval_sampling_cfg=cfg.get("eval_sampling"),
         eval_rewards_cfg=cfg.get("eval_rewards"),
     )
     trainer.train(

--- a/unirl/train_unified_model.py
+++ b/unirl/train_unified_model.py
@@ -58,8 +58,10 @@ def main(cfg: DictConfig) -> None:
         enable_fsdp_offload=cfg.get("enable_fsdp_offload", True),
         eval_interval=cfg.get("eval_interval", 0),
         eval_num_prompts=cfg.get("eval_num_prompts", cfg.batch_size),
-        eval_cfg_text_scale=float(cfg.get("eval_cfg_text_scale", 4.0)),
+        # Unset ⇒ eval inherits `sampling.guidance_scale` instead of a fixed default.
+        eval_cfg_text_scale=cfg.get("eval_cfg_text_scale"),
         eval_eta=float(cfg.get("eval_eta", 0.0)),
+        eval_sampling_cfg=cfg.get("eval_sampling"),
         eval_rewards_cfg=cfg.get("eval_rewards"),
     )
     trainer.train(

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -251,6 +251,63 @@ an evaluation and checkpoint fall on the same step, evaluation runs first.
 - Agentic evaluation is not implemented. Barrier and partial variants raise if
   evaluation is enabled; async variants currently force it off.
 
+## Eval sampling: what eval shares with the RL rollout, and what it does not
+
+Eval **inherits the training `sampling:` block** and overlays only what the recipe
+asks for. The rollout's own params are untouched, so eval settings never leak into
+the trajectories the policy is trained on.
+
+| Recipe key | Overrides | Default when unset |
+| --- | --- | --- |
+| `eval_num_prompts` | prompts pulled from `run.eval_data_path` | `64` (diffusion) |
+| `eval_samples_per_prompt` | images per eval prompt | `4` (diffusion) |
+| `eval_chunk_prompts` | prompts per eval `generate` (driver memory) | `16` (diffusion) |
+| `eval_cfg_text_scale` | CFG scale (`cfg_text_scale` on BAGEL, else `guidance_scale`) | **inherits `sampling.guidance_scale`** |
+| `eval_eta` | SDE noise level; `<= 0` also clears the SDE gate → pure ODE | `0.0` |
+| `eval_sampling:` | **any** `DiffusionSamplingParams` field | inherits `sampling:` |
+
+`eval_sampling:` is a plain overlay, not a Hydra target — it takes no `_target_`,
+and an unknown field raises instead of being silently dropped. It applies last, so
+it wins over the scalar knobs above:
+
+```yaml
+sampling:                       # the RL rollout: cheap, stochastic, CFG on
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  num_inference_steps: 10
+  guidance_scale: 4.0
+  height: 512
+  width: 512
+  eta: 0.7
+  samples_per_prompt: 8
+
+eval_interval: 20
+eval_samples_per_prompt: 4
+eval_sampling:                  # eval only: full step count and resolution
+  num_inference_steps: 28
+  height: 1024
+  width: 1024
+```
+
+CFG is decoupled by construction: `sampling.guidance_scale` is what the rollout
+samples with **and what the trainer replays log-probs at** (they must match — the
+policy being optimized is the CFG-combined sampler), while `eval_cfg_text_scale`
+(or `eval_sampling.guidance_scale`) is eval-only. Leaving it unset inherits the
+training guidance, so a CFG-off run cannot silently evaluate with CFG on.
+
+## Eval media
+
+`logging.log_media: true` uploads a preview grid at every eval under
+`eval/generated_media` (`eval/<suite>/generated_media` for own-set suites), on the
+`eval/step` axis so it lines up with `eval/reward`. `media_log_interval` paces the
+rollout panel only — eval already has `eval_interval` as its cadence.
+
+The grid is a **fixed comparison set**, not a fresh draw: eval prompts are the head
+of the eval file and eval x_T is keyed on prompt content and sibling ordinal
+(`make_prompt_seed_group_id`, independent of rollout id and rank), so the first
+`media_max_items` samples are the same prompts at the same noise at every eval.
+Panels across a run are therefore directly comparable, and so are two runs sharing
+an eval set and `sampling.seed`.
+
 ## Gotchas
 
 - **Multi-update means disjoint optimizer mini-batches, not repeated full-batch

--- a/unirl/trainer/base.py
+++ b/unirl/trainer/base.py
@@ -272,13 +272,9 @@ class BaseTrainer:
         DP_SCATTER-serialized to the training workers right after this call):
 
         1. **Media logging (driver-side).** When the logger wants media this
-           rollout (``UniRLWandBLogger.should_log_media``), take each gen Part's
-           inbound ``media_preview`` or build one from the still-live
-           ``primitives`` (``build_media_preview_for_part`` hydrates a single DP
-           shard), cap to ``media_max_items``, and upload it at the same
-           ``rollout/step`` value :meth:`UniRLWandBLogger.log_rollout_step` uses,
-           so the panels align. Captions default to the frontier-aligned prompt
-           texts (``Sample.conditioning``).
+           rollout (``UniRLWandBLogger.should_log_media``), draw the previews via
+           :meth:`_upload_media_previews` at the same ``rollout/step`` value
+           :meth:`UniRLWandBLogger.log_rollout_step` uses, so the panels align.
         2. **Free the per-rollout payloads.** ``primitives`` (generated
            Images/Videos/Texts/Audios) is consumed upstream by reward scoring and never
            read by training (which uses only segment/conditions/advantages);
@@ -290,38 +286,76 @@ class BaseTrainer:
         Call after scoring / advantages (and any decoded-reading debug dump),
         immediately before dispatching to ``train_track``.
         """
-        from unirl.types.primitives import Images, Texts
-
-        gen_parts = sample.gen_parts()
         wb = self.wandb_logger
         if wb is not None and wb.should_log_media(rollout_id):
-            from unirl.types.media_preview import build_media_preview_for_part
+            self._upload_media_previews(sample, rollout_id + 1, prefix="rollout", step_key="rollout/step")
 
-            multi = len(gen_parts) > 1
-            cond = sample.conditioning()
-            default_prompts = next((list(c.texts) for c in cond if isinstance(c, Texts)), None)
-            input_image = next((c for c in cond if isinstance(c, Images)), None)
-            for part in gen_parts:
-                name = "ar" if isinstance(part.sampling_params, ARSamplingParams) else "diffusion"
-                preview = part.media_preview
-                if preview is None and part.primitives:
-                    preview = build_media_preview_for_part(
-                        part=part,
-                        max_items=wb.media_max_items,
-                        prompts=default_prompts if part is sample.parts[-1] else None,
-                        input_image=input_image,
-                    )
-                if preview is None:
-                    continue
-                if len(preview) > wb.media_max_items:
-                    preview = preview.slice(0, wb.media_max_items)
-                key = f"rollout/{name}/generated_media" if multi else "rollout/generated_media"
-                wb.log_generated_media(rollout_id + 1, preview, key=key)
-
-        for part in gen_parts:
+        for part in sample.gen_parts():
             part.primitives = {}
             part.primitive_metadata = {}
             part.media_preview = None
+
+    def _upload_media_previews(
+        self,
+        sample: Sample,
+        step: int,
+        *,
+        prefix: str,
+        step_key: str,
+    ) -> None:
+        """Upload one preview grid per generated track of ``sample`` under ``prefix``.
+
+        Takes each gen ``Part``'s inbound ``media_preview`` or builds one from its
+        still-live ``primitives`` (``build_media_preview_for_part`` hydrates a single
+        DP shard), caps it to ``media_max_items``, and logs it on ``step_key`` so the
+        panel shares an axis with that caller's scalars. Captions default to the
+        frontier-aligned prompt texts (``Sample.conditioning``). Multi-track samples
+        get one key per track (``{prefix}/{ar,diffusion}/generated_media``).
+
+        Cadence is the CALLER's business — this only decides what to draw.
+        """
+        from unirl.types.media_preview import build_media_preview_for_part
+        from unirl.types.primitives import Images, Texts
+
+        wb = self.wandb_logger
+        gen_parts = sample.gen_parts()
+        multi = len(gen_parts) > 1
+        cond = sample.conditioning()
+        default_prompts = next((list(c.texts) for c in cond if isinstance(c, Texts)), None)
+        input_image = next((c for c in cond if isinstance(c, Images)), None)
+        for part in gen_parts:
+            name = "ar" if isinstance(part.sampling_params, ARSamplingParams) else "diffusion"
+            preview = part.media_preview
+            if preview is None and part.primitives:
+                preview = build_media_preview_for_part(
+                    part=part,
+                    max_items=wb.media_max_items,
+                    prompts=default_prompts if part is sample.parts[-1] else None,
+                    input_image=input_image,
+                )
+            if preview is None:
+                continue
+            if len(preview) > wb.media_max_items:
+                preview = preview.slice(0, wb.media_max_items)
+            key = f"{prefix}/{name}/generated_media" if multi else f"{prefix}/generated_media"
+            wb.log_generated_media(step, preview, key=key, step_key=step_key)
+
+    def _log_eval_media(self, sample: Sample, step: int, *, prefix: str = "eval") -> None:
+        """Upload the eval preview grid for one scored eval chunk.
+
+        Called with the FIRST chunk of an eval sweep, which is a fixed comparison
+        grid rather than a fresh draw: eval prompts are the head of the eval set
+        (``get_eval_samples`` is deterministic) and eval x_T is keyed on prompt
+        content and sibling ordinal (``make_prompt_seed_group_id``, independent of
+        rollout id and rank). Capping at ``media_max_items`` therefore yields the
+        SAME prompts at the SAME noise at every eval, so the panels are a
+        like-for-like A/B across training. Pass a scored Sample so captions carry
+        the eval reward.
+        """
+        wb = self.wandb_logger
+        if wb is None or not wb.should_log_eval_media():
+            return
+        self._upload_media_previews(sample, step, prefix=prefix, step_key="eval/step")
 
     def _wait_for_checkpoints(self, *, timeout: Optional[float] = None) -> None:
         """Flush a pending backend checkpoint before worker teardown.

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -13,6 +13,7 @@ from unirl.distributed.group.placement import placement, remote
 from unirl.distributed.tensor import hydrate
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
+from unirl.trainer.eval_sampling import build_eval_sampling, cfg_scale_of
 from unirl.trainer.eval_suites import EvalRewardSuite, build_eval_suites
 from unirl.types.primitives import Texts
 from unirl.types.sample import Sample
@@ -57,8 +58,9 @@ class DiffusionTrainer(BaseTrainer):
         eval_num_prompts: int = 64,
         eval_samples_per_prompt: int = 4,
         eval_chunk_prompts: int = 16,
-        eval_cfg_text_scale: float = 4.0,
+        eval_cfg_text_scale: Optional[float] = None,
         eval_eta: float = 0.0,
+        eval_sampling_cfg: Optional[Any] = None,
         eval_rewards_cfg: Optional[Any] = None,
         task_config: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -72,8 +74,10 @@ class DiffusionTrainer(BaseTrainer):
         self.eval_num_prompts = int(eval_num_prompts)
         self.eval_samples_per_prompt = int(eval_samples_per_prompt)
         self.eval_chunk_prompts = int(eval_chunk_prompts)
-        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
+        # None = inherit the training guidance, so a CFG-off run cannot silently eval with CFG on.
+        self.eval_cfg_text_scale = None if eval_cfg_text_scale is None else float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
+        self._eval_sampling_cfg = eval_sampling_cfg
         self._eval_rewards_cfg = eval_rewards_cfg
         self._eval_suites: List[EvalRewardSuite] = []
         self._task_config: Dict[str, Any] = dict(task_config) if task_config else {}
@@ -506,15 +510,14 @@ class DiffusionTrainer(BaseTrainer):
         """Periodic eval on the eval set (no training); returns the mean reward.
 
         Mirrors :meth:`_rollout_and_score`'s rollout+reward path but skips advantage/backward.
-        Generates at the deterministic best-quality setting (``cfg_text_scale=
-        eval_cfg_text_scale``, ``eta=eval_eta`` — at ``eval_eta=0`` the SDE gate
-        is also cleared, so the request is pure ODE; ``eval_samples_per_prompt``
-        x_T per prompt) and scores. The training reward plus every shared-set
-        ``eval_rewards`` suite scores the SAME generated images over the default
-        eval set (``run.eval_data_path``, ``eval_num_prompts`` prompts); each
-        own-set suite then gets its own generation pass over its own prompts.
-        All means land in one ``eval/*`` row (``eval/reward`` + ``eval/<suite>``);
-        returns ``eval/reward``.
+        Eval sampling INHERITS the training ``sampling:`` block and overlays the
+        ``eval_*`` knobs plus the recipe's ``eval_sampling:`` block on top — see
+        :func:`unirl.trainer.eval_sampling.build_eval_sampling` for the precedence.
+        The training reward plus every shared-set ``eval_rewards`` suite scores the
+        SAME generated images over the default eval set (``run.eval_data_path``,
+        ``eval_num_prompts`` prompts); each own-set suite then gets its own
+        generation pass over its own prompts. All means land in one ``eval/*`` row
+        (``eval/reward`` + ``eval/<suite>``); returns ``eval/reward``.
 
         ``sync_weights=False`` evaluates the policy already resident in the rollout
         engine without changing its weight version, and ``sleep_after=False`` leaves
@@ -527,22 +530,14 @@ class DiffusionTrainer(BaseTrainer):
                 "DiffusionTrainer.evaluate: no reward configured (the recipe has no `reward:` "
                 "block) — evaluation scores generations and needs one."
             )
-        base_diffusion = self.sampling_params.get("diffusion")
-        replace_kwargs = dict(
-            samples_per_prompt=self.eval_samples_per_prompt,
+        eval_sp = build_eval_sampling(
+            self.sampling_params,
+            cfg_text_scale=self.eval_cfg_text_scale,
             eta=self.eval_eta,
+            samples_per_prompt=self.eval_samples_per_prompt,
+            overrides=self._eval_sampling_cfg,
         )
-        if self.eval_eta <= 0.0:
-            # Deterministic eval must also clear the SDE gate: eta=0 with gated
-            # steps is a contradictory request — the central kernel degrades such
-            # steps to ODE, but worker-resident schedulers (BAGEL) refuse the pair.
-            replace_kwargs.update(sde_indices=[], scheduler=None)
-        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
-            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
-        else:
-            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
-        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
-        eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
+        eval_diffusion = eval_sp["diffusion"]
         self.rollout.wake_up()
         try:
             if sync_weights and self.weight_sync is not None:
@@ -550,20 +545,32 @@ class DiffusionTrainer(BaseTrainer):
             scorers = [("reward", self.reward)] + [
                 (s.name, s.reward) for s in self._eval_suites if s.data_source is None
             ]
-            metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step)
+            metrics = self._eval_pass(
+                self.data_source, self.eval_num_prompts, scorers, eval_sp, step, media_prefix="eval"
+            )
             for suite in self._eval_suites:
                 if suite.data_source is not None:
                     n = suite.num_prompts or self.eval_num_prompts
-                    metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], eval_sp, step))
+                    metrics.update(
+                        self._eval_pass(
+                            suite.data_source,
+                            n,
+                            [(suite.name, suite.reward)],
+                            eval_sp,
+                            step,
+                            media_prefix=f"eval/{suite.name}",
+                        )
+                    )
         finally:
             if sleep_after:
                 self.rollout.sleep()
         logger.info(
-            "EVAL step %d  (%d samples/prompt, cfg=%.1f eta=%.1f)  %s",
+            "EVAL step %d  (%d samples/prompt, %d steps, cfg=%.1f eta=%.1f)  %s",
             step,
             self.eval_samples_per_prompt,
-            self.eval_cfg_text_scale,
-            self.eval_eta,
+            eval_diffusion.num_inference_steps,
+            cfg_scale_of(eval_diffusion),
+            eval_diffusion.eta,
             "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
         )
         self.wandb_logger.log_eval(step, metrics)
@@ -576,6 +583,8 @@ class DiffusionTrainer(BaseTrainer):
         scorers: List[Tuple[str, Any]],
         eval_sp: Dict[str, BaseSamplingParams],
         step: int,
+        *,
+        media_prefix: Optional[str] = None,
     ) -> Dict[str, float]:
         """One generate→score sweep over one eval set; returns each scorer's mean.
 
@@ -583,6 +592,10 @@ class DiffusionTrainer(BaseTrainer):
         never holds N x the KV/decoded on the driver (the it2i memory
         bottleneck). Scores the single scorable (segment-carrying) track with
         every scorer — single-track for now; revisit if multi-track lands.
+
+        ``media_prefix`` names the wandb key family for the preview grid drawn
+        from the FIRST chunk (see :meth:`BaseTrainer._log_eval_media`); the first
+        scorer's Sample is used so captions carry its reward.
         """
         all_inputs = data_source.get_eval_samples(num_prompts)
         n_prompts = all_inputs.batch_size
@@ -593,13 +606,18 @@ class DiffusionTrainer(BaseTrainer):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             request = self._build_request_sample(sub, step, sampling=eval_sp)
             generated = self.rollout.generate(request)
+            first_scored: Optional[Sample] = None
             for name, reward in scorers:
                 scored = reward.score_and_attach(generated)
+                if first_scored is None:
+                    first_scored = scored
                 rewards = scored.parts[-1].rewards
                 if rewards is not None:
                     r = hydrate(rewards).to(torch.float32)
                     sums[name] += float(r.sum().item())
                     counts[name] += int(r.numel())
+            if media_prefix and start == 0 and first_scored is not None:
+                self._log_eval_media(first_scored, step, prefix=media_prefix)
         return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     def train(

--- a/unirl/trainer/eval_sampling.py
+++ b/unirl/trainer/eval_sampling.py
@@ -1,0 +1,84 @@
+"""Eval-time diffusion sampling: the overlay resolver shared by every diffusion-capable trainer."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Dict, Mapping, Optional, Set
+
+from omegaconf import OmegaConf
+
+from unirl.types.sampling import BaseSamplingParams
+
+
+def cfg_scale_of(params: Any) -> float:
+    """The CFG scale a diffusion params object will actually be sampled with.
+
+    BAGEL-family params carry ``cfg_text_scale``; every other family carries
+    ``guidance_scale``. Reading the scale through here keeps log lines and eval
+    overrides on the same field the pipeline consumes.
+    """
+    scale = getattr(params, "cfg_text_scale", None)
+    return float(params.guidance_scale if scale is None else scale)
+
+
+def build_eval_sampling(
+    sampling_params: Dict[str, BaseSamplingParams],
+    *,
+    cfg_text_scale: Optional[float] = None,
+    eta: float = 0.0,
+    samples_per_prompt: Optional[int] = None,
+    overrides: Any = None,
+) -> Dict[str, BaseSamplingParams]:
+    """Return ``sampling_params`` with its ``diffusion`` entry rebuilt for evaluation.
+
+    Eval INHERITS the training ``sampling:`` block and overlays only what the
+    recipe asks for, later winning over earlier:
+
+    1. ``eta`` — recipe ``eval_eta`` (default ``0.0``: deterministic ODE eval).
+    2. ``samples_per_prompt`` when given — recipe ``eval_samples_per_prompt``.
+    3. the CFG scale when ``cfg_text_scale`` is not None — recipe
+       ``eval_cfg_text_scale``. ``None`` inherits the training guidance, so a
+       CFG-off run cannot silently evaluate with CFG on.
+    4. ``overrides`` — the recipe's ``eval_sampling:`` block: any
+       :class:`~unirl.types.sampling.DiffusionSamplingParams` field
+       (``num_inference_steps``, ``height`` / ``width``, ``seed``, ...). Unknown
+       keys raise rather than being silently dropped.
+
+    A resolved ``eta <= 0`` then clears the SDE gate (``sde_indices=[]``,
+    ``scheduler=None``): eta=0 with gated steps is a contradictory request — the
+    central kernel degrades such steps to ODE, and worker-resident schedulers
+    (BAGEL) refuse the pair outright. Overlaying ``eta`` back above 0 keeps the
+    training gate, so an SDE eval stays expressible.
+    """
+    base = sampling_params.get("diffusion")
+    if base is None:
+        raise ValueError("build_eval_sampling: sampling params carry no `diffusion` entry to override.")
+    field_names = {f.name for f in dataclasses.fields(base)}
+
+    updates: Dict[str, Any] = {"eta": float(eta)}
+    if samples_per_prompt is not None:
+        updates["samples_per_prompt"] = int(samples_per_prompt)
+    if cfg_text_scale is not None:
+        updates["cfg_text_scale" if "cfg_text_scale" in field_names else "guidance_scale"] = float(cfg_text_scale)
+    updates.update(_resolve_overrides(overrides, field_names))
+    if float(updates["eta"]) <= 0.0:
+        updates["sde_indices"] = []
+        updates["scheduler"] = None
+    return {**sampling_params, "diffusion": dataclasses.replace(base, **updates)}
+
+
+def _resolve_overrides(overrides: Any, field_names: Set[str]) -> Dict[str, Any]:
+    """Validate a recipe ``eval_sampling:`` block into plain ``dataclasses.replace`` kwargs."""
+    if overrides is None:
+        return {}
+    if OmegaConf.is_config(overrides):
+        overrides = OmegaConf.to_container(overrides, resolve=True)
+    if not isinstance(overrides, Mapping):
+        raise TypeError(
+            "eval_sampling must be a mapping of diffusion sampling fields, "
+            f"got {type(overrides).__name__}. It overlays `sampling:`, so it takes no `_target_`."
+        )
+    unknown = sorted(set(overrides) - field_names)
+    if unknown:
+        raise ValueError(f"eval_sampling has unknown field(s) {unknown}; valid fields are {sorted(field_names)}.")
+    return dict(overrides)

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -38,6 +38,7 @@ from unirl.distributed.tensor import hydrate
 from unirl.models.pe.pipeline import PEPipeline
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
+from unirl.trainer.eval_sampling import build_eval_sampling, cfg_scale_of
 from unirl.trainer.eval_suites import build_eval_suites
 from unirl.types.sample import Sample
 from unirl.types.sampling import ARSamplingParams, BaseSamplingParams, DiffusionSamplingParams
@@ -102,8 +103,9 @@ class PETrainer(BaseTrainer):
         diffusion_group_scope: str = "rewrite",
         eval_interval: int = 0,
         eval_num_prompts: int = 8,
-        eval_cfg_text_scale: float = 4.0,
+        eval_cfg_text_scale: Optional[float] = None,
         eval_eta: float = 0.0,
+        eval_sampling_cfg: Optional[Any] = None,
         eval_rewards_cfg: Optional[Any] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -120,8 +122,10 @@ class PETrainer(BaseTrainer):
 
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
-        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
+        # None = inherit the training guidance, so a CFG-off run cannot silently eval with CFG on.
+        self.eval_cfg_text_scale = None if eval_cfg_text_scale is None else float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
+        self._eval_sampling_cfg = eval_sampling_cfg
 
         pe = pe_cfg if pe_cfg is not None else {}
         self._pe_instruction = pe.get("pe_instruction", None)
@@ -323,14 +327,13 @@ class PETrainer(BaseTrainer):
         land in one ``eval/*`` row (``eval/reward`` + ``eval/<suite>``); returns
         ``eval/reward``.
         """
-        base_diffusion = self.sampling_params.get("diffusion")
-        replace_kwargs = dict(eta=self.eval_eta)
-        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
-            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
-        else:
-            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
-        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
-        eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
+        eval_sp = build_eval_sampling(
+            self.sampling_params,
+            cfg_text_scale=self.eval_cfg_text_scale,
+            eta=self.eval_eta,
+            overrides=self._eval_sampling_cfg,
+        )
+        eval_diffusion = eval_sp["diffusion"]
         self.rollout.wake_up()
         try:
             if self.diffusion_sync is not None:
@@ -340,18 +343,30 @@ class PETrainer(BaseTrainer):
             scorers = [("reward", self.reward)] + [
                 (s.name, s.reward) for s in self._eval_suites if s.data_source is None
             ]
-            metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step)
+            metrics = self._eval_pass(
+                self.data_source, self.eval_num_prompts, scorers, eval_sp, step, media_prefix="eval"
+            )
             for suite in self._eval_suites:
                 if suite.data_source is not None:
                     n = suite.num_prompts or self.eval_num_prompts
-                    metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], eval_sp, step))
+                    metrics.update(
+                        self._eval_pass(
+                            suite.data_source,
+                            n,
+                            [(suite.name, suite.reward)],
+                            eval_sp,
+                            step,
+                            media_prefix=f"eval/{suite.name}",
+                        )
+                    )
         finally:
             self.rollout.sleep()
         logger.info(
-            "EVAL step %d  (cfg=%.1f eta=%.1f)  %s",
+            "EVAL step %d  (%d steps, cfg=%.1f eta=%.1f)  %s",
             step,
-            self.eval_cfg_text_scale,
-            self.eval_eta,
+            eval_diffusion.num_inference_steps,
+            cfg_scale_of(eval_diffusion),
+            eval_diffusion.eta,
             "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
         )
         self.wandb_logger.log_eval(step, metrics)
@@ -364,6 +379,8 @@ class PETrainer(BaseTrainer):
         scorers: List[Tuple[str, Any]],
         eval_sp: Dict[str, BaseSamplingParams],
         step: int,
+        *,
+        media_prefix: Optional[str] = None,
     ) -> Dict[str, float]:
         """One generate→score sweep over one eval set; returns each scorer's mean.
 
@@ -371,6 +388,9 @@ class PETrainer(BaseTrainer):
         P-prompt req, so the chunk must be divisible by the engine dp; ``batch_size``
         is what training already runs, so it is divisible. A ragged tail
         (``num_prompts`` not a multiple of ``batch_size``) is floored off.
+
+        ``media_prefix`` names the wandb key family for the preview grid drawn
+        from the FIRST chunk (see :meth:`BaseTrainer._log_eval_media`).
         """
         all_inputs = data_source.get_eval_samples(num_prompts)
         n_prompts = all_inputs.batch_size
@@ -382,13 +402,18 @@ class PETrainer(BaseTrainer):
             sub = all_inputs.slice(start, min(start + chunk, n_prompts))
             request = self._build_request_sample(sub, step, sampling=eval_sp)
             generated = self.rollout.generate(request)
+            first_scored: Optional[Sample] = None
             for name, reward in scorers:
                 scored = reward.score_and_attach(generated)
+                if first_scored is None:
+                    first_scored = scored
                 rewards = scored.parts[-1].rewards
                 if rewards is not None:
                     r = hydrate(rewards).to(torch.float32)
                     sums[name] += float(r.sum().item())
                     counts[name] += int(r.numel())
+            if media_prefix and start == 0 and first_scored is not None:
+                self._log_eval_media(first_scored, step, prefix=media_prefix)
         return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     def _ckpt_sides(self):

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -68,6 +68,7 @@ from unirl.distributed.tensor import TensorRef, hydrate
 from unirl.distributed.tensor.batch import Batch
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
+from unirl.trainer.eval_sampling import build_eval_sampling, cfg_scale_of
 from unirl.trainer.eval_suites import build_eval_suites
 from unirl.types.primitives import Images, Texts
 from unirl.types.sample import Part, Sample
@@ -145,8 +146,9 @@ class UnifiedModelTrainer(BaseTrainer):
         enable_fsdp_offload: bool = True,
         eval_interval: int = 0,
         eval_num_prompts: int = 32,
-        eval_cfg_text_scale: float = 4.0,
+        eval_cfg_text_scale: Optional[float] = None,
         eval_eta: float = 0.0,
+        eval_sampling_cfg: Optional[Any] = None,
         eval_rewards_cfg: Optional[Any] = None,
     ) -> None:
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
@@ -155,8 +157,10 @@ class UnifiedModelTrainer(BaseTrainer):
 
         self.eval_interval = int(eval_interval)
         self.eval_num_prompts = int(eval_num_prompts)
-        self.eval_cfg_text_scale = float(eval_cfg_text_scale)
+        # None = inherit the training guidance, so a CFG-off run cannot silently eval with CFG on.
+        self.eval_cfg_text_scale = None if eval_cfg_text_scale is None else float(eval_cfg_text_scale)
         self.eval_eta = float(eval_eta)
+        self._eval_sampling_cfg = eval_sampling_cfg
 
         self.dump_dir = str(dump_dir) if dump_dir else None
         self._dump_rollout_id = 0
@@ -617,14 +621,13 @@ class UnifiedModelTrainer(BaseTrainer):
         rollout shares the live FSDP modules; ``_enable_fsdp_offload`` is
         forced False).
         """
-        base_diffusion = self.sampling_params.get("diffusion")
-        replace_kwargs = dict(eta=self.eval_eta)
-        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
-            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
-        else:
-            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
-        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
-        eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
+        eval_sp = build_eval_sampling(
+            self.sampling_params,
+            cfg_text_scale=self.eval_cfg_text_scale,
+            eta=self.eval_eta,
+            overrides=self._eval_sampling_cfg,
+        )
+        eval_diffusion = eval_sp["diffusion"]
         if not self._single_engine and self.weight_sync is not None:
             if self._enable_fsdp_offload:
                 self.backend.onload()
@@ -639,16 +642,26 @@ class UnifiedModelTrainer(BaseTrainer):
                 for eng in self.ar_rollouts + self.dit_rollouts:
                     eng.sleep()
         scorers = [("reward", self.reward)] + [(s.name, s.reward) for s in self._eval_suites if s.data_source is None]
-        metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step)
+        metrics = self._eval_pass(self.data_source, self.eval_num_prompts, scorers, eval_sp, step, media_prefix="eval")
         for suite in self._eval_suites:
             if suite.data_source is not None:
                 n = suite.num_prompts or self.eval_num_prompts
-                metrics.update(self._eval_pass(suite.data_source, n, [(suite.name, suite.reward)], eval_sp, step))
+                metrics.update(
+                    self._eval_pass(
+                        suite.data_source,
+                        n,
+                        [(suite.name, suite.reward)],
+                        eval_sp,
+                        step,
+                        media_prefix=f"eval/{suite.name}",
+                    )
+                )
         logger.info(
-            "EVAL step %d  (cfg=%.1f eta=%.1f)  %s",
+            "EVAL step %d  (%d steps, cfg=%.1f eta=%.1f)  %s",
             step,
-            self.eval_cfg_text_scale,
-            self.eval_eta,
+            eval_diffusion.num_inference_steps,
+            cfg_scale_of(eval_diffusion),
+            eval_diffusion.eta,
             "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
         )
         self.wandb_logger.log_eval(step, metrics)
@@ -661,6 +674,8 @@ class UnifiedModelTrainer(BaseTrainer):
         scorers: List[Tuple[str, Any]],
         eval_sp: Dict[str, BaseSamplingParams],
         step: int,
+        *,
+        media_prefix: Optional[str] = None,
     ) -> Dict[str, float]:
         """One generate→score sweep over one eval set; returns each scorer's mean.
 
@@ -668,6 +683,9 @@ class UnifiedModelTrainer(BaseTrainer):
         so the chunk must be dp-divisible; ``batch_size`` is what training
         runs). A ragged tail (``num_prompts`` not a multiple of ``batch_size``)
         is floored off.
+
+        ``media_prefix`` names the wandb key family for the preview grid drawn
+        from the FIRST chunk (see :meth:`BaseTrainer._log_eval_media`).
         """
         all_inputs = data_source.get_eval_samples(num_prompts)
         n_prompts = all_inputs.batch_size
@@ -688,13 +706,18 @@ class UnifiedModelTrainer(BaseTrainer):
                 finally:
                     for eng in self.ar_rollouts + self.dit_rollouts:
                         eng.sleep()
+            first_scored: Optional[Sample] = None
             for name, reward in scorers:
                 scored = reward.score_and_attach(generated)
+                if first_scored is None:
+                    first_scored = scored
                 rewards = scored.parts[-1].rewards
                 if rewards is not None:
                     r = hydrate(rewards).to(torch.float32)
                     sums[name] += float(r.sum().item())
                     counts[name] += int(r.numel())
+            if media_prefix and start == 0 and first_scored is not None:
+                self._log_eval_media(first_scored, step, prefix=media_prefix)
         return {name: sums[name] / max(1, counts[name]) for name, _ in scorers}
 
     def train(

--- a/unirl/utils/wandb_logger.py
+++ b/unirl/utils/wandb_logger.py
@@ -533,6 +533,7 @@ class UniRLWandBLogger:
         key: str = "rollout/generated_media",
         video_key: Optional[str] = None,
         video_fps: int = 8,
+        step_key: str = "rollout/step",
     ) -> None:
         """Log rollout media preview payload produced by the rollout pipeline.
 
@@ -543,7 +544,7 @@ class UniRLWandBLogger:
 
         Images and videos go to *separate* wandb keys so wandb renders each
         as its native panel type. Both are logged in a single ``wandb.log``
-        call sharing ``"rollout/step"`` so the panels line up on the same
+        call sharing ``step_key`` so the panels line up on the same
         step axis. Captions ("``{prompt:.100} | reward: {r:.2f}``") are
         built once and applied to both ``wandb.Image`` and ``wandb.Video``
         so a sample's image and video panels show identical caption text.
@@ -558,6 +559,9 @@ class UniRLWandBLogger:
                 replacing a trailing ``"_images"`` / ``"_media"`` with
                 ``"_videos"``, or falls back to ``f"{key}/videos"``.
             video_fps: framerate for ``wandb.Video`` mp4 encoding.
+            step_key: step axis the panels are logged on. Eval callers pass
+                ``"eval/step"`` so the grid shares an axis with
+                :meth:`log_eval`'s scalars instead of the rollout axis.
         """
         if media_preview is None:
             return
@@ -616,7 +620,7 @@ class UniRLWandBLogger:
                     return f"{prompt[:100]} | reward: {reward_values[idx]:.2f}"
                 return f"{prompt[:100]}"
 
-            payload: Dict[str, Any] = {"rollout/step": int(rollout_id)}
+            payload: Dict[str, Any] = {step_key: int(rollout_id)}
 
             if has_images:
                 wandb_images = [
@@ -693,6 +697,16 @@ class UniRLWandBLogger:
         logging is off, disabled, or this rollout isn't on the cadence.
         """
         return self.enabled and self.log_media and (int(rollout_id) % self.media_log_interval == 0)
+
+    def should_log_eval_media(self) -> bool:
+        """Whether eval generations should be captured/logged — ``eval_interval`` is the only cadence.
+
+        ``media_log_interval`` deliberately does NOT apply: it paces the rollout
+        panel against the per-rollout clock, while eval already fires on its own
+        (much coarser) ``eval_interval``. Intersecting the two would silently drop
+        most eval grids, which are the panel a run is actually read from.
+        """
+        return self.enabled and self.log_media
 
     def log_rollout_step(
         self,


### PR DESCRIPTION
## Summary

Three complaints from a colleague running FLUX.2-Klein MixGRPO (`flux2_klein_mixgrpo_hpsv2_reward.yaml`), triaged against the code:

**1. Eval reports numbers but no images.** Real gap. `BaseTrainer._drop_decoded` was the only place that uploaded media, hard-keyed to `rollout/generated_media` and only reachable from the training rollout path; `DiffusionTrainer._eval_pass` generated, scored, and dropped the PIL payloads. So a run could show `eval/reward` rising with nothing to look at.

This PR uploads the first eval chunk under `eval/generated_media` (`eval/<suite>/generated_media` for own-set suites), gated by the existing `logging.log_media`, on the `eval/step` axis so the panel shares an x-axis with `eval/reward` (`log_generated_media` grew a `step_key`; it previously hard-coded `rollout/step`). Captions carry prompt + eval reward.

**2. "Fixed seed/prompt so evals are comparable" — already true, just invisible.** Eval prompts are the deterministic head of `run.eval_data_path`, and eval x_T is keyed on prompt content + sibling ordinal (`make_prompt_seed_group_id` → `_derive_group_seed`, independent of rollout id and rank, from #294). So capping the panel at `media_max_items` yields *the same prompts at the same noise at every eval*. Making the images visible is all that was needed — the grid is a like-for-like A/B across training, and across two runs sharing an eval set and `sampling.seed`.

**3. "Decouple CFG between RL and eval" — already supported; only the default needed changing.** `eval_cfg_text_scale` already replaced `guidance_scale` (or `cfg_text_scale` on BAGEL) for eval only, and training replay reads the rollout's own params, so the two never shared. What bit the user was the **4.0 default** — the deliberate "eval always runs with CFG on" convention from #202. That convention is fine when training also runs CFG on, but every in-repo MixGRPO recipe runs `guidance_scale: 1.0`, so turning on `eval_interval` silently evaluated a CFG-off policy at CFG 4, with no log line saying so. Unset now inherits `sampling.guidance_scale`; #202's behavior is still one explicit line away. Usage is documented in `unirl/trainer/README.md`.

**4. Decouple eval params from the RL rollout.** Partially supported and expensive to extend: only `eval_num_prompts` / `eval_samples_per_prompt` / `eval_chunk_prompts` / `eval_cfg_text_scale` / `eval_eta` existed, each hand-written into a `dataclasses.replace` **duplicated across `DiffusionTrainer`, `PETrainer`, and `UnifiedModelTrainer`** — `num_inference_steps`, `height`/`width`, `seed`, negative prompt and the rest were simply not overridable per-eval.

Added an `eval_sampling:` overlay accepting **any** `DiffusionSamplingParams` field, inheriting `sampling:` for everything it does not mention and applying after the scalar knobs. Unknown fields raise instead of being silently dropped. The three trainers now share one `unirl.trainer.eval_sampling.build_eval_sampling`, and their `EVAL` log line reports the *resolved* steps/cfg/eta rather than the requested knobs.

```yaml
sampling:                       # the RL rollout: cheap, stochastic, CFG on
  num_inference_steps: 10
  guidance_scale: 4.0
  height: 512
  eta: 0.7
  samples_per_prompt: 8

eval_interval: 20
eval_samples_per_prompt: 4
eval_sampling:                  # eval only; everything else inherits `sampling`
  num_inference_steps: 28
  height: 1024
  width: 1024
logging:
  log_media: true
```

## Related Issue

N/A

## Test Plan

CPU-only jumpbox, so no GPU rollout — the checks below are config/logic level and the eval generate path itself is unexercised.

- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure` — all 17 hooks pass (ruff check, ruff format, recipe `_target_` resolution over 2476 paths, experimental boundaries).
- Hydra config resolution with the new block:
  `python -m unirl.train_diffusion --config-name=diffusion/sd3/sd3_mixgrpo --cfg job --resolve +eval_interval=20 +eval_sampling.num_inference_steps=28 +eval_sampling.height=1024 +eval_sampling.width=1024` — resolves, block present.
- Throwaway harness over `build_eval_sampling` / `cfg_scale_of` (run, not committed) — 7/7:
  unset cfg inherits training guidance (4.0) and a `guidance_scale: 1.0` run evals at 1.0; explicit `eval_cfg_text_scale` still wins and leaves the training params unmutated; overlay sets `num_inference_steps=28 @ 1024x1024 seed=7` while inheriting cfg and `samples_per_prompt`; overlay beats the scalar knobs and `eta>0` keeps the training SDE gate while `eta<=0` clears `sde_indices`/`scheduler`; a typo'd field and a stray `_target_` both raise.
- Throwaway harness driving `BaseTrainer._log_eval_media` over a real 2-prompt x 4-sample `Sample` with a captured `wandb.log` (run, not committed) — 7/7:
  `log_media: false` uploads nothing; otherwise exactly one payload keyed `eval/generated_media` on `eval/step=40`; capped at `media_max_items=8` with captions `"a red cube | reward: 0.00"`; the cap is a prefix of the deterministic eval order; suite prefix yields `eval/pickscore/generated_media`; **regression** — `_drop_decoded` still logs `rollout/generated_media` on `rollout/step=7` and still frees `primitives`/`media_preview`; `media_log_interval=20` still paces the rollout panel and never the eval panel.

## Compatibility / Risk

- **Behavior change (intended), reverses a #202 convention:** a recipe with `eval_interval > 0` and no `eval_cfg_text_scale` now evaluates at `sampling.guidance_scale` instead of 4.0. That is the point — it removes a silent train/eval mismatch — but any run that *relied* on the 4.0 default must now write `eval_cfg_text_scale: 4.0` (one line, and the EVAL log line now prints the resolved scale either way). No recipe in `examples/` sets both `eval_interval > 0` and an unset scale, so nothing in-tree changes. ReFL is unaffected: `experimental/refl` deliberately dropped eval entirely.
- Eval media is off unless `logging.log_media: true` (default false), so existing runs are untouched. When on, it adds one preview build + upload per eval — the same driver-side cost the rollout panel already pays, at the much coarser `eval_interval` cadence.
- `eval_sampling:` is additive and optional. `_upload_media_previews` is `_drop_decoded`'s previous body verbatim; `log_generated_media`'s `step_key` defaults to the old `rollout/step`.
- No checkpoint, data-format, or API changes.

## Reviewer Notes

- AI-assisted (Claude Code); every line reviewed by the submitter. Duplicate-work check: no open PR touches eval media or eval sampling — the closest, #294, is the merged deterministic-eval-noise fix this builds on.
- Start with `unirl/trainer/eval_sampling.py` (the precedence order is the whole design) and `unirl/trainer/README.md` (the two new sections are the user-facing answer to "I don't know how to drive this").
- Media logging was wired into `PETrainer` and `UnifiedModelTrainer` as well as `DiffusionTrainer` since they share `_eval_pass`'s shape and all log `eval/*`. Only the diffusion path is what the reporting user runs; the other two are unexercised here beyond import/lint.
- Follow-up, deliberately not in this PR: the same colleague asked for an in-repo **MixGRPO recipe with CFG on**. All four current MixGRPO recipes run `guidance_scale: 1.0` and set no `eval_*` knobs, and there is no `flux2_klein` MixGRPO recipe at all. Their local `flux2_klein_mixgrpo_hpsv2_reward.yaml` is close to shippable and would be a good separate PR now that `eval_sampling:` exists.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
