### PR TITLE
feat(flux2_klein): support multiple reference images end to end

### DIFF
--- a/unirl/data/data_source.py
+++ b/unirl/data/data_source.py
@@ -34,7 +34,10 @@ def _load_condition_images(media_refs: List[Any]) -> Optional[List[Images]]:
             for r in (refs or [])
             if getattr(r, "modality", None) == "image" and getattr(r, "role", None) == "condition"
         ]
-        references = [Image(pixels=TF.to_tensor(PIL.Image.open(r.uri).convert("RGB"))) for r in selected]
+        references = []
+        for ref in selected:
+            with PIL.Image.open(ref.uri) as pil:
+                references.append(Image(pixels=TF.to_tensor(pil.convert("RGB"))))
         images_per_prompt.append(references)
         any_loaded = any_loaded or bool(references)
 

--- a/unirl/data/data_source.py
+++ b/unirl/data/data_source.py
@@ -4,14 +4,14 @@ import logging
 import os
 from collections import Counter
 from functools import partial
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, cast
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import torch
 from torch.utils.data import DataLoader
 
 from unirl.types.media import MediaRef, MediaRefs
-from unirl.types.primitives import Image, Images, Texts, Videos
-from unirl.types.sample import Part, PrimitiveMap, Sample
+from unirl.types.primitives import Image, Images, PrimitiveValue, Texts, Videos
+from unirl.types.sample import Part, Sample
 from unirl.utils.video import load_video
 
 from .datasets import PromptExampleDataset, TextPromptDataset, normalize_prompt_example
@@ -19,14 +19,14 @@ from .datasets import PromptExampleDataset, TextPromptDataset, normalize_prompt_
 logger = logging.getLogger(__name__)
 
 
-def _load_condition_images(media_refs: List[Any]) -> Optional[List[Image]]:
-    """Load ``(modality="image", role="condition")`` media refs into ``Image``."""
+def _load_condition_images(media_refs: List[Any]) -> Optional[List[Images]]:
+    """Load ``(image, condition)`` refs into one ``Images`` per slot; ragged batches rejected (the transpose zips)."""
     if not media_refs or not any(media_refs):
         return None
     import PIL.Image
     import torchvision.transforms.functional as TF
 
-    images_per_prompt: List[Optional[Image]] = []
+    images_per_prompt: List[List[Image]] = []
     any_loaded = False
     for refs in media_refs:
         selected = [
@@ -34,25 +34,26 @@ def _load_condition_images(media_refs: List[Any]) -> Optional[List[Image]]:
             for r in (refs or [])
             if getattr(r, "modality", None) == "image" and getattr(r, "role", None) == "condition"
         ]
-        if not selected:
-            images_per_prompt.append(None)
-            continue
-        if len(selected) > 1:
-            raise ValueError(f"Expected at most one condition image per prompt, got {len(selected)}")
-        pil = PIL.Image.open(selected[0].uri).convert("RGB")
-        tensor = TF.to_tensor(pil)
-        images_per_prompt.append(Image(pixels=tensor))
-        any_loaded = True
+        references = [Image(pixels=TF.to_tensor(PIL.Image.open(r.uri).convert("RGB"))) for r in selected]
+        images_per_prompt.append(references)
+        any_loaded = any_loaded or bool(references)
 
     if not any_loaded:
         return None
-    missing = [index for index, image in enumerate(images_per_prompt) if image is None]
+    missing = [index for index, references in enumerate(images_per_prompt) if not references]
     if missing:
         raise ValueError(
             f"Condition-image batch is incomplete: {len(missing)}/{len(images_per_prompt)} "
             f"prompts are missing an image (e.g. prompt index {missing[0]})."
         )
-    return cast(List[Image], images_per_prompt)
+    counts = sorted({len(references) for references in images_per_prompt})
+    if len(counts) > 1:
+        raise ValueError(
+            f"Condition-image batch is ragged: prompts carry {counts} reference images. "
+            f"Every prompt in a batch must carry the same number — bucket the dataset by "
+            f"reference count so each batch is uniform."
+        )
+    return [Images.from_list(list(slot)) for slot in zip(*images_per_prompt)]
 
 
 def _load_condition_videos(media_refs: List[Any]) -> Optional[List[Any]]:
@@ -182,12 +183,12 @@ def _reject_unsupported_media_refs(batch: Dict[str, Any], *, context: str) -> No
 
 
 def _input_sample(
-    primitives: PrimitiveMap,
+    primitives: Dict[str, Union[PrimitiveValue, List[PrimitiveValue]]],
     *,
     sample_ids: List[str],
     metadata: Optional[List[Optional[Dict[str, Any]]]] = None,
 ) -> Sample:
-    """Build the data-source request as a text-rooted input Part chain."""
+    """Build the data-source request as a text-rooted Part chain; a list value chains one Part per element."""
     if len(set(sample_ids)) != len(sample_ids):
         duplicates = sorted(sample_id for sample_id, count in Counter(sample_ids).items() if count > 1)
         raise ValueError(f"Data-source input requires unique root sample_ids; duplicates: {duplicates[:3]}")
@@ -204,11 +205,12 @@ def _input_sample(
     parts = [root]
     parent = root
     for key in ("image", "video", "media"):
-        primitive = primitives.get(key)
-        if primitive is None:
+        value = primitives.get(key)
+        if value is None:
             continue
-        parent = parent.input_child({key: primitive})
-        parts.append(parent)
+        for primitive in value if isinstance(value, list) else [value]:
+            parent = parent.input_child({key: primitive})
+            parts.append(parent)
     return Sample.request(*parts)
 
 
@@ -330,7 +332,7 @@ class MultimodalRLDataSource:
         primitives: Dict[str, Any] = {"text": Texts(texts=prompts)}
         images = _load_condition_images(media_refs)
         if images is not None:
-            primitives["image"] = Images.from_list(images)
+            primitives["image"] = images
         condition_videos = _load_condition_videos(media_refs)
         if condition_videos is not None:
             _validate_homogeneous_videos(condition_videos)
@@ -365,7 +367,7 @@ class MultimodalRLDataSource:
         primitives: Dict[str, Any] = {"text": Texts(texts=prompts)}
         images = _load_condition_images(media_refs)
         if images is not None:
-            primitives["image"] = Images.from_list(images)
+            primitives["image"] = images
         condition_videos = _load_condition_videos(media_refs)
         if condition_videos is not None:
             _validate_homogeneous_videos(condition_videos)

--- a/unirl/models/bagel/pipeline.py
+++ b/unirl/models/bagel/pipeline.py
@@ -136,11 +136,13 @@ class BagelPipeline(Pipeline):
 
     def _extract_input_images(self, conditioning: List[Any], task: str, *, n_prompts: Optional[int]) -> List[Any]:
         """Validated per-sample input PILs for image-input tasks (it2i / i2t / it2t)."""
-        images_prim = next((c for c in conditioning if isinstance(c, Images)), None)
-        if not isinstance(images_prim, Images):
+        image_inputs = [c for c in conditioning if isinstance(c, Images)]
+        if len(image_inputs) != 1:
             raise TypeError(
-                f"BagelPipeline.generate ({task}): expected an Images input in sample.conditioning(), found none"
+                f"BagelPipeline.generate ({task}): expected exactly one Images input in "
+                f"sample.conditioning(), got {len(image_inputs)}"
             )
+        images_prim = image_inputs[0]
         if getattr(self.bundle.model, "vit_model", None) is None:
             raise ValueError(
                 f"BagelPipeline.generate ({task}): the bundle was built without the und ViT; "

--- a/unirl/models/flux2_klein/pipeline.py
+++ b/unirl/models/flux2_klein/pipeline.py
@@ -159,7 +159,7 @@ class Flux2KleinPipeline(Pipeline):
                 f"Flux2KleinPipeline.generate: expected a Texts prompt from sample.conditioning()[0], "
                 f"got {type(texts).__name__ if texts is not None else 'None'}"
             )
-        source_image = next((c for c in conditioning[1:] if isinstance(c, Images)), None)
+        references = [c for c in conditioning[1:] if isinstance(c, Images)]
 
         allowed = {f.name for f in _dc.fields(Flux2KleinDiffusionParams)}
         params_dict = {k: getattr(sampling, k) for k in allowed if hasattr(sampling, k)}
@@ -169,13 +169,15 @@ class Flux2KleinPipeline(Pipeline):
             params = _dc.replace(params, noise_group_ids=list(frontier.group_ids))
 
         klein_conds = self.build_conditions(texts, guidance_scale=float(params.guidance_scale))
-        if source_image is not None:
-            if len(source_image) != len(texts.texts):
-                raise ValueError(
-                    f"Flux2KleinPipeline.generate: image count {len(source_image)} != text count {len(texts.texts)}"
-                )
+        if references:
+            for slot, reference in enumerate(references):
+                if len(reference) != len(texts.texts):
+                    raise ValueError(
+                        f"Flux2KleinPipeline.generate: reference slot {slot} image count "
+                        f"{len(reference)} != text count {len(texts.texts)}"
+                    )
             image_tokens, image_ids = self.vae_encode.encode(
-                source_image,
+                references,
                 height=int(params.height),
                 width=int(params.width),
             )

--- a/unirl/models/flux2_klein/vae.py
+++ b/unirl/models/flux2_klein/vae.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
+from typing import Sequence, Union
 
 import torch
 
@@ -68,7 +69,7 @@ class Flux2KleinVAEDecodeStage(DecodeStage[LatentSegment, Images]):
 
 
 class Flux2KleinVAEEncodeStage:
-    """Encode a source/reference image into packed condition tokens + ids."""
+    """Encode source/reference images into packed condition tokens + ids, one RoPE time offset per slot."""
 
     REFERENCE_TIME_SCALE: int = 10
 
@@ -76,7 +77,26 @@ class Flux2KleinVAEEncodeStage:
         self.bundle = bundle
 
     @torch.no_grad()
-    def encode(self, images: Images, *, height: int, width: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def encode(
+        self,
+        images: Union[Images, Sequence[Images]],
+        *,
+        height: int,
+        width: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        references = [images] if isinstance(images, Images) else list(images)
+        if not references:
+            raise ValueError("Flux2KleinVAEEncodeStage.encode: no reference images given")
+        encoded = [
+            self._encode_slot(reference, height=height, width=width, slot=slot)
+            for slot, reference in enumerate(references)
+        ]
+        tokens = torch.cat([token for token, _ in encoded], dim=1)
+        ids = torch.cat([ref_ids for _, ref_ids in encoded], dim=1)
+        return tokens, ids
+
+    def _encode_slot(self, images: Images, *, height: int, width: int, slot: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Encode one reference slot; T=``scale * (slot + 1)`` must match upstream ``_prepare_image_ids``."""
         if self.bundle.vae is None:
             raise RuntimeError(
                 "Flux2KleinVAEEncodeStage.encode: no VAE loaded "
@@ -122,7 +142,7 @@ class Flux2KleinVAEEncodeStage:
 
         image_tokens = pack_latents(image_latents)
 
-        t = torch.full((1,), self.REFERENCE_TIME_SCALE, device=device, dtype=torch.long)
+        t = torch.full((1,), self.REFERENCE_TIME_SCALE * (slot + 1), device=device, dtype=torch.long)
         h = torch.arange(h_pat, device=device)
         w = torch.arange(w_pat, device=device)
         s = torch.arange(1, device=device)

--- a/unirl/models/hunyuan_image3/modes/i2t.py
+++ b/unirl/models/hunyuan_image3/modes/i2t.py
@@ -32,11 +32,13 @@ def generate(pipeline: "HunyuanImage3Pipeline", sample: Sample) -> Sample:
             f"prompt from sample.conditioning()[0] must be Texts, "
             f"got {type(texts).__name__ if texts is not None else 'None'}"
         )
-    images = next((c for c in conditioning[1:] if isinstance(c, Images)), None)
-    if not isinstance(images, Images):
+    image_inputs = [c for c in conditioning[1:] if isinstance(c, Images)]
+    if len(image_inputs) != 1:
         raise TypeError(
-            "HunyuanImage3Pipeline.generate (i2t): expected a chained Images input in sample.conditioning(), found none"
+            "HunyuanImage3Pipeline.generate (i2t): expected exactly one chained Images input in "
+            f"sample.conditioning(), got {len(image_inputs)}"
         )
+    images = image_inputs[0]
 
     model_cfg: Dict[str, Any] = dict((sample.parts[0].control or {}).get("ar") or {})
     ar_params = HunyuanImage3ARParams(

--- a/unirl/models/hunyuan_image3/modes/it2i.py
+++ b/unirl/models/hunyuan_image3/modes/it2i.py
@@ -105,11 +105,13 @@ def generate(pipeline: "HunyuanImage3Pipeline", sample: Sample) -> Sample:
         f"must be Texts, "
         f"got {type(texts).__name__ if texts is not None else 'None'}",
     )
-    images = next((c for c in conditioning[1:] if isinstance(c, Images)), None)
+    image_inputs = [c for c in conditioning[1:] if isinstance(c, Images)]
     require(
-        isinstance(images, Images),
-        "HunyuanImage3Pipeline.generate (it2i): expected a chained Images input in sample.conditioning(), found none",
+        len(image_inputs) == 1,
+        "HunyuanImage3Pipeline.generate (it2i): expected exactly one chained Images input in "
+        f"sample.conditioning(), got {len(image_inputs)}",
     )
+    images = image_inputs[0]
 
     require(
         int(params.samples_per_prompt) <= 2,

--- a/unirl/models/wan21/pipeline.py
+++ b/unirl/models/wan21/pipeline.py
@@ -158,7 +158,12 @@ class WAN21Pipeline(Pipeline):
                 f"WAN21Pipeline.generate: expected a Texts prompt from sample.conditioning()[0], "
                 f"got {type(texts).__name__ if texts is not None else 'None'}"
             )
-        images_prim = next((c for c in conditioning[1:] if isinstance(c, Images)), None)
+        image_inputs = [c for c in conditioning[1:] if isinstance(c, Images)]
+        if len(image_inputs) > 1:
+            raise ValueError(
+                f"WAN21Pipeline.generate: expected at most one Images conditioning primitive, got {len(image_inputs)}"
+            )
+        images_prim = image_inputs[0] if image_inputs else None
 
         wan_conds = self.build_conditions(texts, guidance_scale=float(params.guidance_scale))
 

--- a/unirl/models/wan22/pipeline.py
+++ b/unirl/models/wan22/pipeline.py
@@ -145,7 +145,12 @@ class WAN22Pipeline(Pipeline):
                 f"WAN22Pipeline.generate: expected a Texts prompt from sample.conditioning()[0], "
                 f"got {type(texts).__name__ if texts is not None else 'None'}"
             )
-        images_prim = next((c for c in conditioning[1:] if isinstance(c, Images)), None)
+        image_inputs = [c for c in conditioning[1:] if isinstance(c, Images)]
+        if len(image_inputs) > 1:
+            raise ValueError(
+                f"WAN22Pipeline.generate: expected at most one Images conditioning primitive, got {len(image_inputs)}"
+            )
+        images_prim = image_inputs[0] if image_inputs else None
 
         primary_g = float(params.guidance_scale)
         low_g = float(params.guidance_scale_2) if params.guidance_scale_2 is not None else primary_g

--- a/unirl/reward/local/per_domain.py
+++ b/unirl/reward/local/per_domain.py
@@ -37,6 +37,7 @@ def _select_request(request: RewardRequest, indices: List[int]) -> RewardRequest
     return RewardRequest(
         primitives={k: _select_rows(v, idx) for k, v in request.primitives.items()},
         generated={k: _select_rows(v, idx) for k, v in request.generated.items()},
+        image_references=[_select_rows(value, idx) for value in request.image_references],
         metadata=_pick(request.metadata),
         prompt_ids=_pick(request.prompt_ids),
         sample_ids=_pick(request.sample_ids),

--- a/unirl/reward/local/video_pickscore.py
+++ b/unirl/reward/local/video_pickscore.py
@@ -69,6 +69,7 @@ class VideoPickScoreScorer(PickScoreRewardScorer):
             request = RewardRequest(
                 primitives=dict(request.primitives),
                 generated={"image": Images.from_dense(frame_pixels)},
+                image_references=list(request.image_references),
                 prompt_ids=request.prompt_ids,
                 sample_ids=request.sample_ids,
                 group_ids=request.group_ids,

--- a/unirl/reward/remote.py
+++ b/unirl/reward/remote.py
@@ -320,13 +320,15 @@ class RemoteRewardBackend(RewardBackend):
 
     def _get_condition_images(self, request: RewardRequest) -> Optional[List[Union[Image.Image, torch.Tensor]]]:
         """Extract per-sample condition images from request primitives."""
-        prim_image = request.primitives.get("image")
+        use_primary_reference = len(request.image_references) > 1
+        prim_image = request.image_references[0] if use_primary_reference else request.primitives.get("image")
         if prim_image is None:
             return None
         from unirl.types.primitives import Images
 
         if not isinstance(prim_image, Images):
-            raise TypeError(f"request.primitives['image'] must be Images, got {type(prim_image).__name__}")
+            source = "request.image_references[0]" if use_primary_reference else "request.primitives['image']"
+            raise TypeError(f"{source} must be Images, got {type(prim_image).__name__}")
         from unirl.utils.media import tensor_frame_to_pil
 
         return [tensor_frame_to_pil(image.pixels) for image in prim_image.to_list()]

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -9,7 +9,7 @@ import torch
 
 from unirl.distributed.group.dispatch import Dispatch, distributed
 from unirl.distributed.group.remote import Remote
-from unirl.types.primitives import PrimitiveValue, primitive_modality_key
+from unirl.types.primitives import Images, PrimitiveValue, primitive_modality_key
 from unirl.types.reward import RewardRequest, RewardResponse
 from unirl.types.sample import Sample, _part_with_field
 from unirl.types.sampling import ARSamplingParams
@@ -22,9 +22,11 @@ logger = logging.getLogger(__name__)
 def _build_reward_request(sample: Sample, preferred_input_kind: str) -> RewardRequest:
     """Assemble a :class:`RewardRequest` from a response ``Sample``."""
     frontier = sample.parts[-1]
+    turns = sample.turns()
     primitives: Dict[str, PrimitiveValue] = {}
-    for prim in sample.conditioning():
-        primitives[primitive_modality_key(prim)] = prim
+    for turn in turns:
+        primitives[primitive_modality_key(turn.content)] = turn.content
+    image_references = [turn.content for turn in turns if turn.role == "user" and isinstance(turn.content, Images)]
 
     if preferred_input_kind not in frontier.primitives:
         raise ValueError(
@@ -41,6 +43,7 @@ def _build_reward_request(sample: Sample, preferred_input_kind: str) -> RewardRe
     return RewardRequest(
         primitives=primitives,
         generated=generated,
+        image_references=image_references,
         audio_sample_rate=audio_sample_rate,
         prompt_ids=[str(sid) for sid in frontier.sample_ids],
         sample_ids=list(frontier.sample_ids),

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_sampling_io.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_sampling_io.py
@@ -108,6 +108,15 @@ def _wrap_validate_with_pipeline_config(SamplingParams) -> None:
 _GEN_SENTINEL = "_unirl_diff_gen_index"
 
 
+def _is_per_prompt_condition_image(ci) -> bool:
+    """Whether ``condition_image`` is per-prompt: nesting, not length (1 prompt, N refs = length-1 list)."""
+    if not isinstance(ci, list) or not ci:
+        return False
+    if all(isinstance(entry, list) for entry in ci):
+        return True
+    return len(ci) > 1
+
+
 def _wrap_diff_generator_generate() -> None:
     """AROUND-wrap ``DiffGenerator.generate`` to index ``condition_image`` per prompt."""
     try:
@@ -125,7 +134,7 @@ def _wrap_diff_generator_generate() -> None:
 
     def generate(self, sampling_params_kwargs=None, *args, **kwargs):
         ci = (sampling_params_kwargs or {}).get("condition_image")
-        if isinstance(ci, list) and len(ci) > 1:
+        if _is_per_prompt_condition_image(ci):
             _local.condition_image_per_prompt = ci
             _local.condition_image_idx = 0
         else:
@@ -313,7 +322,7 @@ def _wrap_prepare_request(utils_mod, SamplingParams) -> None:
         condition_image = getattr(sampling_params, "condition_image", None)
         if condition_image is not None:
             stash = getattr(_local, "condition_image_per_prompt", None)
-            if isinstance(stash, list) and len(stash) > 1:
+            if isinstance(stash, list) and stash:
                 idx = getattr(_local, "condition_image_idx", 0)
                 if idx >= len(stash):
                     raise RuntimeError(

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_sampling_io.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_sampling_io.py
@@ -109,7 +109,7 @@ _GEN_SENTINEL = "_unirl_diff_gen_index"
 
 
 def _is_per_prompt_condition_image(ci) -> bool:
-    """Whether ``condition_image`` is per-prompt: nesting, not length (1 prompt, N refs = length-1 list)."""
+    """Whether ``condition_image`` is per-prompt: nested for multi-ref, or flat with more than one prompt."""
     if not isinstance(ci, list) or not ci:
         return False
     if all(isinstance(entry, list) for entry in ci):

--- a/unirl/rollout/engine/sglang_diffusion/adapters/flux.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/flux.py
@@ -43,30 +43,39 @@ class Flux2KleinAdapter(ImageAdapter):
         return self.model_config.build_schedule_policy()
 
     def build_prompts(self, sample: Sample) -> Dict[str, Any]:
-        """T2I payload, plus the source image when the request carries one."""
+        """T2I payload, plus a ``condition_image`` per ``Images`` slot; one stays flat, 2+ nest per prompt."""
         if not sample.has_image_input():
             return super().build_prompts(sample)
 
         turns, image_batches = sample.vision_conditioning()
         text_turns = [turn.content for turn in turns if isinstance(turn.content, Texts)]
-        if len(text_turns) != 1 or len(image_batches) != 1:
+        if len(text_turns) != 1 or not image_batches:
             raise ValueError(
-                f"{self.model_family!r} ti2i needs exactly 1 text and 1 image turn; "
+                f"{self.model_family!r} ti2i needs exactly 1 text turn and at least 1 image turn; "
                 f"got {len(text_turns)} text, {len(image_batches)} image."
             )
         gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
         prompts = list(text_turns[0].texts)
         unique_prompts, k = utils.deexpand_prompts_from_groups(prompts, list(gen_part.group_ids))
-        pil_images = image_batches[0].to_pils()
-        unique_pils = utils.first_per_group(pil_images, list(gen_part.group_ids)) if k > 1 else pil_images
-        unique_pils = resize_condition_pils(
-            unique_pils,
-            height=int(gen_part.sampling_params.height),
-            width=int(gen_part.sampling_params.width),
-        )
+        per_slot = []
+        for slot in image_batches:
+            pil_images = slot.to_pils()
+            unique_pils = utils.first_per_group(pil_images, list(gen_part.group_ids)) if k > 1 else pil_images
+            per_slot.append(
+                resize_condition_pils(
+                    unique_pils,
+                    height=int(gen_part.sampling_params.height),
+                    width=int(gen_part.sampling_params.width),
+                )
+            )
+        if len(per_slot) == 1:
+            unique_pils = per_slot[0]
+            condition_image: Any = unique_pils if len(unique_pils) > 1 else unique_pils[0]
+        else:
+            condition_image = [list(references) for references in zip(*per_slot)]
         out: Dict[str, Any] = {
             "prompt": unique_prompts if len(unique_prompts) > 1 else unique_prompts[0],
-            "condition_image": unique_pils if len(unique_pils) > 1 else unique_pils[0],
+            "condition_image": condition_image,
         }
         if k > 1:
             out["num_outputs_per_prompt"] = k

--- a/unirl/rollout/engine/vllm_omni/adapters/hi3.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/hi3.py
@@ -230,6 +230,8 @@ class Hi3InputAdapter:
 
         if self.image_input:
             turns, images = sample.vision_conditioning()
+            if len(images) != 1:
+                raise ValueError(f"{self.modality}: expected exactly one Images conditioning batch, got {len(images)}")
             texts = next(t.content for t in turns if isinstance(t.content, Texts))
             pil_images = images[0].to_pils()
         else:

--- a/unirl/types/reward.py
+++ b/unirl/types/reward.py
@@ -24,6 +24,8 @@ class RewardRequest:
 
     primitives: Dict[str, Any] = field(default_factory=dict)
     generated: Dict[str, Any] = field(default_factory=dict)
+    # Ordered user image turns; single-source rewards treat slot 0 as the primary source.
+    image_references: List[Any] = field(default_factory=list)
     metadata: Optional[List[Optional[Dict[str, Any]]]] = None
     prompt_ids: Optional[List[str]] = None
     sample_ids: Optional[List[str]] = None


### PR DESCRIPTION
## Summary

Adds support for **multiple reference images** per prompt, end to end, for FLUX.2-Klein on both
the trainside and SGLang rollout paths.

Today the driver caps condition images at one per prompt (`_load_condition_images` raises on
`len(selected) > 1`), so no model can receive more than one reference regardless of what it
supports. FLUX.2 supports N natively — upstream SGLang's `ImageVAEEncodingStage` already loops
over condition images and `_prepare_image_ids` assigns each reference its own RoPE time offset —
so the work here is removing the cap and carrying the extra references through.

**How references travel.** One input `Part` per reference *slot*, chained off the prompt root:

```
parts[0] {"text"}   ids ["p0","p1"]
parts[1] {"image"}  ids ["p0/0","p1/0"]        <- slot 0, RoPE t=10
parts[2] {"image"}  ids ["p0/0/0","p1/0/0"]    <- slot 1, RoPE t=20
```

This shape is forced by two `Part` invariants: `primitives` is keyed by canonical modality (so one
`Images` per Part), and `len(primitive) == len(sample_ids)` (so one image per sample per Part). A
Part therefore holds a *slot*, not a prompt's reference list — hence the prompt-major →
slot-major transpose in the driver. `Sample.conditioning()` already surfaces the chain in order,
and `vision_conditioning()` already documented its collection as "1..k"; the caps were in the
driver and in consumers that discarded the extras.

**Why FLUX needs no model-side change.** Every reference is resized to the generation canvas
(both paths already did this), so references produce identically-sized token blocks and the
condition tensors stay dense — no ragged batching. And `Flux2KleinDiffusionStep.predict_noise` is
a blind `torch.cat` of condition tokens and ids onto the noise stream, so it is
segment-count-agnostic. `Flux2KleinConditions`, `predict_noise`, `build_condition` and
`patch_conditions` are all untouched; N references are simply a longer sequence.

The only model-side delta is the per-reference RoPE offset, now `scale * (slot + 1)`, replicating
upstream's `t_coords = [scale + scale * k for k in range(N)]`. This matters because the SGLang
path *captures* ids from upstream while the trainside path *recomputes* them — at N=1 both
produced `t=10`, so they agreed by coincidence. Verified byte-identical at N=2.

**Constraint:** batches must be uniform in reference count. `Sample.turns()` resolves every
ancestor id by name, so a Part holding only some samples breaks the lineage walk. Ragged batches
are rejected with an error pointing at bucketing. If ragged N is needed later, the additive fix
is a row-aligned primitive following the existing `MediaRefs` idiom.

**Other models are unaffected but no longer silently truncated.** With the driver cap gone, a
2-reference request reaches whichever model is configured; Qwen-Image-Edit-Plus, HunyuanImage 3.0
and BAGEL keep their own single-reference guards and now surface them instead of the loader
quietly dropping references first.

## Related Issue

N/A

## Test Plan

Lint / static (local):

```
ruff check <5 changed files>                  -> All checks passed!
ruff format --check <5 changed files>         -> 5 files already formatted
python lint/check_docstring_lines.py          -> 3230 docstrings, all one line
python lint/check_core_dependencies.py        -> ok
python lint/check_recipe_targets.py           -> 2496 recipe _target_ paths resolve
python lint/check_experimental_boundaries.py  -> ok
```

Rebased onto current `main` (`f5d71040`). The conflicts were docstrings only — #316 collapsed
every docstring behind `lint/check_docstring_lines.py`, which had already rewritten the same
lines this branch touched; upstream's one-liners are taken as-is wherever they stayed accurate.
One non-cosmetic fix came with it: #366 deleted the `Primitive` alias this branch imported, so
the annotation now uses `PrimitiveValue` from `unirl.types.primitives`. The executable delta is
otherwise unchanged from the verified commit (`git range-diff` confirms), but note the **GPU run
above predates this rebase** — it validated this change against the pre-rebase base, not against
the 30 upstream commits since.

**Rollout-engine verification on GPU — 25/25 passed.** 1x8 H20, single GPU used;
`FLUX.2-klein-base-4B` on pod-local disk; `.venv-sglang` with torch 2.11.0+cu130 and
sglang 0.5.12.post1; recipe `examples/diffusion/flux2_klein/flux2_klein_4b_editreward_sglang.yaml`
instantiated via Hydra (rollout engine only — no optimizer step, no reward service). References
were the three images shipped inside the checkpoint. 512x512, `samples_per_prompt=2`.

| Stage | Result |
|---|---|
| Sample construction | N=1 -> 2 parts, N=2 -> 3 parts; slots batch-wide; lineage `prompt:0:sample:0/0/0`; ragged batch rejected |
| Trainside VAE encode | `(2,1024,128)` -> `(2,2048,128)`; `t=[10]` -> `t=[10,20]`; **N=1 byte-identical to N=2 slot 0** (tokens and ids) |
| SGLang rollout engine | `generate` returned 4 decoded images; `image_latent=(4,2048,128)`, `ids=(4,2048,4)`; engine `t=[10,20]` |
| Id parity | trainside-recomputed vs SGLang-captured ids: shapes match, **`mismatch=0`** |

**Pixel-level check that reference 2 is attended, not ignored — 6/6 passed.** Shapes and id parity
can all pass while the second reference is inert, so a separate run at fixed seed (1234), 8 steps:

| run | references | vs run1 |
|---|---|---|
| run1 | editing + realism | baseline |
| run2 | editing + realism | **mad = 0.000000** (byte-identical PNG) — determinism control |
| run3 | editing + **others** | **mad = 0.034136** — swapping reference 2 changes the output |
| run4 | editing only | mad = 0.054377 — N=2 differs from N=1 |

The determinism control is what makes run3 conclusive: run1/run2 being byte-identical rules out
sampling noise, so the run3 difference is attributable to the swapped second reference alone. All
outputs were coherent photorealistic images (inspected, not only measured); non-degenerate checks
(finite, `0.02 < mean < 0.98`, `std > 0.02`) passed.

Harnesses were run and quoted here, not committed (per `CLAUDE.md` §5).

**Not run:** no training step and no reward service, so there is **no reward-curve evidence** —
this change was validated at the rollout-engine level only. No end-to-end run on a real
multi-reference dataset: `datasets/image_edit/*.jsonl` is single-reference throughout, so a
2-reference bucket needs sourcing before that is meaningful.

## Compatibility / Risk

- **N=1 is preserved on every path**, and this was verified rather than assumed: the driver
  produces the same Sample shape, `_encode_slot(slot=0)` yields `t=10` and tokens/ids
  byte-identical to the previous `encode`, and the SGLang `condition_image` wire shape is
  unchanged (flat/scalar). Nesting is introduced only at N>=2.
- **Data format:** dataset manifests may now carry more than one `(image, condition)` `MediaRef`
  per prompt. Existing single-reference manifests are unaffected.
- **New failure mode by design:** batches with differing reference counts are now rejected, where
  previously any count above one was rejected outright. Note this is a *per-batch* invariant and
  the data source has no bucketing sampler (`sampler=None`, plain shuffle), so in practice a
  dataset must currently hold one reference count per file/run. A grouping batch sampler would
  lift that, and is deliberately left out of this PR.
- **Highest-risk edit** is `_patches/patch_sampling_io.py`: the per-prompt stash now keys on
  *nesting* rather than list length, because one prompt with N references is a length-1 outer
  list (`[[r1, r2]]`) which the old `len(stash) > 1` test treated as single-prompt. This is a
  reinterpretation of an existing wire field rather than an extension — worth reviewer attention.
- No checkpoint, API, or resource-requirement changes. Sequence length grows with N (see below).

## Reviewer Notes

- **AI assistance:** this change was authored with AI assistance (Claude). The diff, the GPU
  verification, and this description should be reviewed on that basis.
- **Duplicate-work check:** no open PRs on the fork touch this area. Note that
  `LIN-690/minimax-h3-ref2va` (unmerged, elsewhere) contains an N-reference *model* layer for up
  to 12 references that is blocked by this same driver cap — it touches only `unirl/models/`, so
  there is no file overlap, and this change unblocks it.
- **Cost, and the practical limit on N:** each reference is resized to the full generation canvas
  and therefore contributes a full canvas of tokens — 1024 at 512², 4096 at 1024², the same order
  as the noise stream — and attention is quadratic. Recipes adopting multi-reference should cap N
  or shrink the canvas. This is a larger practical constraint than anything in the diff.
- **Open question worth a maintainer's view:** FLUX distinguishes references only by RoPE time
  offset, with no `Picture i` text template (unlike Qwen-Image-Edit-Plus). In the pixel test the
  second reference produced a stylistic rather than structural shift. Whether the checkpoint
  treats reference *order* as semantically meaningful, or the set as roughly symmetric, should be
  settled before a dataset relies on ordering.
- **Suggested review order:** `data_source.py` (the layout decision), then
  `flux2_klein/vae.py` (the RoPE offset), then `patch_sampling_io.py` (the wire reinterpretation).

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.


