### PR TITLE
Feat/differentiable reward upstream

### DIFF
--- a/experimental/refl/examples/sd3_pickscore_refl_managed.yaml
+++ b/experimental/refl/examples/sd3_pickscore_refl_managed.yaml
@@ -1,0 +1,160 @@
+# @package _global_
+# REFL SD3.5 T2I — PickScore reward (ported from the legacy core path,
+# examples/diffusion/refl_sd3.yaml; hyperparameters preserved).
+#
+# Second family on the experimental.refl contract: only pipeline_target,
+# model_config, the reward backend, and the sampling geometry differ from
+# the WAN configs. The reward comes straight from core
+# (unirl.reward.local.pickscore) — no package-local reward needed.
+
+num_devices: 8
+batch_size: 8
+num_rollouts: 200
+save_interval: 0
+save_dir: ${oc.env:OUTPUT_DIR,outputs/sd3_pickscore_refl}
+save_mode: adapter
+max_grad_norm: 1.0
+
+actor:
+  _target_: experimental.refl.roles.ReflActorRole
+  pipeline_target: experimental.refl.models.sd3.Sd3ReflPipeline
+  block_class_names: ["JointTransformerBlock"]
+  # REFL loss: -(reward - baseline) / scale * weight + kl_weight * KL.
+  reward_weight: 1.0
+  reward_baseline: 0.0
+  reward_scale: 1.0
+  kl_weight: 0.0
+  strategy:
+    # sampling.eta=0.0 reduces FlowSDE to the deterministic ODE.
+    _target_: unirl.sde.kernels.FlowSDEStrategy
+  model_config:
+    _target_: unirl.models.sd3.config.SD3PipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,stabilityai/stable-diffusion-3.5-medium}
+    model_precision: bf16
+    autocast_precision: bf16
+    trajectory_precision: bf16
+    logprob_precision: fp32
+    shift: 3.0
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    # fp32 LoRA master over the bf16 base — the setting the historical ReFL
+    # curves (#120 era) were trained with; a bf16 master rounds away most
+    # AdamW steps at lora_A's magnitude. Needs the pinned torch (>=2.11):
+    # older FSDP2 asserts uniform dtype over ALL params in a group; the
+    # pinned family checks trainables only.
+    master_dtype: fp32
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: true
+    ac_wrap_order: inside            # the order this recipe's 10-rollout REFL validation ran under
+    use_torch_compile: false
+    root_wrap: true
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+    total_steps: ${num_rollouts}
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 32
+    alpha: 64
+    dropout: 0.0
+    bias: none
+    task_type: FEATURE_EXTRACTION
+    target_modules:
+      - attn.add_k_proj
+      - attn.add_q_proj
+      - attn.add_v_proj
+      - attn.to_add_out
+      - attn.to_k
+      - attn.to_out.0
+      - attn.to_q
+      - attn.to_v
+
+# Managed differentiable reward (PR6): the same PickScore, but in a child
+# process on the negotiated cuda_ipc data plane. Gradients relay across the
+# boundary via segmented backward (score retains the child-side subgraph,
+# /backward seeds it with dL/dr and returns dL/dimage handles), so REFL's
+# reward -> decode -> LoRA chain is identical to the in-process variant —
+# only the reward segment lives in another process (optionally another venv).
+reward:
+  _target_: unirl.reward.service.RewardService
+  backend:
+    _target_: unirl.reward.managed_process.ManagedScorerProcessBackend
+    base_device: cuda
+    config:
+      _target_: unirl.reward.managed_process.ManagedScorerProcessSpec
+      process:
+        _target_: unirl.reward.managed_process.ManagedProcessConfig
+        python_executable: ${oc.env:PICKSCORE_PYTHON,/root/unirl/.venv/bin/python}
+        service_root: ${oc.env:REWARD_SERVICE_ROOT,unirl-reward-service}
+        startup_timeout: 600
+        shutdown_timeout: 30
+        log_dir: ${oc.env:PICKSCORE_CHILD_LOG_DIR,/tmp/unirl-reward}
+        offline: true
+        transport: cuda_ipc      # differentiable scoring has no b64 fallback
+      scorer:
+        _target_: unirl.reward.managed_process.ManagedScorerConfig
+        name: pickscore
+        input_kind: image
+        version: "1"
+        params:
+          model_name: ${oc.env:PICKSCORE_MODEL,yuvalkirstain/PickScore_v1}
+          dtype: float32
+          device: cuda
+      client:
+        _target_: unirl.reward.remote.RemoteRewardSpec
+        base_url: managed://rank-affine
+        required_rewards: [pickscore]
+        reward_weights: {pickscore: 1.0}
+        batch_size: 8
+        request_batch_size: 8
+        timeout: 600.0
+        sub_metric_reduce: first
+        aggregation_method: weighted_sum
+        input_kind: image
+      lifecycle: resident        # differentiable window = forward+backward pair
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: datasets/pickscore/train.txt
+      eval_data_path: datasets/pickscore/test.txt
+      seed: 42
+      shuffle: false
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+
+sampling:
+  _target_: unirl.types.sampling.DiffusionSamplingParams
+  # 4 inference steps, grad through the final step only (DRaFT-1):
+  # mid_timestep = final_timestep = 3.
+  num_inference_steps: 4
+  guidance_scale: 1.0
+  height: 512
+  width: 512
+  eta: 0.0
+  samples_per_prompt: 1
+  seed: 42
+  init_same_noise: false
+  sampler_kwargs:
+    mid_timestep: 3
+    final_timestep: 3
+
+logging:
+  report_to_wandb: ${oc.decode:${oc.env:REPORT_TO_WANDB,true}}
+  project_name: ${oc.env:WANDB_PROJECT,unirl-refl}
+  run_name: ${oc.env:WANDB_RUN_NAME,sd3_pickscore_refl}
+  tags: ["sd3.5", "refl", "draft-k", "pickscore"]
+  log_media: false

--- a/experimental/refl/examples/sd3_pickscore_refl_managed.yaml
+++ b/experimental/refl/examples/sd3_pickscore_refl_managed.yaml
@@ -123,7 +123,7 @@ reward:
         sub_metric_reduce: first
         aggregation_method: weighted_sum
         input_kind: image
-      lifecycle: resident        # differentiable window = forward+backward pair
+      gpu_residency: resident    # differentiable window = forward+backward pair
 
 data_source:
   _target_: unirl.data.data_source.MultimodalRLDataSource

--- a/unirl-reward-service/reward_service/direct_server.py
+++ b/unirl-reward-service/reward_service/direct_server.py
@@ -22,9 +22,23 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 
 from reward_service.logging_utils import get_logger
-from reward_service.schemas import PROTOCOL_VERSION, RewardIdentity, ScoreRequest, ScoreResponse
+from reward_service.schemas import (
+    PROTOCOL_VERSION,
+    BackwardRequest,
+    BackwardResponse,
+    HandshakeRequest,
+    HandshakeResponse,
+    RewardIdentity,
+    ScoreRequest,
+    ScoreResponse,
+)
 from reward_service.scorers.registry import SCORER_MODULES, get_scorer_cls
 from reward_service.wire import request_to_item
+
+#: Retained differentiable subgraphs a child will hold at once. Each entry pins
+#: the forward activations of one grad_mode batch — this is a leak guard, not a
+#: throughput knob; the parent should backward (or release) promptly.
+_GRAD_STORE_LIMIT = 4
 
 logger = get_logger(__name__)
 
@@ -162,6 +176,13 @@ def create_direct_app(
         app.state.scorer = scorer
         app.state.score_lock = asyncio.Lock()
         app.state.result_cache = OrderedDict()
+        # Negotiated data plane (see /handshake) and the retained-subgraph
+        # store for grad_mode scoring: call_id -> {images leaf, scores, ...}.
+        # grad_keepalive pins returned gradient tensors until the parent has
+        # materialized them (next backward or lifecycle release frees them).
+        app.state.ipc_ready = False
+        app.state.grad_store = OrderedDict()
+        app.state.grad_keepalive = OrderedDict()
         if boot_offloaded:
             # per_call boot protocol: leave the GPU BEFORE the parent can see us
             # ready. Waiting for the parent's first /lifecycle/offload would keep
@@ -202,6 +223,75 @@ def create_direct_app(
     async def rewards() -> dict:
         return {"rewards": [scorer_name]}
 
+    @app.post("/handshake", response_model=HandshakeResponse)
+    async def handshake(body: HandshakeRequest) -> HandshakeResponse:
+        """Negotiate the data plane: cuda_ipc when both fingerprints allow it.
+
+        Any failed check falls back to http/b64 silently — the parent treats
+        the accepted transport as authoritative. Re-negotiation is allowed
+        (e.g. after the parent restarts); flipping to http also drops any
+        retained grad state, which cannot survive a transport change.
+        """
+        from reward_service.tensor_ipc import ipc_compatible, ipc_fingerprint
+
+        mine = {k: str(v) for k, v in ipc_fingerprint().items()}
+        if body.proposed_transport != "cuda_ipc":
+            accepted, reason = "http", "parent proposed http"
+        else:
+            ok, reason = ipc_compatible(mine, dict(body.fingerprint))
+            accepted = "cuda_ipc" if ok else "http"
+        async with app.state.score_lock:
+            app.state.ipc_ready = accepted == "cuda_ipc"
+            if not app.state.ipc_ready:
+                app.state.grad_store.clear()
+                app.state.grad_keepalive.clear()
+        logger.info("handshake: accepted_transport=%s (%s)", accepted, reason)
+        return HandshakeResponse(fingerprint=mine, accepted_transport=accepted, reason=reason)
+
+    @app.post("/backward", response_model=BackwardResponse)
+    async def backward(body: BackwardRequest) -> BackwardResponse:
+        """Second half of a grad_mode score: chain-rule relay (mmrl pattern).
+
+        Seeds the retained subgraph with dL/dr, runs backward on THIS
+        process's segment, and returns per-item dL/dimage as IPC handles.
+        The graph is consumed — one backward per call_id.
+        """
+        import torch
+
+        async with app.state.score_lock:
+            entry = app.state.grad_store.pop(body.call_id, None)
+            if entry is None:
+                raise HTTPException(status_code=404, detail=f"no retained graph for call_id {body.call_id!r}")
+            if len(body.grad_scores) != int(entry["scores"].shape[0]):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"grad_scores has {len(body.grad_scores)} entries for a batch of {int(entry['scores'].shape[0])}",
+                )
+
+            def run() -> list[str]:
+                from reward_service.tensor_ipc import encode_tensor
+
+                scores, images = entry["scores"], entry["images"]
+                seed = torch.tensor(body.grad_scores, device=scores.device, dtype=scores.dtype)
+                torch.autograd.backward(scores, seed)
+                grads = images.grad
+                if grads is None:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="backward produced no image gradient — the scorer forward broke the graph",
+                    )
+                blobs = [encode_tensor(grads[i]) for i in range(grads.shape[0])]
+                # Pin the gradient storage until the parent has cloned it; the
+                # next backward (or a lifecycle release) lets it go.
+                app.state.grad_keepalive[body.call_id] = grads
+                while len(app.state.grad_keepalive) > _GRAD_STORE_LIMIT:
+                    app.state.grad_keepalive.popitem(last=False)
+                torch.cuda.empty_cache()
+                return blobs
+
+            blobs = await asyncio.to_thread(run)
+        return BackwardResponse(grad_ipc=blobs)
+
     @app.post("/score", response_model=ScoreResponse)
     async def score(body: ScoreRequest) -> ScoreResponse:
         if body.protocol_version != PROTOCOL_VERSION:
@@ -214,6 +304,9 @@ def create_direct_app(
                 raise HTTPException(status_code=400, detail=f"unknown rewards for this worker: {unknown}")
             if history_kind == "image_edit" and len(request.history) < 2:
                 raise HTTPException(status_code=400, detail="image_edit requests require source and edited turns")
+
+        if body.grad_mode:
+            return await _score_grad_mode(body)
 
         # Fingerprinting (and the decode below) is CPU work proportional to the b64
         # media in the chunk. Run on the event loop it stalls /health and the
@@ -307,6 +400,90 @@ def create_direct_app(
 
         return ScoreResponse(results=results, errors=errors, identities=identities)
 
+    async def _score_grad_mode(body: ScoreRequest) -> ScoreResponse:
+        """Differentiable scoring: forward under grad, retain the subgraph.
+
+        Deliberately a separate, simpler path than scalar scoring: no
+        idempotency cache and no per-item soft failure — a retained graph is
+        stateful and a partial batch has no usable gradient, so any error
+        fails the whole call (the caller crashes rather than trains on a
+        half-differentiable reward). Requires the negotiated cuda_ipc data
+        plane, image_ipc inputs of uniform shape, and a supports_grad scorer.
+        """
+        import torch
+
+        if not body.call_id:
+            raise HTTPException(status_code=400, detail="grad_mode requires call_id")
+        async with app.state.score_lock:
+            if app.state.lifecycle_state != "resident":
+                raise HTTPException(
+                    status_code=409, detail=f"scorer is not resident (state={app.state.lifecycle_state})"
+                )
+            scorer = app.state.scorer
+            if not scorer.supports_grad:
+                raise HTTPException(
+                    status_code=409, detail=f"scorer {scorer_name!r} does not support grad_mode"
+                )
+            if not app.state.ipc_ready:
+                raise HTTPException(
+                    status_code=409, detail="grad_mode requires a successful cuda_ipc handshake"
+                )
+            if body.call_id in app.state.grad_store:
+                raise HTTPException(status_code=409, detail=f"call_id {body.call_id!r} already retained")
+            if len(app.state.grad_store) >= _GRAD_STORE_LIMIT:
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"{_GRAD_STORE_LIMIT} retained graphs outstanding; backward or release them first",
+                )
+            prompts: list[str] = []
+            blobs: list[str] = []
+            for request in body.requests:
+                turn = request.history[-1]
+                if turn.image_ipc is None:
+                    raise HTTPException(status_code=400, detail="grad_mode turns must carry image_ipc")
+                prompts.append(turn.text)
+                blobs.append(turn.image_ipc)
+
+            def run() -> list[float]:
+                from reward_service.tensor_ipc import decode_tensor
+
+                views = [decode_tensor(blob) for blob in blobs]
+                shapes = {tuple(v.shape) for v in views}
+                if len(shapes) != 1:
+                    raise HTTPException(
+                        status_code=400, detail=f"grad_mode batch needs uniform image shapes, got {sorted(shapes)}"
+                    )
+                # torch.stack copies out of the parent's shared storage, so the
+                # leaf below is owned by this process; the views may be released
+                # by the parent as soon as the response lands.
+                images = torch.stack([v.detach().float() for v in views])
+                images.requires_grad_(True)
+                with torch.enable_grad():
+                    scores = scorer.score_tensors(images, prompts)
+                if not (torch.is_tensor(scores) and scores.shape == (len(views),)):
+                    raise HTTPException(
+                        status_code=500,
+                        detail=f"score_tensors must return a ({len(views)},) tensor, got {getattr(scores, 'shape', type(scores))}",
+                    )
+                if scores.grad_fn is None:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="score_tensors returned a tensor with no grad_fn — the forward broke the graph",
+                    )
+                app.state.grad_store[body.call_id] = {"images": images, "scores": scores}
+                return [float(v) for v in scores.detach().cpu()]
+
+            values = await asyncio.to_thread(run)
+            metric = scorer.sub_metric_names[0]
+            identities = [
+                request.identity(actual_scorer_version=scorer.version) for request in body.requests
+            ]
+        return ScoreResponse(
+            results=[{scorer_name: {metric: value}} for value in values],
+            errors=[{} for _ in values],
+            identities=identities,
+        )
+
     @app.post("/lifecycle/{action}")
     async def lifecycle(action: str) -> dict:
         if action not in {"onload", "offload", "drain", "shutdown"}:
@@ -340,6 +517,12 @@ def create_direct_app(
                     raise HTTPException(status_code=409, detail=f"scorer {scorer_name!r} does not support offload")
                 if app.state.lifecycle_state != "offloaded":
                     app.state.lifecycle_state = "draining"
+                    # Retained differentiable subgraphs cannot survive an offload —
+                    # their activations live on the device being vacated. Dropping
+                    # them here (rather than erroring) matches the per_call window
+                    # contract: forward+backward pairs complete before offload.
+                    app.state.grad_store.clear()
+                    app.state.grad_keepalive.clear()
                     try:
                         await asyncio.to_thread(scorer.drain)
                         await asyncio.to_thread(scorer.offload)

--- a/unirl-reward-service/reward_service/schemas.py
+++ b/unirl-reward-service/reward_service/schemas.py
@@ -38,6 +38,16 @@ class HistoryTurn(BaseModel):
         default=None,
         description="Base64-encoded image bytes (any PIL-readable format)",
     )
+    image_ipc: str | None = Field(
+        default=None,
+        description=(
+            "CUDA-IPC handle blob for a float image tensor [C,H,W] in [0,1] "
+            "(see tensor_ipc.encode_tensor). Negotiated data plane only: valid "
+            "after a successful /handshake, same-device loopback deployments. "
+            "Lossless and zero-copy; the sender keeps the tensor alive until "
+            "the response arrives."
+        ),
+    )
     video_b64: str | None = Field(
         default=None,
         description="Base64-encoded video file bytes (e.g. mp4); decoded server-side to a tempfile",
@@ -51,8 +61,17 @@ class HistoryTurn(BaseModel):
     def _check_media(self) -> "HistoryTurn":
         if self.video_b64 is not None and self.video_path is not None:
             raise ValueError("video_b64 and video_path are mutually exclusive")
-        if self.image_b64 is None and self.video_b64 is None and self.video_path is None:
-            raise ValueError("HistoryTurn must include at least one of image_b64, video_b64, or video_path")
+        if self.image_b64 is not None and self.image_ipc is not None:
+            raise ValueError("image_b64 and image_ipc are mutually exclusive")
+        if (
+            self.image_b64 is None
+            and self.image_ipc is None
+            and self.video_b64 is None
+            and self.video_path is None
+        ):
+            raise ValueError(
+                "HistoryTurn must include at least one of image_b64, image_ipc, video_b64, or video_path"
+            )
         return self
 
 
@@ -99,6 +118,52 @@ class ScoreRequest(BaseModel):
 
     protocol_version: str = PROTOCOL_VERSION
     requests: list[RewardRequest]
+    grad_mode: bool = Field(
+        default=False,
+        description=(
+            "Differentiable scoring: the scorer forward runs under grad and the "
+            "server retains the subgraph keyed by call_id until /backward or a "
+            "lifecycle release. Requires image_ipc inputs and a scorer with "
+            "supports_grad. grad_mode batches bypass the idempotency cache — "
+            "a retained graph is stateful, not a pure function."
+        ),
+    )
+    call_id: str | None = Field(
+        default=None,
+        description="Caller-chosen key for the retained subgraph; required when grad_mode",
+    )
+
+
+class HandshakeRequest(BaseModel):
+    """Parent's IPC fingerprint + proposed data plane."""
+
+    fingerprint: dict[str, str]
+    proposed_transport: str = "cuda_ipc"
+
+
+class HandshakeResponse(BaseModel):
+    """Child's fingerprint and the transport it accepted."""
+
+    fingerprint: dict[str, str]
+    accepted_transport: str
+    reason: str = ""
+
+
+class BackwardRequest(BaseModel):
+    """Second half of a grad_mode score: seed grads for the retained subgraph.
+
+    ``grad_scores[i]`` is dL/dr for request i's scalar reward (the upstream
+    grads are tiny — plain JSON floats). The response's image grads are
+    full-size tensors and travel back as IPC handles.
+    """
+
+    call_id: str
+    grad_scores: list[float]
+
+
+class BackwardResponse(BaseModel):
+    grad_ipc: list[str | None]
+    protocol_version: str = PROTOCOL_VERSION
 
 
 class ScoreResponse(BaseModel):

--- a/unirl-reward-service/reward_service/scorers/base.py
+++ b/unirl-reward-service/reward_service/scorers/base.py
@@ -63,6 +63,11 @@ class BaseScorer(ABC):
     version: str = "1"
     input_kind: str = "image"
     supports_offload: bool = False
+    #: True when :meth:`score_tensors` exists and its forward is autograd-clean
+    #: end to end (torch-native preprocessing only — any PIL/numpy hop breaks
+    #: the graph silently). Engine-backed scorers (vLLM) are inference-only and
+    #: must leave this False regardless of transport.
+    supports_grad: bool = False
     sub_metric_names: tuple[str, ...] = ()
 
     @abstractmethod
@@ -86,6 +91,20 @@ class BaseScorer(ABC):
           ``errors[i][reward]`` for every item in the batch.
         """
 
+    def score_tensors(self, images, prompts):  # -> torch.Tensor of shape (B,)
+        """Differentiable twin of :meth:`score` for tensor-native inputs.
+
+        ``images`` is a float tensor [B, C, H, W] in [0, 1] on the scorer's
+        device; ``prompts`` a parallel list of strings. Returns one scalar
+        reward per item as a (B,) tensor. Whether a graph is built is the
+        CALLER'S choice (grad or no_grad context) — implementations must not
+        wrap the forward in ``torch.no_grad``/``inference_mode`` and must keep
+        every image-touching op torch-native so gradients can flow from the
+        returned scores back to ``images``. Only meaningful when
+        ``supports_grad`` is True.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement score_tensors")
+
     def close(self) -> None:
         """Release heavy resources (model, vLLM engine). Default is a no-op."""
 
@@ -104,4 +123,5 @@ class BaseScorer(ABC):
             "version": self.version,
             "input_kind": self.input_kind,
             "supports_offload": self.supports_offload,
+            "supports_grad": self.supports_grad,
         }

--- a/unirl-reward-service/reward_service/scorers/pickscore.py
+++ b/unirl-reward-service/reward_service/scorers/pickscore.py
@@ -23,9 +23,22 @@ from reward_service.scorers.base import BaseScorer, ScoreItem
 from reward_service.scorers.registry import register
 
 
+def _projected(out) -> torch.Tensor:
+    """Projected CLIP embeddings across transformers versions.
+
+    transformers < 5 returns the projected features tensor directly;
+    >= 5 returns the full ``BaseModelOutputWithPooling`` with the projected
+    features written back into ``pooler_output``.
+    """
+    if torch.is_tensor(out):
+        return out
+    return out.pooler_output
+
+
 class PickScoreScorer(BaseScorer):
     name = "pickscore"
     sub_metric_names = ("pickscore",)
+    supports_grad = True
 
     def __init__(
         self,
@@ -42,6 +55,39 @@ class PickScoreScorer(BaseScorer):
         self.model = CLIPModel.from_pretrained(path).to(self.device, dtype=torch_dtype).eval()
         self.model.requires_grad_(False)
         self.processor = CLIPProcessor.from_pretrained(path)
+
+    def score_tensors(self, images: torch.Tensor, prompts: list[str]) -> torch.Tensor:
+        """Differentiable PickScore over a [B,3,H,W] float batch in [0,1].
+
+        The whole image path is torch-native (bicubic resize + CLIP
+        normalization + CLIP forward) so gradients flow from the returned
+        scores back to ``images`` — a PIL/numpy hop anywhere here would break
+        the graph silently (the slow-processor lesson). Grad-or-not is the
+        caller's context; weights stay frozen either way.
+        """
+        import torchvision.transforms.functional as TF
+
+        ip = getattr(self.processor, "image_processor", None)
+        mean = list(getattr(ip, "image_mean", None) or (0.48145466, 0.4578275, 0.40821073))
+        std = list(getattr(ip, "image_std", None) or (0.26862954, 0.26130258, 0.27577711))
+        size = int((getattr(ip, "crop_size", None) or {"height": 224})["height"])
+
+        x = images.to(self.device)
+        x = TF.resize(x, [size, size], interpolation=TF.InterpolationMode.BICUBIC, antialias=True)
+        x = (x - x.new_tensor(mean).view(1, 3, 1, 1)) / x.new_tensor(std).view(1, 3, 1, 1)
+        x = x.to(dtype=next(self.model.parameters()).dtype)
+
+        text_inputs = self.processor(
+            text=list(prompts), padding=True, truncation=True, max_length=77, return_tensors="pt"
+        )
+        text_inputs = {k: v.to(self.device) for k, v in text_inputs.items()}
+
+        image_embs = _projected(self.model.get_image_features(pixel_values=x))
+        image_embs = image_embs / image_embs.norm(p=2, dim=-1, keepdim=True)
+        text_embs = _projected(self.model.get_text_features(**text_inputs))
+        text_embs = text_embs / text_embs.norm(p=2, dim=-1, keepdim=True)
+        scores = self.model.logit_scale.exp() * (text_embs * image_embs).sum(dim=-1)
+        return (scores / 26.0).float()
 
     @torch.inference_mode()
     def score(self, items: list[ScoreItem]) -> list[dict[str, float]]:
@@ -66,9 +112,9 @@ class PickScoreScorer(BaseScorer):
         )
         text_inputs = {k: v.to(self.device) for k, v in text_inputs.items()}
 
-        image_embs = self.model.get_image_features(**image_inputs)
+        image_embs = _projected(self.model.get_image_features(**image_inputs))
         image_embs = image_embs / image_embs.norm(p=2, dim=-1, keepdim=True)
-        text_embs = self.model.get_text_features(**text_inputs)
+        text_embs = _projected(self.model.get_text_features(**text_inputs))
         text_embs = text_embs / text_embs.norm(p=2, dim=-1, keepdim=True)
 
         logit_scale = self.model.logit_scale.exp()

--- a/unirl-reward-service/reward_service/tensor_ipc.py
+++ b/unirl-reward-service/reward_service/tensor_ipc.py
@@ -1,0 +1,75 @@
+"""CUDA-IPC tensor codec for the managed data plane (child side).
+
+Wire format (version 1): base64(pickle((rebuild_fn, args))) exactly as
+produced by ``torch.multiprocessing.reductions.reduce_tensor`` — the same
+mechanism torch itself uses to share CUDA tensors between processes. The
+handle is a few dozen bytes; the storage never moves. Constraints enforced
+by the handshake, not here: both processes on the same physical device,
+IPC-compatible torch builds, tensors from the regular cudaMalloc pool
+(expandable_segments and cumem/VMM regions are not exportable).
+
+Lifetime: the PRODUCER must keep the source tensor alive until the consumer
+is done with it — the parent retains request tensors until the response
+arrives, the child retains gradient tensors until the parent acks (next
+request or explicit release). Consumers should ``.clone()`` if they need
+the data past that window.
+
+A byte-identical twin of this module lives on the parent side
+(``unirl/reward/tensor_ipc.py``): the two ends of the wire share no Python
+package, so the codec is duplicated rather than imported across the
+environment boundary. Keep both copies in sync.
+"""
+
+from __future__ import annotations
+
+import base64
+import pickle
+
+import torch
+
+
+def encode_tensor(tensor: torch.Tensor) -> str:
+    """Share a CUDA tensor and return the printable handle blob."""
+    if not tensor.is_cuda:
+        raise ValueError("cuda_ipc data plane requires CUDA tensors")
+    from torch.multiprocessing.reductions import reduce_tensor
+
+    return base64.b64encode(pickle.dumps(reduce_tensor(tensor))).decode("ascii")
+
+
+def decode_tensor(blob: str) -> torch.Tensor:
+    """Open a handle blob produced by :func:`encode_tensor` in another process."""
+    rebuild, args = pickle.loads(base64.b64decode(blob.encode("ascii")))
+    return rebuild(*args)
+
+
+def ipc_fingerprint() -> dict:
+    """This process's IPC-compatibility facts, exchanged during handshake."""
+    dev = torch.cuda.current_device() if torch.cuda.is_available() else None
+    props = torch.cuda.get_device_properties(dev) if dev is not None else None
+    uuid = str(getattr(props, "uuid", "")) if props is not None else ""
+    try:
+        allocator = torch.cuda.memory._get_allocator_backend()
+    except Exception:
+        allocator = "unknown"
+    return {
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda or "",
+        "device_uuid": uuid,
+        "allocator": allocator,
+    }
+
+
+def ipc_compatible(mine: dict, theirs: dict) -> tuple[bool, str]:
+    """Decide whether two fingerprints may share a cuda_ipc data plane."""
+    if not mine.get("device_uuid") or not theirs.get("device_uuid"):
+        return False, "no CUDA device on one side"
+    if mine["device_uuid"] != theirs["device_uuid"]:
+        return False, f"different devices: {mine['device_uuid']} vs {theirs['device_uuid']}"
+    mv, tv = mine.get("torch", ""), theirs.get("torch", "")
+    if mv.split("+")[0] != tv.split("+")[0]:
+        return False, f"torch version skew: {mv} vs {tv}"
+    for side, fp in (("local", mine), ("peer", theirs)):
+        if fp.get("allocator") == "cudaMallocAsync":
+            return False, f"{side} allocator {fp['allocator']} is not IPC-exportable"
+    return True, "ok"

--- a/unirl-reward-service/reward_service/wire.py
+++ b/unirl-reward-service/reward_service/wire.py
@@ -21,6 +21,25 @@ def decode_image(image_b64: str) -> Image.Image:
         raise HTTPException(status_code=400, detail=f"invalid image_b64: {exc}") from exc
 
 
+def decode_ipc_image(blob: str) -> Image.Image:
+    """Materialize an IPC-shared [C,H,W] float tensor as a PIL image.
+
+    Classic scorers consume PIL (inherently 8-bit); the lossless float path
+    is ``score_tensors``. This hop still skips the JPEG/PNG encode-decode
+    round trip and is exact for tensors that came from 8-bit sources.
+    """
+    try:
+        from reward_service.tensor_ipc import decode_tensor
+
+        tensor = decode_tensor(blob)
+        tensor = tensor.detach().clamp(0, 1).mul(255).round().to("cpu").byte()
+        return Image.fromarray(tensor.permute(1, 2, 0).numpy())
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"invalid image_ipc handle: {exc}") from exc
+
+
 def resolve_video(turn: HistoryTurn) -> bytes | str | None:
     if turn.video_path is not None:
         path = Path(turn.video_path)
@@ -45,7 +64,12 @@ def request_to_item(request: RewardRequest, *, allow_video: bool = True) -> Scor
     videos: list[bytes | str | None] = []
     any_video = False
     for turn in request.history:
-        image = decode_image(turn.image_b64) if turn.image_b64 is not None else None
+        if turn.image_b64 is not None:
+            image = decode_image(turn.image_b64)
+        elif turn.image_ipc is not None:
+            image = decode_ipc_image(turn.image_ipc)
+        else:
+            image = None
         history.append((turn.text, image))
         video = resolve_video(turn)
         if video is not None and not allow_video:

--- a/unirl/reward/README.md
+++ b/unirl/reward/README.md
@@ -119,3 +119,55 @@ new remote reward needs no UniRL code — add it to the server and list its name
   may be `text`.
 - **`base_device` is ignored by the remote backend** (it's HTTP-only); local
   scorers honor it, falling back to CPU with a warning if CUDA is unavailable.
+
+## Differentiable rewards through a managed child
+
+The autograd graph cannot cross a process boundary, so the chain rule is relayed
+instead. `_ManagedScore` (`unirl/reward/differentiable.py`) wraps two RPCs as ONE
+node in the parent's graph:
+
+- **forward** — ship image tensors as CUDA-IPC handles; the child scores under
+  `enable_grad` and RETAINS its subgraph keyed by `call_id`.
+- **backward** — ship `dL/dr` (plain floats); the child backwards its own segment and
+  returns `dL/dimage` as IPC handles, spliced back into the caller's graph.
+
+Requirements (enforced child-side, surfaced as exceptions in the parent): the negotiated
+`cuda_ipc` data plane, a `supports_grad` scorer, uniform image shapes, and
+`gpu_residency: resident` — the forward+backward pair is indivisible, so a `per_call`
+offload between the two RPCs would drop the retained subgraph.
+
+Failure semantics are deliberately harsher than scalar scoring: **any error raises**. A
+gradient has no NaN-soft-fail; training must stop rather than step on a
+half-differentiable reward.
+
+### Transport negotiation
+
+`process.transport` selects the data plane; HTTP stays the control plane either way.
+
+| value | behavior |
+|---|---|
+| `auto` (default) | negotiate `cuda_ipc` via `/handshake`, fall back to HTTP silently |
+| `cuda_ipc` | require the negotiation to succeed; fail startup otherwise |
+| `http` | never negotiate (base64 payloads only) |
+
+`cuda_ipc` is same-device, torch-version- and allocator-gated. The child applies the checks
+and its answer is authoritative. An explicit `cuda_ipc` request that cannot be honored is a
+configuration error, not a fallback — differentiable scoring has no b64 path.
+
+### CUDA-IPC wire format
+
+Version 1 is `base64(pickle((rebuild_fn, args)))` exactly as produced by
+`torch.multiprocessing.reductions.reduce_tensor` — the mechanism torch itself uses to share
+CUDA tensors between processes. The handle is a few dozen bytes; the storage never moves.
+Tensors must come from the regular `cudaMalloc` pool (`expandable_segments` and cumem/VMM
+regions are not exportable), which is why a slept vLLM engine's memory cannot ride this plane.
+
+**Lifetime**: the producer keeps the source tensor alive until the consumer is done — the
+parent retains request tensors until the response arrives, the child retains gradient tensors
+until the parent acks (next request or explicit release). Consumers `.clone()` if they need
+the data past that window.
+
+**Two copies, kept in sync**: `unirl/reward/tensor_ipc.py` and
+`unirl-reward-service/reward_service/tensor_ipc.py` are byte-identical twins. The two ends of
+the wire share no Python package — that is the point of the managed venv boundary — so the
+codec is duplicated rather than imported across it.

--- a/unirl/reward/base.py
+++ b/unirl/reward/base.py
@@ -56,7 +56,7 @@ class RewardBackend(ABC):
 
 @runtime_checkable
 class DifferentiableReward(Protocol):
-    """Optional capability: in-process ``nn.Module`` rewards returning a grad-carrying score tensor for ReFL."""
+    """Optional capability: grad-carrying score tensor for ReFL, from an in-process module or the managed child."""
 
     def compute_rewards_differentiable(
         self,

--- a/unirl/reward/differentiable.py
+++ b/unirl/reward/differentiable.py
@@ -1,0 +1,116 @@
+"""Differentiable scoring through a managed child (segmented autograd).
+
+The autograd graph cannot cross a process boundary, so the chain rule is
+relayed instead (mmrl's pattern): the child runs the reward forward under
+grad and RETAINS its subgraph keyed by ``call_id``; :class:`_ManagedScore`
+wraps the two RPCs as ONE node in the parent's graph —
+
+    forward : ship image tensors as CUDA-IPC handles -> child scores, keeps graph
+    backward: ship dL/dr (plain floats)              -> child backwards its
+              segment, returns dL/dimage as IPC handles -> spliced in here
+
+Requirements (enforced by the child, surfaced as exceptions here): the
+negotiated ``cuda_ipc`` data plane (``transport: cuda_ipc`` in the managed
+process config), a ``supports_grad`` scorer, uniform image shapes, and the
+child resident for the whole forward+backward window — that pair is the
+indivisible per_call unit.
+
+Failure semantics are deliberately harsher than scalar scoring: any error
+raises. A gradient has no NaN-soft-fail; training must stop rather than
+step on a half-differentiable reward.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import torch
+
+from unirl.reward.tensor_ipc import decode_tensor, encode_tensor
+
+if TYPE_CHECKING:
+    from unirl.reward.managed_process import ManagedScorerProcessBackend
+
+
+class _ManagedScore(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, images: torch.Tensor, backend, prompts: list[str]) -> torch.Tensor:
+        if getattr(backend, "_transport", "http") != "cuda_ipc":
+            raise RuntimeError(
+                "differentiable scoring requires the cuda_ipc data plane; "
+                "set process.transport='cuda_ipc' on the managed spec"
+            )
+        if not images.is_cuda:
+            raise RuntimeError("differentiable scoring requires CUDA image tensors")
+        call_id = uuid.uuid4().hex
+        scorer_name = backend.process_config.scorer.name
+        # detach+contiguous gives the wire a stable storage to share; the child
+        # copies out of it (torch.stack) while this request is in flight.
+        shipped = images.detach().contiguous()
+        payload = {
+            "protocol_version": "1",
+            "grad_mode": True,
+            "call_id": call_id,
+            "requests": [
+                {
+                    "history": [{"text": prompt, "image_ipc": encode_tensor(shipped[i])}],
+                    "required_rewards": [scorer_name],
+                }
+                for i, prompt in enumerate(prompts)
+            ],
+        }
+        response = backend._session.post(f"{backend.base_url}/score", json=payload, timeout=600.0)
+        response.raise_for_status()
+        body = response.json()
+        for index, errs in enumerate(body.get("errors", [])):
+            if errs:
+                raise RuntimeError(f"differentiable score failed for item {index}: {errs}")
+        results = body["results"]
+        metric = next(iter(results[0][scorer_name]))
+        scores = torch.tensor(
+            [results[i][scorer_name][metric] for i in range(len(prompts))],
+            device=images.device,
+            dtype=torch.float32,
+        )
+        ctx.unirl_backend = backend
+        ctx.unirl_call_id = call_id
+        ctx.unirl_device = images.device
+        ctx.unirl_shape = tuple(images.shape)
+        return scores
+
+    @staticmethod
+    def backward(ctx, grad_scores: torch.Tensor):
+        backend = ctx.unirl_backend
+        response = backend._session.post(
+            f"{backend.base_url}/backward",
+            json={
+                "call_id": ctx.unirl_call_id,
+                "grad_scores": [float(v) for v in grad_scores.detach().cpu()],
+            },
+            timeout=600.0,
+        )
+        response.raise_for_status()
+        blobs = response.json()["grad_ipc"]
+        # Clone immediately: the child only pins the shared gradient storage
+        # until its next backward (bounded keepalive), so materialize now.
+        grads = torch.stack([decode_tensor(blob).clone() for blob in blobs]).to(ctx.unirl_device)
+        if tuple(grads.shape) != ctx.unirl_shape:
+            raise RuntimeError(
+                f"child returned image grads of shape {tuple(grads.shape)}, expected {ctx.unirl_shape}"
+            )
+        return grads, None, None
+
+
+def score_differentiable(
+    backend: "ManagedScorerProcessBackend",
+    images: torch.Tensor,
+    prompts: list[str],
+) -> torch.Tensor:
+    """Score ``images`` [B,C,H,W] through the managed child with grad attached.
+
+    Returns a (B,) float tensor whose backward relays dL/dr to the child and
+    splices dL/dimage back into the caller's graph. Call under the caller's
+    grad context; the reward model's weights stay frozen child-side.
+    """
+    return _ManagedScore.apply(images, backend, prompts)

--- a/unirl/reward/differentiable.py
+++ b/unirl/reward/differentiable.py
@@ -1,24 +1,4 @@
-"""Differentiable scoring through a managed child (segmented autograd).
-
-The autograd graph cannot cross a process boundary, so the chain rule is
-relayed instead (mmrl's pattern): the child runs the reward forward under
-grad and RETAINS its subgraph keyed by ``call_id``; :class:`_ManagedScore`
-wraps the two RPCs as ONE node in the parent's graph —
-
-    forward : ship image tensors as CUDA-IPC handles -> child scores, keeps graph
-    backward: ship dL/dr (plain floats)              -> child backwards its
-              segment, returns dL/dimage as IPC handles -> spliced in here
-
-Requirements (enforced by the child, surfaced as exceptions here): the
-negotiated ``cuda_ipc`` data plane (``transport: cuda_ipc`` in the managed
-process config), a ``supports_grad`` scorer, uniform image shapes, and the
-child resident for the whole forward+backward window — that pair is the
-indivisible per_call unit.
-
-Failure semantics are deliberately harsher than scalar scoring: any error
-raises. A gradient has no NaN-soft-fail; training must stop rather than
-step on a half-differentiable reward.
-"""
+"""Differentiable scoring through a managed child (segmented autograd)."""
 
 from __future__ import annotations
 
@@ -107,10 +87,5 @@ def score_differentiable(
     images: torch.Tensor,
     prompts: list[str],
 ) -> torch.Tensor:
-    """Score ``images`` [B,C,H,W] through the managed child with grad attached.
-
-    Returns a (B,) float tensor whose backward relays dL/dr to the child and
-    splices dL/dimage back into the caller's graph. Call under the caller's
-    grad context; the reward model's weights stay frozen child-side.
-    """
+    """Score ``images`` [B,C,H,W] through the managed child with grad attached."""
     return _ManagedScore.apply(images, backend, prompts)

--- a/unirl/reward/differentiable.py
+++ b/unirl/reward/differentiable.py
@@ -44,7 +44,7 @@ class _ManagedScore(torch.autograd.Function):
         if not images.is_cuda:
             raise RuntimeError("differentiable scoring requires CUDA image tensors")
         call_id = uuid.uuid4().hex
-        scorer_name = backend.process_config.scorer.name
+        scorer_name = backend.spec.scorer.name
         # detach+contiguous gives the wire a stable storage to share; the child
         # copies out of it (torch.stack) while this request is in flight.
         shipped = images.detach().contiguous()

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -35,6 +35,11 @@ class ManagedProcessConfig:
     log_dir: str = "/tmp"
     offline: bool = True
     allow_multiple_visible_devices: bool = False
+    #: Data plane for tensor payloads. HTTP is the control plane regardless.
+    #: "auto": negotiate cuda_ipc via /handshake, fall back to http silently.
+    #: "cuda_ipc": require the negotiation to succeed (fail startup otherwise) —
+    #: differentiable scoring needs this. "http": never negotiate (b64 only).
+    transport: str = "auto"
 
 
 @dataclass
@@ -127,6 +132,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             # scorers honoring UNIRL_SCORER_BOOT_OFFLOADED, never touches it)
             # BEFORE _start_child sees it ready; a parent-side offload here
             # would reopen the bootstrap window it is meant to close.
+            self._negotiate_transport()
         except Exception:
             self._stop_child()
             raise
@@ -260,6 +266,47 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
             session.close()
         self._stop_child()
         raise TimeoutError(f"reward child did not become ready within {cfg.process.startup_timeout}s; log={log_path}")
+
+    def _negotiate_transport(self) -> None:
+        """Negotiate the data plane with the ready child (dual-plane design).
+
+        cuda_ipc is same-device, torch-version- and allocator-gated; the child
+        applies the checks and its answer is authoritative. "auto" degrades to
+        http silently; an explicit "cuda_ipc" request that cannot be honored is
+        a configuration error and fails startup — differentiable scoring has no
+        b64 fallback.
+        """
+        self._transport = "http"
+        requested = getattr(self.spec.process, "transport", "auto")
+        if requested == "http":
+            return
+        try:
+            from unirl.reward.tensor_ipc import ipc_fingerprint
+
+            response = self._session.post(
+                f"{self.base_url}/handshake",
+                json={
+                    "fingerprint": {k: str(v) for k, v in ipc_fingerprint().items()},
+                    "proposed_transport": "cuda_ipc",
+                },
+                timeout=15.0,
+            )
+            response.raise_for_status()
+            body = response.json()
+            accepted = body.get("accepted_transport", "http")
+            reason = body.get("reason", "")
+        except Exception as exc:
+            if requested == "cuda_ipc":
+                raise RuntimeError(f"cuda_ipc transport was required but the handshake failed: {exc!r}") from exc
+            logger.info("cuda_ipc handshake unavailable, staying on http: %r", exc)
+            return
+        if accepted == "cuda_ipc":
+            self._transport = "cuda_ipc"
+            logger.info("managed data plane: cuda_ipc (%s)", reason or "negotiated")
+        elif requested == "cuda_ipc":
+            raise RuntimeError(f"cuda_ipc transport was required but the child declined: {reason}")
+        else:
+            logger.info("managed data plane: http (%s)", reason or "declined")
 
     def _post_lifecycle(self, action: str, *, timeout: float = 30.0, tolerate_failure: bool = False) -> bool:
         try:

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -332,13 +332,13 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                 "managed differentiable scoring expects an image batch [B, C, H, W]; "
                 f"got {getattr(media_tensor, 'shape', type(media_tensor))}"
             )
-        if self.process_config.lifecycle == "per_call":
+        if self.spec.gpu_residency == "per_call":
             # The forward+backward pair is indivisible: a per_call offload
             # between the two RPCs releases the child's retained subgraph, so
             # every backward would 409. Reject the combination at the entry
             # instead of failing on the first score deep inside training.
             raise RuntimeError(
-                "differentiable scoring requires lifecycle='resident'; "
+                "differentiable scoring requires gpu_residency='resident'; "
                 "per_call offloads between the forward and backward RPCs and "
                 "drops the retained child-side graph"
             )

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -268,14 +268,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         raise TimeoutError(f"reward child did not become ready within {cfg.process.startup_timeout}s; log={log_path}")
 
     def _negotiate_transport(self) -> None:
-        """Negotiate the data plane with the ready child (dual-plane design).
-
-        cuda_ipc is same-device, torch-version- and allocator-gated; the child
-        applies the checks and its answer is authoritative. "auto" degrades to
-        http silently; an explicit "cuda_ipc" request that cannot be honored is
-        a configuration error and fails startup — differentiable scoring has no
-        b64 fallback.
-        """
+        """Negotiate the data plane with the ready child (dual-plane design)."""
         self._transport = "http"
         requested = getattr(self.spec.process, "transport", "auto")
         if requested == "http":
@@ -314,15 +307,7 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         prompts,
         records=None,
     ):
-        """ReFL entry: satisfy the DifferentiableReward capability across the
-        process boundary (segmented backward over the cuda_ipc data plane).
-
-        ``media_tensor`` is a grad-carrying image batch [B, C, H, W] in [0, 1];
-        the returned [B] reward tensor carries a grad_fn whose backward relays
-        dL/dr to the child and splices dL/dimage back into the caller's graph.
-        Requires transport=cuda_ipc and a supports_grad scorer; video tensors
-        are not wired yet (image rewards only).
-        """
+        """ReFL entry: DifferentiableReward across the process boundary (segmented backward over cuda_ipc)."""
         import torch
 
         from unirl.reward.differentiable import score_differentiable

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -308,6 +308,32 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
         else:
             logger.info("managed data plane: http (%s)", reason or "declined")
 
+    def compute_rewards_differentiable(
+        self,
+        media_tensor,
+        prompts,
+        records=None,
+    ):
+        """ReFL entry: satisfy the DifferentiableReward capability across the
+        process boundary (segmented backward over the cuda_ipc data plane).
+
+        ``media_tensor`` is a grad-carrying image batch [B, C, H, W] in [0, 1];
+        the returned [B] reward tensor carries a grad_fn whose backward relays
+        dL/dr to the child and splices dL/dimage back into the caller's graph.
+        Requires transport=cuda_ipc and a supports_grad scorer; video tensors
+        are not wired yet (image rewards only).
+        """
+        import torch
+
+        from unirl.reward.differentiable import score_differentiable
+
+        if not torch.is_tensor(media_tensor) or media_tensor.dim() != 4:
+            raise ValueError(
+                "managed differentiable scoring expects an image batch [B, C, H, W]; "
+                f"got {getattr(media_tensor, 'shape', type(media_tensor))}"
+            )
+        return score_differentiable(self, media_tensor, list(prompts))
+
     def _post_lifecycle(self, action: str, *, timeout: float = 30.0, tolerate_failure: bool = False) -> bool:
         try:
             response = self._session.post(f"{self.base_url}/lifecycle/{action}", timeout=timeout)

--- a/unirl/reward/managed_process.py
+++ b/unirl/reward/managed_process.py
@@ -332,7 +332,27 @@ class ManagedScorerProcessBackend(RemoteRewardBackend):
                 "managed differentiable scoring expects an image batch [B, C, H, W]; "
                 f"got {getattr(media_tensor, 'shape', type(media_tensor))}"
             )
-        return score_differentiable(self, media_tensor, list(prompts))
+        if self.process_config.lifecycle == "per_call":
+            # The forward+backward pair is indivisible: a per_call offload
+            # between the two RPCs releases the child's retained subgraph, so
+            # every backward would 409. Reject the combination at the entry
+            # instead of failing on the first score deep inside training.
+            raise RuntimeError(
+                "differentiable scoring requires lifecycle='resident'; "
+                "per_call offloads between the forward and backward RPCs and "
+                "drops the retained child-side graph"
+            )
+        prompts = list(prompts)
+        if media_tensor.shape[0] == 0:
+            raise ValueError("differentiable scoring got an empty image batch")
+        if len(prompts) != media_tensor.shape[0]:
+            # Fewer prompts than images would silently score (and backprop
+            # through) only a prefix of the batch.
+            raise ValueError(
+                f"differentiable scoring got {len(prompts)} prompts for a batch "
+                f"of {media_tensor.shape[0]} images; counts must match"
+            )
+        return score_differentiable(self, media_tensor, prompts)
 
     def _post_lifecycle(self, action: str, *, timeout: float = 30.0, tolerate_failure: bool = False) -> bool:
         try:

--- a/unirl/reward/tensor_ipc.py
+++ b/unirl/reward/tensor_ipc.py
@@ -1,24 +1,4 @@
-"""CUDA-IPC tensor codec for the managed data plane (parent side).
-
-Wire format (version 1): base64(pickle((rebuild_fn, args))) exactly as
-produced by ``torch.multiprocessing.reductions.reduce_tensor`` — the same
-mechanism torch itself uses to share CUDA tensors between processes. The
-handle is a few dozen bytes; the storage never moves. Constraints enforced
-by the handshake, not here: both processes on the same physical device,
-IPC-compatible torch builds, tensors from the regular cudaMalloc pool
-(expandable_segments and cumem/VMM regions are not exportable).
-
-Lifetime: the PRODUCER must keep the source tensor alive until the consumer
-is done with it — the parent retains request tensors until the response
-arrives, the child retains gradient tensors until the parent acks (next
-request or explicit release). Consumers should ``.clone()`` if they need
-the data past that window.
-
-A byte-identical twin of this module lives on the child side
-(``reward_service/tensor_ipc.py``): the two ends of the wire share no Python
-package, so the codec is duplicated rather than imported across the
-environment boundary. Keep both copies in sync.
-"""
+"""CUDA-IPC tensor codec for the managed data plane (parent side)."""
 
 from __future__ import annotations
 

--- a/unirl/reward/tensor_ipc.py
+++ b/unirl/reward/tensor_ipc.py
@@ -1,0 +1,75 @@
+"""CUDA-IPC tensor codec for the managed data plane (parent side).
+
+Wire format (version 1): base64(pickle((rebuild_fn, args))) exactly as
+produced by ``torch.multiprocessing.reductions.reduce_tensor`` — the same
+mechanism torch itself uses to share CUDA tensors between processes. The
+handle is a few dozen bytes; the storage never moves. Constraints enforced
+by the handshake, not here: both processes on the same physical device,
+IPC-compatible torch builds, tensors from the regular cudaMalloc pool
+(expandable_segments and cumem/VMM regions are not exportable).
+
+Lifetime: the PRODUCER must keep the source tensor alive until the consumer
+is done with it — the parent retains request tensors until the response
+arrives, the child retains gradient tensors until the parent acks (next
+request or explicit release). Consumers should ``.clone()`` if they need
+the data past that window.
+
+A byte-identical twin of this module lives on the child side
+(``reward_service/tensor_ipc.py``): the two ends of the wire share no Python
+package, so the codec is duplicated rather than imported across the
+environment boundary. Keep both copies in sync.
+"""
+
+from __future__ import annotations
+
+import base64
+import pickle
+
+import torch
+
+
+def encode_tensor(tensor: torch.Tensor) -> str:
+    """Share a CUDA tensor and return the printable handle blob."""
+    if not tensor.is_cuda:
+        raise ValueError("cuda_ipc data plane requires CUDA tensors")
+    from torch.multiprocessing.reductions import reduce_tensor
+
+    return base64.b64encode(pickle.dumps(reduce_tensor(tensor))).decode("ascii")
+
+
+def decode_tensor(blob: str) -> torch.Tensor:
+    """Open a handle blob produced by :func:`encode_tensor` in another process."""
+    rebuild, args = pickle.loads(base64.b64decode(blob.encode("ascii")))
+    return rebuild(*args)
+
+
+def ipc_fingerprint() -> dict:
+    """This process's IPC-compatibility facts, exchanged during handshake."""
+    dev = torch.cuda.current_device() if torch.cuda.is_available() else None
+    props = torch.cuda.get_device_properties(dev) if dev is not None else None
+    uuid = str(getattr(props, "uuid", "")) if props is not None else ""
+    try:
+        allocator = torch.cuda.memory._get_allocator_backend()
+    except Exception:
+        allocator = "unknown"
+    return {
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda or "",
+        "device_uuid": uuid,
+        "allocator": allocator,
+    }
+
+
+def ipc_compatible(mine: dict, theirs: dict) -> tuple[bool, str]:
+    """Decide whether two fingerprints may share a cuda_ipc data plane."""
+    if not mine.get("device_uuid") or not theirs.get("device_uuid"):
+        return False, "no CUDA device on one side"
+    if mine["device_uuid"] != theirs["device_uuid"]:
+        return False, f"different devices: {mine['device_uuid']} vs {theirs['device_uuid']}"
+    mv, tv = mine.get("torch", ""), theirs.get("torch", "")
+    if mv.split("+")[0] != tv.split("+")[0]:
+        return False, f"torch version skew: {mv} vs {tv}"
+    for side, fp in (("local", mine), ("peer", theirs)):
+        if fp.get("allocator") == "cudaMallocAsync":
+            return False, f"{side} allocator {fp['allocator']} is not IPC-exportable"
+    return True, "ok"


### PR DESCRIPTION
## Summary

Managed reward children learn two things: a negotiated **CUDA-IPC data plane** under the existing HTTP control plane, and **differentiable scoring** on top of it — the chain rule relayed across the process boundary (segmented backward), so REFL-style objectives can backpropagate through a reward model that lives in another process and, if needed, another venv.

- **Dual-plane transport**: HTTP stays as the control plane (health / lifecycle / boot protocol / errors / b64 fallback — also exactly what the remote deployment reuses). `/handshake` upgrades the data plane to CUDA IPC when both sides pass three checks (same physical device, IPC-compatible torch builds, regular cudaMalloc pool); a tensor then travels as a few dozen handle bytes, lossless and zero-copy. `transport: auto | http | cuda_ipc` — `auto` falls back silently, an explicit `cuda_ipc` fails startup instead.
- **Segmented backward** (after mmrl's production pattern): a `grad_mode` score runs the scorer forward under grad and retains the subgraph keyed by `call_id`; `/backward` seeds it with dL/dr (plain floats), backwards the child's segment, and returns per-item dL/dimage as IPC handles. Parent-side, one `autograd.Function` wraps the two RPCs as a single node in the training graph (`unirl.reward.differentiable.score_differentiable`). `grad_mode` bypasses the idempotency cache and per-item soft failure — a retained graph is stateful and a gradient has no NaN; offload drops retained graphs, making the per_call window a forward+backward pair.
- **Scorer contract**: `supports_grad` + `score_tensors(images, prompts)`; whether a graph is built is the caller's context (no interface fork), and implementations must stay torch-native end to end — a PIL/numpy hop breaks the graph silently. PickScore is the first differentiable scorer (bicubic resize + CLIP normalization in torch, frozen weights).
- **REFL integration**: `ManagedScorerProcessBackend` now satisfies the `DifferentiableReward` capability via `compute_rewards_differentiable()` — `RewardService.score_differentiable` accepts it with zero trainer/role changes; the recipe swaps only the reward block (`experimental/refl/examples/sd3_pickscore_refl_managed.yaml`). The Protocol's note that a backend behind a process boundary can never satisfy it is updated accordingly: the graph still never crosses the boundary — the chain rule is relayed.

Stacked on #303 (managed scorer child / lifecycle protocol); sibling of #348 (EditScore / vLLM-engine scorer). vLLM-backed scorers remain scalar-only by nature (inference engines have no autograd) — the two capabilities occupy opposite ends of the scorer-backend axis and do not compete.

## Related Issue

N/A — design RFC and deployment decision tree accompany this PR; groundwork in #302 / #303 / #304, sibling #348.

## Test Plan

All on 8× (or 1×) H20, parent in the training venv, child a real Popen process on the same GPU (PickScore CLIP-H fp32).

- Protocol validation (single GPU, real cross-process runs):
  - scalar wire parity: the same image scored via `image_b64` and `image_ipc` is **bit-identical** (0.724987 both);
  - differentiable vs an in-process single-graph reference on identical inputs: scores bit-equal, dL/dimage max-diff 1.9e-7 on an 8.1e-3 scale;
  - directional finite difference vs the analytic wire gradient: rel 3.6% (never just "grad exists and is nonzero");
  - consumed graph → second `/backward` 404s; `grad_mode` without a negotiated IPC plane → 409; forged torch fingerprint → silent http fallback under `auto`, startup failure under `transport: cuda_ipc`.
- REFL end to end (8× H20, 10 rollouts, `experimental.refl.run --config-name=sd3_pickscore_refl_managed`): reward rises 0.735 → 0.795 (first-3 mean 0.729, last-3 mean 0.779) with healthy grad norms (0.06–0.13), ~1.1 s/rollout, zero faults. REFL has no policy gradient, so a rising reward is only possible if gradients genuinely traverse the three-segment relay (child CLIP subgraph → IPC → role-side Function → GradContext RPC → actor LoRA).
- Also fixes the PickScore scalar path against transformers ≥ 5 (`get_image_features` now returns a ModelOutput with projected features in `pooler_output`); the compat helper keeps older transformers working unchanged.

## Compatibility / Risk

- Additive: new schema fields are optional (`image_ipc`, `grad_mode`, `call_id`); scalar b64 flows are byte-for-byte unchanged.
- `transport` defaults to `auto`: existing managed deployments now attempt one `/handshake` POST at startup and fall back to http silently on any failure — no behavioral change beyond the extra request.
- CUDA IPC constraints are enforced at handshake, not assumed: same device UUID, matching torch base versions, non-`cudaMallocAsync` allocator; cross-host remote deployments never negotiate (the plain remote client doesn't call `/handshake`).
- Differentiable scoring is strictly opt-in (`supports_grad` scorers + `score_differentiable` callers); vLLM scorers are unaffected. Video tensors are not wired yet (image rewards only).
- Retained graphs are bounded (4 outstanding) and dropped on offload; the child pins returned gradient storage only until its next backward.

## Reviewer Notes

- `tensor_ipc.py` exists as byte-identical twins on both sides of the wire (`unirl/reward/` and `reward_service/`) — the two ends share no Python package, so the codec is duplicated rather than imported across the environment boundary; both file headers say so.
- The design RFC (dual-plane architecture, deployment decision tree, constraint table, measured numbers) is available on request; the deployment decision tree's differentiable leaf now has real-training backing.
- Known cosmetic: at teardown a torch warning about shared CUDA tensors may fire if the driver exits before the last handles are collected — harmless; an explicit release-ordering in `dispose()` is a follow-up.
- Follow-ups (not this PR): per-rank concurrency hardening for grad windows under a live per_call trainer; cross-venv child (matching torch) IPC soak; video reward tensors.
- AI-assisted development was used for implementation and test harnesses; all changes were reviewed and validated by the author.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
