### PR TITLE
feat(qwen3-omni): add Talker direct-TTS training

### DIFF
--- a/examples/ar/qwen3_omni_talker_tts_gspo_lora_trainside_1x8.yaml
+++ b/examples/ar/qwen3_omni_talker_tts_gspo_lora_trainside_1x8.yaml
@@ -1,0 +1,177 @@
+# @package _global_
+# Talker TTS GSPO — Phase 1 trainside (standalone Talker layer-0 LoRA).
+#
+# Prep RL prompts (no codes required):
+#   python -m unirl.utils.prepare_talker_tts_data --rl_prompts_only \
+#     --input_jsonl /path/raw_tts.jsonl --output_jsonl data/talker_rl/train.jsonl \
+#     --talker_model "$QWEN3_OMNI_PATH"
+#
+# Four-GPU smoke (all future GPU smokes use exactly this visibility):
+#   CUDA_VISIBLE_DEVICES=0,1,2,3 GPUS_PER_NODE=4 \
+#   QWEN3_OMNI_PATH=... DATA_PATH=data/talker_rl/train.jsonl \
+#   TTS_ASR_MODEL=... TTS_SPEAKER_MODEL=... \
+#   TTS_SPEAKER_REFERENCE_BANK=... TTS_MOS_BACKEND=utmos TTS_MOS_MODEL=... \
+#   ENTRY=train_ar bash examples/run_experiment_single_node.sh \
+#     ar/qwen3_omni_talker_tts_gspo_lora_trainside_1x8
+#
+# Every heavy reward dependency is an env interpolation without a fallback.
+# Missing model/reference configuration therefore aborts Hydra construction
+# before the first rollout instead of silently substituting a proxy reward.
+
+num_devices: 8
+devices_per_node: ${oc.env:GPUS_PER_NODE,8}
+batch_size: 4
+
+num_rollouts: 500
+weight_sync_interval: 1
+
+adv_normalization_scope: group
+
+eval_interval: 20
+eval_num_prompts: 4
+eval_samples_per_prompt: 1
+eval_temperature: 1.0
+
+logging:
+  report_to_wandb: true
+  project_name: unirl-qwen3-omni-talker
+  run_name: qwen3_omni_talker_tts_gspo_lora_trainside_1x8
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [gspo, qwen3-omni, talker, tts, trainside, lora]
+
+bundle:
+  _target_: unirl.models.qwen3_omni.talker_bundle.Qwen3OmniTalkerBundle.from_config
+  config:
+    _target_: unirl.models.qwen3_omni.config.Qwen3OmniPipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:QWEN3_OMNI_PATH}
+    model_precision: bf16
+    attn_implementation: sdpa
+    enable_talker: true
+    meta_init_transformer: true
+    freeze_thinker: true
+    freeze_mtp: true
+    freeze_talker_embeddings: true
+    freeze_code2wav: true
+    freeze_vision_tower: true
+    freeze_audio_tower: true
+    phase1_layer0_lora_only: true
+    use_lora: true
+    lora_target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+    use_gradient_checkpointing: true
+    max_prompt_length: 2048
+    default_speaker: Ethan
+
+pipeline:
+  _target_: unirl.models.qwen3_omni.talker_pipeline.Qwen3OmniTalkerPipeline.from_bundle
+  max_prompt_length: 2048
+  decode_audio: true
+  autocast_precision: bf16
+  logprob_precision: fp32
+  do_sample: true
+  repetition_penalty: 1.05
+  suppress_special_tokens: true
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Qwen3OmniMoeTalkerDecoderLayer"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    forward_prefetch: true
+    activation_checkpointing: false
+    use_torch_compile: false
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 8
+    alpha: 16
+    target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+    exclude_modules: ".*code_predictor.*"
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.0
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: constant
+    warmup_steps: 0
+
+rollout:
+  _target_: unirl.rollout.engine.trainside.engine.TrainsideRolloutEngine
+  stage_attrs: [ar]
+  forward_batch_size: 1
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  truncated_reward: zero
+  backend:
+    _target_: unirl.reward.local.tts_composite.TTSCompositeScorer
+    base_device: ${oc.env:TTS_REWARD_DEVICE,cuda}
+    config:
+      _target_: unirl.reward.local.tts_composite.TTSCompositeSpec
+      batch_size: 4
+      device: auto
+      weights:
+        tts_wer: 0.60
+        tts_speaker_sim: 0.15
+        tts_utmos: 0.15
+        tts_stability: 0.10
+      content_component: tts_wer
+      min_content_weight_fraction: 0.50
+      quality_gates:
+        tts_stability: 1.0
+        tts_utmos: 0.30
+      penalty_thresholds:
+        tts_speaker_sim: 0.40
+      penalty_factors:
+        tts_speaker_sim: 0.50
+      component_configs:
+        tts_wer:
+          asr_model_id: ${oc.env:TTS_ASR_MODEL}
+        tts_speaker_sim:
+          speaker_model_id: ${oc.env:TTS_SPEAKER_MODEL}
+          reference_bank_path: ${oc.env:TTS_SPEAKER_REFERENCE_BANK}
+        tts_utmos:
+          backend: ${oc.env:TTS_MOS_BACKEND}
+          model_path: ${oc.env:TTS_MOS_MODEL}
+
+algorithm:
+  _target_: unirl.algorithms.gspo.GSPO
+  stage_attr: ar
+  clip_range: 3.0e-4
+  old_logp_source: rollout
+  sampling_temperature: 0.9
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.qwen3_omni.talker_conditions.Qwen3OmniTalkerConditions
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+  num_updates_per_batch: 1
+
+sampling:
+  _target_: unirl.types.sampling.ARSamplingParams
+  samples_per_prompt: 4
+  max_new_tokens: 512
+  temperature: 0.9
+  top_p: 1.0
+  top_k: 50
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: ${oc.env:DATA_PATH,data/talker_rl/train.jsonl}
+      eval_data_path: ${oc.env:EVAL_DATA_PATH,${oc.env:DATA_PATH,data/talker_rl/train.jsonl}}
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+      samples_per_prompt: ${sampling.samples_per_prompt}

--- a/examples/ar/qwen3_omni_talker_tts_gspo_lora_vllm_omni_1x8.yaml
+++ b/examples/ar/qwen3_omni_talker_tts_gspo_lora_vllm_omni_1x8.yaml
@@ -1,0 +1,176 @@
+# @package _global_
+# Talker TTS GSPO — Phase 1B direct-TTS vLLM-Omni.
+#
+# The pinned upstream vllm-omni 0.20.0 is intentionally rejected: it exposes
+# Thinker -> Talker spoken-response, not the required direct-prefix RL contract.
+# Startup requires UNIRL_DIRECT_TTS_ROLLOUT_CAPABILITIES contract v1; until a
+# patched engine advertises it, use the trainside recipe:
+#   ar/qwen3_omni_talker_tts_gspo_lora_trainside_1x8
+#
+# Opt-in real-engine 1x4 smoke (all future GPU smokes use exactly this visibility):
+#   CUDA_VISIBLE_DEVICES=0,1,2,3 GPUS_PER_NODE=4 \
+#   QWEN3_OMNI_PATH=... DATA_PATH=data/talker_rl/train.jsonl \
+#   TTS_ASR_MODEL=... TTS_SPEAKER_MODEL=... \
+#   TTS_SPEAKER_REFERENCE_BANK=... TTS_MOS_BACKEND=utmos TTS_MOS_MODEL=... \
+#   ENTRY=train_ar bash examples/run_experiment_single_node.sh \
+#     ar/qwen3_omni_talker_tts_gspo_lora_vllm_omni_1x8
+
+num_devices: 8
+devices_per_node: ${oc.env:GPUS_PER_NODE,8}
+batch_size: 4
+
+num_rollouts: 500
+weight_sync_interval: 1
+adv_normalization_scope: group
+
+rollout_anchor_device: 1
+enable_fsdp_offload: true
+
+logging:
+  report_to_wandb: true
+  project_name: unirl-qwen3-omni-talker
+  run_name: qwen3_omni_talker_tts_gspo_lora_vllm_omni_1x8
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [gspo, qwen3-omni, talker, tts, vllm-omni, lora]
+
+bundle:
+  _target_: unirl.models.qwen3_omni.talker_bundle.Qwen3OmniTalkerBundle.from_config
+  config:
+    _target_: unirl.models.qwen3_omni.config.Qwen3OmniPipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:QWEN3_OMNI_PATH}
+    model_precision: bf16
+    attn_implementation: sdpa
+    enable_talker: true
+    meta_init_transformer: true
+    freeze_thinker: true
+    freeze_mtp: true
+    freeze_talker_embeddings: true
+    freeze_code2wav: true
+    freeze_vision_tower: true
+    freeze_audio_tower: true
+    phase1_layer0_lora_only: true
+    use_lora: true
+    lora_target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+    use_gradient_checkpointing: true
+    max_prompt_length: 2048
+    default_speaker: Ethan
+
+pipeline:
+  _target_: unirl.models.qwen3_omni.talker_pipeline.Qwen3OmniTalkerPipeline.from_bundle
+  max_prompt_length: 2048
+  decode_audio: true
+  autocast_precision: bf16
+  logprob_precision: fp32
+  do_sample: true
+  repetition_penalty: 1.05
+  suppress_special_tokens: true
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Qwen3OmniMoeTalkerDecoderLayer"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: false
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 8
+    alpha: 16
+    target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+    exclude_modules: ".*code_predictor.*"
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: 1.0e-5
+
+rollout:
+  _target_: unirl.rollout.engine.vllm_omni.engine.VLLMOmniRolloutEngine
+  model_config: ${bundle.config}
+  config:
+    _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
+    model_path: ${oc.env:QWEN3_OMNI_PATH}
+    modality: qwen3_omni_talker
+    stage_yaml_override: qwen3_omni_talker_tts_rl_1x4.yaml
+    enable_sleep_mode: true
+    max_prompt_length: 2048
+    omni_extra:
+      stage_init_timeout: 1200
+      init_timeout: 1800
+
+sync:
+  _target_: unirl.distributed.weight_sync.lora.qwen3_omni_talker.Qwen3OmniTalkerLoraWeightSync
+  param_prefix: "talker."
+  adapter_name: default
+  verify: true
+  copy: true
+
+reward:
+  _target_: unirl.reward.service.RewardService
+  truncated_reward: zero
+  backend:
+    _target_: unirl.reward.local.tts_composite.TTSCompositeScorer
+    base_device: ${oc.env:TTS_REWARD_DEVICE,cuda}
+    config:
+      _target_: unirl.reward.local.tts_composite.TTSCompositeSpec
+      batch_size: 4
+      device: auto
+      weights:
+        tts_wer: 0.60
+        tts_speaker_sim: 0.15
+        tts_utmos: 0.15
+        tts_stability: 0.10
+      content_component: tts_wer
+      min_content_weight_fraction: 0.50
+      quality_gates:
+        tts_stability: 1.0
+        tts_utmos: 0.30
+      penalty_thresholds:
+        tts_speaker_sim: 0.40
+      penalty_factors:
+        tts_speaker_sim: 0.50
+      component_configs:
+        tts_wer:
+          asr_model_id: ${oc.env:TTS_ASR_MODEL}
+        tts_speaker_sim:
+          speaker_model_id: ${oc.env:TTS_SPEAKER_MODEL}
+          reference_bank_path: ${oc.env:TTS_SPEAKER_REFERENCE_BANK}
+        tts_utmos:
+          backend: ${oc.env:TTS_MOS_BACKEND}
+          model_path: ${oc.env:TTS_MOS_MODEL}
+
+algorithm:
+  _target_: unirl.algorithms.gspo.GSPO
+  stage_attr: ar
+  clip_range: 3.0e-4
+  old_logp_source: rollout
+  sampling_temperature: 0.9
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.qwen3_omni.talker_conditions.Qwen3OmniTalkerConditions
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+
+sampling:
+  _target_: unirl.types.sampling.ARSamplingParams
+  samples_per_prompt: 4
+  max_new_tokens: 512
+  temperature: 0.9
+  top_p: 1.0
+  top_k: 50
+
+data_source:
+  _target_: unirl.data.data_source.MultimodalRLDataSource
+  args:
+    run:
+      data_path: ${oc.env:DATA_PATH,data/talker_rl/train.jsonl}
+      eval_data_path: ${oc.env:EVAL_DATA_PATH,${oc.env:DATA_PATH,data/talker_rl/train.jsonl}}
+    algorithm:
+      prompts_per_rollout: ${batch_size}
+      samples_per_prompt: ${sampling.samples_per_prompt}

--- a/examples/sft/qwen3_omni_talker_sft.yaml
+++ b/examples/sft/qwen3_omni_talker_sft.yaml
@@ -1,0 +1,121 @@
+# @package _global_
+# Direct-TTS SFT — standalone Talker(+MTP), frozen Thinker embedding/Code2Wav.
+#
+# Data MUST be produced offline and carry exact model/codec fingerprints.
+#
+# Prep:
+#   python -m unirl.utils.prepare_talker_tts_data \
+#     --input_jsonl /path/raw_tts.jsonl --output_jsonl data/talker_sft/train.jsonl \
+#     --talker_model "$QWEN3_OMNI_PATH" --mimi_model "$MIMI_PATH"
+# Copy both printed SHA-256 values into TALKER_MODEL_FINGERPRINT and
+# TALKER_CODEC_FINGERPRINT. No fingerprint has a recipe fallback.
+#
+# Four-GPU smoke (all future GPU smokes use exactly this visibility):
+#   CUDA_VISIBLE_DEVICES=0,1,2,3 GPUS_PER_NODE=4 ENTRY=train_sft \
+#   QWEN3_OMNI_PATH=... SFT_DATA=data/talker_sft/train.jsonl \
+#   SFT_EVAL_DATA=data/talker_sft/val.jsonl \
+#   TALKER_MODEL_FINGERPRINT=... TALKER_CODEC_FINGERPRINT=... \
+#   bash examples/run_experiment_single_node.sh sft/qwen3_omni_talker_sft
+
+num_devices: 8
+batch_size: 8
+num_steps: 500
+eval_interval: 50
+eval_batch_size: 4
+eval_num_samples: -1
+save_interval: 100
+save_mode: auto
+
+logging:
+  report_to_wandb: true
+  project_name: unirl-qwen3-omni-talker
+  run_name: qwen3_omni_talker_sft
+  entity: ${oc.env:WANDB_ENTITY,null}
+  tags: [sft, qwen3-omni, talker, tts]
+
+# PEFT receives one adapter, but these independently overrideable regexes select
+# the main Talker and nested MTP subtrees. Optimizer LRs are split separately.
+talker_lora_targets: '^(?!code_predictor\.).*\.(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)$'
+mtp_lora_targets: '^code_predictor\..*\.(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)$'
+
+bundle:
+  _target_: unirl.models.qwen3_omni.talker_bundle.Qwen3OmniTalkerBundle.from_config
+  config:
+    _target_: unirl.models.qwen3_omni.config.Qwen3OmniPipelineConfig
+    pretrained_model_ckpt_path: ${oc.env:QWEN3_OMNI_PATH}
+    model_precision: bf16
+    attn_implementation: sdpa
+    enable_talker: true
+    freeze_thinker: true
+    freeze_code2wav: true
+    use_gradient_checkpointing: true
+    max_prompt_length: 2048
+    default_speaker: Ethan
+
+pipeline:
+  _target_: unirl.models.qwen3_omni.talker_pipeline.Qwen3OmniTalkerPipeline.from_bundle
+  max_prompt_length: 2048
+  decode_audio: false
+  autocast_precision: bf16
+  logprob_precision: fp32
+
+backend:
+  _target_: unirl.train.backend.fsdp.FSDPBackend
+  block_class_names: ["Qwen3OmniMoeTalkerDecoderLayer"]
+  trainable_attr: transformer
+  fsdp_cfg:
+    _target_: unirl.train.configs.FSDPConfig
+    param_dtype: bf16
+    cpu_offload: false
+    mixed_precision: true
+    fsdp_mode: full
+    reshard_after_forward: true
+    activation_checkpointing: false
+    use_torch_compile: false
+  lora_cfg:
+    _target_: unirl.train.configs.LoraConfig
+    rank: 8
+    alpha: 16
+    target_modules: '${talker_lora_targets}|${mtp_lora_targets}'
+  optimizer_cfg:
+    _target_: unirl.train.backend.base.OptimizerConfig
+    learning_rate: ${oc.env:TALKER_LR,2.0e-5}
+    param_group_lrs:
+      code_predictor: ${oc.env:TALKER_MTP_LR,2.0e-5}
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_epsilon: 1.0e-8
+    weight_decay: 0.01
+  scheduler_cfg:
+    _target_: unirl.train.backend.base.LrSchedulerConfig
+    type: cosine
+    warmup_steps: 25
+    total_steps: ${num_steps}
+
+algorithm:
+  _target_: unirl.algorithms.talker_sft.TalkerSFT
+  stage_attr: ar
+  lambda_sft: ${oc.env:TALKER_SFT_LAMBDA,2.0}
+  conditions_cls:
+    _target_: hydra.utils.get_class
+    path: unirl.models.qwen3_omni.talker_conditions.Qwen3OmniTalkerConditions
+
+stack:
+  _target_: unirl.train.stack.TrainStack
+  micro_batch_size: 1
+  max_grad_norm: 1.0
+
+track_builder:
+  _target_: unirl.models.qwen3_omni.talker_sft.TalkerSupervisedTrackBuilder
+  max_response_length: 2048
+  max_prompt_length: 2048
+  append_codec_eos: true
+  expected_codec_fingerprint: ${oc.env:TALKER_CODEC_FINGERPRINT}
+  expected_model_fingerprint: ${oc.env:TALKER_MODEL_FINGERPRINT}
+  strict_fingerprints: true
+
+data_source:
+  _target_: unirl.data.sft.SupervisedDataSource
+  manifest_path: ${oc.env:SFT_DATA}
+  eval_manifest_path: ${oc.env:SFT_EVAL_DATA,${oc.env:SFT_DATA}}
+  seed: 42

--- a/run_ljspeech_talker_sft.sh
+++ b/run_ljspeech_talker_sft.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODE="${1:-smoke}"
+
+ARCHIVE="${LJSPEECH_ARCHIVE:-${ROOT}/LJSpeech-1.1.tar.bz2}"
+DATA_ROOT="${LJSPEECH_TALKER_DATA_ROOT:-${ROOT}/datasets/ljspeech_talker}"
+SOURCE_ROOT="${DATA_ROOT}/source"
+LJSPEECH_DIR="${SOURCE_ROOT}/LJSpeech-1.1"
+MANIFEST_DIR="${DATA_ROOT}/manifests"
+CODE_DIR="${DATA_ROOT}/mimi_codes"
+LOG_DIR="${DATA_ROOT}/logs"
+MODEL_DIR="${ROOT}/models"
+
+QWEN3_OMNI_PATH="${QWEN3_OMNI_PATH:-/apdcephfs_cq8/share_1611098/bruceszchen/HF_Models/hub/models--Qwen--Qwen3-Omni-30B-A3B-Instruct/snapshots/26291f793822fb6be9555850f06dfe95f2d7e695}"
+MIMI_PATH="${MIMI_PATH:-${MODEL_DIR}/kyutai-mimi}"
+GPU_CLEANUP_CMD=(bash /apdcephfs_hldy/share_303576955/bruceszchen/tmp/ft_local/occupy_gpu_ray/run_occupy.sh stop)
+
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+export GPUS_PER_NODE=4
+export HF_HOME="${HF_HOME:-/apdcephfs_cq8/share_1611098/bruceszchen/HF_Models}"
+export PYTHONPATH="${ROOT}:${PYTHONPATH:-}"
+export TOKENIZERS_PARALLELISM=false
+export WANDB_MODE="${WANDB_MODE:-offline}"
+
+mkdir -p "${SOURCE_ROOT}" "${MANIFEST_DIR}" "${CODE_DIR}" "${LOG_DIR}" "${MODEL_DIR}"
+
+usage() {
+  cat <<'EOF'
+Usage: bash run_ljspeech_talker_sft.sh <mode>
+
+Modes:
+  prepare-smoke  Extract LJSpeech, build deterministic splits, encode 32+8 Mimi samples.
+  smoke          Prepare if needed, then run a 20-step 4-GPU overfit/integration smoke.
+  smoke-mtp      Run the 20-step smoke with only MTP LoRA trainable.
+  prepare-full   Encode the full 12,844 train + 256 validation rows.
+  train          Run the full LoRA SFT (default 3,200 steps) from prepared full data.
+  train-mtp      Recommended voice adaptation: freeze layer-0, train MTP LoRA only.
+  all            Run smoke, prepare-full, then full training.
+
+Environment overrides:
+  QWEN3_OMNI_PATH, MIMI_PATH, LJSPEECH_ARCHIVE, LJSPEECH_TALKER_DATA_ROOT
+  TALKER_LR, TALKER_MTP_LR, TALKER_SFT_LAMBDA, FULL_STEPS, FULL_BATCH_SIZE
+EOF
+}
+
+ensure_gpu_0_3_free() {
+  local busy=0
+  while IFS=',' read -r index used; do
+    index="$(echo "${index}" | tr -d ' ')"
+    used="$(echo "${used}" | tr -cd '0-9')"
+    if [[ "${index}" =~ ^[0-3]$ ]] && (( used > 512 )); then
+      busy=1
+    fi
+  done < <(nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits)
+
+  if (( busy )); then
+    echo "GPU 0-3 are occupied; running the requested cleanup command."
+    "${GPU_CLEANUP_CMD[@]}"
+    sleep 5
+  fi
+
+  while IFS=',' read -r index used; do
+    index="$(echo "${index}" | tr -d ' ')"
+    used="$(echo "${used}" | tr -cd '0-9')"
+    if [[ "${index}" =~ ^[0-3]$ ]] && (( used > 512 )); then
+      echo "GPU ${index} still uses ${used} MiB after cleanup; refusing to use another GPU." >&2
+      exit 1
+    fi
+  done < <(nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits)
+}
+
+extract_and_split() {
+  if [[ ! -f "${ARCHIVE}" ]]; then
+    echo "Missing LJSpeech archive: ${ARCHIVE}" >&2
+    exit 1
+  fi
+  if [[ ! -f "${LJSPEECH_DIR}/metadata.csv" ]]; then
+    echo "Extracting ${ARCHIVE} ..."
+    tar -xjf "${ARCHIVE}" -C "${SOURCE_ROOT}"
+  fi
+  python "${ROOT}/scripts/prepare_ljspeech_talker_manifests.py" \
+    --ljspeech_dir "${LJSPEECH_DIR}" \
+    --output_dir "${MANIFEST_DIR}" \
+    --speaker Ethan \
+    --language en \
+    --val_size 256 \
+    --smoke_train_size 32 \
+    --smoke_val_size 8
+}
+
+ensure_mimi() {
+  if [[ -f "${MIMI_PATH}/config.json" ]] && compgen -G "${MIMI_PATH}/*.safetensors" >/dev/null; then
+    return
+  fi
+  echo "Downloading kyutai/mimi to ${MIMI_PATH} ..."
+  python - "${MIMI_PATH}" <<'PY'
+import sys
+from huggingface_hub import snapshot_download
+
+snapshot_download(
+    repo_id="kyutai/mimi",
+    local_dir=sys.argv[1],
+    local_dir_use_symlinks=False,
+)
+PY
+}
+
+encode_split() {
+  local input_jsonl="$1"
+  local output_jsonl="$2"
+  local log_file="$3"
+  if [[ -s "${output_jsonl}" ]]; then
+    echo "Reusing encoded manifest ${output_jsonl}"
+    return
+  fi
+  ensure_gpu_0_3_free
+  python -m unirl.utils.prepare_talker_tts_data \
+    --input_jsonl "${input_jsonl}" \
+    --output_jsonl "${output_jsonl}" \
+    --talker_model "${QWEN3_OMNI_PATH}" \
+    --mimi_model "${MIMI_PATH}" \
+    --device cuda:0 2>&1 | tee "${log_file}"
+}
+
+write_fingerprint_env() {
+  local encoded_jsonl="$1"
+  python - "${encoded_jsonl}" "${CODE_DIR}/fingerprints.env" <<'PY'
+import json
+import shlex
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    row = json.loads(next(line for line in handle if line.strip()))
+metadata = row["metadata"]
+model_sha = metadata["talker_model_fingerprint"]["sha256"]
+codec_sha = metadata["codec_fingerprint"]["sha256"]
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    handle.write(f"TALKER_MODEL_FINGERPRINT={shlex.quote(model_sha)}\n")
+    handle.write(f"TALKER_CODEC_FINGERPRINT={shlex.quote(codec_sha)}\n")
+PY
+}
+
+prepare_smoke() {
+  extract_and_split
+  ensure_mimi
+  encode_split \
+    "${MANIFEST_DIR}/raw_smoke_train.jsonl" \
+    "${CODE_DIR}/smoke_train.jsonl" \
+    "${LOG_DIR}/encode_smoke_train.log"
+  encode_split \
+    "${MANIFEST_DIR}/raw_smoke_val.jsonl" \
+    "${CODE_DIR}/smoke_val.jsonl" \
+    "${LOG_DIR}/encode_smoke_val.log"
+  write_fingerprint_env "${CODE_DIR}/smoke_train.jsonl"
+}
+
+prepare_full() {
+  extract_and_split
+  ensure_mimi
+  if [[ ! -s "${CODE_DIR}/train.jsonl" ]]; then
+    local shard_dir="${MANIFEST_DIR}/full_train_shards"
+    mkdir -p "${shard_dir}"
+    python - "${MANIFEST_DIR}/raw_train.jsonl" "${shard_dir}" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+output = Path(sys.argv[2])
+rows = [line for line in source.read_text(encoding="utf-8").splitlines() if line.strip()]
+chunk = (len(rows) + 3) // 4
+for index in range(4):
+    part = rows[index * chunk : (index + 1) * chunk]
+    (output / f"raw_train_{index}.jsonl").write_text(
+        "".join(f"{line}\n" for line in part),
+        encoding="utf-8",
+    )
+PY
+    ensure_gpu_0_3_free
+    local pids=()
+    for gpu in 0 1 2 3; do
+      local shard_output="${CODE_DIR}/train_${gpu}.jsonl"
+      if [[ -s "${shard_output}" ]]; then
+        echo "Reusing encoded train shard ${shard_output}"
+        continue
+      fi
+      python -m unirl.utils.prepare_talker_tts_data \
+        --input_jsonl "${shard_dir}/raw_train_${gpu}.jsonl" \
+        --output_jsonl "${shard_output}" \
+        --talker_model "${QWEN3_OMNI_PATH}" \
+        --mimi_model "${MIMI_PATH}" \
+        --device "cuda:${gpu}" \
+        --log_every 100 >"${LOG_DIR}/encode_train_${gpu}.log" 2>&1 &
+      pids+=("$!")
+    done
+    local failed=0
+    for pid in "${pids[@]}"; do
+      wait "${pid}" || failed=1
+    done
+    if (( failed )); then
+      echo "At least one full-data Mimi encoder failed; inspect ${LOG_DIR}/encode_train_*.log" >&2
+      exit 1
+    fi
+    python - "${CODE_DIR}" <<'PY'
+import os
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+target = root / "train.jsonl"
+tmp = root / f".train.jsonl.tmp.{os.getpid()}"
+with tmp.open("w", encoding="utf-8") as output:
+    for index in range(4):
+        with (root / f"train_{index}.jsonl").open(encoding="utf-8") as source:
+            for line in source:
+                if line.strip():
+                    output.write(line)
+tmp.replace(target)
+PY
+  fi
+  encode_split \
+    "${MANIFEST_DIR}/raw_val.jsonl" \
+    "${CODE_DIR}/val.jsonl" \
+    "${LOG_DIR}/encode_val.log"
+  write_fingerprint_env "${CODE_DIR}/train.jsonl"
+}
+
+run_training() {
+  local train_jsonl="$1"
+  local val_jsonl="$2"
+  local steps="$3"
+  local batch_size="$4"
+  local eval_interval="$5"
+  local save_interval="$6"
+  local save_dir="$7"
+  local run_name="$8"
+  local scope="${9:-talker_mtp}"
+  local warmup_steps=25
+  local scope_overrides=()
+  if [[ "${scope}" == "mtp_only" ]]; then
+    scope_overrides+=("backend.lora_cfg.target_modules=\${mtp_lora_targets}")
+  elif [[ "${scope}" != "talker_mtp" ]]; then
+    echo "Unknown SFT scope: ${scope}" >&2
+    exit 1
+  fi
+  if (( steps <= warmup_steps )); then
+    warmup_steps=$(( steps / 10 ))
+    (( warmup_steps > 0 )) || warmup_steps=1
+  fi
+
+  if [[ ! -s "${train_jsonl}" || ! -s "${val_jsonl}" ]]; then
+    echo "Missing encoded train/validation manifests." >&2
+    exit 1
+  fi
+  if [[ ! -f "${CODE_DIR}/fingerprints.env" ]]; then
+    write_fingerprint_env "${train_jsonl}"
+  fi
+  # shellcheck disable=SC1091
+  source "${CODE_DIR}/fingerprints.env"
+  export TALKER_MODEL_FINGERPRINT TALKER_CODEC_FINGERPRINT
+  export QWEN3_OMNI_PATH
+  export SFT_DATA="${train_jsonl}"
+  export SFT_EVAL_DATA="${val_jsonl}"
+  export TALKER_LR="${TALKER_LR:-1.0e-5}"
+  export TALKER_MTP_LR="${TALKER_MTP_LR:-2.0e-5}"
+  export TALKER_SFT_LAMBDA="${TALKER_SFT_LAMBDA:-2.0}"
+
+  ensure_gpu_0_3_free
+  mkdir -p "${save_dir}"
+  INSTALL_EDITABLE=0 \
+  ENTRY=train_sft \
+  GPUS_PER_NODE=4 \
+  bash "${ROOT}/examples/run_experiment_single_node.sh" \
+    sft/qwen3_omni_talker_sft \
+    "+devices_per_node=4" \
+    "num_steps=${steps}" \
+    "batch_size=${batch_size}" \
+    "eval_interval=${eval_interval}" \
+    "eval_batch_size=4" \
+    "eval_num_samples=-1" \
+    "save_interval=${save_interval}" \
+    "+save_dir=${save_dir}" \
+    "logging.run_name=${run_name}" \
+    "logging.report_to_wandb=false" \
+    "+bundle.config.meta_init_transformer=true" \
+    "bundle.config.max_prompt_length=512" \
+    "pipeline.max_prompt_length=512" \
+    "track_builder.max_prompt_length=512" \
+    "track_builder.max_response_length=256" \
+    "backend.block_class_names=[Qwen3OmniMoeTalkerDecoderLayer,Qwen3OmniMoeTalkerCodePredictorDecoderLayer]" \
+    "+backend.fsdp_cfg.root_wrap=false" \
+    "backend.scheduler_cfg.warmup_steps=${warmup_steps}" \
+    "${scope_overrides[@]}" 2>&1 | tee "${LOG_DIR}/${run_name}.log"
+}
+
+run_smoke() {
+  prepare_smoke
+  run_training \
+    "${CODE_DIR}/smoke_train.jsonl" \
+    "${CODE_DIR}/smoke_val.jsonl" \
+    "${SMOKE_STEPS:-20}" \
+    4 \
+    5 \
+    10 \
+    "${ROOT}/outputs/qwen3_omni_talker_ljspeech_smoke" \
+    qwen3_omni_talker_ljspeech_smoke
+}
+
+run_mtp_smoke() {
+  prepare_smoke
+  run_training \
+    "${CODE_DIR}/smoke_train.jsonl" \
+    "${CODE_DIR}/smoke_val.jsonl" \
+    "${SMOKE_STEPS:-20}" \
+    4 \
+    5 \
+    10 \
+    "${ROOT}/outputs/qwen3_omni_talker_ljspeech_mtp_only_smoke" \
+    qwen3_omni_talker_ljspeech_mtp_only_smoke \
+    mtp_only
+}
+
+run_full() {
+  if [[ ! -s "${CODE_DIR}/train.jsonl" || ! -s "${CODE_DIR}/val.jsonl" ]]; then
+    echo "Run prepare-full before train." >&2
+    exit 1
+  fi
+  run_training \
+    "${CODE_DIR}/train.jsonl" \
+    "${CODE_DIR}/val.jsonl" \
+    "${FULL_STEPS:-3200}" \
+    "${FULL_BATCH_SIZE:-8}" \
+    "${FULL_EVAL_INTERVAL:-100}" \
+    "${FULL_SAVE_INTERVAL:-400}" \
+    "${ROOT}/outputs/qwen3_omni_talker_ljspeech" \
+    qwen3_omni_talker_ljspeech \
+    talker_mtp
+}
+
+run_mtp_only() {
+  if [[ ! -s "${CODE_DIR}/train.jsonl" || ! -s "${CODE_DIR}/val.jsonl" ]]; then
+    echo "Run prepare-full before train-mtp." >&2
+    exit 1
+  fi
+  run_training \
+    "${CODE_DIR}/train.jsonl" \
+    "${CODE_DIR}/val.jsonl" \
+    "${MTP_ONLY_STEPS:-800}" \
+    "${FULL_BATCH_SIZE:-8}" \
+    "${MTP_ONLY_EVAL_INTERVAL:-100}" \
+    "${MTP_ONLY_SAVE_INTERVAL:-200}" \
+    "${ROOT}/outputs/qwen3_omni_talker_ljspeech_mtp_only" \
+    qwen3_omni_talker_ljspeech_mtp_only \
+    mtp_only
+}
+
+case "${MODE}" in
+  prepare-smoke) prepare_smoke ;;
+  smoke) run_smoke ;;
+  smoke-mtp) run_mtp_smoke ;;
+  prepare-full) prepare_full ;;
+  train) run_full ;;
+  train-mtp) run_mtp_only ;;
+  all)
+    run_smoke
+    prepare_full
+    run_full
+    ;;
+  -h|--help|help) usage ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/prepare_ljspeech_talker_manifests.py
+++ b/scripts/prepare_ljspeech_talker_manifests.py
@@ -1,0 +1,123 @@
+"""Convert an extracted LJSpeech release into deterministic Talker SFT manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Dict, List
+
+
+def _write_jsonl(path: Path, rows: List[Dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+    tmp.replace(path)
+
+
+def _load_rows(root: Path, *, speaker: str, language: str) -> List[Dict[str, object]]:
+    metadata_path = root / "metadata.csv"
+    wav_dir = root / "wavs"
+    if not metadata_path.is_file():
+        raise FileNotFoundError(f"LJSpeech metadata is missing: {metadata_path}")
+    if not wav_dir.is_dir():
+        raise FileNotFoundError(f"LJSpeech wav directory is missing: {wav_dir}")
+
+    rows: List[Dict[str, object]] = []
+    with metadata_path.open(encoding="utf-8") as handle:
+        # LJSpeech uses a literal pipe separator, not RFC CSV quoting. Some raw
+        # transcripts begin with an unmatched quote, so csv.reader would merge
+        # the raw/normalized fields. Split the first two pipes literally.
+        for line_number, line in enumerate(handle, 1):
+            fields = line.rstrip("\r\n").split("|", 2)
+            if len(fields) != 3:
+                raise ValueError(
+                    f"{metadata_path}:{line_number}: expected id|raw|normalized, got {len(fields)} fields"
+                )
+            utterance_id, raw_text, normalized_text = (field.strip() for field in fields)
+            text = normalized_text or raw_text
+            wav_path = (wav_dir / f"{utterance_id}.wav").resolve()
+            if not utterance_id or not text:
+                raise ValueError(f"{metadata_path}:{line_number}: empty utterance id or transcript")
+            if not wav_path.is_file():
+                raise FileNotFoundError(f"{metadata_path}:{line_number}: missing {wav_path}")
+            rows.append(
+                {
+                    "sample_id": utterance_id,
+                    "text": text,
+                    "audio": str(wav_path),
+                    "speaker": speaker,
+                    "language": language,
+                    "metadata": {
+                        "speaker": speaker,
+                        "language": language,
+                        "source": "LJSpeech-1.1",
+                        "raw_transcript": raw_text,
+                    },
+                }
+            )
+    if len(rows) != 13_100:
+        raise ValueError(f"Expected 13,100 LJSpeech rows, found {len(rows)}")
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ljspeech_dir", required=True)
+    parser.add_argument("--output_dir", required=True)
+    parser.add_argument("--speaker", default="Ethan")
+    parser.add_argument("--language", default="en")
+    parser.add_argument("--val_size", type=int, default=256)
+    parser.add_argument("--smoke_train_size", type=int, default=32)
+    parser.add_argument("--smoke_val_size", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=20260811)
+    args = parser.parse_args()
+
+    rows = _load_rows(
+        Path(args.ljspeech_dir).expanduser().resolve(),
+        speaker=str(args.speaker),
+        language=str(args.language),
+    )
+    if not 1 <= args.val_size < len(rows):
+        raise ValueError(f"val_size must lie in [1, {len(rows) - 1}]")
+    rng = random.Random(int(args.seed))
+    rng.shuffle(rows)
+    val_rows = rows[: args.val_size]
+    train_rows = rows[args.val_size :]
+    if not 1 <= args.smoke_train_size <= len(train_rows):
+        raise ValueError("smoke_train_size is outside the train split")
+    if not 1 <= args.smoke_val_size <= len(val_rows):
+        raise ValueError("smoke_val_size is outside the validation split")
+
+    output = Path(args.output_dir).expanduser().resolve()
+    manifests = {
+        "raw_train.jsonl": train_rows,
+        "raw_val.jsonl": val_rows,
+        "raw_smoke_train.jsonl": train_rows[: args.smoke_train_size],
+        "raw_smoke_val.jsonl": val_rows[: args.smoke_val_size],
+    }
+    for name, split_rows in manifests.items():
+        _write_jsonl(output / name, split_rows)
+
+    print(
+        json.dumps(
+            {
+                "output_dir": str(output),
+                "train_rows": len(train_rows),
+                "val_rows": len(val_rows),
+                "smoke_train_rows": args.smoke_train_size,
+                "smoke_val_rows": args.smoke_val_size,
+                "speaker": args.speaker,
+                "language": args.language,
+                "seed": args.seed,
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/select_ljspeech_talker_checkpoint.py
+++ b/scripts/select_ljspeech_talker_checkpoint.py
@@ -1,0 +1,152 @@
+"""Compare UniRL Talker LoRA checkpoints on fixed sampled WER/EOS metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from unirl.models.qwen3_omni.config import Qwen3OmniPipelineConfig
+from unirl.models.qwen3_omni.talker_bundle import Qwen3OmniTalkerBundle
+from unirl.models.qwen3_omni.talker_pipeline import Qwen3OmniTalkerPipeline
+from unirl.reward.local.tts_metrics import score_edit_metric
+from unirl.types.primitives import Texts
+from unirl.types.sample import Part, Sample
+from unirl.types.sampling import ARSamplingParams
+from unirl.utils.eval_talker_tts_baseline import _load_unirl_lora_checkpoint
+
+
+def _rows(path: str, count: int):
+    result = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                result.append(json.loads(line))
+            if len(result) == count:
+                break
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--checkpoint_root", required=True)
+    parser.add_argument("--eval_jsonl", required=True)
+    parser.add_argument("--asr_model", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--samples", type=int, default=8)
+    parser.add_argument("--max_new_tokens", type=int, default=256)
+    parser.add_argument("--seed", type=int, default=20260811)
+    args = parser.parse_args()
+
+    candidates = sorted(
+        Path(args.checkpoint_root).glob("checkpoint-*/checkpoint.pt"),
+        key=lambda path: int(path.parent.name.rsplit("-", 1)[1]),
+    )
+    if not candidates:
+        raise FileNotFoundError(f"No checkpoint-*/checkpoint.pt under {args.checkpoint_root}")
+    rows = _rows(args.eval_jsonl, args.samples)
+
+    config = Qwen3OmniPipelineConfig(
+        pretrained_model_ckpt_path=args.model_path,
+        model_precision="bf16",
+        device=args.device,
+        enable_talker=True,
+    )
+    bundle = Qwen3OmniTalkerBundle.from_config(config)
+    _load_unirl_lora_checkpoint(bundle, str(candidates[0]))
+    pipeline = Qwen3OmniTalkerPipeline.from_bundle(bundle, decode_audio=True)
+    codec_eos = int(bundle.config.talker_config.codec_eos_token_id)
+
+    from transformers import pipeline as hf_pipeline
+
+    asr = hf_pipeline(
+        "automatic-speech-recognition",
+        model=args.asr_model,
+        device=0 if args.device.startswith("cuda") else -1,
+        torch_dtype=torch.float16 if args.device.startswith("cuda") else torch.float32,
+    )
+
+    summaries = []
+    for checkpoint_path in candidates:
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+        incompatible = bundle.talker.load_state_dict(checkpoint["policy_state_dict"], strict=False)
+        if incompatible.unexpected_keys:
+            raise RuntimeError(f"{checkpoint_path}: unexpected keys {incompatible.unexpected_keys[:8]}")
+        random.seed(args.seed)
+        np.random.seed(args.seed)
+        torch.manual_seed(args.seed)
+        torch.cuda.manual_seed_all(args.seed)
+
+        scored = []
+        for row in rows:
+            metadata = row["metadata"]
+            transcript = str(metadata["normalized_transcript"])
+            sample_id = str(row["sample_id"])
+            request = Sample(
+                parts=[
+                    Part.input(
+                        [sample_id],
+                        primitives={"text": Texts(texts=[transcript])},
+                        metadata=[{"speaker": str(metadata["speaker"])}],
+                    )
+                ]
+            ).fork(
+                1,
+                sampling_params=ARSamplingParams(
+                    max_new_tokens=args.max_new_tokens,
+                    temperature=0.9,
+                    top_p=1.0,
+                    top_k=50,
+                ),
+            )
+            output = pipeline.generate(request).parts[-1]
+            tokens = output.segment.tokens
+            eos_ok = bool(tokens.numel() and int(tokens[-1]) == codec_eos)
+            waveform = output.primitives["audio"].to_list()[0].waveform
+            prediction = asr(
+                {
+                    "array": waveform.detach().float().cpu().numpy(),
+                    "sampling_rate": 24000,
+                },
+                generate_kwargs={"language": "english"},
+            )
+            hypothesis = str(prediction.get("text", "")).strip()
+            wer = float(score_edit_metric(transcript, hypothesis, metric="wer", language="en")["rate"])
+            scored.append(
+                {
+                    "sample_id": sample_id,
+                    "wer": wer,
+                    "eos_ok": eos_ok,
+                    "codec_steps": int(tokens.numel()),
+                    "hypothesis": hypothesis,
+                }
+            )
+        summary = {
+            "step": int(checkpoint.get("step", -1)),
+            "checkpoint": str(checkpoint_path),
+            "mean_wer": sum(item["wer"] for item in scored) / len(scored),
+            "eos_failure_rate": sum(not item["eos_ok"] for item in scored) / len(scored),
+            "rows": scored,
+        }
+        summaries.append(summary)
+        print(json.dumps({key: summary[key] for key in ("step", "mean_wer", "eos_failure_rate")}), flush=True)
+
+    result = {
+        "samples": len(rows),
+        "seed": args.seed,
+        "best_by_wer": min(summaries, key=lambda item: item["mean_wer"])["step"],
+        "checkpoints": summaries,
+    }
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/unirl/algorithms/__init__.py
+++ b/unirl/algorithms/__init__.py
@@ -16,10 +16,12 @@ from .flowgrpo import FlowGRPO, FlowGRPOConfig
 from .grpo import GRPO, GRPOConfig
 from .gspo import GSPO, GSPOConfig
 from .sft import SFT, FlowMatchSFT
+from .talker_sft import TalkerSFT
 
 __all__ = [
     "SFT",
     "FlowMatchSFT",
+    "TalkerSFT",
     "GRPO",
     "GRPOConfig",
     "GSPO",

--- a/unirl/algorithms/talker_sft.py
+++ b/unirl/algorithms/talker_sft.py
@@ -1,0 +1,183 @@
+"""Explicit dual-loss SFT for Qwen3-Omni Talker + MTP."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Type
+
+import torch
+
+from unirl.types.conditions import Condition
+from unirl.types.segments import TextSegment
+
+from .base import AlgorithmStepResult, StageAlgorithm, typed_conditions
+
+
+class TalkerSFT(StageAlgorithm):
+    """Optimize layer-0 CE plus the mean CE of all 15 Mimi residual layers.
+
+    The reduction is per sample, then averaged across valid samples:
+
+    ``layer0_ce + lambda_sft * mean(mtp_ce_layer_1..15)``.
+
+    This keeps the two independently masked timelines exact: layer-0 supervises
+    the appended codec EOS, while MTP supervises only real Mimi frames.
+    """
+
+    supports_multi_update = True
+    requires_advantages = False
+    loss_weighting = "sample"
+
+    def __init__(
+        self,
+        *,
+        stage: Any = None,
+        pipeline: Any = None,
+        stage_attr: str = "ar",
+        lambda_sft: float = 2.0,
+        conditions_cls: Optional[Type[Any]] = None,
+    ) -> None:
+        super().__init__()
+        if stage is None and pipeline is None:
+            raise ValueError("TalkerSFT: either `stage` or `pipeline` must be provided")
+        if stage is None:
+            stage = getattr(pipeline, stage_attr)
+        if not callable(getattr(stage, "replay_sft", None)):
+            raise TypeError("TalkerSFT requires a stage exposing replay_sft(conditions, segment)")
+        if not math.isfinite(float(lambda_sft)) or float(lambda_sft) < 0.0:
+            raise ValueError(f"TalkerSFT.lambda_sft must be finite and >= 0, got {lambda_sft!r}")
+        self.stage = stage
+        self.lambda_sft = float(lambda_sft)
+        self.conditions_cls = conditions_cls
+
+    def compute_loss_and_backward(
+        self,
+        *,
+        conditions: Mapping[str, Condition],
+        segment: TextSegment,
+        advantages: Optional[torch.Tensor],
+        training_progress: float,
+        loss_scale: float,
+    ) -> AlgorithmStepResult:
+        del advantages, training_progress
+        loss, stats = self._dual_ce(conditions, segment)
+        if loss is None:
+            return AlgorithmStepResult(loss=0.0, metrics={}, num_steps_or_tokens=0, has_backward=False)
+        (loss * loss_scale).backward()
+        metrics: Dict[str, Any] = {
+            "talker_sft_loss": float(loss.detach().item()),
+            "layer0_ce": stats["layer0_ce"],
+            "layer0_ppl": math.exp(min(stats["layer0_ce"], 20.0)),
+            "mtp_ce": stats["mtp_ce"],
+            "mtp_ppl": math.exp(min(stats["mtp_ce"], 20.0)),
+            "lambda_sft": self.lambda_sft,
+            "talker_sft_samples": stats["samples"],
+            "layer0_tokens": stats["layer0_tokens"],
+            "mtp_frames": stats["mtp_frames"],
+        }
+        for index, value in enumerate(stats["mtp_layer_ce"], 1):
+            metrics[f"mtp_ce_layer_{index:02d}"] = value
+        return AlgorithmStepResult(
+            loss=float(loss.detach().item()),
+            metrics=metrics,
+            num_steps_or_tokens=round(stats["samples"]),
+            has_backward=True,
+        )
+
+    @torch.no_grad()
+    def evaluate_loss(
+        self,
+        *,
+        conditions: Mapping[str, Condition],
+        segment: TextSegment,
+        sample_ids: Optional[Sequence[str]] = None,
+    ) -> Tuple[float, float]:
+        del sample_ids
+        loss, stats = self._dual_ce(conditions, segment)
+        if loss is None:
+            return 0.0, 0.0
+        return float(loss.item()) * stats["samples"], stats["samples"]
+
+    def _dual_ce(
+        self,
+        conditions: Mapping[str, Condition],
+        segment: TextSegment,
+    ) -> Tuple[Optional[torch.Tensor], Dict[str, Any]]:
+        if segment is None or segment.tokens is None or segment.lengths is None:
+            raise ValueError("TalkerSFT requires a packed TextSegment with layer-0 targets")
+        if segment.tokens.numel() == 0:
+            return None, {}
+        typed = typed_conditions(conditions, self.conditions_cls)
+        mtp_masks = getattr(typed, "mtp_loss_masks", None)
+        if mtp_masks is None:
+            raise ValueError("TalkerSFT requires typed conditions.mtp_loss_masks")
+
+        layer0_logp, mtp_logp = self.stage.replay_sft(typed, segment=segment)
+        if layer0_logp.ndim != 1 or layer0_logp.shape[0] != segment.tokens.shape[0]:
+            raise ValueError(
+                f"TalkerSFT layer0 log-probs must be [{segment.tokens.shape[0]}], got {tuple(layer0_logp.shape)}"
+            )
+        if mtp_logp.ndim != 2 or mtp_logp.shape != (segment.tokens.shape[0], 15):
+            raise ValueError(
+                f"TalkerSFT MTP log-probs must be [{segment.tokens.shape[0]}, 15], got {tuple(mtp_logp.shape)}"
+            )
+        lengths = [int(value) for value in segment.lengths.tolist()]
+        if len(mtp_masks) != len(lengths):
+            raise ValueError(f"TalkerSFT mtp_loss_masks len {len(mtp_masks)} != batch {len(lengths)}")
+        layer0_parts = torch.split(layer0_logp, lengths)
+        mtp_parts = torch.split(mtp_logp, lengths)
+        if segment.loss_mask is None:
+            layer0_masks = [torch.ones_like(part) for part in layer0_parts]
+        else:
+            layer0_masks = torch.split(segment.loss_mask.to(layer0_logp), lengths)
+
+        objectives = []
+        layer0_ces = []
+        mtp_layer_ces = []
+        layer0_token_count = 0.0
+        mtp_frame_count = 0.0
+        for index, (logp0, logp_mtp, mask0, raw_mtp_mask) in enumerate(
+            zip(layer0_parts, mtp_parts, layer0_masks, mtp_masks)
+        ):
+            mask0 = mask0.to(device=logp0.device, dtype=logp0.dtype).flatten()
+            mtp_mask = torch.as_tensor(raw_mtp_mask, device=logp_mtp.device, dtype=logp_mtp.dtype).flatten()
+            if mask0.shape[0] != logp0.shape[0] or mtp_mask.shape[0] != logp_mtp.shape[0]:
+                raise ValueError(
+                    f"TalkerSFT sample {index}: mask timelines layer0={mask0.shape[0]}, "
+                    f"mtp={mtp_mask.shape[0]}, expected={logp0.shape[0]}"
+                )
+            layer0_weight = mask0.sum()
+            mtp_weight = mtp_mask.sum()
+            if float(layer0_weight.item()) <= 0.0:
+                if float(mtp_weight.item()) != 0.0:
+                    raise ValueError(f"TalkerSFT sample {index}: padded layer-0 row has nonzero MTP weight")
+                continue
+            if float(mtp_weight.item()) <= 0.0:
+                raise ValueError(f"TalkerSFT sample {index}: no valid MTP frames")
+            layer0_ce = -(logp0 * mask0).sum() / layer0_weight
+            per_layer_mtp_ce = -(logp_mtp * mtp_mask[:, None]).sum(dim=0) / mtp_weight
+            mtp_ce = per_layer_mtp_ce.mean()
+            objectives.append(layer0_ce + self.lambda_sft * mtp_ce)
+            layer0_ces.append(layer0_ce)
+            mtp_layer_ces.append(per_layer_mtp_ce)
+            layer0_token_count += float(layer0_weight.item())
+            mtp_frame_count += float(mtp_weight.item())
+
+        if not objectives:
+            return None, {}
+        loss = torch.stack(objectives).mean()
+        layer0_ce_mean = torch.stack(layer0_ces).mean()
+        mtp_layer_ce_mean = torch.stack(mtp_layer_ces).mean(dim=0)
+        if not torch.isfinite(loss):
+            raise RuntimeError(f"TalkerSFT produced non-finite loss {float(loss.detach().item())!r}")
+        return loss, {
+            "samples": float(len(objectives)),
+            "layer0_ce": float(layer0_ce_mean.detach().item()),
+            "mtp_ce": float(mtp_layer_ce_mean.mean().detach().item()),
+            "mtp_layer_ce": [float(value) for value in mtp_layer_ce_mean.detach().tolist()],
+            "layer0_tokens": layer0_token_count,
+            "mtp_frames": mtp_frame_count,
+        }
+
+
+__all__ = ["TalkerSFT"]

--- a/unirl/distributed/weight_sync/lora/qwen3_omni_talker.py
+++ b/unirl/distributed/weight_sync/lora/qwen3_omni_talker.py
@@ -1,0 +1,53 @@
+"""LoRA sync guard for Qwen3-Omni direct-TTS Phase 1."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from unirl.distributed.weight_sync.lora.remote import RemoteLoraWeightSync
+
+_CANONICAL_PREFIX = "talker."
+_ENGINE_PREFIX = "base_model.model.talker."
+_FORBIDDEN_COMPONENTS = (".code_predictor.", "thinker.", "code2wav.")
+
+
+def validate_talker_lora_keys(
+    tensors: Mapping[str, Any],
+    *,
+    engine_envelope: bool = False,
+) -> None:
+    """Reject empty, non-Talker, MTP, Thinker, or Code2Wav LoRA payloads."""
+
+    if not isinstance(tensors, Mapping) or not tensors:
+        raise RuntimeError("Talker LoRA sync requires a non-empty tensor mapping")
+    prefix = _ENGINE_PREFIX if engine_envelope else _CANONICAL_PREFIX
+    invalid = []
+    for raw_name in tensors:
+        name = str(raw_name)
+        if not name.startswith(prefix):
+            invalid.append(name)
+            continue
+        lowered = name.lower()
+        if any(component in lowered for component in _FORBIDDEN_COMPONENTS):
+            invalid.append(name)
+            continue
+        if not (name.endswith(".lora_A.weight") or name.endswith(".lora_B.weight")):
+            invalid.append(name)
+    if invalid:
+        scope = "engine-envelope" if engine_envelope else "canonical"
+        raise RuntimeError(
+            "Phase-1 direct-TTS LoRA sync accepts only trainable non-MTP "
+            f"Talker adapter tensors in {scope} form; invalid={invalid[:12]}"
+        )
+
+
+class Qwen3OmniTalkerLoraWeightSync(RemoteLoraWeightSync):
+    """Remote sync that proves the extracted payload is Talker-layer0 only."""
+
+    def _extract(self):
+        lora_tensors, peft_config = super()._extract()
+        validate_talker_lora_keys(lora_tensors)
+        return lora_tensors, peft_config
+
+
+__all__ = ["Qwen3OmniTalkerLoraWeightSync", "validate_talker_lora_keys"]

--- a/unirl/distributed/weight_sync/lora/remote.py
+++ b/unirl/distributed/weight_sync/lora/remote.py
@@ -166,7 +166,7 @@ class RemoteLoraWeightSync(LoraWeightSyncBase):
         pending = [
             (
                 role,
-                worker.call.remote(role, "tp_per_stage", (), {}),
+                worker.call.remote(role, "lora_tp_per_stage", (), {}),
                 worker.call.remote(role, "loaded_lora_checksums", (), {"adapter_id": int(DIFFRL_LORA_INT_ID)}),
             )
             for role, workers in self._targets

--- a/unirl/models/qwen3_omni/__init__.py
+++ b/unirl/models/qwen3_omni/__init__.py
@@ -1,4 +1,4 @@
-"""Public API for the typed Qwen3-Omni thinker AR pipeline."""
+"""Public API for the typed Qwen3-Omni thinker / talker AR pipelines."""
 
 from unirl.models.qwen3_omni.ar import (
     Qwen3OmniARParams,
@@ -10,14 +10,47 @@ from unirl.models.qwen3_omni.chat_template import Qwen3OmniChatTemplateStage
 from unirl.models.qwen3_omni.conditions import Qwen3OmniARConditions
 from unirl.models.qwen3_omni.config import Qwen3OmniPipelineConfig
 from unirl.models.qwen3_omni.pipeline import Qwen3OmniPipeline
+from unirl.models.qwen3_omni.talker_ar import (
+    Qwen3OmniTalkerARParams,
+    Qwen3OmniTalkerARStage,
+    Qwen3OmniTalkerARStep,
+)
+from unirl.models.qwen3_omni.talker_bundle import (
+    FrozenThinkerEmbeddingProvider,
+    Qwen3OmniTalkerBundle,
+)
+from unirl.models.qwen3_omni.talker_conditions import Qwen3OmniTalkerConditions
+from unirl.models.qwen3_omni.talker_contract import (
+    AUDIO_SAMPLE_RATE,
+    NUM_CODE_GROUPS,
+)
+from unirl.models.qwen3_omni.talker_pipeline import (
+    Qwen3OmniTalkerPipeline,
+    build_tts_messages,
+    tokenize_tts_batch,
+)
+from unirl.models.qwen3_omni.talker_prefix import build_talker_prefix_tts, resolve_speaker_id
 
 __all__ = [
+    "AUDIO_SAMPLE_RATE",
+    "NUM_CODE_GROUPS",
     "Qwen3OmniARConditions",
     "Qwen3OmniARParams",
     "Qwen3OmniARStage",
     "Qwen3OmniARStep",
     "Qwen3OmniBundle",
+    "FrozenThinkerEmbeddingProvider",
     "Qwen3OmniChatTemplateStage",
     "Qwen3OmniPipeline",
     "Qwen3OmniPipelineConfig",
+    "Qwen3OmniTalkerARParams",
+    "Qwen3OmniTalkerARStage",
+    "Qwen3OmniTalkerARStep",
+    "Qwen3OmniTalkerBundle",
+    "Qwen3OmniTalkerConditions",
+    "Qwen3OmniTalkerPipeline",
+    "build_talker_prefix_tts",
+    "build_tts_messages",
+    "resolve_speaker_id",
+    "tokenize_tts_batch",
 ]

--- a/unirl/models/qwen3_omni/bundle.py
+++ b/unirl/models/qwen3_omni/bundle.py
@@ -1,9 +1,9 @@
-"""Weights, processor, and tokenizer for the Qwen3-Omni thinker."""
+"""Weights, processor, and tokenizer for the Qwen3-Omni Thinker path."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
@@ -12,12 +12,19 @@ from unirl.models.types.bundle import Bundle
 from unirl.utils.dtypes import parse_torch_dtype
 
 from .config import Qwen3OmniPipelineConfig
-
 logger = logging.getLogger(__name__)
 
 
 class Qwen3OmniBundle(Bundle):
-    """Qwen3-Omni thinker bundle: thinker transformer + processor + tokenizer."""
+    """Qwen3-Omni Thinker bundle.
+
+    Thinker-only mode (default)
+        ``transformer`` is the standalone Thinker CausalLM (existing RL path).
+
+    Compatibility Talker mode (``config.enable_talker=True``)
+        :meth:`from_config` delegates to the independent
+        :class:`Qwen3OmniTalkerBundle`; it does not load a full Omni model.
+    """
 
     def __init__(
         self,
@@ -28,6 +35,10 @@ class Qwen3OmniBundle(Bundle):
         dtype: torch.dtype,
         device: torch.device,
         pretrained_path: str,
+        omni: Optional[nn.Module] = None,
+        enable_talker: bool = False,
+        default_speaker: str = "Ethan",
+        tts_system_instruction: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.transformer = transformer
@@ -36,11 +47,40 @@ class Qwen3OmniBundle(Bundle):
         self.dtype = dtype
         self.device = device
         self.pretrained_path = pretrained_path
+        self.omni = omni
+        self.enable_talker = bool(enable_talker)
+        self.default_speaker = str(default_speaker)
+        self.tts_system_instruction = tts_system_instruction
+
+    @property
+    def thinker(self) -> nn.Module:
+        if self.omni is not None and hasattr(self.omni, "thinker"):
+            return self.omni.thinker
+        return self.transformer
+
+    @property
+    def talker(self) -> nn.Module:
+        if self.omni is None or not hasattr(self.omni, "talker"):
+            raise RuntimeError("Qwen3OmniBundle.talker requires enable_talker=True (full Omni load).")
+        return self.omni.talker
+
+    @property
+    def code2wav(self) -> nn.Module:
+        if self.omni is None or not hasattr(self.omni, "code2wav"):
+            raise RuntimeError("Qwen3OmniBundle.code2wav requires enable_talker=True (full Omni load).")
+        return self.omni.code2wav
 
     @classmethod
     def from_config(cls, config: Qwen3OmniPipelineConfig) -> "Qwen3OmniBundle":
         from transformers import AutoConfig, AutoProcessor
-        from transformers.models.qwen3_omni_moe import Qwen3OmniMoeThinkerForConditionalGeneration
+
+        if config.enable_talker:
+            # Compatibility entry for existing recipes. Direct TTS now uses a
+            # standalone Talker bundle and never constructs/full-forwards the
+            # 30B Thinker. Thinker-only construction below remains unchanged.
+            from .talker_bundle import Qwen3OmniTalkerBundle
+
+            return Qwen3OmniTalkerBundle.from_config(config)
 
         path = config.pretrained_model_ckpt_path
 
@@ -50,24 +90,22 @@ class Qwen3OmniBundle(Bundle):
 
         dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
 
-        # Build the standalone thinker from its nested config.
-        full_cfg = AutoConfig.from_pretrained(path, trust_remote_code=bool(config.trust_remote_code))
-        thinker_cfg = full_cfg.thinker_config
-
         if config.meta_init_transformer:
-            # FSDP sharded loading requires remapping checkpoint ``thinker.`` keys.
             raise NotImplementedError(
-                "Qwen3OmniBundle: meta_init_transformer=True is not yet supported "
-                "(needs a strip-'thinker.' key remap in the sharded loader). Use "
-                "meta_init_transformer=False (eager from_pretrained auto-strips the "
-                "prefix via base_model_prefix='thinker')."
+                "Qwen3OmniBundle Thinker path: meta_init_transformer=True is not "
+                "yet supported (needs a strip-'thinker.' checkpoint mapping). "
+                "The standalone Qwen3OmniTalkerBundle supports Talker meta-init."
             )
 
         load_kwargs = {}
         if getattr(config, "attn_implementation", None):
             load_kwargs["attn_implementation"] = str(config.attn_implementation)
 
-        # ``base_model_prefix`` maps full-checkpoint keys to the standalone thinker.
+        omni: Optional[nn.Module] = None
+        from transformers.models.qwen3_omni_moe import Qwen3OmniMoeThinkerForConditionalGeneration
+
+        full_cfg = AutoConfig.from_pretrained(path, trust_remote_code=bool(config.trust_remote_code))
+        thinker_cfg = full_cfg.thinker_config
         transformer = Qwen3OmniMoeThinkerForConditionalGeneration.from_pretrained(
             path,
             config=thinker_cfg,
@@ -76,7 +114,6 @@ class Qwen3OmniBundle(Bundle):
             **load_kwargs,
         ).to(device)
 
-        # Freeze the top-level encoders while leaving the decoder trainable.
         if config.freeze_vision_tower and hasattr(transformer, "visual"):
             transformer.visual.requires_grad_(False)
             logger.info("Froze thinker vision tower (%d params).", sum(1 for _ in transformer.visual.parameters()))
@@ -86,14 +123,15 @@ class Qwen3OmniBundle(Bundle):
 
         if config.use_gradient_checkpointing:
             if hasattr(transformer, "gradient_checkpointing_enable"):
-                transformer.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
+                transformer.gradient_checkpointing_enable(
+                    gradient_checkpointing_kwargs={"use_reentrant": False}
+                )
             else:
                 logger.warning(
                     "Qwen3-Omni thinker %s does not expose gradient_checkpointing_enable; skipping.",
                     type(transformer).__name__,
                 )
 
-        # Load multimodal preprocessing assets from the checkpoint root.
         processor = AutoProcessor.from_pretrained(
             path,
             trust_remote_code=bool(config.trust_remote_code),
@@ -109,6 +147,10 @@ class Qwen3OmniBundle(Bundle):
             dtype=dtype,
             device=device,
             pretrained_path=path,
+            omni=omni,
+            enable_talker=bool(config.enable_talker),
+            default_speaker=str(config.default_speaker),
+            tts_system_instruction=config.tts_system_instruction,
         )
 
 

--- a/unirl/models/qwen3_omni/config.py
+++ b/unirl/models/qwen3_omni/config.py
@@ -46,7 +46,8 @@ class Qwen3OmniPipelineConfig:
     # Whether to include the video's audio track in TMRoPE inputs.
     use_audio_in_video: bool = False
 
-    # Unsupported until the FSDP loader remaps checkpoint ``thinker.`` keys.
+    # Talker direct-TTS supports meta-init and prefix-selective ``talker.*``
+    # loading. The legacy Thinker-only path remains eager-only.
     meta_init_transformer: bool = False
 
     system_instruction: Optional[str] = None
@@ -54,6 +55,27 @@ class Qwen3OmniPipelineConfig:
     # (for example tool schemas). Required tensor/tokenization return-shape
     # kwargs are enforced by the chat-template stage.
     chat_template_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    # --- Talker TTS RL / SFT ---
+    # Compatibility switch: Qwen3OmniBundle.from_config delegates to the
+    # standalone Qwen3OmniTalkerBundle. It loads only the frozen Thinker input
+    # embedding table, Talker+MTP, and frozen Code2Wav.
+    enable_talker: bool = False
+    # Legacy option retained for recipe compatibility; direct TTS has no full
+    # Thinker to freeze and always freezes its embedding provider.
+    freeze_thinker: bool = True
+    # Always freeze Code2Wav (decode-for-reward / SFT observation only).
+    freeze_code2wav: bool = True
+    # Phase-1 RL freezes the residual decoder and both embedding providers.
+    freeze_mtp: bool = False
+    freeze_talker_embeddings: bool = True
+    phase1_layer0_lora_only: bool = False
+    # Default TTS system prompt when the dataset does not supply one.
+    tts_system_instruction: Optional[str] = (
+        "You are a high-quality TTS model. Convert the user's text into natural speech audio."
+    )
+    # Default speaker when Part metadata omits ``speaker``.
+    default_speaker: str = "Ethan"
 
     def __post_init__(self) -> None:
         validate_precision_type(self.model_precision, field="Qwen3OmniPipelineConfig.model_precision")
@@ -63,6 +85,17 @@ class Qwen3OmniPipelineConfig:
             raise ValueError(f"Qwen3OmniPipelineConfig.video_max_frames must be >= 1, got {self.video_max_frames!r}")
         if self.video_max_pixels is not None and int(self.video_max_pixels) < 1:
             raise ValueError(f"Qwen3OmniPipelineConfig.video_max_pixels must be >= 1, got {self.video_max_pixels!r}")
+        if self.phase1_layer0_lora_only and not self.use_lora:
+            raise ValueError(
+                "Qwen3OmniPipelineConfig.phase1_layer0_lora_only requires use_lora=True"
+            )
+        if self.phase1_layer0_lora_only and not (
+            self.freeze_mtp and self.freeze_code2wav and self.freeze_talker_embeddings
+        ):
+            raise ValueError(
+                "Phase-1 layer0-LoRA mode requires freeze_mtp, freeze_code2wav, "
+                "and freeze_talker_embeddings"
+            )
 
 
 __all__ = ["Qwen3OmniPipelineConfig"]

--- a/unirl/models/qwen3_omni/talker_ar.py
+++ b/unirl/models/qwen3_omni/talker_ar.py
@@ -1,0 +1,831 @@
+"""Autoregression and replay for the Qwen3-Omni Talker (TTS codec policy)."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+
+from unirl.models.types.ar import ARSamplingParams, ARStage, ARStep
+from unirl.types.segments import SegmentStatus, TextSegment
+from unirl.utils.dtypes import parse_torch_dtype
+
+from .bundle import Qwen3OmniBundle
+from .talker_bundle import Qwen3OmniTalkerBundle
+from .talker_conditions import Qwen3OmniTalkerConditions
+from .talker_contract import NUM_CODE_GROUPS
+from .talker_prefix import build_talker_prefix_tts, resolve_speaker_id
+from .talker_residual import add_trailing_text_hidden, predict_residual_step, replay_residual_step
+from .talker_sampling import (
+    TalkerSamplingConfig,
+    TalkerSamplingProcessor,
+    append_token_history,
+    suppress_special_codec_ids,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Qwen3OmniTalkerARParams:
+    """Per-request Talker AR knobs."""
+
+    max_tokens: int = 1024
+    temperature: float = 0.9
+    top_p: float = 1.0
+    top_k: int = 50
+    repetition_penalty: float = 1.05
+    do_sample: bool = True
+    suppress_special_tokens: bool = True
+    suppress_token_ids: Optional[List[int]] = None
+    eos_token_id: Optional[int] = None
+    disable_eos: bool = False
+
+
+class Qwen3OmniTalkerARStep(ARStep):
+    """Sample one codec layer-0 token from logits with behavior log-probs."""
+
+    def __init__(
+        self,
+        *,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        top_k: int = 0,
+        repetition_penalty: float = 1.0,
+        suppress_token_ids: Optional[List[int]] = None,
+        eos_token_id: Optional[int] = None,
+        do_sample: bool = True,
+    ) -> None:
+        self.processor = TalkerSamplingProcessor(
+            TalkerSamplingConfig(
+                temperature=float(temperature),
+                top_p=float(top_p),
+                top_k=int(top_k),
+                repetition_penalty=float(repetition_penalty),
+                suppress_token_ids=tuple(int(t) for t in (suppress_token_ids or [])),
+                eos_token_id=eos_token_id,
+                do_sample=bool(do_sample),
+            )
+        )
+
+    def step(
+        self,
+        logits: torch.Tensor,
+        token_history: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.processor.sample(logits, token_history=token_history)
+
+
+TalkerBundle = Union[Qwen3OmniBundle, Qwen3OmniTalkerBundle]
+
+
+@dataclass
+class _TalkerDecodeState:
+    """One exact Talker trajectory state, shared by rollout and replay."""
+
+    prefix_embeds: torch.Tensor
+    prefix_ids: torch.Tensor
+    prefix_position_ids: torch.Tensor
+    rope_deltas: torch.Tensor
+    trailing_text_hidden: torch.Tensor
+    tts_pad_embed: torch.Tensor
+    use_cache: bool
+    generation_step: int = 0
+    past_key_values: Any = None
+    history: Optional[torch.Tensor] = None
+    generated_embeds: Optional[torch.Tensor] = None
+
+    @property
+    def prefix_length(self) -> int:
+        return int(self.prefix_embeds.shape[1])
+
+    def _generated_position_ids(self, count: int) -> torch.Tensor:
+        if count <= 0:
+            return self.prefix_position_ids[..., :0]
+        batch_size = int(self.prefix_embeds.shape[0])
+        delta = self.rope_deltas.reshape(batch_size, -1)[:, :1]
+        positions = torch.arange(count, device=self.prefix_embeds.device, dtype=delta.dtype).view(1, -1)
+        positions = positions + delta + self.prefix_length
+        return positions.unsqueeze(0).expand(self.prefix_position_ids.shape[0], -1, -1)
+
+    def model_inputs(self) -> Dict[str, Any]:
+        if self.generation_step == 0:
+            inputs_embeds = self.prefix_embeds
+            position_ids = self.prefix_position_ids
+        else:
+            if self.generated_embeds is None or self.generated_embeds.shape[1] != self.generation_step:
+                raise RuntimeError("Talker decode state has a misaligned generated-embedding timeline")
+            generated_positions = self._generated_position_ids(self.generation_step)
+            if self.use_cache:
+                inputs_embeds = self.generated_embeds[:, -1:, :]
+                position_ids = generated_positions[..., -1:]
+            else:
+                inputs_embeds = torch.cat((self.prefix_embeds, self.generated_embeds), dim=1)
+                position_ids = torch.cat((self.prefix_position_ids, generated_positions), dim=-1)
+        total_length = self.prefix_length + self.generation_step
+        attention_mask = torch.ones(
+            (self.prefix_embeds.shape[0], total_length),
+            dtype=torch.long,
+            device=self.prefix_embeds.device,
+        )
+        return {
+            "inputs_embeds": inputs_embeds,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": self.past_key_values if self.use_cache else None,
+            "use_cache": self.use_cache,
+            # Official prefill returns generation_step=0; the first incremental
+            # forward consumes that value.  Our state counts actions already
+            # appended, hence the one-step offset here.
+            "generation_step": max(self.generation_step - 1, 0),
+            "talker_input_ids": self.prefix_ids,
+            "trailing_text_hidden": self.trailing_text_hidden,
+            "tts_pad_embed": self.tts_pad_embed,
+            "output_hidden_states": True,
+            "return_dict": True,
+        }
+
+    def advance(self, *, output: Any, token_id: torch.Tensor, next_embed: torch.Tensor) -> None:
+        if self.use_cache:
+            cache = getattr(output, "past_key_values", None)
+            if cache is None:
+                raise RuntimeError(
+                    "Talker decode requested use_cache=True but the model returned no cache; "
+                    "refusing to silently restart the prefix with an advanced timeline"
+                )
+            self.past_key_values = cache
+        self.history = append_token_history(self.history, token_id)
+        self.generated_embeds = (
+            next_embed
+            if self.generated_embeds is None
+            else torch.cat((self.generated_embeds, next_embed), dim=1)
+        )
+        self.generation_step += 1
+
+
+def _talker_owner(bundle: TalkerBundle) -> Any:
+    """Return the object that owns config/talker/code2wav.
+
+    New direct-TTS bundles own these directly. The fallback keeps manually
+    constructed legacy full-Omni bundles usable without making the production
+    path depend on them.
+    """
+    if hasattr(bundle, "config") and hasattr(bundle, "input_embedding_provider"):
+        return bundle
+    omni = getattr(bundle, "omni", None)
+    if omni is None:
+        raise ValueError(
+            "Qwen3OmniTalkerARStage requires Qwen3OmniTalkerBundle or a legacy bundle containing a full Omni model"
+        )
+    return omni
+
+
+def _suppress_special_codec_ids(model: Any) -> List[int]:
+    cfg = model.config.talker_config
+    return list(
+        suppress_special_codec_ids(
+            vocab_size=int(cfg.text_config.vocab_size),
+            codec_eos_token_id=int(cfg.codec_eos_token_id),
+        )
+    )
+
+
+def _build_decode_state(
+    *,
+    owner: Any,
+    input_ids: torch.Tensor,
+    speaker_id: int,
+    device: torch.device,
+    batch_idx: int,
+    expected_prefix_ids: Optional[Any],
+    use_cache: bool,
+) -> _TalkerDecodeState:
+    prefix_embeds, prefix_ids, trailing_text_hidden, tts_pad_embed = build_talker_prefix_tts(
+        owner,
+        input_ids=input_ids,
+        speaker_id=speaker_id,
+        device=device,
+        expected_prefix_ids=expected_prefix_ids,
+        batch_idx=batch_idx,
+    )
+    prefix_mask = torch.ones(prefix_ids.shape, dtype=torch.long, device=device)
+    prefix_position_ids, rope_deltas = owner.talker.get_rope_index(
+        prefix_ids,
+        attention_mask=prefix_mask,
+    )
+    return _TalkerDecodeState(
+        prefix_embeds=prefix_embeds,
+        prefix_ids=prefix_ids,
+        prefix_position_ids=prefix_position_ids.to(device),
+        rope_deltas=rope_deltas.to(device),
+        trailing_text_hidden=trailing_text_hidden,
+        tts_pad_embed=tts_pad_embed,
+        use_cache=bool(use_cache),
+    )
+
+
+def _talker_hidden_sequence(output: Any) -> torch.Tensor:
+    hidden_states = getattr(output, "hidden_states", None)
+    if not isinstance(hidden_states, (tuple, list)) or not hidden_states:
+        raise RuntimeError("Talker forward did not return hidden states required by the residual transition")
+    model_hiddens = hidden_states[0] if isinstance(hidden_states[0], (tuple, list)) else hidden_states
+    if not isinstance(model_hiddens, (tuple, list)) or not model_hiddens:
+        raise RuntimeError("Talker forward returned a malformed hidden-state payload")
+    hidden = model_hiddens[-1]
+    if not isinstance(hidden, torch.Tensor) or hidden.dim() != 3:
+        raise RuntimeError("Talker forward returned a malformed final hidden state")
+    return hidden
+
+
+def _last_talker_hidden(output: Any) -> torch.Tensor:
+    return _talker_hidden_sequence(output)[:, -1:, :]
+
+
+class Qwen3OmniTalkerARStage(ARStage[Qwen3OmniTalkerConditions]):
+    """Talker(+MTP) codec AR stage for TTS RL / SFT."""
+
+    def __init__(
+        self,
+        *,
+        model: TalkerBundle,
+        autocast_precision: str = "bf16",
+        logprob_precision: str = "fp32",
+    ) -> None:
+        if not getattr(model, "enable_talker", False):
+            raise ValueError("Qwen3OmniTalkerARStage requires a Talker-enabled bundle.")
+        self.model = model
+        self.owner = _talker_owner(model)
+        self.autocast_dtype = parse_torch_dtype(
+            autocast_precision, field_name="Qwen3OmniTalkerARStage.autocast_precision"
+        )
+        self.logprob_dtype = parse_torch_dtype(logprob_precision, field_name="Qwen3OmniTalkerARStage.logprob_precision")
+
+    def trainable_module(self) -> torch.nn.Module:
+        return self.model.transformer
+
+    def autoregress(
+        self,
+        conditions: Qwen3OmniTalkerConditions,
+        *,
+        sampling_params: ARSamplingParams,
+        params: Optional[Qwen3OmniTalkerARParams] = None,
+        **_kwargs: Any,
+    ) -> Tuple[TextSegment, Dict[str, Any]]:
+        """Sample layer-0 codes (+ MTP residuals) per sample; return segment + talker control."""
+        if conditions.prompt is None or conditions.prompt.input_ids is None:
+            raise ValueError("Qwen3OmniTalkerARStage.autoregress: requires conditions.prompt.input_ids")
+        if conditions.prompt.attention_mask is None:
+            raise ValueError("Qwen3OmniTalkerARStage.autoregress: requires conditions.prompt.attention_mask")
+
+        owner = self.owner
+        talker = owner.talker
+        device = next(talker.parameters()).device
+        input_ids = conditions.prompt.input_ids.to(device)
+        batch_size = int(input_ids.shape[0])
+        if conditions.speaker_ids is not None:
+            speaker_ids = [int(v) for v in conditions.speaker_ids]
+        else:
+            speakers = list(conditions.speakers or [self.model.default_speaker] * batch_size)
+            speaker_ids = [resolve_speaker_id(owner, name) for name in speakers]
+        if len(speaker_ids) != batch_size:
+            raise ValueError(
+                f"Qwen3OmniTalkerARStage.autoregress: speaker_ids len {len(speaker_ids)} != batch {batch_size}"
+            )
+
+        knobs = params or Qwen3OmniTalkerARParams()
+        max_new = int(sampling_params.max_new_tokens if sampling_params.max_new_tokens else knobs.max_tokens)
+        temperature = float(
+            sampling_params.temperature if sampling_params.temperature is not None else knobs.temperature
+        )
+        top_p = float(sampling_params.top_p if sampling_params.top_p is not None else knobs.top_p)
+        top_k = int(sampling_params.top_k if sampling_params.top_k is not None else knobs.top_k)
+        if knobs.disable_eos:
+            codec_eos = None
+        elif sampling_params.stop_token_id is not None:
+            codec_eos = int(sampling_params.stop_token_id)
+        elif knobs.eos_token_id is not None:
+            codec_eos = int(knobs.eos_token_id)
+        else:
+            codec_eos = int(owner.config.talker_config.codec_eos_token_id)
+        if knobs.suppress_token_ids is not None:
+            suppress = [int(token_id) for token_id in knobs.suppress_token_ids]
+        elif knobs.suppress_special_tokens:
+            suppress = _suppress_special_codec_ids(owner)
+        else:
+            suppress = []
+        behavior_config = TalkerSamplingConfig(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            repetition_penalty=float(knobs.repetition_penalty),
+            suppress_token_ids=tuple(suppress),
+            eos_token_id=codec_eos,
+            do_sample=bool(knobs.do_sample),
+        )
+        step = Qwen3OmniTalkerARStep(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            repetition_penalty=float(knobs.repetition_penalty),
+            suppress_token_ids=suppress,
+            eos_token_id=codec_eos,
+            do_sample=bool(knobs.do_sample),
+        )
+
+        all_tokens: List[List[int]] = []
+        all_logps: List[List[float]] = []
+        all_residuals: List[torch.Tensor] = []
+        all_prefix_ids: List[torch.Tensor] = []
+        all_statuses: List[int] = []
+
+        for b in range(batch_size):
+            state = _build_decode_state(
+                owner=owner,
+                input_ids=input_ids,
+                speaker_id=speaker_ids[b],
+                device=device,
+                batch_idx=b,
+                expected_prefix_ids=None,
+                use_cache=True,
+            )
+            all_prefix_ids.append(state.prefix_ids.squeeze(0).detach().cpu())
+            tokens_b: List[int] = []
+            logps_b: List[float] = []
+            residuals_b: List[torch.Tensor] = []
+
+            finished = False
+
+            for _ in range(max_new):
+                if finished:
+                    break
+                with torch.no_grad():
+                    out = talker(**state.model_inputs())
+                logits = out.logits[:, -1, :]
+                token_id, logp0 = step.step(logits, token_history=state.history)
+                tid = int(token_id.item())
+                tokens_b.append(tid)
+
+                with torch.no_grad():
+                    residual_step = predict_residual_step(
+                        talker=talker,
+                        past_hidden=_last_talker_hidden(out),
+                        layer0_ids=token_id,
+                    )
+                residual = residual_step.residual_codes
+                residuals_b.append(residual.squeeze(0))  # [15]
+                # Phase-1 policy action is layer0 only.  Frozen MTP residuals
+                # define the next state and waveform, but are not folded into
+                # the policy log-probability.
+                logps_b.append(float(logp0.item()))
+
+                if bool(step.processor.is_eos(token_id).item()):
+                    finished = True
+
+                next_embed = add_trailing_text_hidden(
+                    residual_step.next_codec_hidden,
+                    generation_step=state.generation_step,
+                    trailing_text_hidden=state.trailing_text_hidden,
+                    tts_pad_embed=state.tts_pad_embed,
+                ).to(talker.dtype)
+                state.advance(output=out, token_id=token_id, next_embed=next_embed)
+
+            all_tokens.append(tokens_b)
+            all_logps.append(logps_b)
+            all_statuses.append(
+                int(SegmentStatus.COMPLETED if finished else SegmentStatus.TRUNCATED)
+            )
+            if residuals_b:
+                all_residuals.append(torch.stack(residuals_b, dim=1))  # [15, T]
+            else:
+                all_residuals.append(torch.zeros((NUM_CODE_GROUPS - 1, 0), dtype=torch.long, device=device))
+
+        segment = TextSegment.pack(
+            tokens=[torch.tensor(toks, dtype=torch.long, device=device) for toks in all_tokens],
+            log_probs=[torch.tensor(lps, dtype=torch.float32, device=device) for lps in all_logps],
+            status=torch.tensor(all_statuses, dtype=torch.long, device=device),
+        )
+        control = {
+            "residual_codes": [r.detach().cpu() for r in all_residuals],
+            "speaker_ids": speaker_ids,
+            "prefix_ids": all_prefix_ids,
+            "behavior_sampling": behavior_config.to_dict(),
+        }
+        return segment, control
+
+    def replay(
+        self,
+        conditions: Qwen3OmniTalkerConditions,
+        *,
+        segment: TextSegment,
+        temperature: Optional[float] = None,
+    ) -> torch.Tensor:
+        """Replay processed layer-0 behavior log-probs packed like ``segment``."""
+        layer0_logps, _ = self._replay_teacher_forced(
+            conditions,
+            segment=segment,
+            temperature=temperature,
+            include_mtp=False,
+        )
+        return layer0_logps
+
+    def replay_sft(
+        self,
+        conditions: Qwen3OmniTalkerConditions,
+        *,
+        segment: TextSegment,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return vectorized teacher-forced ``(layer0, MTP)`` log-probs.
+
+        Each sample executes one full-sequence Talker forward and exactly 15
+        frame-batched MTP forwards. Layer-0 includes the codec EOS target, while
+        the corresponding MTP row is zero-filled and excluded by the SFT mask.
+        This path is deliberately independent of rollout replay's exact
+        frame-by-frame state machine.
+        """
+        if conditions.prompt is None or conditions.prompt.input_ids is None:
+            raise ValueError("Qwen3OmniTalkerARStage.replay_sft: conditions.prompt.input_ids is None")
+        if conditions.prompt.attention_mask is None:
+            raise ValueError("Qwen3OmniTalkerARStage.replay_sft: conditions.prompt.attention_mask is None")
+        if segment.tokens is None or segment.cu_seqlens is None or segment.lengths is None:
+            raise ValueError("Qwen3OmniTalkerARStage.replay_sft: segment requires packed tokens")
+
+        owner = self.owner
+        talker = owner.talker
+        device = next(talker.parameters()).device
+        input_ids = conditions.prompt.input_ids.to(device)
+        batch_size = int(input_ids.shape[0])
+        lengths = [int(length) for length in segment.lengths.tolist()]
+        cu = [int(offset) for offset in segment.cu_seqlens.tolist()]
+        if len(lengths) != batch_size:
+            raise ValueError(
+                f"Qwen3OmniTalkerARStage.replay_sft: segment batch {len(lengths)} != prompt batch {batch_size}"
+            )
+
+        if conditions.speaker_ids is not None:
+            speaker_ids = [int(value) for value in conditions.speaker_ids]
+        else:
+            speakers = list(conditions.speakers or [self.model.default_speaker] * batch_size)
+            speaker_ids = [resolve_speaker_id(owner, name) for name in speakers]
+        if len(speaker_ids) != batch_size:
+            raise ValueError(
+                f"Qwen3OmniTalkerARStage.replay_sft: speaker_ids len {len(speaker_ids)} != batch {batch_size}"
+            )
+
+        residual_codes = conditions.residual_codes
+        if residual_codes is None or len(residual_codes) != batch_size:
+            actual = None if residual_codes is None else len(residual_codes)
+            raise ValueError(
+                f"Qwen3OmniTalkerARStage.replay_sft: residual_codes len {actual} != batch {batch_size}"
+            )
+        mtp_masks = conditions.mtp_loss_masks
+        if mtp_masks is not None and len(mtp_masks) != batch_size:
+            raise ValueError(
+                f"Qwen3OmniTalkerARStage.replay_sft: mtp_loss_masks len {len(mtp_masks)} != batch {batch_size}"
+            )
+
+        codec_eos = int(owner.config.talker_config.codec_eos_token_id)
+        predictor_embeddings = talker.code_predictor.get_input_embeddings()
+        if not isinstance(predictor_embeddings, (torch.nn.ModuleList, list, tuple)):
+            raise TypeError("Talker code_predictor.get_input_embeddings() must return per-codebook embeddings")
+        if len(predictor_embeddings) != NUM_CODE_GROUPS - 1:
+            raise ValueError(
+                f"Talker SFT requires {NUM_CODE_GROUPS - 1} MTP embedding tables, "
+                f"got {len(predictor_embeddings)}"
+            )
+        layer0_embedding = talker.get_input_embeddings()
+
+        packed_layer0: List[torch.Tensor] = []
+        packed_mtp: List[torch.Tensor] = []
+        for batch_idx, packed_length in enumerate(lengths):
+            if packed_length < 2:
+                raise ValueError(
+                    f"Talker SFT sample {batch_idx}: expected at least one codec frame plus EOS, "
+                    f"got length {packed_length}"
+                )
+            layer0_targets = segment.tokens[
+                cu[batch_idx] : cu[batch_idx] + packed_length
+            ].to(device=device, dtype=torch.long)
+            if int(layer0_targets[-1].item()) != codec_eos:
+                raise ValueError(
+                    f"Talker SFT sample {batch_idx}: final layer-0 target must be codec EOS {codec_eos}"
+                )
+            frame_count = packed_length - 1
+            layer0_frames = layer0_targets[:frame_count].view(1, frame_count)
+
+            residuals = residual_codes[batch_idx].to(device=device, dtype=torch.long)
+            expected_shape = (NUM_CODE_GROUPS - 1, packed_length)
+            if tuple(residuals.shape) != expected_shape:
+                raise ValueError(
+                    f"Talker SFT residual_codes[{batch_idx}] expected {expected_shape}, "
+                    f"got {tuple(residuals.shape)}"
+                )
+            if torch.any(residuals[:, -1] != 0):
+                raise ValueError(f"Talker SFT residual_codes[{batch_idx}] EOS column must be zero-filled")
+            if mtp_masks is not None:
+                mtp_mask = torch.as_tensor(mtp_masks[batch_idx]).flatten()
+                if mtp_mask.shape[0] != packed_length:
+                    raise ValueError(
+                        f"Talker SFT mtp_loss_masks[{batch_idx}] length {mtp_mask.shape[0]} "
+                        f"!= target length {packed_length}"
+                    )
+                if float(mtp_mask[-1].item()) != 0.0:
+                    raise ValueError(f"Talker SFT mtp_loss_masks[{batch_idx}] must exclude the EOS row")
+
+            prefix_embeds, _prefix_ids, trailing_text_hidden, tts_pad_embed = build_talker_prefix_tts(
+                owner,
+                input_ids=input_ids,
+                speaker_id=speaker_ids[batch_idx],
+                device=device,
+                expected_prefix_ids=(
+                    conditions.prefix_ids[batch_idx]
+                    if conditions.prefix_ids is not None
+                    else None
+                ),
+                batch_idx=batch_idx,
+            )
+
+            layer0_frame_embeds = layer0_embedding(layer0_frames)
+            codec_frame_embeds = layer0_frame_embeds
+            for predictor_idx, embedding in enumerate(predictor_embeddings):
+                residual_frame_ids = residuals[predictor_idx, :frame_count].view(1, frame_count)
+                codec_frame_embeds = codec_frame_embeds + embedding(residual_frame_ids)
+
+            text_length = min(frame_count, int(trailing_text_hidden.shape[1]))
+            aligned_text = trailing_text_hidden[:, :text_length]
+            if text_length < frame_count:
+                aligned_text = torch.cat(
+                    (
+                        aligned_text,
+                        tts_pad_embed.expand(-1, frame_count - text_length, -1),
+                    ),
+                    dim=1,
+                )
+            codec_inputs = (
+                codec_frame_embeds
+                + aligned_text.to(device=codec_frame_embeds.device, dtype=codec_frame_embeds.dtype)
+            ).to(dtype=talker.dtype)
+            full_inputs_embeds = torch.cat((prefix_embeds, codec_inputs), dim=1)
+            attention_mask = torch.ones(
+                full_inputs_embeds.shape[:2],
+                dtype=torch.long,
+                device=device,
+            )
+            talker_output = talker(
+                inputs_embeds=full_inputs_embeds,
+                attention_mask=attention_mask,
+                use_cache=False,
+                trailing_text_hidden=trailing_text_hidden,
+                tts_pad_embed=tts_pad_embed,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+
+            prefix_length = int(prefix_embeds.shape[1])
+            target_start = prefix_length - 1
+            target_end = target_start + packed_length
+            target_logits = talker_output.logits[:, target_start:target_end, :].float()
+            if int(target_logits.shape[1]) != packed_length:
+                raise RuntimeError(
+                    f"Talker SFT sample {batch_idx}: Talker returned {target_logits.shape[1]} "
+                    f"target positions, expected {packed_length}"
+                )
+            layer0_logp = (
+                torch.log_softmax(target_logits, dim=-1)
+                .gather(-1, layer0_targets.view(1, packed_length, 1))
+                .reshape(packed_length)
+            )
+
+            hidden_sequence = _talker_hidden_sequence(talker_output)
+            codec_hidden = hidden_sequence[:, target_start : target_start + frame_count, :]
+            if int(codec_hidden.shape[1]) != frame_count:
+                raise RuntimeError(
+                    f"Talker SFT sample {batch_idx}: Talker returned {codec_hidden.shape[1]} "
+                    f"codec hidden states, expected {frame_count}"
+                )
+            hidden_size = int(codec_hidden.shape[-1])
+            hidden_flat = codec_hidden.reshape(frame_count, 1, hidden_size)
+            layer0_flat = layer0_frame_embeds.reshape(frame_count, 1, hidden_size)
+
+            frame_mtp_logps = []
+            for predictor_idx in range(NUM_CODE_GROUPS - 1):
+                mtp_inputs = [hidden_flat, layer0_flat]
+                for previous_idx in range(predictor_idx):
+                    previous_ids = residuals[previous_idx, :frame_count].view(1, frame_count)
+                    previous_embed = predictor_embeddings[previous_idx](previous_ids)
+                    mtp_inputs.append(previous_embed.reshape(frame_count, 1, hidden_size))
+                predictor_output = talker.code_predictor(
+                    inputs_embeds=torch.cat(mtp_inputs, dim=1).to(dtype=talker.dtype),
+                    generation_steps=predictor_idx,
+                    use_cache=False,
+                )
+                mtp_logits = predictor_output.logits[:, -1, :].float()
+                mtp_targets = residuals[predictor_idx, :frame_count]
+                frame_mtp_logps.append(
+                    torch.log_softmax(mtp_logits, dim=-1)
+                    .gather(-1, mtp_targets[:, None])
+                    .squeeze(-1)
+                )
+
+            mtp_logp = torch.stack(frame_mtp_logps, dim=-1)
+            mtp_logp = torch.cat(
+                (
+                    mtp_logp,
+                    mtp_logp.new_zeros((1, NUM_CODE_GROUPS - 1)),
+                ),
+                dim=0,
+            )
+            packed_layer0.append(layer0_logp.to(dtype=self.logprob_dtype))
+            packed_mtp.append(mtp_logp.to(dtype=self.logprob_dtype))
+
+        if not packed_layer0:
+            return (
+                torch.zeros(0, dtype=self.logprob_dtype, device=device),
+                torch.zeros((0, NUM_CODE_GROUPS - 1), dtype=self.logprob_dtype, device=device),
+            )
+        return torch.cat(packed_layer0, dim=0), torch.cat(packed_mtp, dim=0)
+
+    def _replay_teacher_forced(
+        self,
+        conditions: Qwen3OmniTalkerConditions,
+        *,
+        segment: TextSegment,
+        temperature: Optional[float],
+        include_mtp: bool,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if conditions.prompt is None or conditions.prompt.input_ids is None:
+            raise ValueError("Qwen3OmniTalkerARStage.replay: conditions.prompt.input_ids is None")
+        if conditions.prompt.attention_mask is None:
+            raise ValueError("Qwen3OmniTalkerARStage.replay: conditions.prompt.attention_mask is None")
+        if segment.tokens is None or segment.cu_seqlens is None or segment.lengths is None:
+            raise ValueError("Qwen3OmniTalkerARStage.replay: segment requires packed tokens")
+
+        owner = self.owner
+        talker = owner.talker
+        device = next(talker.parameters()).device
+        input_ids = conditions.prompt.input_ids.to(device)
+        batch_size = int(input_ids.shape[0])
+        if conditions.speaker_ids is not None:
+            speaker_ids = [int(v) for v in conditions.speaker_ids]
+        else:
+            speakers = list(conditions.speakers or [self.model.default_speaker] * batch_size)
+            speaker_ids = [resolve_speaker_id(owner, name) for name in speakers]
+        if len(speaker_ids) != batch_size:
+            raise ValueError(f"Qwen3OmniTalkerARStage.replay: speaker_ids len {len(speaker_ids)} != batch {batch_size}")
+        lengths = [int(n) for n in segment.lengths.tolist()]
+        cu = [int(c) for c in segment.cu_seqlens.tolist()]
+        behavior_processor = None
+        if not include_mtp:
+            behavior_config = conditions.validate_rollout_replay(lengths=lengths)
+            if temperature is not None and float(temperature) != float(behavior_config.temperature):
+                raise ValueError(
+                    "Talker replay temperature differs from the stored behavior distribution: "
+                    f"requested={temperature}, rollout={behavior_config.temperature}"
+                )
+            behavior_processor = TalkerSamplingProcessor(behavior_config)
+
+        residual_codes = conditions.residual_codes
+        if residual_codes is None:
+            raise ValueError(
+                "Qwen3OmniTalkerARStage.replay requires residual_codes; "
+                "zero-filled residuals do not reproduce the rollout state"
+            )
+        if len(residual_codes) != batch_size:
+            raise ValueError(
+                f"Qwen3OmniTalkerARStage.replay: residual_codes len {len(residual_codes)} != batch {batch_size}"
+            )
+
+        flat_parts: List[torch.Tensor] = []
+        flat_mtp_parts: List[torch.Tensor] = []
+        for b in range(batch_size):
+            n = lengths[b]
+            if n == 0:
+                continue
+            layer0 = segment.tokens[cu[b] : cu[b] + n].to(device=device, dtype=torch.long).view(1, -1)
+            residuals = residual_codes[b].to(device=device, dtype=torch.long)
+            if residuals.dim() != 2 or residuals.shape[0] != NUM_CODE_GROUPS - 1:
+                raise ValueError(f"residual_codes[{b}] expected [15, T], got {tuple(residuals.shape)}")
+            if int(residuals.shape[1]) != n:
+                raise ValueError(
+                    f"Qwen3OmniTalkerARStage.replay: residual_codes[{b}] timeline "
+                    f"{residuals.shape[1]} != layer-0 timeline {n}"
+                )
+
+            state = _build_decode_state(
+                owner=owner,
+                input_ids=input_ids,
+                speaker_id=speaker_ids[b],
+                device=device,
+                batch_idx=b,
+                expected_prefix_ids=(
+                    conditions.prefix_ids[b]
+                    if conditions.prefix_ids is not None
+                    else None
+                ),
+                # Training replay must remain correct when gradient
+                # checkpointing disables caches.  Eval rollout/replay may use
+                # the exact incremental path and verifies that a cache exists.
+                use_cache=(not torch.is_grad_enabled() and not talker.training),
+            )
+
+            token_logps = []
+            mtp_logps = []
+            for pos in range(n):
+                talker_out = talker(**state.model_inputs())
+                target = layer0[:, pos]
+                if include_mtp:
+                    token_logps.append(
+                        torch.log_softmax(talker_out.logits[:, -1, :].float(), dim=-1)
+                        .gather(-1, target[:, None])
+                        .squeeze(-1)
+                    )
+                else:
+                    assert behavior_processor is not None
+                    token_logps.append(
+                        behavior_processor.score(
+                            talker_out.logits[:, -1, :],
+                            target,
+                            token_history=state.history,
+                        )
+                    )
+                residual_step = replay_residual_step(
+                    talker=talker,
+                    past_hidden=_last_talker_hidden(talker_out),
+                    layer0_ids=target,
+                    residual_codes=residuals[:, pos].view(1, -1),
+                    return_log_probs=include_mtp,
+                    use_cache=state.use_cache,
+                )
+                if include_mtp:
+                    if residual_step.log_probs is None:
+                        raise RuntimeError("MTP replay did not return target log-probs")
+                    mtp_logps.append(residual_step.log_probs)
+                next_embed = add_trailing_text_hidden(
+                    residual_step.next_codec_hidden,
+                    generation_step=state.generation_step,
+                    trailing_text_hidden=state.trailing_text_hidden,
+                    tts_pad_embed=state.tts_pad_embed,
+                ).to(talker.dtype)
+                state.advance(output=talker_out, token_id=target, next_embed=next_embed)
+            logp0 = torch.cat(token_logps, dim=0)
+            flat_parts.append(logp0.to(dtype=self.logprob_dtype))
+            if include_mtp:
+                flat_mtp_parts.append(torch.cat(mtp_logps, dim=0).to(dtype=self.logprob_dtype))
+
+        if not flat_parts:
+            empty_layer0 = torch.zeros(0, dtype=self.logprob_dtype, device=device)
+            empty_mtp = torch.zeros(
+                (0, NUM_CODE_GROUPS - 1),
+                dtype=self.logprob_dtype,
+                device=device,
+            )
+            return empty_layer0, empty_mtp if include_mtp else None
+        return (
+            torch.cat(flat_parts, dim=0),
+            torch.cat(flat_mtp_parts, dim=0) if include_mtp else None,
+        )
+
+    def decode_codes_to_audio(
+        self,
+        *,
+        layer0_codes: List[torch.Tensor],
+        residual_codes: List[torch.Tensor],
+    ) -> List[torch.Tensor]:
+        """Decode per-sample codes → mono waveforms ``[L]`` at 24 kHz."""
+        owner = self.owner
+        code2wav = owner.code2wav
+        device = next(code2wav.parameters()).device
+        wavs: List[torch.Tensor] = []
+        for layer0, residual in zip(layer0_codes, residual_codes):
+            layer0 = layer0.to(device=device, dtype=torch.long).view(-1)
+            residual = residual.to(device=device, dtype=torch.long)
+            if layer0.numel() == 0:
+                wavs.append(torch.zeros(0, device=device))
+                continue
+            # Drop trailing EOS if present for vocoder input.
+            eos = int(owner.config.talker_config.codec_eos_token_id)
+            if int(layer0[-1].item()) == eos:
+                layer0 = layer0[:-1]
+                residual = residual[:, : layer0.numel()]
+            if layer0.numel() == 0:
+                wavs.append(torch.zeros(0, device=device))
+                continue
+            # codes layout expected by code2wav: [num_quantizers, T]
+            codes = torch.cat([layer0.view(1, -1), residual[:, : layer0.numel()]], dim=0)
+            with torch.no_grad():
+                audio = code2wav.chunked_decode(
+                    codes.unsqueeze(0).to(device),
+                    chunk_size=300,
+                    left_context_size=25,
+                )
+            audio = audio.detach().float().reshape(-1).cpu()
+            wavs.append(audio)
+        return wavs
+
+
+__all__ = [
+    "Qwen3OmniTalkerARParams",
+    "Qwen3OmniTalkerARStage",
+    "Qwen3OmniTalkerARStep",
+]

--- a/unirl/models/qwen3_omni/talker_bundle.py
+++ b/unirl/models/qwen3_omni/talker_bundle.py
@@ -1,0 +1,395 @@
+"""Standalone Qwen3-Omni Talker bundle for direct TTS.
+
+Unlike the Thinker bundle, this path never constructs or executes the full
+Thinker. It keeps only the frozen Thinker token embedding table needed by the
+text-only direct-TTS prefix, the trainable Talker (including MTP), and the
+frozen Code2Wav decoder.
+"""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+from typing import Any, Iterator, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from unirl.models.types.bundle import Bundle
+from unirl.models.types.meta_init import build_meta_init_transformer
+from unirl.utils.dtypes import parse_torch_dtype
+
+logger = logging.getLogger(__name__)
+
+
+class FrozenThinkerEmbeddingProvider(nn.Module):
+    """The only Thinker component direct TTS needs: its input embedding table."""
+
+    def __init__(self, embedding: nn.Embedding) -> None:
+        super().__init__()
+        self.embedding = embedding
+        self.requires_grad_(False)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embedding(input_ids)
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        """Compatibility with the full Thinker's embedding accessor."""
+        return self.embedding
+
+
+def _checkpoint_shards(weights_dir: str) -> list[str]:
+    if not os.path.isdir(weights_dir):
+        raise FileNotFoundError(
+            f"Qwen3OmniTalkerBundle: checkpoint directory not found: {weights_dir!r}"
+        )
+    shards = sorted(glob.glob(os.path.join(weights_dir, "*.safetensors")))
+    if not shards:
+        raise FileNotFoundError(
+            f"Qwen3OmniTalkerBundle: no *.safetensors files under {weights_dir!r}"
+        )
+    return shards
+
+
+def _iter_prefixed_checkpoint_tensors(
+    weights_dir: str,
+    *,
+    key_prefix: str,
+) -> Iterator[Tuple[str, torch.Tensor]]:
+    """Yield only ``key_prefix`` tensors, one at a time, with the prefix stripped."""
+    from safetensors import safe_open
+
+    matched = 0
+    for shard in _checkpoint_shards(weights_dir):
+        with safe_open(shard, framework="pt", device="cpu") as handle:
+            for source_key in handle.keys():
+                if not source_key.startswith(key_prefix):
+                    continue
+                target_key = source_key[len(key_prefix) :]
+                if not target_key:
+                    continue
+                matched += 1
+                yield target_key, handle.get_tensor(source_key)
+    if matched == 0:
+        raise ValueError(
+            f"Qwen3OmniTalkerBundle: no checkpoint tensors matched prefix "
+            f"{key_prefix!r} under {weights_dir!r}"
+        )
+
+
+def _stream_load_prefixed_module(
+    module: nn.Module,
+    weights_dir: str,
+    *,
+    key_prefix: str,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> None:
+    """Materialize a meta module from one composite-checkpoint subtree.
+
+    Tensors are mmap-read and assigned one at a time, so loading the frozen
+    embedding provider or Code2Wav never materializes the full Omni state dict.
+    """
+    from accelerate.utils.modeling import set_module_tensor_to_device
+
+    expected = set(module.state_dict().keys())
+    loaded: set[str] = set()
+    unexpected: list[str] = []
+    for target_key, value in _iter_prefixed_checkpoint_tensors(
+        weights_dir,
+        key_prefix=key_prefix,
+    ):
+        if target_key not in expected:
+            unexpected.append(target_key)
+            continue
+        target_dtype = dtype if value.is_floating_point() else value.dtype
+        set_module_tensor_to_device(
+            module,
+            target_key,
+            device,
+            value=value,
+            dtype=target_dtype,
+        )
+        loaded.add(target_key)
+
+    meta_params = [name for name, param in module.named_parameters() if param.is_meta]
+    if any(".experts.gate_up_proj" in name or ".experts.down_proj" in name for name in meta_params):
+        # HF stores Qwen3-Omni experts per expert/projection, while the runtime
+        # owns stacked 3-D parameters. The streaming pass above intentionally
+        # skipped those source-only keys; reconstruct only the still-meta fused
+        # destinations before validating materialization.
+        from unirl.train.backend.sharded_load import (
+            _fuse_hf_expert_keys,
+            _read_safetensors_dir,
+        )
+
+        expert_state = _read_safetensors_dir(weights_dir, key_prefix=key_prefix)
+        expert_state = _fuse_hf_expert_keys(expert_state, module)
+        for name in list(meta_params):
+            value = expert_state.get(name)
+            if not isinstance(value, torch.Tensor):
+                continue
+            set_module_tensor_to_device(
+                module,
+                name,
+                device,
+                value=value,
+                dtype=dtype if value.is_floating_point() else value.dtype,
+            )
+            loaded.add(name)
+        del expert_state
+
+    # HF may omit a tied destination (for Talker, codec_head) from the
+    # checkpoint. Re-establish ties before checking for unmaterialized params.
+    if getattr(module, "_tied_weights_keys", None) and hasattr(module, "tie_weights"):
+        module.tie_weights()
+
+    meta_params = [name for name, param in module.named_parameters() if param.is_meta]
+    if meta_params:
+        raise RuntimeError(
+            f"Qwen3OmniTalkerBundle: {len(meta_params)} parameter(s) remained on "
+            f"meta after loading prefix {key_prefix!r}: {meta_params[:8]}"
+        )
+    if not loaded:
+        raise RuntimeError(
+            f"Qwen3OmniTalkerBundle: prefix {key_prefix!r} did not load any "
+            f"state-dict keys for {type(module).__name__}"
+        )
+    if unexpected:
+        logger.debug(
+            "Ignored %d checkpoint key(s) below %s not owned by %s: %s",
+            len(unexpected),
+            key_prefix,
+            type(module).__name__,
+            unexpected[:6],
+        )
+
+    # Parameters are already on ``device``; this moves init-computed,
+    # non-persistent buffers (RoPE/Code2Wav offsets) without a second model copy.
+    module.to(device=device)
+
+
+def _build_frozen_embedding_provider(
+    full_config: Any,
+    *,
+    weights_dir: str,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> FrozenThinkerEmbeddingProvider:
+    from accelerate import init_empty_weights
+
+    text_config = full_config.thinker_config.text_config
+    with init_empty_weights(include_buffers=False):
+        embedding = nn.Embedding(
+            int(text_config.vocab_size),
+            int(text_config.hidden_size),
+            getattr(text_config, "pad_token_id", None),
+        )
+    _stream_load_prefixed_module(
+        embedding,
+        weights_dir,
+        key_prefix="thinker.model.embed_tokens.",
+        device=device,
+        dtype=dtype,
+    )
+    provider = FrozenThinkerEmbeddingProvider(embedding)
+    provider.eval()
+    return provider
+
+
+class Qwen3OmniTalkerBundle(Bundle):
+    """Direct-TTS bundle: frozen input embeddings + Talker/MTP + Code2Wav."""
+
+    def __init__(
+        self,
+        *,
+        transformer: nn.Module,
+        input_embedding_provider: FrozenThinkerEmbeddingProvider,
+        code2wav: nn.Module,
+        processor: Any,
+        tokenizer: Any,
+        config: Any,
+        dtype: torch.dtype,
+        device: torch.device,
+        pretrained_path: str,
+        default_speaker: str = "Ethan",
+        tts_system_instruction: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.input_embedding_provider = input_embedding_provider
+        self._code2wav = code2wav
+        self.processor = processor
+        self.tokenizer = tokenizer
+        self.config = config
+        self.dtype = dtype
+        self.device = device
+        self.pretrained_path = pretrained_path
+        self.enable_talker = True
+        self.default_speaker = str(default_speaker)
+        self.tts_system_instruction = tts_system_instruction
+
+    @property
+    def talker(self) -> nn.Module:
+        return self.transformer
+
+    @property
+    def code2wav(self) -> nn.Module:
+        return self._code2wav
+
+    @property
+    def thinker(self) -> FrozenThinkerEmbeddingProvider:
+        """Compatibility accessor; this is not a full Thinker model."""
+        return self.input_embedding_provider
+
+    @property
+    def omni(self) -> "Qwen3OmniTalkerBundle":
+        """Legacy compatibility facade for callers that only access Omni parts."""
+        return self
+
+    @classmethod
+    def from_config(cls, config: Any) -> "Qwen3OmniTalkerBundle":
+        from accelerate import init_empty_weights
+        from transformers import AutoConfig, AutoProcessor, AutoTokenizer
+        from transformers.models.qwen3_omni_moe import (
+            Qwen3OmniMoeCode2Wav,
+            Qwen3OmniMoeTalkerForConditionalGeneration,
+        )
+
+        path = config.pretrained_model_ckpt_path
+        tokenizer_path = getattr(config, "tokenizer_ckpt_path", None) or path
+        device = config.device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if isinstance(device, str):
+            device = torch.device(device)
+        dtype = parse_torch_dtype(config.model_precision, field_name="model_precision")
+
+        full_config = AutoConfig.from_pretrained(
+            path,
+            trust_remote_code=bool(getattr(config, "trust_remote_code", True)),
+        )
+        if not getattr(full_config, "enable_audio_output", False):
+            raise ValueError(
+                "Qwen3OmniTalkerBundle requires a full Omni checkpoint with "
+                "enable_audio_output=true"
+            )
+        if getattr(config, "attn_implementation", None):
+            full_config.talker_config._attn_implementation = str(config.attn_implementation)
+
+        talker_factory = lambda: Qwen3OmniMoeTalkerForConditionalGeneration(
+            full_config.talker_config
+        )
+        meta_init = bool(getattr(config, "meta_init_transformer", False))
+        if meta_init:
+            talker, meta_init_state = build_meta_init_transformer(
+                talker_factory,
+                dtype=dtype,
+            )
+        else:
+            with init_empty_weights(include_buffers=False):
+                talker = talker_factory()
+            _stream_load_prefixed_module(
+                talker,
+                path,
+                key_prefix="talker.",
+                device=device,
+                dtype=dtype,
+            )
+
+        if getattr(config, "use_gradient_checkpointing", False):
+            if hasattr(talker, "gradient_checkpointing_enable"):
+                talker.gradient_checkpointing_enable(
+                    gradient_checkpointing_kwargs={"use_reentrant": False}
+                )
+            else:
+                logger.warning(
+                    "Talker %s does not expose gradient_checkpointing_enable; skipping.",
+                    type(talker).__name__,
+                )
+
+        freeze_mtp = bool(getattr(config, "freeze_mtp", False))
+        freeze_talker_embeddings = bool(getattr(config, "freeze_talker_embeddings", True))
+        phase1_layer0_lora_only = bool(getattr(config, "phase1_layer0_lora_only", False))
+        if phase1_layer0_lora_only:
+            # Freeze before PEFT injection.  Newly injected layer-0 LoRA tensors
+            # become trainable; a post-injection guard in unirl.train.lora
+            # re-freezes excluded subtrees and verifies the invariant.
+            talker.requires_grad_(False)
+            setattr(talker, "_unirl_phase1_layer0_lora_only", True)
+        if freeze_mtp:
+            talker.code_predictor.requires_grad_(False)
+            setattr(talker, "_unirl_freeze_mtp_after_lora", True)
+        if freeze_talker_embeddings:
+            get_embeddings = getattr(talker, "get_input_embeddings", None)
+            if not callable(get_embeddings):
+                if phase1_layer0_lora_only:
+                    raise TypeError("Phase-1 Talker must expose get_input_embeddings()")
+                logger.warning("Talker %s has no input embedding accessor; cannot freeze it.", type(talker).__name__)
+            else:
+                get_embeddings().requires_grad_(False)
+                setattr(talker, "_unirl_freeze_embeddings_after_lora", True)
+
+        embedding_provider = _build_frozen_embedding_provider(
+            full_config,
+            weights_dir=path,
+            device=device,
+            dtype=dtype,
+        )
+        with init_empty_weights(include_buffers=False):
+            code2wav = Qwen3OmniMoeCode2Wav(full_config.code2wav_config)
+        _stream_load_prefixed_module(
+            code2wav,
+            path,
+            key_prefix="code2wav.",
+            device=device,
+            dtype=dtype,
+        )
+        if bool(getattr(config, "freeze_code2wav", True)):
+            code2wav.requires_grad_(False)
+            code2wav.eval()
+
+        processor = AutoProcessor.from_pretrained(
+            path,
+            trust_remote_code=bool(getattr(config, "trust_remote_code", True)),
+        )
+        if tokenizer_path != path:
+            tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer_path,
+                trust_remote_code=bool(getattr(config, "trust_remote_code", True)),
+            )
+            if hasattr(processor, "tokenizer"):
+                processor.tokenizer = tokenizer
+        else:
+            tokenizer = getattr(processor, "tokenizer", None) or processor
+        if (
+            getattr(tokenizer, "pad_token", None) is None
+            and getattr(tokenizer, "eos_token", None) is not None
+        ):
+            tokenizer.pad_token = tokenizer.eos_token
+
+        bundle = cls(
+            transformer=talker,
+            input_embedding_provider=embedding_provider,
+            code2wav=code2wav,
+            processor=processor,
+            tokenizer=tokenizer,
+            config=full_config,
+            dtype=dtype,
+            device=device,
+            pretrained_path=path,
+            default_speaker=str(getattr(config, "default_speaker", "Ethan")),
+            tts_system_instruction=getattr(config, "tts_system_instruction", None),
+        )
+        if meta_init:
+            # Pattern B: the backend wraps/shards the standalone Talker, then
+            # mmap-reads only ``talker.*`` tensors from the full Omni checkpoint.
+            bundle._transformer_weights_path = path
+            bundle._transformer_weights_key_prefix = "talker."
+            bundle._meta_init_state = meta_init_state
+        return bundle
+
+
+__all__ = [
+    "FrozenThinkerEmbeddingProvider",
+    "Qwen3OmniTalkerBundle",
+]

--- a/unirl/models/qwen3_omni/talker_conditions.py
+++ b/unirl/models/qwen3_omni/talker_conditions.py
@@ -1,0 +1,146 @@
+"""Typed conditions for Qwen3-Omni Talker TTS AR."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from unirl.distributed.tensor.batch import Batch, FieldKind, field
+from unirl.types.conditions import TextTokenCondition
+
+from .talker_contract import NUM_CODE_GROUPS
+from .talker_sampling import TalkerSamplingConfig
+
+
+@dataclass
+class Qwen3OmniTalkerConditions(Batch):
+    """Compact, replayable direct-TTS conditions.
+
+    Conditions intentionally carry IDs/codes only: prompt IDs+mask, discrete
+    speaker IDs, Talker prefix IDs, MTP residual codes, and the exact
+    behavior sampling configuration. Waveforms and full hidden states never
+    enter the trajectory.
+    """
+
+    prompt: Optional[TextTokenCondition] = field(kind=FieldKind.CONCAT, default=None)
+    speaker_ids: Optional[List[int]] = field(kind=FieldKind.CONCAT, default=None)
+    prefix_ids: Optional[List[Any]] = field(kind=FieldKind.CONCAT, default=None)
+    # Legacy input accepted for old rollout adapters. New direct-TTS paths store
+    # speaker_ids instead and never emit this field.
+    speakers: Optional[List[str]] = field(kind=FieldKind.CONCAT, default=None)
+    # Per-sample residual codec codes ``[15, T]`` aligned with frontier layer-0 lengths.
+    # Filled by Talker generate so GSPO ``stage.replay(conditions, segment=...)`` can
+    # recompute MTP logπ without a custom algorithm fork.
+    residual_codes: Optional[List[Any]] = field(kind=FieldKind.CONCAT, default=None)
+    # Per-sample ``[T]`` SFT weights for residual targets. The appended layer-0
+    # EOS has no Mimi residual target and therefore carries weight zero.
+    mtp_loss_masks: Optional[List[Any]] = field(kind=FieldKind.CONCAT, default=None)
+    # Exact layer-0 behavior distribution used by rollout. Replay must not
+    # silently fall back to unfiltered logits.
+    behavior_sampling: Optional[Dict[str, Any]] = field(kind=FieldKind.SHARED, default=None)
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "Qwen3OmniTalkerConditions":
+        prompt = d.get("prompt")
+        if not isinstance(prompt, TextTokenCondition):
+            raise TypeError(
+                f"Qwen3OmniTalkerConditions.from_dict: expected d['prompt'] to be a "
+                f"TextTokenCondition, got {type(prompt).__name__ if prompt is not None else 'None'}"
+            )
+        speakers = d.get("speakers")
+        if speakers is not None and not isinstance(speakers, list):
+            raise TypeError(
+                f"Qwen3OmniTalkerConditions.from_dict: expected d['speakers'] to be a list, "
+                f"got {type(speakers).__name__}"
+            )
+        speaker_ids = d.get("speaker_ids")
+        if speaker_ids is not None and not isinstance(speaker_ids, list):
+            raise TypeError(
+                "Qwen3OmniTalkerConditions.from_dict: expected d['speaker_ids'] "
+                f"to be a list, got {type(speaker_ids).__name__}"
+            )
+        prefix_ids = d.get("prefix_ids")
+        if prefix_ids is not None and not isinstance(prefix_ids, list):
+            raise TypeError(
+                "Qwen3OmniTalkerConditions.from_dict: expected d['prefix_ids'] "
+                f"to be a list, got {type(prefix_ids).__name__}"
+            )
+        mtp_loss_masks = d.get("mtp_loss_masks")
+        if mtp_loss_masks is not None and not isinstance(mtp_loss_masks, list):
+            raise TypeError(
+                "Qwen3OmniTalkerConditions.from_dict: expected d['mtp_loss_masks'] "
+                f"to be a list, got {type(mtp_loss_masks).__name__}"
+            )
+        return cls(
+            prompt=prompt,
+            speaker_ids=[int(v) for v in speaker_ids] if speaker_ids is not None else None,
+            prefix_ids=prefix_ids,
+            speakers=speakers,
+            residual_codes=d.get("residual_codes"),
+            mtp_loss_masks=mtp_loss_masks,
+            behavior_sampling=d.get("behavior_sampling"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        if self.prompt is None:
+            raise ValueError("Qwen3OmniTalkerConditions.to_dict: prompt field is None")
+        out: Dict[str, Any] = {"prompt": self.prompt}
+        if self.speaker_ids is not None:
+            out["speaker_ids"] = [int(v) for v in self.speaker_ids]
+        elif self.speakers is not None:
+            # Compatibility for trajectories produced by the old vLLM adapter.
+            out["speakers"] = list(self.speakers)
+        if self.prefix_ids is not None:
+            out["prefix_ids"] = list(self.prefix_ids)
+        if self.residual_codes is not None:
+            out["residual_codes"] = list(self.residual_codes)
+        if self.mtp_loss_masks is not None:
+            out["mtp_loss_masks"] = list(self.mtp_loss_masks)
+        if self.behavior_sampling is not None:
+            out["behavior_sampling"] = dict(self.behavior_sampling)
+        return out
+
+    def validate_rollout_replay(self, *, lengths: List[int]) -> TalkerSamplingConfig:
+        """Validate the complete, lossless layer-0 trajectory contract."""
+        if self.prompt is None or self.prompt.input_ids is None or self.prompt.attention_mask is None:
+            raise ValueError("Talker rollout replay requires prompt input_ids and attention_mask")
+        batch_size = int(self.prompt.input_ids.shape[0])
+        if len(lengths) != batch_size:
+            raise ValueError(f"Talker replay lengths batch {len(lengths)} != prompt batch {batch_size}")
+        if self.speaker_ids is None:
+            raise ValueError("Talker rollout replay requires discrete speaker_ids")
+        if len(self.speaker_ids) != batch_size:
+            raise ValueError(f"Talker replay speaker_ids len {len(self.speaker_ids)} != batch {batch_size}")
+        if self.prefix_ids is None:
+            raise ValueError("Talker rollout replay requires the exact rollout prefix_ids")
+        if len(self.prefix_ids) != batch_size:
+            raise ValueError(f"Talker replay prefix_ids len {len(self.prefix_ids)} != batch {batch_size}")
+        if self.residual_codes is None:
+            raise ValueError("Talker rollout replay requires the exact rollout residual_codes")
+        if len(self.residual_codes) != batch_size:
+            raise ValueError(f"Talker replay residual_codes len {len(self.residual_codes)} != batch {batch_size}")
+        for index, (raw_prefix, raw_residual, length) in enumerate(
+            zip(self.prefix_ids, self.residual_codes, lengths)
+        ):
+            import torch
+
+            prefix = torch.as_tensor(raw_prefix)
+            residual = torch.as_tensor(raw_residual)
+            if prefix.numel() == 0 or prefix.dim() not in (1, 2):
+                raise ValueError(f"prefix_ids[{index}] must be a non-empty rank-1/2 tensor")
+            if residual.dim() != 2 or residual.shape[0] != NUM_CODE_GROUPS - 1:
+                raise ValueError(
+                    f"residual_codes[{index}] expected [{NUM_CODE_GROUPS - 1}, T], "
+                    f"got {tuple(residual.shape)}"
+                )
+            if int(residual.shape[1]) != int(length):
+                raise ValueError(
+                    f"residual_codes[{index}] timeline {residual.shape[1]} "
+                    f"!= layer-0 timeline {length}"
+                )
+        if self.behavior_sampling is None:
+            raise ValueError("Talker rollout replay requires the exact behavior_sampling payload")
+        return TalkerSamplingConfig.from_dict(dict(self.behavior_sampling))
+
+
+__all__ = ["Qwen3OmniTalkerConditions"]

--- a/unirl/models/qwen3_omni/talker_contract.py
+++ b/unirl/models/qwen3_omni/talker_contract.py
@@ -1,0 +1,20 @@
+"""Stable scalar constants for the Qwen3-Omni direct-TTS contract.
+
+Phase-1 RL treats only layer-0 codec tokens, including codec EOS, as policy
+actions. Frozen MTP residual codes are replay state and Code2Wav output is a
+reward observation; neither contributes an independently weighted policy
+log-probability.
+"""
+
+from __future__ import annotations
+
+# Mimi / Qwen3-Omni talker codebook groups (layer0 + 15 residual).
+NUM_CODE_GROUPS: int = 16
+
+# Code2Wav / Mimi operating rate.
+AUDIO_SAMPLE_RATE: int = 24000
+
+__all__ = [
+    "AUDIO_SAMPLE_RATE",
+    "NUM_CODE_GROUPS",
+]

--- a/unirl/models/qwen3_omni/talker_data.py
+++ b/unirl/models/qwen3_omni/talker_data.py
@@ -1,0 +1,149 @@
+"""Offline Talker codec-data provenance helpers.
+
+Fingerprints are deliberately cheap enough to compute on every training worker:
+configuration files are content-hashed and local weight shards are identified by
+their relative name and byte size.  The resulting digest catches model/revision,
+codec-layout, and accidental checkpoint-directory mismatches without reading a
+multi-hundred-GB checkpoint into memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from .talker_contract import AUDIO_SAMPLE_RATE, NUM_CODE_GROUPS
+
+FINGERPRINT_SCHEMA = "unirl.talker-fingerprint.v1"
+CODEC_DATA_SCHEMA = "unirl.talker-codec-data.v1"
+
+_METADATA_FILES = (
+    "config.json",
+    "generation_config.json",
+    "model.safetensors.index.json",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _local_identity(path: Path) -> Dict[str, Any]:
+    files: Dict[str, Any] = {}
+    for name in _METADATA_FILES:
+        candidate = path / name
+        if candidate.is_file():
+            files[name] = {"sha256": _sha256_file(candidate), "size": candidate.stat().st_size}
+    shards = sorted(path.glob("*.safetensors"))
+    if shards:
+        files["weight_shards"] = [{"name": shard.name, "size": shard.stat().st_size} for shard in shards]
+    if not files:
+        raise FileNotFoundError(
+            f"Cannot fingerprint {str(path)!r}: no model/config metadata or safetensors shards found."
+        )
+    return {"type": "local", "files": files}
+
+
+def model_fingerprint(
+    reference: str,
+    *,
+    kind: str,
+    revision: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return a stable model/checkpoint fingerprint dictionary."""
+    reference = str(reference).strip()
+    if not reference:
+        raise ValueError("model_fingerprint requires a non-empty model reference")
+    path = Path(reference).expanduser()
+    if path.exists():
+        identity = _local_identity(path.resolve() if path.is_dir() else path.resolve().parent)
+    else:
+        identity = {"type": "hub", "repository": reference, "revision": revision or "default"}
+    payload = {
+        "schema": FINGERPRINT_SCHEMA,
+        "kind": str(kind),
+        "identity": identity,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return {
+        "schema": FINGERPRINT_SCHEMA,
+        "kind": str(kind),
+        "source": reference,
+        "revision": revision,
+        "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+    }
+
+
+def codec_fingerprint(
+    reference: str,
+    *,
+    revision: Optional[str] = None,
+    sample_rate: int = AUDIO_SAMPLE_RATE,
+    channels: int = 1,
+    num_quantizers: int = NUM_CODE_GROUPS,
+) -> Dict[str, Any]:
+    """Fingerprint the Mimi weights together with the exact encoded layout."""
+    model = model_fingerprint(reference, kind="mimi_codec_model", revision=revision)
+    payload = {
+        "schema": FINGERPRINT_SCHEMA,
+        "kind": "mimi_codec",
+        "model_sha256": model["sha256"],
+        "sample_rate": int(sample_rate),
+        "channels": int(channels),
+        "num_quantizers": int(num_quantizers),
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return {
+        **payload,
+        "source": reference,
+        "revision": revision,
+        "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+    }
+
+
+def fingerprint_sha(value: Any, *, field_name: str) -> str:
+    """Extract and validate a fingerprint digest from a dict or raw SHA string."""
+    if isinstance(value, Mapping):
+        if value.get("schema") != FINGERPRINT_SCHEMA:
+            raise ValueError(f"{field_name} has schema {value.get('schema')!r}; expected {FINGERPRINT_SCHEMA!r}.")
+        value = value.get("sha256")
+    digest = str(value or "").strip().lower()
+    if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+        raise ValueError(f"{field_name} must contain a 64-character SHA-256 digest.")
+    return digest
+
+
+def assert_fingerprint(
+    actual: Any,
+    expected: Any,
+    *,
+    field_name: str,
+    sample_id: str,
+) -> None:
+    actual_sha = fingerprint_sha(actual, field_name=field_name)
+    expected_sha = fingerprint_sha(expected, field_name=f"expected_{field_name}")
+    if actual_sha != expected_sha:
+        raise ValueError(
+            f"Talker SFT record {sample_id!r} {field_name} mismatch: "
+            f"row={actual_sha}, expected={expected_sha}. Re-encode offline with the configured model/codec."
+        )
+
+
+__all__ = [
+    "CODEC_DATA_SCHEMA",
+    "FINGERPRINT_SCHEMA",
+    "assert_fingerprint",
+    "codec_fingerprint",
+    "fingerprint_sha",
+    "model_fingerprint",
+]

--- a/unirl/models/qwen3_omni/talker_oracle.py
+++ b/unirl/models/qwen3_omni/talker_oracle.py
@@ -1,0 +1,178 @@
+"""Adapters around the official Qwen3-Omni implementation used for parity tests.
+
+This module deliberately keeps oracle calls separate from production helpers:
+tests compare independently constructed prefixes/mixes/decodes instead of
+having both sides call the same implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class OracleTalkerPrefix:
+    inputs_embeds: torch.Tensor
+    input_ids: torch.Tensor
+    trailing_text_hidden: torch.Tensor
+    tts_pad_embed: torch.Tensor
+
+
+def checkpoint_skip_reason(path: Optional[str]) -> Optional[str]:
+    """Return why ``path`` cannot be used as a real Omni oracle checkpoint."""
+    if not path:
+        return "QWEN3_OMNI_PATH is not set"
+    root = Path(path)
+    config_path = root / "config.json"
+    if not config_path.is_file():
+        return f"{config_path} is missing"
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return f"cannot read {config_path}: {exc}"
+    if not config.get("enable_audio_output", False):
+        return "checkpoint config has enable_audio_output=false"
+    if "talker_config" not in config or "code2wav_config" not in config:
+        return "checkpoint config does not contain Talker and Code2Wav configs"
+    has_weights = (root / "model.safetensors").is_file() or (root / "model.safetensors.index.json").is_file()
+    has_weights = has_weights or any(root.glob("model-*.safetensors"))
+    if not has_weights:
+        return f"{root} has config assets but no model safetensors"
+    return None
+
+
+def build_oracle_talker_prefix(
+    omni: Any,
+    *,
+    thinker_outputs: Any,
+    input_ids: torch.Tensor,
+    speaker_name: str,
+    device: torch.device,
+    batch_idx: int = 0,
+) -> OracleTalkerPrefix:
+    """Build a text-only prefix through the official private oracle methods."""
+    config = omni.config
+    sample_ids = input_ids[batch_idx : batch_idx + 1].to(device)
+    thinker_embed = thinker_outputs.hidden_states[0][batch_idx : batch_idx + 1].to(device)
+    accept_layer = int(config.talker_config.accept_hidden_layer)
+    thinker_hidden = thinker_outputs.hidden_states[accept_layer][batch_idx : batch_idx + 1].to(device)
+    multimodal_mask = torch.zeros_like(sample_ids, dtype=torch.bool, device=device)
+
+    starts = torch.nonzero(sample_ids[0] == config.im_start_token_id).view(-1)
+    starts = torch.cat((starts, torch.tensor([sample_ids.shape[1]], dtype=starts.dtype, device=device)))
+    special = torch.tensor(
+        [[config.tts_bos_token_id, config.tts_eos_token_id, config.tts_pad_token_id]],
+        dtype=sample_ids.dtype,
+        device=device,
+    )
+    thinker_embeddings = omni.thinker.get_input_embeddings()
+    if hasattr(thinker_embeddings, "base_layer"):
+        thinker_embeddings = thinker_embeddings.base_layer
+    tts_bos, tts_eos, tts_pad = (
+        omni.talker.text_projection(thinker_embeddings(special)).to(device).chunk(3, dim=1)
+    )
+    speaker_id = config.talker_config.speaker_id.get(str(speaker_name).lower())
+    if speaker_id is None:
+        raise ValueError(f"unknown oracle speaker {speaker_name!r}")
+
+    embed_parts = []
+    id_parts = []
+    trailing = None
+    for index in range(len(starts) - 1):
+        start = starts[index]
+        end = starts[index + 1]
+        role = sample_ids[0, start + 1]
+        if role == config.system_token_id:
+            continue
+        if role == config.user_token_id:
+            embed_parts.append(
+                omni._get_talker_user_parts(
+                    start,
+                    end,
+                    multimodal_mask,
+                    thinker_hidden,
+                    thinker_embed,
+                )
+            )
+            id_parts.append(sample_ids[:, start:end])
+        elif role == config.assistant_token_id and index == len(starts) - 2:
+            assistant_embed, assistant_ids, trailing = omni._get_talker_assistant_parts(
+                start,
+                end,
+                int(speaker_id),
+                thinker_embed,
+                tts_pad,
+                tts_bos,
+                tts_eos,
+            )
+            embed_parts.append(assistant_embed)
+            id_parts.append(assistant_ids)
+        elif role != config.assistant_token_id:
+            raise AssertionError(f"unexpected role token {int(role)}")
+    if trailing is None:
+        raise RuntimeError("official oracle did not find the final assistant span")
+    return OracleTalkerPrefix(
+        inputs_embeds=torch.cat(embed_parts, dim=1),
+        input_ids=torch.cat(id_parts, dim=1),
+        trailing_text_hidden=trailing,
+        tts_pad_embed=tts_pad,
+    )
+
+
+def oracle_prepare_residual_step(
+    talker: Any,
+    *,
+    layer0_ids: torch.Tensor,
+    hidden_states: Any,
+    generation_step: int,
+    trailing_text_hidden: torch.Tensor,
+    tts_pad_embed: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Invoke the official ``prepare_inputs_for_generation`` residual branch."""
+    layer0_ids = layer0_ids.to(dtype=torch.long).view(-1, 1)
+    prepared = talker.prepare_inputs_for_generation(
+        layer0_ids,
+        attention_mask=torch.ones_like(layer0_ids),
+        is_first_iteration=False,
+        use_cache=True,
+        hidden_states=hidden_states,
+        generation_step=int(generation_step),
+        trailing_text_hidden=trailing_text_hidden,
+        tts_pad_embed=tts_pad_embed,
+    )
+    return prepared["inputs_embeds"], prepared["residual_codes"]
+
+
+def manual_chunked_decode(
+    code2wav: Any,
+    codes: torch.Tensor,
+    *,
+    chunk_size: int = 300,
+    left_context_size: int = 25,
+) -> torch.Tensor:
+    """Independent transcription of the official chunked decoder."""
+    chunks = []
+    start = 0
+    while start < codes.shape[-1]:
+        end = min(start + int(chunk_size), codes.shape[-1])
+        context = int(left_context_size) if start - int(left_context_size) > 0 else start
+        wav = code2wav(codes[..., start - context : end])
+        chunks.append(wav[..., context * int(code2wav.total_upsample) :])
+        start = end
+    if not chunks:
+        return torch.empty((*codes.shape[:-2], 1, 0), dtype=torch.float32, device=codes.device)
+    return torch.cat(chunks, dim=-1)
+
+
+__all__ = [
+    "OracleTalkerPrefix",
+    "build_oracle_talker_prefix",
+    "checkpoint_skip_reason",
+    "manual_chunked_decode",
+    "oracle_prepare_residual_step",
+]

--- a/unirl/models/qwen3_omni/talker_pipeline.py
+++ b/unirl/models/qwen3_omni/talker_pipeline.py
@@ -1,0 +1,298 @@
+"""Typed TTS rollout pipeline for Qwen3-Omni Talker."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+
+from unirl.models.types.pipeline import Pipeline
+from unirl.types.conditions import TextTokenCondition
+from unirl.types.primitives import Audios, Texts
+from unirl.types.sample import Sample
+from unirl.types.sampling import ARSamplingParams
+
+from .bundle import Qwen3OmniBundle
+from .talker_ar import Qwen3OmniTalkerARParams, Qwen3OmniTalkerARStage
+from .talker_bundle import Qwen3OmniTalkerBundle
+from .talker_conditions import Qwen3OmniTalkerConditions
+from .talker_contract import AUDIO_SAMPLE_RATE
+from .talker_prefix import resolve_speaker_id
+
+TalkerBundle = Union[Qwen3OmniBundle, Qwen3OmniTalkerBundle]
+
+
+_DEFAULT_TTS_SYSTEM = (
+    "You are a high-quality TTS model. Convert the user's text into natural speech audio."
+)
+
+
+def build_tts_messages(
+    *,
+    text: str,
+    system_instruction: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Teacher-provided assistant transcript for native Talker text alignment.
+
+    Qwen3-Omni Talker injects the final assistant span into
+    ``trailing_text_hidden`` one text token per codec step. Using
+    ``assistant=<audio>`` leaves that timeline nearly empty and lets SFT reduce
+    codec CE without learning what to say. Direct TTS therefore supplies the
+    desired transcript as the assistant text while the user turn states the
+    read-aloud task.
+    """
+    return [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": system_instruction or _DEFAULT_TTS_SYSTEM}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": f"Read the following text aloud:\n{text}"}],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    ]
+
+
+def tokenize_tts_batch(
+    bundle: TalkerBundle,
+    texts: List[str],
+    *,
+    system_instruction: Optional[str] = None,
+    max_length: int = 4096,
+) -> TextTokenCondition:
+    """Tokenize a batch of TTS prompts into left-aligned padded tensors."""
+    tokenizer = bundle.tokenizer
+    processor = bundle.processor
+    input_rows: List[List[int]] = []
+    for text in texts:
+        messages = build_tts_messages(text=text, system_instruction=system_instruction)
+        # Use the Omni processor with explicit text content mappings. Its
+        # checkpoint owns the chat template; the nested tokenizer does not.
+        tmpl = getattr(processor, "apply_chat_template", None) or getattr(tokenizer, "apply_chat_template", None)
+        if tmpl is None:
+            raise RuntimeError("tokenize_tts_batch: processor/tokenizer missing apply_chat_template")
+        ids = tmpl(
+            messages,
+            tokenize=True,
+            add_generation_prompt=False,
+            return_tensors=None,
+        )
+        if isinstance(ids, dict):
+            ids = ids.get("input_ids") or ids.get("input_ids".upper())
+        if isinstance(ids, torch.Tensor):
+            ids = ids.view(-1).tolist()
+        elif (
+            isinstance(ids, (list, tuple))
+            and len(ids) == 1
+            and isinstance(ids[0], (list, tuple))
+        ):
+            ids = ids[0]
+        input_rows.append([int(t) for t in ids])
+
+    max_len = min(max(len(r) for r in input_rows), int(max_length))
+    pad_id = int(getattr(tokenizer, "pad_token_id", None) or 0)
+    batch_ids = []
+    batch_mask = []
+    for row in input_rows:
+        row = row[:max_len]
+        pad = max_len - len(row)
+        # Left pad so the assistant span stays right-aligned for Talker prefix.
+        batch_ids.append([pad_id] * pad + row)
+        batch_mask.append([0] * pad + [1] * len(row))
+    device = bundle.device
+    return TextTokenCondition(
+        input_ids=torch.tensor(batch_ids, dtype=torch.long, device=device),
+        attention_mask=torch.tensor(batch_mask, dtype=torch.long, device=device),
+    )
+
+
+class Qwen3OmniTalkerPipeline(Pipeline):
+    """Talker TTS pipeline: text(+speaker) → codec TextSegment + Audios."""
+
+    def __init__(
+        self,
+        *,
+        bundle: TalkerBundle,
+        ar: Optional[Qwen3OmniTalkerARStage] = None,
+        max_prompt_length: int = 4096,
+        system_instruction: Optional[str] = None,
+        autocast_precision: str = "bf16",
+        logprob_precision: str = "fp32",
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+        suppress_special_tokens: bool = True,
+        suppress_token_ids: Optional[List[int]] = None,
+        eos_token_id: Optional[int] = None,
+        disable_eos: bool = False,
+        decode_audio: bool = True,
+    ) -> None:
+        super().__init__()
+        if not bundle.enable_talker:
+            raise ValueError("Qwen3OmniTalkerPipeline requires bundle.enable_talker=True")
+        self.bundle = bundle
+        self.max_prompt_length = int(max_prompt_length)
+        self.system_instruction = system_instruction or bundle.tts_system_instruction or _DEFAULT_TTS_SYSTEM
+        self.decode_audio = bool(decode_audio)
+        self.do_sample = bool(do_sample)
+        self.repetition_penalty = float(repetition_penalty)
+        self.suppress_special_tokens = bool(suppress_special_tokens)
+        self.suppress_token_ids = (
+            None if suppress_token_ids is None else [int(token_id) for token_id in suppress_token_ids]
+        )
+        self.eos_token_id = None if eos_token_id is None else int(eos_token_id)
+        self.disable_eos = bool(disable_eos)
+        self.ar = ar or Qwen3OmniTalkerARStage(
+            model=bundle,
+            autocast_precision=autocast_precision,
+            logprob_precision=logprob_precision,
+        )
+
+    @classmethod
+    def from_bundle(
+        cls,
+        bundle: TalkerBundle,
+        *,
+        max_prompt_length: int = 4096,
+        system_instruction: Optional[str] = None,
+        autocast_precision: str = "bf16",
+        logprob_precision: str = "fp32",
+        do_sample: bool = True,
+        repetition_penalty: float = 1.05,
+        suppress_special_tokens: bool = True,
+        suppress_token_ids: Optional[List[int]] = None,
+        eos_token_id: Optional[int] = None,
+        disable_eos: bool = False,
+        decode_audio: bool = True,
+        **_kwargs: Any,
+    ) -> "Qwen3OmniTalkerPipeline":
+        return cls(
+            bundle=bundle,
+            max_prompt_length=max_prompt_length,
+            system_instruction=system_instruction,
+            autocast_precision=autocast_precision,
+            logprob_precision=logprob_precision,
+            do_sample=do_sample,
+            repetition_penalty=repetition_penalty,
+            suppress_special_tokens=suppress_special_tokens,
+            suppress_token_ids=suppress_token_ids,
+            eos_token_id=eos_token_id,
+            disable_eos=disable_eos,
+            decode_audio=decode_audio,
+        )
+
+    def _speaker_ids_from_sample(self, sample: Sample, batch_size: int) -> List[int]:
+        meta = sample.root_metadata(-1)
+        owner = getattr(self.bundle, "omni", None) or self.bundle
+        speaker_ids: List[int] = []
+        for i in range(batch_size):
+            m = meta[i] if meta is not None and i < len(meta) else None
+            if isinstance(m, dict) and m.get("speaker_id") is not None:
+                speaker_ids.append(int(m["speaker_id"]))
+            else:
+                speaker = (
+                    str(m["speaker"])
+                    if isinstance(m, dict) and m.get("speaker")
+                    else self.bundle.default_speaker
+                )
+                speaker_ids.append(resolve_speaker_id(owner, speaker))
+        return speaker_ids
+
+    def _conditions_for(self, sample: Sample) -> Qwen3OmniTalkerConditions:
+        texts_prim = None
+        for prim in sample.conditioning():
+            if isinstance(prim, Texts):
+                texts_prim = prim
+                break
+        if texts_prim is None:
+            raise ValueError("Qwen3OmniTalkerPipeline: conditioning must include Texts prompts")
+        texts = list(texts_prim.texts)
+        speaker_ids = self._speaker_ids_from_sample(sample, len(texts))
+        prompt = tokenize_tts_batch(
+            self.bundle,
+            texts,
+            system_instruction=self.system_instruction,
+            max_length=self.max_prompt_length,
+        )
+        return Qwen3OmniTalkerConditions(prompt=prompt, speaker_ids=speaker_ids)
+
+    def generate(self, sample: Sample) -> Sample:
+        frontier = sample.frontier_gen_part(ARSamplingParams)
+        ar = frontier.sampling_params
+        assert isinstance(ar, ARSamplingParams)
+
+        conds = self._conditions_for(sample)
+        params = Qwen3OmniTalkerARParams(
+            max_tokens=int(ar.max_new_tokens),
+            temperature=float(ar.temperature),
+            top_p=float(ar.top_p),
+            top_k=int(ar.top_k),
+            repetition_penalty=self.repetition_penalty,
+            do_sample=self.do_sample,
+            suppress_special_tokens=self.suppress_special_tokens,
+            suppress_token_ids=self.suppress_token_ids,
+            eos_token_id=self.eos_token_id,
+            disable_eos=self.disable_eos,
+        )
+        sampling_params = ARSamplingParams(
+            samples_per_prompt=int(ar.samples_per_prompt),
+            max_new_tokens=int(params.max_tokens),
+            temperature=float(params.temperature),
+            top_p=float(params.top_p),
+            top_k=int(params.top_k),
+            stop_token_id=ar.stop_token_id,
+        )
+        segment, talker_ctrl = self.ar.autoregress(conds, sampling_params=sampling_params, params=params)
+
+        # Attach residuals onto conditions so TrainStack/GSPO replay can see them.
+        conds = Qwen3OmniTalkerConditions(
+            prompt=conds.prompt,
+            speaker_ids=talker_ctrl["speaker_ids"],
+            prefix_ids=talker_ctrl["prefix_ids"],
+            residual_codes=talker_ctrl["residual_codes"],
+            behavior_sampling=dict(talker_ctrl["behavior_sampling"]),
+        )
+
+        primitives: Dict[str, Any] = {}
+        # Keep the spoken transcript on the frontier for text-routed diagnostics.
+        texts_prim = None
+        for prim in sample.conditioning():
+            if isinstance(prim, Texts):
+                texts_prim = prim
+                break
+        if texts_prim is not None:
+            primitives["text"] = texts_prim
+
+        if self.decode_audio and segment.tokens is not None and segment.cu_seqlens is not None:
+            cu = [int(c) for c in segment.cu_seqlens.tolist()]
+            layer0_list = [segment.tokens[cu[i] : cu[i + 1]].detach().cpu() for i in range(len(cu) - 1)]
+            wavs = self.ar.decode_codes_to_audio(
+                layer0_codes=layer0_list,
+                residual_codes=list(talker_ctrl["residual_codes"]),
+            )
+            from unirl.types.primitives import Audio
+
+            audio_items = []
+            for w in wavs:
+                if w.numel() == 0:
+                    audio_items.append(Audio(waveform=torch.zeros(1)))
+                else:
+                    # Audios pack along L; keep mono [L].
+                    audio_items.append(Audio(waveform=w.reshape(-1)))
+            primitives["audio"] = Audios.from_list(audio_items)
+
+        filled = frontier.fill(
+            segment=segment,
+            primitives=primitives,
+            conditions=conds.to_dict(),
+            primitive_metadata={"audio": {"sample_rate": AUDIO_SAMPLE_RATE}} if "audio" in primitives else None,
+            status=segment.status,
+        )
+        return sample.replace_frontier(filled)
+
+
+__all__ = [
+    "Qwen3OmniTalkerPipeline",
+    "build_tts_messages",
+    "tokenize_tts_batch",
+]

--- a/unirl/models/qwen3_omni/talker_prefix.py
+++ b/unirl/models/qwen3_omni/talker_prefix.py
@@ -1,0 +1,193 @@
+"""Direct-TTS Talker prefix construction independent of private oracle APIs."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+import torch
+
+
+def resolve_speaker_id(omni: Any, speaker_name: str) -> int:
+    """Map a speaker display name to the discrete Talker speaker token id."""
+    speaker_map = getattr(omni.config.talker_config, "speaker_id", None) or {}
+    speaker_id = speaker_map.get(str(speaker_name).lower())
+    if speaker_id is None:
+        known = sorted(speaker_map.keys())
+        raise ValueError(f"Speaker {speaker_name!r} not in talker_config.speaker_id; known={known}")
+    return int(speaker_id)
+
+
+def build_talker_prefix_tts(
+    model: Any,
+    *,
+    input_ids: torch.Tensor,
+    device: torch.device,
+    thinker_outputs: Any = None,
+    speaker_name: Optional[str] = None,
+    speaker_id: Optional[int] = None,
+    expected_prefix_ids: Optional[torch.Tensor] = None,
+    batch_idx: int = 0,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build Talker prefix embeds/ids for one TTS sample.
+
+    Returns
+    -------
+    talker_input_embed : [1, P, H]
+    talker_input_ids : [1, P]
+    trailing_text_hidden : [1, T_text, H]
+    tts_pad_embed : [1, 1, H]
+    """
+    config = model.config
+    talker = model.talker
+    sample_input_ids = input_ids[batch_idx : batch_idx + 1].to(device)
+    provider = getattr(model, "input_embedding_provider", None)
+    if provider is None:
+        thinker = getattr(model, "thinker", None)
+        get_embeddings = getattr(thinker, "get_input_embeddings", None)
+        if not callable(get_embeddings):
+            raise TypeError(
+                "build_talker_prefix_tts requires an input_embedding_provider "
+                "or a legacy thinker.get_input_embeddings() accessor"
+            )
+        provider = get_embeddings()
+        if hasattr(provider, "base_layer"):
+            provider = provider.base_layer
+    if thinker_outputs is not None:
+        # Compatibility/oracle path. hidden_states[0] is the input embedding,
+        # not a transformed Thinker hidden state.
+        thinker_embed = thinker_outputs.hidden_states[0][batch_idx : batch_idx + 1].to(device)
+    else:
+        # Direct TTS performs exactly one frozen embedding lookup. It does not
+        # execute the Thinker decoder, vision tower, or audio tower.
+        with torch.no_grad():
+            thinker_embed = provider(sample_input_ids).to(device)
+
+    im_start_positions = torch.nonzero(sample_input_ids[0] == config.im_start_token_id).view(-1)
+    im_start_indexes = torch.cat(
+        (im_start_positions, torch.tensor([sample_input_ids.shape[1]], device=device, dtype=im_start_positions.dtype)),
+        dim=0,
+    )
+
+    talker_special_tokens = torch.tensor(
+        [[config.tts_bos_token_id, config.tts_eos_token_id, config.tts_pad_token_id]],
+        device=device,
+        dtype=sample_input_ids.dtype,
+    )
+
+    tts_bos_embed, tts_eos_embed, tts_pad_embed = (
+        talker.text_projection(provider(talker_special_tokens))
+        .to(device)
+        .chunk(3, dim=1)
+    )
+
+    if speaker_id is None:
+        if speaker_name is None:
+            raise ValueError("build_talker_prefix_tts requires speaker_id or speaker_name")
+        speaker_id = resolve_speaker_id(model, speaker_name)
+    speaker_id = int(speaker_id)
+
+    talker_input_embeds = []
+    talker_input_ids = []
+    trailing_text_hidden = None
+
+    for i in range(len(im_start_indexes) - 1):
+        im_start_index = im_start_indexes[i]
+        segment_end_index = im_start_indexes[i + 1]
+        role_token = sample_input_ids[0][im_start_index + 1]
+
+        if role_token == config.system_token_id:
+            continue
+        if role_token == config.user_token_id:
+            # Direct TTS is text-only: every user token follows the official
+            # text_projection(Thinker input embedding) branch.
+            user_part = talker.text_projection(
+                thinker_embed[:, im_start_index:segment_end_index]
+            ).to(device)
+            talker_input_embeds.append(user_part.to(dtype=talker.dtype))
+            talker_input_ids.append(sample_input_ids[:, im_start_index:segment_end_index])
+        elif role_token == config.assistant_token_id and i == len(im_start_indexes) - 2:
+            assistant_hidden = talker.text_projection(
+                thinker_embed[:, im_start_index:segment_end_index]
+            ).to(device)
+            if assistant_hidden.shape[1] < 4:
+                raise RuntimeError(
+                    "build_talker_prefix_tts: final assistant span must contain at least "
+                    "<im_start>, role, newline, and one content token"
+                )
+            assistant_text_hidden = torch.cat(
+                (
+                    assistant_hidden[:, :3],
+                    tts_pad_embed.expand(-1, 4, -1),
+                    tts_bos_embed,
+                    assistant_hidden[:, 3:4],
+                ),
+                dim=1,
+            )
+            codec_special_tokens = torch.tensor(
+                [
+                    [
+                        config.talker_config.codec_nothink_id,
+                        config.talker_config.codec_think_bos_id,
+                        config.talker_config.codec_think_eos_id,
+                        speaker_id,
+                        config.talker_config.codec_pad_id,
+                        config.talker_config.codec_bos_id,
+                    ]
+                ],
+                dtype=torch.long,
+                device=device,
+            )
+            assistant_codec_hidden = torch.cat(
+                (
+                    torch.zeros(
+                        (1, 3, config.talker_config.text_config.hidden_size),
+                        device=device,
+                        dtype=talker.dtype,
+                    ),
+                    talker.get_input_embeddings()(codec_special_tokens).to(device),
+                ),
+                dim=1,
+            )
+            assistant_embeds = assistant_text_hidden + assistant_codec_hidden
+            assistant_ids = torch.full(
+                (1, assistant_text_hidden.shape[1]),
+                fill_value=config.tts_pad_token_id,
+                dtype=torch.long,
+                device=device,
+            )
+            trailing_text_hidden = torch.cat((assistant_hidden[:, 4:], tts_eos_embed), dim=1)
+            talker_input_embeds.append(assistant_embeds)
+            talker_input_ids.append(assistant_ids)
+        elif role_token == config.assistant_token_id:
+            continue
+        else:
+            raise AssertionError(
+                f"Expect role id after <|im_start|> (assistant/user/system), got token={int(role_token)}"
+            )
+
+    if trailing_text_hidden is None:
+        raise RuntimeError("build_talker_prefix_tts: failed to build trailing_text_hidden (missing assistant span)")
+
+    talker_input_embed = torch.cat([embed.to(device) for embed in talker_input_embeds], dim=1)
+    talker_input_id = torch.cat([ids.to(device) for ids in talker_input_ids], dim=1)
+    if expected_prefix_ids is not None:
+        expected = torch.as_tensor(
+            expected_prefix_ids,
+            device=device,
+            dtype=talker_input_id.dtype,
+        )
+        if expected.numel() != talker_input_id.numel():
+            raise ValueError(
+                "build_talker_prefix_tts: replay prefix ID length "
+                f"{expected.numel()} != reconstructed {talker_input_id.numel()}"
+            )
+        expected = expected.view_as(talker_input_id)
+        if not torch.equal(talker_input_id, expected):
+            raise ValueError(
+                "build_talker_prefix_tts: reconstructed prefix IDs differ from "
+                "the replay trajectory"
+            )
+    return talker_input_embed, talker_input_id, trailing_text_hidden.to(device), tts_pad_embed
+
+
+__all__ = ["build_talker_prefix_tts", "resolve_speaker_id"]

--- a/unirl/models/qwen3_omni/talker_residual.py
+++ b/unirl/models/qwen3_omni/talker_residual.py
@@ -1,0 +1,247 @@
+"""Official Qwen3-Omni MTP residual-hidden mixing primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+import torch
+
+
+@dataclass(frozen=True)
+class TalkerResidualStep:
+    """Residual codec ids and the mixed hidden used by the next Talker step."""
+
+    residual_codes: torch.Tensor
+    next_codec_hidden: torch.Tensor
+    log_probs: Optional[torch.Tensor] = None
+
+
+def _predictor_embeddings(code_predictor: Any) -> Sequence[torch.nn.Module]:
+    embeddings = code_predictor.get_input_embeddings()
+    if not isinstance(embeddings, (torch.nn.ModuleList, list, tuple)):
+        raise TypeError("code_predictor.get_input_embeddings() must return per-codebook embedding modules")
+    return embeddings
+
+
+def mix_residual_hidden(
+    *,
+    layer0_hidden: torch.Tensor,
+    residual_codes: torch.Tensor,
+    predictor_hidden_states: Sequence[Any],
+    predictor_embeddings: Sequence[torch.nn.Module],
+) -> torch.Tensor:
+    """Reproduce the official residual mixer in ``prepare_inputs_for_generation``.
+
+    The first term is the sampled layer-0 embedding.  Intermediate terms are
+    MTP model hidden states, not embeddings of the corresponding residual ids.
+    Only the final residual code uses its embedding table.
+    """
+    if layer0_hidden.dim() != 3 or layer0_hidden.shape[1] != 1:
+        raise ValueError(f"layer0_hidden must be [B, 1, H], got {tuple(layer0_hidden.shape)}")
+    if residual_codes.dim() != 2:
+        raise ValueError(f"residual_codes must be [B, R], got {tuple(residual_codes.shape)}")
+    num_residual = int(residual_codes.shape[1])
+    if num_residual < 1:
+        raise ValueError("residual_codes must contain at least one residual code")
+    if len(predictor_embeddings) < num_residual:
+        raise ValueError(f"need {num_residual} residual embedding tables, got {len(predictor_embeddings)}")
+
+    # HF generate returns one hidden-state entry per predictor forward.  The
+    # first predicts residual-1 from [Talker hidden, layer0 embedding].  The
+    # following R-1 entries expose the hidden for residuals 1..R-1.
+    middle_entries = list(predictor_hidden_states[1:])
+    if len(middle_entries) != num_residual - 1:
+        raise ValueError(
+            "predictor_hidden_states must contain one entry per generated residual; "
+            f"expected {num_residual}, got {len(predictor_hidden_states)}"
+        )
+
+    middle_hiddens = []
+    for entry in middle_entries:
+        hidden = entry[0] if isinstance(entry, (tuple, list)) else entry
+        if hidden.dim() != 3:
+            raise ValueError(f"predictor hidden must be rank 3, got {tuple(hidden.shape)}")
+        middle_hiddens.append(hidden.to(device=layer0_hidden.device, dtype=layer0_hidden.dtype))
+
+    final_hidden = predictor_embeddings[num_residual - 1](residual_codes[..., -1:]).to(
+        device=layer0_hidden.device, dtype=layer0_hidden.dtype
+    )
+    codec_hiddens = [layer0_hidden, *middle_hiddens, final_hidden]
+    return torch.cat(codec_hiddens, dim=1).sum(dim=1, keepdim=True)
+
+
+def residual_step_from_generate(
+    *,
+    talker: Any,
+    layer0_ids: torch.Tensor,
+    predictor_result: Any,
+) -> TalkerResidualStep:
+    """Convert an MTP ``generate`` result to the official next-step state."""
+    layer0_ids = layer0_ids.to(dtype=torch.long).view(-1, 1)
+    residual_codes = predictor_result.sequences.to(device=layer0_ids.device, dtype=torch.long)
+    layer0_hidden = talker.get_input_embeddings()(layer0_ids)
+    next_hidden = mix_residual_hidden(
+        layer0_hidden=layer0_hidden,
+        residual_codes=residual_codes,
+        predictor_hidden_states=predictor_result.hidden_states,
+        predictor_embeddings=_predictor_embeddings(talker.code_predictor),
+    )
+    return TalkerResidualStep(residual_codes=residual_codes, next_codec_hidden=next_hidden)
+
+
+def predict_residual_step(
+    *,
+    talker: Any,
+    past_hidden: torch.Tensor,
+    layer0_ids: torch.Tensor,
+) -> TalkerResidualStep:
+    """Run the frozen MTP decoder using the exact official generation settings."""
+    layer0_ids = layer0_ids.to(device=past_hidden.device, dtype=torch.long).view(-1, 1)
+    layer0_hidden = talker.get_input_embeddings()(layer0_ids)
+    result = talker.code_predictor.generate(
+        inputs_embeds=torch.cat((past_hidden, layer0_hidden), dim=1),
+        max_new_tokens=int(talker.config.num_code_groups) - 1,
+        do_sample=True,
+        top_k=50,
+        top_p=0.8,
+        output_hidden_states=True,
+        return_dict_in_generate=True,
+    )
+    return residual_step_from_generate(talker=talker, layer0_ids=layer0_ids, predictor_result=result)
+
+
+def replay_residual_step(
+    *,
+    talker: Any,
+    past_hidden: torch.Tensor,
+    layer0_ids: torch.Tensor,
+    residual_codes: torch.Tensor,
+    return_log_probs: bool = False,
+    use_cache: bool = True,
+) -> TalkerResidualStep:
+    """Teacher-force frozen residual ids while preserving official MTP hiddens."""
+    layer0_ids = layer0_ids.to(device=past_hidden.device, dtype=torch.long).view(-1, 1)
+    residual_codes = residual_codes.to(device=past_hidden.device, dtype=torch.long)
+    if residual_codes.dim() != 2:
+        raise ValueError(f"residual_codes must be [B, R], got {tuple(residual_codes.shape)}")
+    expected = int(talker.config.num_code_groups) - 1
+    if residual_codes.shape[1] != expected:
+        raise ValueError(f"expected {expected} residual groups, got {residual_codes.shape[1]}")
+
+    code_predictor = talker.code_predictor
+    layer0_hidden = talker.get_input_embeddings()(layer0_ids)
+    predictor_hidden_states = []
+    token_log_probs = []
+    past_key_values = None
+    attention_mask = None
+    full_inputs_embeds = torch.cat((past_hidden, layer0_hidden), dim=1)
+    for index in range(expected):
+        if use_cache and index == 0:
+            inputs_embeds = full_inputs_embeds
+            attention_mask = torch.ones(
+                (inputs_embeds.shape[0], inputs_embeds.shape[1]),
+                dtype=torch.long,
+                device=inputs_embeds.device,
+            )
+            output = code_predictor(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                use_cache=True,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+        elif use_cache:
+            attention_mask = torch.cat(
+                (
+                    attention_mask,
+                    torch.ones(
+                        (attention_mask.shape[0], 1),
+                        dtype=attention_mask.dtype,
+                        device=attention_mask.device,
+                    ),
+                ),
+                dim=1,
+            )
+            output = code_predictor(
+                input_ids=residual_codes[:, index - 1 : index],
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                generation_steps=index,
+                use_cache=True,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+        else:
+            if index > 0:
+                previous_embedding = _predictor_embeddings(code_predictor)[index - 1](
+                    residual_codes[:, index - 1 : index]
+                ).to(device=full_inputs_embeds.device, dtype=full_inputs_embeds.dtype)
+                full_inputs_embeds = torch.cat((full_inputs_embeds, previous_embedding), dim=1)
+            attention_mask = torch.ones(
+                (full_inputs_embeds.shape[0], full_inputs_embeds.shape[1]),
+                dtype=torch.long,
+                device=full_inputs_embeds.device,
+            )
+            output = code_predictor(
+                inputs_embeds=full_inputs_embeds,
+                attention_mask=attention_mask,
+                use_cache=False,
+                output_hidden_states=True,
+                return_dict=True,
+            )
+        # Cached generation exposes one token per entry.  Full recomputation
+        # exposes the complete prefix, so retain only the equivalent final token.
+        hidden_entry = output.hidden_states
+        if not use_cache:
+            hidden_entry = tuple(hidden[:, -1:, :] for hidden in hidden_entry)
+        predictor_hidden_states.append(hidden_entry)
+        if return_log_probs:
+            logits = output.logits[:, -1, :].float()
+            target = residual_codes[:, index]
+            token_log_probs.append(torch.log_softmax(logits, dim=-1).gather(-1, target[:, None]).squeeze(-1))
+        if use_cache:
+            past_key_values = output.past_key_values
+            if past_key_values is None and index + 1 < expected:
+                raise RuntimeError(
+                    "Talker MTP replay requested use_cache=True but the code predictor "
+                    "returned no cache; refusing to advance a misordered residual state"
+                )
+
+    next_hidden = mix_residual_hidden(
+        layer0_hidden=layer0_hidden,
+        residual_codes=residual_codes,
+        predictor_hidden_states=predictor_hidden_states,
+        predictor_embeddings=_predictor_embeddings(code_predictor),
+    )
+    log_probs = torch.stack(token_log_probs, dim=-1) if token_log_probs else None
+    return TalkerResidualStep(
+        residual_codes=residual_codes,
+        next_codec_hidden=next_hidden,
+        log_probs=log_probs,
+    )
+
+
+def add_trailing_text_hidden(
+    codec_hidden: torch.Tensor,
+    *,
+    generation_step: int,
+    trailing_text_hidden: torch.Tensor,
+    tts_pad_embed: torch.Tensor,
+) -> torch.Tensor:
+    """Add the official aligned text hidden (or TTS pad after text ends)."""
+    if int(generation_step) < trailing_text_hidden.shape[1]:
+        text_hidden = trailing_text_hidden[:, int(generation_step) : int(generation_step) + 1]
+    else:
+        text_hidden = tts_pad_embed
+    return codec_hidden + text_hidden.to(device=codec_hidden.device, dtype=codec_hidden.dtype)
+
+
+__all__ = [
+    "TalkerResidualStep",
+    "add_trailing_text_hidden",
+    "mix_residual_hidden",
+    "predict_residual_step",
+    "replay_residual_step",
+    "residual_step_from_generate",
+]

--- a/unirl/models/qwen3_omni/talker_sampling.py
+++ b/unirl/models/qwen3_omni/talker_sampling.py
@@ -1,0 +1,223 @@
+"""Shared behavior-distribution processing for Qwen3-Omni Talker.
+
+Rollout and replay must call the same processor.  In particular, behavior
+log-probabilities are computed *after* repetition penalty, token suppression,
+temperature, top-k, and top-p have changed the distribution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class TalkerSamplingConfig:
+    temperature: float = 0.9
+    top_k: int = 50
+    top_p: float = 1.0
+    repetition_penalty: float = 1.05
+    suppress_token_ids: Tuple[int, ...] = ()
+    eos_token_id: Optional[int] = None
+    do_sample: bool = True
+
+    def __post_init__(self) -> None:
+        if self.temperature < 0.0:
+            raise ValueError(f"temperature must be >= 0, got {self.temperature}")
+        # Match the user-facing generation convention: temperature=0 is a
+        # deterministic request, not an invalid division.  Persist the resolved
+        # mode so rollout and replay cannot interpret the same payload
+        # differently.
+        if self.temperature == 0.0 and self.do_sample:
+            object.__setattr__(self, "do_sample", False)
+        if self.top_k < 0:
+            raise ValueError(f"top_k must be >= 0, got {self.top_k}")
+        if not 0.0 < self.top_p <= 1.0:
+            raise ValueError(f"top_p must be in (0, 1], got {self.top_p}")
+        if self.repetition_penalty <= 0.0:
+            raise ValueError(f"repetition_penalty must be > 0, got {self.repetition_penalty}")
+
+    def to_dict(self) -> dict:
+        return {
+            "temperature": float(self.temperature),
+            "top_k": int(self.top_k),
+            "top_p": float(self.top_p),
+            "repetition_penalty": float(self.repetition_penalty),
+            "suppress_token_ids": tuple(int(token_id) for token_id in self.suppress_token_ids),
+            "eos_token_id": None if self.eos_token_id is None else int(self.eos_token_id),
+            "do_sample": bool(self.do_sample),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "TalkerSamplingConfig":
+        if not isinstance(payload, dict):
+            raise TypeError(f"Talker sampling payload must be a dict, got {type(payload).__name__}")
+        required = {
+            "temperature",
+            "top_k",
+            "top_p",
+            "repetition_penalty",
+            "suppress_token_ids",
+            "eos_token_id",
+            "do_sample",
+        }
+        missing = sorted(required - set(payload))
+        unknown = sorted(set(payload) - required)
+        if missing or unknown:
+            raise ValueError(
+                "Talker sampling payload must be complete and canonical; "
+                f"missing={missing}, unknown={unknown}"
+            )
+        return cls(
+            temperature=float(payload["temperature"]),
+            top_k=int(payload["top_k"]),
+            top_p=float(payload["top_p"]),
+            repetition_penalty=float(payload["repetition_penalty"]),
+            suppress_token_ids=tuple(int(token_id) for token_id in payload["suppress_token_ids"]),
+            eos_token_id=None if payload["eos_token_id"] is None else int(payload["eos_token_id"]),
+            do_sample=bool(payload["do_sample"]),
+        )
+
+
+class TalkerSamplingProcessor:
+    """HF-compatible Talker logits processor/warper with exact behavior logp."""
+
+    def __init__(self, config: TalkerSamplingConfig) -> None:
+        self.config = config
+
+    def _apply_repetition_penalty(
+        self,
+        logits: torch.Tensor,
+        token_history: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        penalty = float(self.config.repetition_penalty)
+        if penalty == 1.0 or token_history is None or token_history.numel() == 0:
+            return logits
+        if token_history.dim() != 2 or token_history.shape[0] != logits.shape[0]:
+            raise ValueError(
+                "token_history must be [B, T] with the same batch size as logits; "
+                f"got history={tuple(token_history.shape)}, logits={tuple(logits.shape)}"
+            )
+        history = token_history.to(device=logits.device, dtype=torch.long)
+        if bool(((history < 0) | (history >= logits.shape[-1])).any()):
+            raise ValueError("token_history contains ids outside the Talker codec vocabulary")
+        selected = torch.gather(logits, 1, history)
+        selected = torch.where(selected < 0, selected * penalty, selected / penalty)
+        return logits.scatter(1, history, selected)
+
+    def process(
+        self,
+        logits: torch.Tensor,
+        *,
+        token_history: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Return processed float32 logits defining the actual behavior policy."""
+        if logits.dim() != 2:
+            raise ValueError(f"expected logits [B, vocab], got {tuple(logits.shape)}")
+        work = logits.float().clone()
+        work = self._apply_repetition_penalty(work, token_history)
+
+        if self.config.suppress_token_ids:
+            suppress = torch.as_tensor(self.config.suppress_token_ids, dtype=torch.long, device=work.device)
+            if bool(((suppress < 0) | (suppress >= work.shape[-1])).any()):
+                raise ValueError("suppress_token_ids contains ids outside the Talker codec vocabulary")
+            work.index_fill_(1, suppress, float("-inf"))
+        if bool(torch.isneginf(work).all(dim=-1).any()):
+            raise RuntimeError("Talker sampling processors removed every token from at least one row")
+
+        if self.config.do_sample:
+            work = work / float(self.config.temperature)
+
+            top_k = min(int(self.config.top_k), work.shape[-1])
+            if top_k > 0:
+                threshold = torch.topk(work, top_k, dim=-1).values[..., -1, None]
+                work = work.masked_fill(work < threshold, float("-inf"))
+
+            if self.config.top_p < 1.0:
+                # Match transformers.TopPLogitsWarper: sort ascending, remove the
+                # low-probability tail whose cumulative mass is <= 1 - top_p,
+                # while always retaining at least one token.
+                sorted_logits, sorted_indices = torch.sort(work, descending=False, dim=-1)
+                cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+                sorted_remove = cumulative_probs <= (1.0 - float(self.config.top_p))
+                sorted_remove[..., -1:] = False
+                remove = torch.zeros_like(sorted_remove).scatter(1, sorted_indices, sorted_remove)
+                work = work.masked_fill(remove, float("-inf"))
+        else:
+            # Greedy decoding is a deterministic behavior policy.  Its exact
+            # distribution is a point mass, not softmax(raw_logits).
+            selected = work.argmax(dim=-1, keepdim=True)
+            greedy = torch.full_like(work, float("-inf"))
+            work = greedy.scatter(1, selected, torch.zeros_like(selected, dtype=work.dtype))
+
+        if bool(torch.isneginf(work).all(dim=-1).any()):
+            raise RuntimeError("Talker sampling processors removed every token from at least one row")
+        return work
+
+    def log_probs(
+        self,
+        logits: torch.Tensor,
+        *,
+        token_history: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        return F.log_softmax(self.process(logits, token_history=token_history), dim=-1)
+
+    def score(
+        self,
+        logits: torch.Tensor,
+        token_ids: torch.Tensor,
+        *,
+        token_history: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        token_ids = token_ids.to(device=logits.device, dtype=torch.long).view(-1, 1)
+        if token_ids.shape[0] != logits.shape[0]:
+            raise ValueError("token_ids batch size must match logits")
+        return self.log_probs(logits, token_history=token_history).gather(1, token_ids).squeeze(1)
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        *,
+        token_history: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        processed = self.process(logits, token_history=token_history)
+        if self.config.do_sample:
+            token_ids = torch.multinomial(processed.softmax(dim=-1), 1, generator=generator).squeeze(1)
+        else:
+            token_ids = processed.argmax(dim=-1)
+        logp = F.log_softmax(processed, dim=-1).gather(1, token_ids[:, None]).squeeze(1)
+        return token_ids, logp
+
+    def is_eos(self, token_ids: torch.Tensor) -> torch.Tensor:
+        if self.config.eos_token_id is None:
+            return torch.zeros_like(token_ids, dtype=torch.bool)
+        return token_ids == int(self.config.eos_token_id)
+
+
+def suppress_special_codec_ids(*, vocab_size: int, codec_eos_token_id: int) -> tuple[int, ...]:
+    """Official Qwen3-Omni suppression set for the upper 1024 codec ids."""
+    start = max(0, int(vocab_size) - 1024)
+    eos = int(codec_eos_token_id)
+    return tuple(token_id for token_id in range(start, int(vocab_size)) if token_id != eos)
+
+
+def append_token_history(
+    token_history: Optional[torch.Tensor],
+    token_ids: torch.Tensor,
+) -> torch.Tensor:
+    token_ids = token_ids.to(dtype=torch.long).view(-1, 1)
+    if token_history is None:
+        return token_ids
+    return torch.cat((token_history.to(device=token_ids.device, dtype=torch.long), token_ids), dim=1)
+
+
+__all__ = [
+    "TalkerSamplingConfig",
+    "TalkerSamplingProcessor",
+    "append_token_history",
+    "suppress_special_codec_ids",
+]

--- a/unirl/models/qwen3_omni/talker_sft.py
+++ b/unirl/models/qwen3_omni/talker_sft.py
@@ -1,0 +1,234 @@
+"""Supervised track builder for Qwen3-Omni Talker TTS SFT."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Sequence, Tuple
+
+import torch
+
+from unirl.distributed.group.dispatch import Dispatch, distributed
+from unirl.distributed.group.remote import Remote
+from unirl.models.qwen3_omni.talker_conditions import Qwen3OmniTalkerConditions
+from unirl.models.qwen3_omni.talker_contract import NUM_CODE_GROUPS
+from unirl.models.qwen3_omni.talker_data import (
+    CODEC_DATA_SCHEMA,
+    assert_fingerprint,
+    fingerprint_sha,
+    model_fingerprint,
+)
+from unirl.models.qwen3_omni.talker_pipeline import tokenize_tts_batch
+from unirl.types.sample import Part
+from unirl.types.segments import TextSegment
+
+logger = logging.getLogger(__name__)
+
+Record = Dict[str, Any]
+
+
+def _sample_ids(records: Sequence[Record]) -> List[str]:
+    return [str(r.get("sample_id", f"sft:{i}")) for i, r in enumerate(records)]
+
+
+def _pad_flags(records: Sequence[Record]) -> List[bool]:
+    return [bool(r.get("_eval_pad", False)) for r in records]
+
+
+def _record_text(record: Record) -> str:
+    meta = record.get("metadata") or {}
+    if not isinstance(meta, dict):
+        raise TypeError(f"Talker SFT record {record.get('sample_id')!r} metadata must be a dict")
+    normalized = meta.get("normalized_transcript")
+    if not isinstance(normalized, str) or not normalized.strip():
+        raise ValueError(
+            f"Talker SFT record {record.get('sample_id')!r} missing metadata.normalized_transcript; "
+            "run prepare_talker_tts_data."
+        )
+    prompt = record.get("prompt")
+    if prompt is not None and str(prompt) != normalized:
+        raise ValueError(f"Talker SFT record {record.get('sample_id')!r} prompt differs from normalized_transcript.")
+    return normalized
+
+
+def _record_speaker(record: Record, default: str) -> str:
+    meta = record.get("metadata") or {}
+    if isinstance(meta, dict) and meta.get("speaker"):
+        return str(meta["speaker"])
+    if record.get("speaker"):
+        return str(record["speaker"])
+    return default
+
+
+def _record_codes(record: Record) -> Tuple[torch.Tensor, int]:
+    """Return an exact ``([16, T], valid_length)`` offline Mimi target."""
+    meta = record.get("metadata") or {}
+    if not isinstance(meta, dict):
+        raise TypeError(f"Talker SFT record {record.get('sample_id')!r} metadata must be a dict")
+    codes = record.get("audio_codes")
+    if codes is None:
+        codes = meta.get("audio_codes")
+    if codes is None:
+        raise ValueError(
+            f"Talker SFT record {record.get('sample_id')!r} missing audio_codes "
+            "(run prepare_talker_tts_data to cache Mimi codes)."
+        )
+    t = torch.as_tensor(codes, dtype=torch.long)
+    if t.dim() != 2 or t.shape[0] != NUM_CODE_GROUPS:
+        raise ValueError(
+            f"Talker SFT record {record.get('sample_id')!r}: audio_codes expected "
+            f"[{NUM_CODE_GROUPS}, T], got {tuple(t.shape)}"
+        )
+    length = meta.get("audio_code_length", record.get("audio_code_length"))
+    if not isinstance(length, int) or isinstance(length, bool):
+        raise ValueError(f"Talker SFT record {record.get('sample_id')!r} missing integer metadata.audio_code_length")
+    if length < 1 or length > t.shape[1]:
+        raise ValueError(
+            f"Talker SFT record {record.get('sample_id')!r}: audio_code_length={length} is outside [1, {t.shape[1]}]."
+        )
+    return t, length
+
+
+class TalkerSupervisedTrackBuilder(Remote):
+    """JSONL TTS records → Talker training ``Part`` (layer0 TextSegment + residual conditions).
+
+    Expected record fields (normalized by ``SupervisedDataSource``):
+    - ``prompt``: text to speak
+    - ``metadata.speaker`` / ``speaker``
+    - ``metadata.audio_codes`` or ``audio_codes``: ``[16, T]`` Mimi codes
+    """
+
+    def __init__(
+        self,
+        *,
+        pipeline: Any,
+        max_response_length: int = 4096,
+        max_prompt_length: int = 4096,
+        append_codec_eos: bool = True,
+        expected_codec_fingerprint: str,
+        expected_model_fingerprint: str = "",
+        strict_fingerprints: bool = True,
+    ) -> None:
+        super().__init__()
+        self.pipeline = pipeline
+        self.max_response_length = int(max_response_length)
+        self.max_prompt_length = int(max_prompt_length)
+        self.append_codec_eos = bool(append_codec_eos)
+        self.strict_fingerprints = bool(strict_fingerprints)
+        if not getattr(pipeline.bundle, "enable_talker", False):
+            raise ValueError("TalkerSupervisedTrackBuilder requires pipeline.bundle.enable_talker=True")
+        if self.max_response_length <= int(self.append_codec_eos):
+            raise ValueError("max_response_length leaves no room for an audio-code target")
+        if self.strict_fingerprints and not str(expected_codec_fingerprint).strip():
+            raise ValueError(
+                "TalkerSupervisedTrackBuilder requires expected_codec_fingerprint in strict mode; "
+                "copy the digest printed by prepare_talker_tts_data."
+            )
+        self.expected_codec_fingerprint = (
+            fingerprint_sha(expected_codec_fingerprint, field_name="expected_codec_fingerprint")
+            if str(expected_codec_fingerprint).strip()
+            else ""
+        )
+        if str(expected_model_fingerprint).strip():
+            self.expected_model_fingerprint = fingerprint_sha(
+                expected_model_fingerprint,
+                field_name="expected_model_fingerprint",
+            )
+        else:
+            self.expected_model_fingerprint = model_fingerprint(
+                pipeline.bundle.pretrained_path,
+                kind="qwen3_omni_talker",
+            )["sha256"]
+
+    def _validate_record(self, record: Record) -> None:
+        if not self.strict_fingerprints:
+            return
+        sample_id = str(record.get("sample_id", "<unknown>"))
+        meta = record.get("metadata") or {}
+        if meta.get("codec_data_schema") != CODEC_DATA_SCHEMA:
+            raise ValueError(
+                f"Talker SFT record {sample_id!r} has codec_data_schema={meta.get('codec_data_schema')!r}; "
+                f"expected {CODEC_DATA_SCHEMA!r}. Online/legacy codec targets are not accepted."
+            )
+        assert_fingerprint(
+            meta.get("talker_model_fingerprint"),
+            self.expected_model_fingerprint,
+            field_name="talker_model_fingerprint",
+            sample_id=sample_id,
+        )
+        assert_fingerprint(
+            meta.get("codec_fingerprint"),
+            self.expected_codec_fingerprint,
+            field_name="codec_fingerprint",
+            sample_id=sample_id,
+        )
+        for field_name in ("speaker", "language", "normalized_transcript"):
+            if not isinstance(meta.get(field_name), str) or not meta[field_name].strip():
+                raise ValueError(f"Talker SFT record {sample_id!r} missing metadata.{field_name}")
+
+    @distributed(dispatch_mode=Dispatch.DP_SCATTER)
+    def build(self, records: List[Record]) -> Part:
+        if not records:
+            raise ValueError("TalkerSupervisedTrackBuilder.build: empty shard")
+        bundle = self.pipeline.bundle
+        omni = bundle.omni
+        device = bundle.device
+        codec_eos = int(omni.config.talker_config.codec_eos_token_id)
+        codebook_size = int(omni.config.code2wav_config.codebook_size)
+        default_speaker = bundle.default_speaker
+
+        for record in records:
+            self._validate_record(record)
+        texts = [_record_text(r) for r in records]
+        speakers = [_record_speaker(r, default_speaker) for r in records]
+        prompt = tokenize_tts_batch(
+            bundle,
+            texts,
+            system_instruction=getattr(self.pipeline, "system_instruction", None),
+            max_length=self.max_prompt_length,
+        )
+
+        tokens: List[torch.Tensor] = []
+        masks: List[torch.Tensor] = []
+        residuals: List[torch.Tensor] = []
+        mtp_masks: List[torch.Tensor] = []
+        for r, is_pad in zip(records, _pad_flags(records)):
+            codes, valid_length = _record_codes(r)
+            t = min(valid_length, self.max_response_length - int(self.append_codec_eos))
+            codes = codes[:, :t].contiguous()
+            if int(codes.min().item()) < 0 or int(codes.max().item()) >= codebook_size:
+                raise ValueError(
+                    f"Talker SFT record {r.get('sample_id')!r}: Mimi code outside [0, {codebook_size - 1}]."
+                )
+            layer0 = codes[0].tolist()
+            if self.append_codec_eos:
+                layer0 = layer0 + [codec_eos]
+                residual = torch.cat(
+                    [codes[1:, :], torch.zeros((NUM_CODE_GROUPS - 1, 1), dtype=torch.long)],
+                    dim=1,
+                )
+                mtp_mask = torch.cat([torch.ones(t, dtype=torch.float32), torch.zeros(1, dtype=torch.float32)])
+            else:
+                residual = codes[1:, :].contiguous()
+                mtp_mask = torch.ones(t, dtype=torch.float32)
+            tokens.append(torch.tensor(layer0, dtype=torch.long, device=device))
+            fill = 0.0 if is_pad else 1.0
+            masks.append(torch.full((len(layer0),), fill, dtype=torch.float32, device=device))
+            residuals.append(residual.to(device=device))
+            mtp_masks.append((mtp_mask * fill).to(device=device))
+
+        conds = Qwen3OmniTalkerConditions(
+            prompt=prompt,
+            speakers=speakers,
+            residual_codes=residuals,
+            mtp_loss_masks=mtp_masks,
+        )
+        segment = TextSegment.pack(tokens=tokens, loss_mask=masks)
+        return Part(
+            sample_ids=_sample_ids(records),
+            conditions=conds.to_dict(),
+            segment=segment,
+            metadata=[dict(record.get("metadata") or {}) for record in records],
+        )
+
+
+__all__ = ["TalkerSupervisedTrackBuilder"]

--- a/unirl/reward/local/registry.py
+++ b/unirl/reward/local/registry.py
@@ -33,6 +33,11 @@ _BUILTIN_SCORERS: Dict[str, Tuple[str, str]] = {
     "clap": ("unirl.reward.local.clap", "CLAPRewardScorer"),
     "imagebind": ("unirl.reward.local.imagebind", "ImageBindRewardScorer"),
     "t2av_composite": ("unirl.reward.local.t2av_composite", "T2AVCompositeScorer"),
+    "tts_wer": ("unirl.reward.local.tts_wer", "TTSWerRewardScorer"),
+    "tts_speaker_sim": ("unirl.reward.local.tts_speaker_sim", "TTSSpeakerSimRewardScorer"),
+    "tts_utmos": ("unirl.reward.local.tts_utmos", "TTSUTMOSRewardScorer"),
+    "tts_stability": ("unirl.reward.local.tts_stability", "TTSStabilityRewardScorer"),
+    "tts_composite": ("unirl.reward.local.tts_composite", "TTSCompositeScorer"),
 }
 
 _BUILTIN_SPECS: Dict[str, Tuple[str, str]] = {
@@ -52,6 +57,11 @@ _BUILTIN_SPECS: Dict[str, Tuple[str, str]] = {
     "clap": ("unirl.reward.local.clap", "CLAPSpec"),
     "imagebind": ("unirl.reward.local.imagebind", "ImageBindSpec"),
     "t2av_composite": ("unirl.reward.local.t2av_composite", "T2AVCompositeSpec"),
+    "tts_wer": ("unirl.reward.local.tts_wer", "TTSWerSpec"),
+    "tts_speaker_sim": ("unirl.reward.local.tts_speaker_sim", "TTSSpeakerSimSpec"),
+    "tts_utmos": ("unirl.reward.local.tts_utmos", "TTSUTMOSSpec"),
+    "tts_stability": ("unirl.reward.local.tts_stability", "TTSStabilitySpec"),
+    "tts_composite": ("unirl.reward.local.tts_composite", "TTSCompositeSpec"),
 }
 
 

--- a/unirl/reward/local/tts_composite.py
+++ b/unirl/reward/local/tts_composite.py
@@ -1,0 +1,195 @@
+"""Content-primary TTS reward with explicit quality gates and penalties."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field, fields as dataclass_fields
+from typing import Any, Dict, List
+
+from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
+from unirl.types.reward import RewardRequest, RewardResponse
+
+from .registry import resolve_builtin_reward_scorer_class, resolve_builtin_reward_spec_class
+
+
+class TTSCompositeScorer(RewardBackend):
+    """Weighted reward where content dominates and quality can veto."""
+
+    input_kind = "audio"
+
+    def __init__(self, *, config: "TTSCompositeSpec", base_device: str) -> None:
+        super().__init__(model_name="tts_composite", batch_size=config.batch_size)
+        self.weights: Dict[str, float] = dict(config.weights or {})
+        if not self.weights:
+            raise ValueError("TTSCompositeScorer requires non-empty weights.")
+        if any(float(weight) < 0 for weight in self.weights.values()):
+            raise ValueError("TTSCompositeScorer weights must be non-negative.")
+        weight_sum = float(sum(self.weights.values()))
+        content_fraction = float(self.weights.get(config.content_component, 0.0)) / weight_sum
+        if content_fraction < config.min_content_weight_fraction:
+            raise ValueError(
+                f"Content component {config.content_component!r} contributes {content_fraction:.3f}, "
+                f"below min_content_weight_fraction={config.min_content_weight_fraction:.3f}."
+            )
+        self._config = config
+        self._scorers: Dict[str, RewardBackend] = {}
+        for name in self.weights:
+            inner_cls = resolve_builtin_reward_scorer_class(name)
+            inner_spec_cls = resolve_builtin_reward_spec_class(name)
+            allowed = {item.name for item in dataclass_fields(inner_spec_cls)}
+            component_config = dict(config.component_configs.get(name, {}))
+            unknown = sorted(set(component_config) - allowed)
+            if unknown:
+                raise ValueError(f"Unknown config keys for {name}: {unknown}.")
+            if "device" in allowed:
+                component_config.setdefault("device", config.device)
+            if "batch_size" in allowed:
+                component_config.setdefault("batch_size", config.batch_size)
+            inner_spec = inner_spec_cls(**component_config)
+            self._scorers[name] = inner_cls(config=inner_spec, base_device=base_device)
+        self.training_eligible = all(
+            bool(getattr(scorer, "training_eligible", True)) for scorer in self._scorers.values()
+        )
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        start = time.time()
+        bs = request.batch_size
+        try:
+            import torch
+
+            component_rewards: Dict[str, List[float]] = {}
+            component_details: Dict[str, List[Dict[str, Any]]] = {}
+            total = torch.zeros(bs, dtype=torch.float32)
+            successes = [True] * bs
+            sample_errors: List[List[str]] = [[] for _ in range(bs)]
+            for name, scorer in self._scorers.items():
+                resp = scorer.compute_rewards(request)
+                comp = torch.tensor(list(resp.rewards), dtype=torch.float32)
+                if comp.numel() != bs:
+                    raise RuntimeError(
+                        f"TTSCompositeScorer: inner scorer {name!r} returned {comp.numel()} for batch {bs}."
+                    )
+                component_rewards[name] = comp.tolist()
+                component_details[name] = list(resp.details or [{} for _ in range(bs)])
+                for metric_name, values in dict(resp.component_rewards or {}).items():
+                    if len(values) == bs:
+                        component_rewards[f"{name}/{metric_name}"] = [float(value) for value in values]
+                for index in range(bs):
+                    ok = index < len(resp.successes) and bool(resp.successes[index])
+                    successes[index] = successes[index] and ok
+                    if not ok:
+                        error = resp.errors[index] if index < len(resp.errors) else "unknown component failure"
+                        sample_errors[index].append(f"{name}: {error}")
+                total = total + float(self.weights[name]) * comp
+            total = total / float(sum(self.weights.values()))
+
+            gate_pass = torch.ones(bs, dtype=torch.bool)
+            for name, threshold in self._config.quality_gates.items():
+                if name not in component_rewards:
+                    raise ValueError(f"quality_gates references inactive component {name!r}.")
+                passed = torch.tensor(component_rewards[name]) >= float(threshold)
+                component_rewards[f"gate/{name}"] = passed.float().tolist()
+                gate_pass &= passed
+
+            penalty_multiplier = torch.ones(bs, dtype=torch.float32)
+            for name, threshold in self._config.penalty_thresholds.items():
+                if name not in component_rewards:
+                    raise ValueError(f"penalty_thresholds references inactive component {name!r}.")
+                factor = float(self._config.penalty_factors.get(name, 1.0))
+                below = torch.tensor(component_rewards[name]) < float(threshold)
+                penalty_multiplier = torch.where(
+                    below,
+                    penalty_multiplier * factor,
+                    penalty_multiplier,
+                )
+                component_rewards[f"penalty/{name}"] = torch.where(
+                    below,
+                    torch.full((bs,), factor),
+                    torch.ones(bs),
+                ).tolist()
+            total = torch.where(gate_pass, total * penalty_multiplier, torch.zeros_like(total))
+            # A failed model/reference is not a legitimate zero reward. Keep the
+            # numeric placeholder for shape stability but mark it failed so
+            # RewardService refuses to attach it to a training sample.
+            total = torch.where(torch.tensor(successes), total, torch.zeros_like(total))
+            details = [
+                {
+                    "status": "available" if successes[index] else "failed",
+                    "components": {
+                        name: component_details[name][index] if index < len(component_details[name]) else {}
+                        for name in self._scorers
+                    },
+                    "quality_gate_passed": bool(gate_pass[index]),
+                    "penalty_multiplier": float(penalty_multiplier[index]),
+                }
+                for index in range(bs)
+            ]
+            return RewardResponse(
+                rewards=total.tolist(),
+                component_rewards=component_rewards,
+                details=details,
+                successes=successes,
+                errors=["; ".join(items) if items else None for items in sample_errors],
+                compute_time=time.time() - start,
+            )
+        except Exception as e:
+            return RewardResponse(
+                rewards=[0.0] * bs,
+                successes=[False] * bs,
+                errors=[str(e)] * bs,
+                compute_time=time.time() - start,
+            )
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+    def is_available(self) -> bool:
+        return all(s.is_available() for s in self._scorers.values())
+
+    def offload(self) -> None:
+        for s in self._scorers.values():
+            if hasattr(s, "offload"):
+                s.offload()
+
+    def onload(self) -> None:
+        for s in self._scorers.values():
+            if hasattr(s, "onload"):
+                s.onload()
+
+    def dispose(self) -> None:
+        for s in self._scorers.values():
+            if hasattr(s, "dispose"):
+                s.dispose()
+
+
+@dataclass
+class TTSCompositeSpec(BaseRewardComponentSpec):
+    batch_size: int = 4
+    device: str = "auto"
+    weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "tts_wer": 0.65,
+            "tts_speaker_sim": 0.15,
+            "tts_utmos": 0.15,
+            "tts_stability": 0.05,
+        }
+    )
+    component_configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    content_component: str = "tts_wer"
+    min_content_weight_fraction: float = 0.50
+    quality_gates: Dict[str, float] = field(
+        default_factory=lambda: {
+            "tts_stability": 1.0,
+            "tts_utmos": 0.30,
+        }
+    )
+    penalty_thresholds: Dict[str, float] = field(default_factory=lambda: {"tts_speaker_sim": 0.40})
+    penalty_factors: Dict[str, float] = field(default_factory=lambda: {"tts_speaker_sim": 0.50})
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.min_content_weight_fraction <= 1.0:
+            raise ValueError("min_content_weight_fraction must be in [0, 1].")
+        for name, factor in self.penalty_factors.items():
+            if not 0.0 <= float(factor) <= 1.0:
+                raise ValueError(f"penalty factor for {name!r} must be in [0, 1].")

--- a/unirl/reward/local/tts_metrics.py
+++ b/unirl/reward/local/tts_metrics.py
@@ -1,0 +1,208 @@
+"""Shared, dependency-light primitives for trustworthy TTS rewards."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Sequence
+
+import torch
+
+from unirl.types.reward import RewardResponse
+
+_CJK_LANGUAGES = frozenset({"zh", "yue", "ja", "ko"})
+_SPACE_RE = re.compile(r"\s+")
+
+
+class RewardUnavailableError(RuntimeError):
+    """Raised when a required reward model or reference is unavailable."""
+
+
+def language_root(language: str) -> str:
+    return str(language or "").strip().lower().replace("_", "-").split("-", 1)[0]
+
+
+def normalize_tts_text(text: str, *, language: str = "") -> str:
+    """Normalize Unicode, digits, punctuation, and spacing deterministically.
+
+    NFKC canonicalizes full-width Latin letters and decimal digits. Punctuation,
+    symbols, and control characters become spaces for whitespace-tokenized
+    languages and are removed between CJK characters by the final whitespace
+    collapse. Number values are intentionally not rewritten into words: that is
+    locale-dependent and would make the reference depend on a hidden NLP model.
+    """
+
+    normalized = unicodedata.normalize("NFKC", str(text or "")).casefold()
+    chars: List[str] = []
+    for char in normalized:
+        category = unicodedata.category(char)
+        if category[0] in {"P", "S", "C"}:
+            chars.append(" ")
+        else:
+            chars.append(char)
+    normalized = _SPACE_RE.sub(" ", "".join(chars)).strip()
+    if language_root(language) in _CJK_LANGUAGES:
+        # Spaces are not lexical boundaries for character-error languages.
+        normalized = normalized.replace(" ", "")
+    return normalized
+
+
+def metric_for_language(language: str, cer_languages: Iterable[str]) -> str:
+    roots = {language_root(item) for item in cer_languages}
+    return "cer" if language_root(language) in roots else "wer"
+
+
+def metric_tokens(text: str, *, metric: str, language: str = "") -> List[str]:
+    normalized = normalize_tts_text(text, language=language)
+    if metric == "cer":
+        return list(normalized.replace(" ", ""))
+    if metric == "wer":
+        return normalized.split()
+    raise ValueError(f"Unsupported edit metric {metric!r}; expected 'wer' or 'cer'.")
+
+
+@dataclass(frozen=True)
+class EditCounts:
+    substitutions: int
+    deletions: int
+    insertions: int
+    reference_units: int
+    hypothesis_units: int
+
+    @property
+    def errors(self) -> int:
+        return self.substitutions + self.deletions + self.insertions
+
+    @property
+    def rate(self) -> float:
+        if self.reference_units == 0:
+            return 0.0 if self.hypothesis_units == 0 else 1.0
+        return float(self.errors) / float(self.reference_units)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "substitutions": self.substitutions,
+            "deletions": self.deletions,
+            "insertions": self.insertions,
+            "errors": self.errors,
+            "reference_units": self.reference_units,
+            "hypothesis_units": self.hypothesis_units,
+            "rate": self.rate,
+        }
+
+
+def edit_counts(reference: Sequence[str], hypothesis: Sequence[str]) -> EditCounts:
+    """Levenshtein distance with a stable S/D/I traceback.
+
+    Tie-breaking is substitution, deletion, insertion. The distance is
+    unaffected by this choice; deterministic raw counts make evaluation diffs
+    reproducible.
+    """
+
+    n, m = len(reference), len(hypothesis)
+    distance = [[0] * (m + 1) for _ in range(n + 1)]
+    operation = [[""] * (m + 1) for _ in range(n + 1)]
+    for i in range(1, n + 1):
+        distance[i][0] = i
+        operation[i][0] = "D"
+    for j in range(1, m + 1):
+        distance[0][j] = j
+        operation[0][j] = "I"
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            if reference[i - 1] == hypothesis[j - 1]:
+                distance[i][j] = distance[i - 1][j - 1]
+                operation[i][j] = "M"
+                continue
+            candidates = (
+                (distance[i - 1][j - 1] + 1, "S"),
+                (distance[i - 1][j] + 1, "D"),
+                (distance[i][j - 1] + 1, "I"),
+            )
+            distance[i][j], operation[i][j] = min(candidates, key=lambda item: item[0])
+
+    substitutions = deletions = insertions = 0
+    i, j = n, m
+    while i or j:
+        op = operation[i][j]
+        if op == "M":
+            i -= 1
+            j -= 1
+        elif op == "S":
+            substitutions += 1
+            i -= 1
+            j -= 1
+        elif op == "D":
+            deletions += 1
+            i -= 1
+        elif op == "I":
+            insertions += 1
+            j -= 1
+        else:  # only reachable at [0, 0]
+            break
+    return EditCounts(substitutions, deletions, insertions, n, m)
+
+
+def score_edit_metric(reference: str, hypothesis: str, *, metric: str, language: str = "") -> Dict[str, Any]:
+    ref_units = metric_tokens(reference, metric=metric, language=language)
+    hyp_units = metric_tokens(hypothesis, metric=metric, language=language)
+    counts = edit_counts(ref_units, hyp_units)
+    return {
+        "metric": metric,
+        "reference_normalized": normalize_tts_text(reference, language=language),
+        "hypothesis_normalized": normalize_tts_text(hypothesis, language=language),
+        **counts.as_dict(),
+    }
+
+
+def unavailable_response(batch_size: int, *, component: str, reason: str) -> RewardResponse:
+    """A dry-run diagnostic response that cannot enter training."""
+
+    message = f"{component} unavailable: {reason}"
+    return RewardResponse(
+        rewards=[0.0] * batch_size,
+        successes=[False] * batch_size,
+        errors=[message] * batch_size,
+        details=[{"status": "unavailable", "component": component, "reason": reason} for _ in range(batch_size)],
+    )
+
+
+def mono_waveform(waveform: torch.Tensor) -> torch.Tensor:
+    wav = waveform.detach().float().cpu()
+    if wav.ndim == 2:
+        # Audios convention is [L, C], while some callers still provide [C, L].
+        wav = wav.mean(dim=1 if wav.shape[0] >= wav.shape[1] else 0)
+    elif wav.ndim != 1:
+        wav = wav.reshape(-1)
+    return wav.contiguous()
+
+
+def resample_waveform(waveform: torch.Tensor, source_rate: int, target_rate: int) -> torch.Tensor:
+    wav = mono_waveform(waveform)
+    if int(source_rate) == int(target_rate):
+        return wav
+    if source_rate <= 0 or target_rate <= 0:
+        raise ValueError(f"Sample rates must be positive, got {source_rate} -> {target_rate}.")
+    target_length = max(1, round(wav.numel() * float(target_rate) / float(source_rate)))
+    return torch.nn.functional.interpolate(
+        wav.view(1, 1, -1),
+        size=target_length,
+        mode="linear",
+        align_corners=False,
+    ).view(-1)
+
+
+__all__ = [
+    "EditCounts",
+    "RewardUnavailableError",
+    "edit_counts",
+    "language_root",
+    "metric_for_language",
+    "metric_tokens",
+    "mono_waveform",
+    "normalize_tts_text",
+    "resample_waveform",
+    "score_edit_metric",
+    "unavailable_response",
+]

--- a/unirl/reward/local/tts_speaker_sim.py
+++ b/unirl/reward/local/tts_speaker_sim.py
@@ -1,0 +1,270 @@
+"""Fail-closed TTS speaker similarity using speaker-verification embeddings."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.base import LocalRewardBackend
+from unirl.reward.local.tts_metrics import (
+    RewardUnavailableError,
+    mono_waveform,
+    resample_waveform,
+    unavailable_response,
+)
+from unirl.types.reward import RewardRequest, RewardResponse
+
+logger = logging.getLogger(__name__)
+
+
+class TTSSpeakerSimRewardScorer(LocalRewardBackend):
+    """Cosine similarity between generated speech and a reference wav / speaker embedding.
+
+    Every sample must provide ``speaker_embedding`` or ``ref_audio``, or resolve
+    ``speaker`` / ``speaker_id`` in a fixed reference bank. Missing references
+    are failures, never an energy proxy.
+    """
+
+    canonical_model_name = "tts_speaker_sim"
+    input_kind = "audio"
+
+    def __init__(self, *, config: "TTSSpeakerSimSpec", base_device: str) -> None:
+        self._spec = config
+        self.training_eligible = not config.dry_run
+        device = config.device if config.device and config.device != "auto" else base_device
+        super().__init__(model_name="tts_speaker_sim", device=device, batch_size=config.batch_size)
+        self.input_kind = "audio"
+
+    def _load_model(self) -> None:
+        self._encoder = None
+        self._processor = None
+        self._reference_bank: Dict[str, Any] = {}
+        self._unavailable_reason = None
+        if self._spec.reference_bank_path:
+            bank_path = Path(self._spec.reference_bank_path)
+            try:
+                raw = json.loads(bank_path.read_text(encoding="utf-8"))
+                if not isinstance(raw, dict):
+                    raise TypeError("reference bank root must be a JSON object")
+                self._reference_bank = raw
+                self._reference_bank_dir = bank_path.parent
+            except Exception as exc:
+                raise RewardUnavailableError(f"Failed to load speaker reference bank {bank_path}: {exc}") from exc
+        else:
+            self._reference_bank_dir = Path(".")
+        if self._spec.dry_run:
+            self._unavailable_reason = "dry_run=True; speaker encoder was intentionally not loaded"
+            return
+        model_id = str(self._spec.speaker_model_id or "").strip()
+        if not model_id:
+            raise RewardUnavailableError(
+                "TTSSpeakerSimRewardScorer requires speaker_model_id in training mode."
+            )
+        try:
+            from transformers import AutoFeatureExtractor
+
+            try:
+                from transformers import AutoModelForAudioXVector
+
+                model_cls = AutoModelForAudioXVector
+            except ImportError:  # pragma: no cover - older transformers
+                from transformers import AutoModel
+
+                model_cls = AutoModel
+
+            self._processor = AutoFeatureExtractor.from_pretrained(model_id)
+            self._encoder = model_cls.from_pretrained(model_id).to(self.device).eval()
+            logger.info("TTSSpeakerSimRewardScorer: loaded %s", model_id)
+        except Exception as exc:  # pragma: no cover
+            raise RewardUnavailableError(
+                f"TTSSpeakerSimRewardScorer failed to load {model_id!r}: {exc}"
+            ) from exc
+
+    def _embed(self, waveform: torch.Tensor, sample_rate: int) -> torch.Tensor:
+        if self._encoder is None or self._processor is None:
+            raise RewardUnavailableError(self._unavailable_reason or "speaker encoder is not loaded")
+        target_rate = int(getattr(self._processor, "sampling_rate", sample_rate) or sample_rate)
+        wav = resample_waveform(waveform, sample_rate, target_rate)
+        inputs = self._processor(
+            wav.numpy(),
+            sampling_rate=target_rate,
+            return_tensors="pt",
+            padding=True,
+        )
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+        with torch.no_grad():
+            out = self._encoder(**inputs)
+        embedding = getattr(out, "embeddings", None)
+        if embedding is not None:
+            emb = embedding.squeeze(0)
+        else:
+            hidden = getattr(out, "last_hidden_state", None)
+            if hidden is None or hidden.ndim != 3:
+                raise RuntimeError("Speaker encoder returned neither embeddings nor last_hidden_state.")
+            # Statistics pooling is the standard utterance-level fallback for
+            # speaker verification; a plain hidden-state mean discards useful
+            # speaker-discriminative variance.
+            mask = inputs.get("attention_mask")
+            if mask is None or mask.shape[-1] != hidden.shape[1]:
+                weights = torch.ones(hidden.shape[:2], device=hidden.device, dtype=hidden.dtype)
+            else:
+                weights = mask.to(hidden.dtype)
+            weights = weights.unsqueeze(-1)
+            denom = weights.sum(dim=1).clamp_min(1.0)
+            mean = (hidden * weights).sum(dim=1) / denom
+            variance = ((hidden - mean.unsqueeze(1)).square() * weights).sum(dim=1) / denom
+            emb = torch.cat([mean, variance.clamp_min(1e-9).sqrt()], dim=-1).squeeze(0)
+        return torch.nn.functional.normalize(emb.float(), dim=-1)
+
+    def _load_ref_wav(self, path: str) -> Tuple[torch.Tensor, int]:
+        try:
+            import soundfile as sf
+
+            data, sr = sf.read(path, always_2d=False)
+            return mono_waveform(torch.tensor(data, dtype=torch.float32)), int(sr)
+        except Exception as exc:
+            raise ValueError(f"Failed to read ref_audio {path!r}: {exc}") from exc
+
+    def _reference(self, meta: Dict[str, Any], generated_embedding: torch.Tensor) -> Tuple[torch.Tensor, str]:
+        source: Any = None
+        source_name = ""
+        if meta.get("speaker_embedding") is not None:
+            source = {"speaker_embedding": meta["speaker_embedding"]}
+            source_name = "sample_embedding"
+        elif meta.get("ref_audio") is not None:
+            source = {
+                "ref_audio": meta["ref_audio"],
+                "sample_rate": meta.get("ref_audio_sample_rate"),
+            }
+            source_name = "sample_audio"
+        else:
+            speaker = str(meta.get("speaker_id") or meta.get("speaker") or "")
+            if speaker and speaker in self._reference_bank:
+                source = self._reference_bank[speaker]
+                source_name = f"reference_bank:{speaker}"
+        if source is None:
+            raise ValueError(
+                "speaker reference missing; provide per-sample ref_audio/speaker_embedding "
+                "or a speaker key present in reference_bank_path"
+            )
+
+        if isinstance(source, list):
+            source = {"speaker_embedding": source}
+        elif isinstance(source, str):
+            source = {"ref_audio": source}
+        if not isinstance(source, dict):
+            raise TypeError(f"Invalid speaker reference entry: {type(source).__name__}")
+
+        if source.get("speaker_embedding") is not None:
+            ref = torch.as_tensor(
+                source["speaker_embedding"],
+                dtype=torch.float32,
+                device=generated_embedding.device,
+            ).view(-1)
+            ref = torch.nn.functional.normalize(ref, dim=-1)
+        elif source.get("ref_audio") is not None:
+            ref_audio = source["ref_audio"]
+            if torch.is_tensor(ref_audio):
+                ref_rate = int(source.get("sample_rate") or self._spec.default_sample_rate)
+                ref_wav = ref_audio
+            else:
+                ref_path = Path(str(ref_audio))
+                if not ref_path.is_absolute():
+                    ref_path = self._reference_bank_dir / ref_path
+                ref_wav, ref_rate = self._load_ref_wav(str(ref_path))
+            ref = self._embed(ref_wav, ref_rate)
+        else:
+            raise ValueError("Speaker reference entry has neither speaker_embedding nor ref_audio.")
+        if ref.numel() != generated_embedding.numel():
+            raise ValueError(
+                f"Speaker embedding dimension mismatch: generated={generated_embedding.numel()}, "
+                f"reference={ref.numel()}."
+            )
+        return ref, source_name
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        if self._encoder is None:
+            return unavailable_response(
+                request.batch_size,
+                component=self.canonical_model_name,
+                reason=self._unavailable_reason or "speaker encoder is not loaded",
+            )
+        start = time.time()
+        audios = request.audio
+        if audios is None:
+            raise ValueError("TTSSpeakerSimRewardScorer requires generated audio.")
+        sr = int(request.audio_sample_rate or self._spec.default_sample_rate)
+        rewards: List[float] = []
+        raw_similarities: List[float] = []
+        successes: List[bool] = []
+        errors: List[str | None] = []
+        details: List[Dict[str, Any]] = []
+        for i, wav in enumerate(audios):
+            try:
+                if wav is None or wav.numel() == 0:
+                    raise ValueError("generated audio is empty")
+                meta = request.metadata[i] if request.metadata and i < len(request.metadata) else None
+                meta = meta if isinstance(meta, dict) else {}
+                gen_emb = self._embed(wav, sr)
+                ref_emb, reference_source = self._reference(meta, gen_emb)
+                similarity = float(torch.dot(gen_emb.view(-1), ref_emb.view(-1)).clamp(-1.0, 1.0).item())
+                scale = self._spec.similarity_ceiling - self._spec.similarity_floor
+                reward = (similarity - self._spec.similarity_floor) / scale
+                rewards.append(float(max(0.0, min(1.0, reward))))
+                raw_similarities.append(similarity)
+                successes.append(True)
+                errors.append(None)
+                details.append(
+                    {
+                        "status": "available",
+                        "raw_similarity": similarity,
+                        "reference_source": reference_source,
+                    }
+                )
+            except Exception as exc:
+                rewards.append(0.0)
+                raw_similarities.append(-1.0)
+                successes.append(False)
+                errors.append(f"{type(exc).__name__}: {exc}")
+                details.append({"status": "failed", "error": errors[-1]})
+        return RewardResponse(
+            rewards=rewards,
+            component_rewards={"raw_similarity": raw_similarities},
+            details=details,
+            successes=successes,
+            errors=errors,
+            compute_time=time.time() - start,
+        )
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        return list(self.compute_rewards(request).rewards)
+
+    def is_available(self) -> bool:
+        return self._encoder is not None and not self._spec.dry_run
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+
+@dataclass
+class TTSSpeakerSimSpec(BaseRewardComponentSpec):
+    batch_size: int = 4
+    device: str = "auto"
+    speaker_model_id: str = "microsoft/wavlm-base-plus-sv"
+    reference_bank_path: str = ""
+    default_sample_rate: int = 24000
+    similarity_floor: float = 0.0
+    similarity_ceiling: float = 1.0
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        if self.similarity_ceiling <= self.similarity_floor:
+            raise ValueError("similarity_ceiling must be greater than similarity_floor.")

--- a/unirl/reward/local/tts_stability.py
+++ b/unirl/reward/local/tts_stability.py
@@ -1,0 +1,192 @@
+"""Hard fail-closed gates for TTS rollout and waveform stability."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import torch
+
+from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
+from unirl.reward.local.tts_metrics import mono_waveform
+from unirl.types.reward import RewardRequest, RewardResponse
+
+
+class TTSStabilityRewardScorer(RewardBackend):
+    """Return 1 only when every configured rollout/audio gate passes."""
+
+    input_kind = "audio"
+
+    def __init__(self, *, config: "TTSStabilitySpec", base_device: str) -> None:
+        super().__init__(model_name="tts_stability", batch_size=config.batch_size)
+        self._spec = config
+        self.input_kind = "audio"
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        start = time.time()
+        audios = request.audio
+        if audios is None:
+            raise ValueError("TTSStabilityRewardScorer requires generated audio.")
+        sr = int(request.audio_sample_rate or self._spec.default_sample_rate)
+        rewards: List[float] = []
+        details: List[Dict[str, Any]] = []
+        gate_names = (
+            "empty",
+            "decode_failure",
+            "missing_eos",
+            "extreme_duration",
+            "silence",
+            "clipping",
+            "codec_repetition",
+            "audio_repetition",
+            "non_finite",
+        )
+        components: Dict[str, List[float]] = {f"gate_{name}": [] for name in gate_names}
+        components.update({"duration_s": [], "rms": [], "clip_fraction": [], "audio_repetition_fraction": []})
+        for i, wav in enumerate(audios):
+            meta = request.metadata[i] if request.metadata and i < len(request.metadata) else {}
+            meta = meta if isinstance(meta, dict) else {}
+            rollout = meta.get("rollout", {})
+            rollout = rollout if isinstance(rollout, dict) else {}
+            merged = {**meta, **rollout}
+
+            gates = {name: False for name in gate_names}
+            duration_s = rms = clip_fraction = repetition_fraction = 0.0
+            if wav is None or wav.numel() == 0:
+                gates["empty"] = True
+            else:
+                w = mono_waveform(wav)
+                gates["non_finite"] = not bool(torch.isfinite(w).all())
+                if not gates["non_finite"]:
+                    duration_s = float(w.numel()) / float(sr)
+                    rms = float(w.square().mean().sqrt().item())
+                    clip_fraction = float((w.abs() >= self._spec.clipping_amplitude).float().mean().item())
+                    repetition_fraction = self._audio_repetition_fraction(w, sr)
+                    gates["silence"] = rms < self._spec.silence_rms
+                    gates["clipping"] = clip_fraction > self._spec.max_clipping_fraction
+                    gates["audio_repetition"] = repetition_fraction > self._spec.max_audio_repetition_fraction
+
+                    expected = merged.get("expected_duration_s")
+                    extreme = duration_s < self._spec.min_seconds or duration_s > self._spec.max_seconds
+                    if expected is not None:
+                        expected = float(expected)
+                        if expected <= 0:
+                            extreme = True
+                        else:
+                            ratio = duration_s / expected
+                            extreme = extreme or ratio < self._spec.min_expected_duration_ratio
+                            extreme = extreme or ratio > self._spec.max_expected_duration_ratio
+                    gates["extreme_duration"] = extreme
+
+            gates["decode_failure"] = bool(merged.get("decode_failure", False))
+            has_eos = merged.get("has_eos")
+            if has_eos is None:
+                status = merged.get("segment_status")
+                if isinstance(status, str):
+                    has_eos = status.strip().lower() in {"completed", "stop"}
+                elif status is not None:
+                    has_eos = int(status) == 1
+            gates["missing_eos"] = has_eos is not True if self._spec.require_eos else False
+
+            codec_max_run = float(merged.get("codec_max_run_fraction", 0.0) or 0.0)
+            codec_repetition = float(merged.get("codec_repetition_fraction", 0.0) or 0.0)
+            codec_unique = float(merged.get("codec_unique_ratio", 1.0) or 0.0)
+            gates["codec_repetition"] = (
+                codec_max_run > self._spec.max_codec_run_fraction
+                or codec_repetition > self._spec.max_codec_repetition_fraction
+                or codec_unique < self._spec.min_codec_unique_ratio
+            )
+
+            failed = [name for name, failed_gate in gates.items() if failed_gate]
+            score = 0.0 if failed else 1.0
+            rewards.append(score)
+            for name in gate_names:
+                components[f"gate_{name}"].append(float(gates[name]))
+            components["duration_s"].append(duration_s)
+            components["rms"].append(rms)
+            components["clip_fraction"].append(clip_fraction)
+            components["audio_repetition_fraction"].append(repetition_fraction)
+            details.append(
+                {
+                    "status": "passed" if not failed else "gated",
+                    "failed_gates": failed,
+                    "gates": gates,
+                    "duration_s": duration_s,
+                    "rms": rms,
+                    "clip_fraction": clip_fraction,
+                    "audio_repetition_fraction": repetition_fraction,
+                    "rollout": rollout,
+                }
+            )
+        return RewardResponse(
+            rewards=rewards,
+            component_rewards=components,
+            details=details,
+            successes=[True] * len(rewards),
+            errors=[None] * len(rewards),
+            compute_time=time.time() - start,
+        )
+
+    def _audio_repetition_fraction(self, waveform: torch.Tensor, sample_rate: int) -> float:
+        frame = max(8, round(self._spec.repetition_frame_seconds * sample_rate))
+        if waveform.numel() < frame * 2:
+            return 0.0
+        frames = waveform.unfold(0, frame, frame)
+        if frames.shape[0] < 2:
+            return 0.0
+        frames = frames - frames.mean(dim=1, keepdim=True)
+        norms = frames.norm(dim=1).clamp_min(1e-8)
+        best = 0.0
+        max_lag = min(self._spec.repetition_max_lag_frames, frames.shape[0] - 1)
+        for lag in range(1, max_lag + 1):
+            similarities = (frames[lag:] * frames[:-lag]).sum(dim=1) / (norms[lag:] * norms[:-lag])
+            fraction = float((similarities > self._spec.repetition_cosine_threshold).float().mean().item())
+            best = max(best, fraction)
+        return best
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+    def is_available(self) -> bool:
+        return True
+
+
+@dataclass
+class TTSStabilitySpec(BaseRewardComponentSpec):
+    batch_size: int = 8
+    device: str = "auto"
+    default_sample_rate: int = 24000
+    min_seconds: float = 0.2
+    max_seconds: float = 60.0
+    silence_rms: float = 1e-4
+    clipping_amplitude: float = 0.999
+    max_clipping_fraction: float = 0.01
+    min_expected_duration_ratio: float = 0.25
+    max_expected_duration_ratio: float = 4.0
+    max_codec_run_fraction: float = 0.20
+    max_codec_repetition_fraction: float = 0.85
+    min_codec_unique_ratio: float = 0.02
+    repetition_frame_seconds: float = 0.20
+    repetition_max_lag_frames: int = 8
+    repetition_cosine_threshold: float = 0.995
+    max_audio_repetition_fraction: float = 0.80
+    require_eos: bool = True
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.min_seconds) or self.min_seconds < 0:
+            raise ValueError("min_seconds must be finite and non-negative.")
+        if self.max_seconds <= self.min_seconds:
+            raise ValueError("max_seconds must be greater than min_seconds.")
+        for name in (
+            "max_clipping_fraction",
+            "max_codec_run_fraction",
+            "max_codec_repetition_fraction",
+            "min_codec_unique_ratio",
+            "max_audio_repetition_fraction",
+        ):
+            value = float(getattr(self, name))
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be in [0, 1], got {value}.")

--- a/unirl/reward/local/tts_utmos.py
+++ b/unirl/reward/local/tts_utmos.py
@@ -1,0 +1,200 @@
+"""Fail-closed UTMOS/DNSMOS perceptual quality reward."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import torch
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.base import LocalRewardBackend
+from unirl.reward.local.tts_metrics import (
+    RewardUnavailableError,
+    mono_waveform,
+    resample_waveform,
+    unavailable_response,
+)
+from unirl.types.reward import RewardRequest, RewardResponse
+
+logger = logging.getLogger(__name__)
+
+
+class TTSUTMOSRewardScorer(LocalRewardBackend):
+    """Map configured UTMOS or DNSMOS predictions into one common [0, 1] scale."""
+
+    canonical_model_name = "tts_utmos"
+    input_kind = "audio"
+
+    def __init__(self, *, config: "TTSUTMOSSpec", base_device: str) -> None:
+        self._spec = config
+        self.training_eligible = not config.dry_run
+        device = config.device if config.device and config.device != "auto" else base_device
+        super().__init__(model_name="tts_utmos", device=device, batch_size=config.batch_size)
+        self.input_kind = "audio"
+
+    def _load_model(self) -> None:
+        self._predictor = None
+        self._unavailable_reason = None
+        if self._spec.dry_run:
+            self._unavailable_reason = "dry_run=True; MOS model was intentionally not loaded"
+            return
+        backend = self._spec.backend.strip().lower()
+        try:
+            if backend == "utmos":
+                import utmos  # type: ignore
+
+                parameters = inspect.signature(utmos.Score).parameters
+                kwargs: Dict[str, Any] = {}
+                if self._spec.model_path and "model_path" in parameters:
+                    kwargs["model_path"] = self._spec.model_path
+                if "device" in parameters:
+                    kwargs["device"] = self.device
+                self._predictor = utmos.Score(**kwargs)
+                if self._spec.model_path and "model_path" not in parameters:
+                    raise TypeError("Installed utmos.Score does not support configured model_path.")
+            elif backend == "dnsmos":
+                if not self._spec.model_path:
+                    raise ValueError("DNSMOS requires model_path to an ONNX model.")
+                import onnxruntime as ort
+
+                providers = (
+                    ["CUDAExecutionProvider", "CPUExecutionProvider"]
+                    if str(self.device).startswith("cuda")
+                    else ["CPUExecutionProvider"]
+                )
+                self._predictor = ort.InferenceSession(self._spec.model_path, providers=providers)
+            else:
+                raise ValueError(f"Unsupported MOS backend {self._spec.backend!r}; expected utmos or dnsmos.")
+            logger.info("TTSUTMOSRewardScorer: loaded %s backend", backend)
+        except Exception as exc:
+            raise RewardUnavailableError(
+                f"TTSUTMOSRewardScorer failed to load {backend or '<empty>'} model: {exc}"
+            ) from exc
+
+    def _predict_mos(self, waveform: torch.Tensor, sample_rate: int) -> float:
+        if self._predictor is None:
+            raise RewardUnavailableError(self._unavailable_reason or "MOS model is not loaded")
+        wav = resample_waveform(waveform, sample_rate, self._spec.model_sample_rate)
+        if self._spec.backend == "utmos":
+            return float(self._predictor.score(wav.numpy(), self._spec.model_sample_rate))
+
+        import numpy as np
+
+        session = self._predictor
+        input_name = self._spec.dnsmos_input_name or session.get_inputs()[0].name
+        outputs = session.run(None, {input_name: wav.numpy().astype(np.float32)[None, :]})
+        if not outputs:
+            raise RuntimeError("DNSMOS returned no outputs.")
+        values = np.asarray(outputs[self._spec.dnsmos_output_tensor]).reshape(-1)
+        if self._spec.dnsmos_output_index >= values.size:
+            raise IndexError(
+                f"DNSMOS output index {self._spec.dnsmos_output_index} exceeds output size {values.size}."
+            )
+        return float(values[self._spec.dnsmos_output_index])
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        if self._predictor is None:
+            return unavailable_response(
+                request.batch_size,
+                component=self.canonical_model_name,
+                reason=self._unavailable_reason or "MOS model is not loaded",
+            )
+        start = time.time()
+        audios = request.audio
+        if audios is None:
+            raise ValueError("TTSUTMOSRewardScorer requires generated audio.")
+        sr = int(request.audio_sample_rate or self._spec.default_sample_rate)
+        rewards: List[float] = []
+        raw_mos: List[float] = []
+        quality_pass: List[float] = []
+        successes: List[bool] = []
+        errors: List[str | None] = []
+        details: List[Dict[str, Any]] = []
+        for wav in audios:
+            try:
+                if wav is None or wav.numel() == 0:
+                    raise ValueError("generated audio is empty")
+                if not torch.isfinite(wav).all():
+                    raise ValueError("generated audio contains non-finite samples")
+                mos = self._predict_mos(mono_waveform(wav), sr)
+                if not torch.isfinite(torch.tensor(mos)):
+                    raise ValueError(f"MOS model returned non-finite value {mos!r}")
+                mapped = (mos - self._spec.mos_floor) / (self._spec.mos_ceiling - self._spec.mos_floor)
+                reward = float(max(0.0, min(1.0, mapped)))
+                passed = mos >= self._spec.mos_threshold
+                rewards.append(reward)
+                raw_mos.append(mos)
+                quality_pass.append(float(passed))
+                successes.append(True)
+                errors.append(None)
+                details.append(
+                    {
+                        "status": "available",
+                        "backend": self._spec.backend,
+                        "raw_mos": mos,
+                        "mapped_reward": reward,
+                        "threshold": self._spec.mos_threshold,
+                        "passed": passed,
+                    }
+                )
+            except Exception as exc:
+                rewards.append(0.0)
+                raw_mos.append(0.0)
+                quality_pass.append(0.0)
+                successes.append(False)
+                errors.append(f"{type(exc).__name__}: {exc}")
+                details.append({"status": "failed", "error": errors[-1]})
+        return RewardResponse(
+            rewards=rewards,
+            component_rewards={"raw_mos": raw_mos, "quality_pass": quality_pass},
+            details=details,
+            successes=successes,
+            errors=errors,
+            compute_time=time.time() - start,
+        )
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        return list(self.compute_rewards(request).rewards)
+
+    def is_available(self) -> bool:
+        return self._predictor is not None and not self._spec.dry_run
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+
+@dataclass
+class TTSUTMOSSpec(BaseRewardComponentSpec):
+    batch_size: int = 4
+    device: str = "auto"
+    backend: str = "utmos"
+    model_path: str = ""
+    default_sample_rate: int = 24000
+    model_sample_rate: int = 16000
+    mos_floor: float = 1.0
+    mos_ceiling: float = 5.0
+    mos_threshold: float = 2.5
+    dnsmos_input_name: str = ""
+    dnsmos_output_tensor: int = 0
+    # DNSMOS primary output is commonly [SIG, BAK, OVRL], so OVRL is index 2.
+    dnsmos_output_index: int = 2
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        self.backend = self.backend.strip().lower()
+        if self.backend not in {"utmos", "dnsmos"}:
+            raise ValueError("TTSUTMOSSpec.backend must be 'utmos' or 'dnsmos'.")
+        if self.mos_ceiling <= self.mos_floor:
+            raise ValueError("mos_ceiling must be greater than mos_floor.")
+        if not self.mos_floor <= self.mos_threshold <= self.mos_ceiling:
+            raise ValueError("mos_threshold must be within [mos_floor, mos_ceiling].")
+        if self.model_sample_rate <= 0:
+            raise ValueError("model_sample_rate must be positive.")
+
+
+__all__ = ["TTSUTMOSRewardScorer", "TTSUTMOSSpec"]

--- a/unirl/reward/local/tts_wer.py
+++ b/unirl/reward/local/tts_wer.py
@@ -1,0 +1,231 @@
+"""TTS intelligibility reward via fail-closed multilingual ASR."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+from unirl.reward.base import BaseRewardComponentSpec
+from unirl.reward.local.base import LocalRewardBackend
+from unirl.reward.local.tts_metrics import (
+    RewardUnavailableError,
+    metric_for_language,
+    score_edit_metric,
+    unavailable_response,
+)
+from unirl.types.reward import RewardRequest, RewardResponse
+
+logger = logging.getLogger(__name__)
+
+
+def word_error_rate(reference: str, hypothesis: str) -> float:
+    """Backward-compatible WER helper using the shared normalization."""
+    return float(score_edit_metric(reference, hypothesis, metric="wer")["rate"])
+
+
+def char_error_rate(reference: str, hypothesis: str, *, language: str = "") -> float:
+    return float(score_edit_metric(reference, hypothesis, metric="cer", language=language)["rate"])
+
+
+def wer_to_reward(wer: float, *, wer_cap: float = 1.0) -> float:
+    cap = max(float(wer_cap), 1e-6)
+    return float(max(0.0, min(1.0, 1.0 - float(wer) / cap)))
+
+
+class TTSWerRewardScorer(LocalRewardBackend):
+    """Reward = clipped ``1 - selected_error_rate / error_rate_cap``.
+
+    Expected request fields:
+    - ``generated["audio"]`` + ``audio_sample_rate``
+    - reference transcript in metadata or conditioning text
+    - optional metadata ``language``; configured languages use CER, others WER
+    """
+
+    canonical_model_name = "tts_wer"
+    input_kind = "audio"
+
+    def __init__(self, *, config: "TTSWerSpec", base_device: str) -> None:
+        self._spec = config
+        self.training_eligible = not config.dry_run
+        device = config.device if config.device and config.device != "auto" else base_device
+        super().__init__(model_name="tts_wer", device=device, batch_size=config.batch_size)
+        self.input_kind = "audio"
+
+    def _load_model(self) -> None:
+        self._asr = None
+        self._unavailable_reason = None
+        if self._spec.dry_run:
+            self._unavailable_reason = "dry_run=True; ASR was intentionally not loaded"
+            return
+        model_id = str(self._spec.asr_model_id or "").strip()
+        if not model_id:
+            raise RewardUnavailableError("TTSWerRewardScorer requires a non-empty asr_model_id in training mode.")
+        try:
+            import torch
+            from transformers import pipeline
+
+            device: Any = -1
+            if str(self.device).startswith("cuda") and torch.cuda.is_available():
+                suffix = str(self.device).partition(":")[2]
+                device = int(suffix) if suffix else 0
+            self._asr = pipeline(
+                "automatic-speech-recognition",
+                model=model_id,
+                device=device,
+            )
+            logger.info("TTSWerRewardScorer: loaded ASR %s", model_id)
+        except Exception as exc:  # pragma: no cover - optional dep
+            raise RewardUnavailableError(f"TTSWerRewardScorer failed to load ASR {model_id!r}: {exc}") from exc
+
+    def _transcribe(self, waveform, sample_rate: int, language: str) -> str:
+        if self._asr is None:
+            raise RewardUnavailableError(self._unavailable_reason or "ASR model is not loaded")
+
+        wav = waveform.detach().float().cpu().numpy()
+        if wav.ndim > 1:
+            wav = wav.mean(axis=0 if wav.shape[0] < wav.shape[-1] else -1)
+        kwargs: Dict[str, Any] = {}
+        language_key = language.strip().lower().replace("_", "-")
+        language_root = language_key.split("-", 1)[0]
+        mapped_language = self._spec.asr_language_map.get(
+            language_key,
+            self._spec.asr_language_map.get(language_root, language_root),
+        )
+        if self._spec.pass_language_to_asr and mapped_language:
+            kwargs["generate_kwargs"] = {"language": mapped_language}
+        out = self._asr(
+            {"array": wav.astype("float32"), "sampling_rate": int(sample_rate)},
+            **kwargs,
+        )
+        if isinstance(out, dict):
+            return str(out.get("text", ""))
+        return str(out)
+
+    def _sample_context(self, request: RewardRequest, idx: int) -> Tuple[str, str]:
+        meta = None
+        if request.metadata is not None and idx < len(request.metadata):
+            meta = request.metadata[idx]
+        language = str(meta.get("language", "") if isinstance(meta, dict) else "")
+        if isinstance(meta, dict):
+            for key in ("normalized_transcript", "transcript", "text", "prompt"):
+                if meta.get(key):
+                    return str(meta[key]), language
+        prompts = request.prompts
+        if idx < len(prompts):
+            return str(prompts[idx]), language
+        return "", language
+
+    def compute_rewards(self, request: RewardRequest) -> RewardResponse:
+        if self._asr is None:
+            return unavailable_response(
+                request.batch_size,
+                component=self.canonical_model_name,
+                reason=self._unavailable_reason or "ASR model is not loaded",
+            )
+        start = time.time()
+        audios = request.audio
+        if audios is None:
+            raise ValueError("TTSWerRewardScorer requires generated audio.")
+        sr = int(request.audio_sample_rate or self._spec.default_sample_rate)
+        rewards: List[float] = []
+        successes: List[bool] = []
+        errors: List[str | None] = []
+        details: List[Dict[str, Any]] = []
+        components: Dict[str, List[float]] = {
+            key: []
+            for key in (
+                "selected_error_rate",
+                "wer",
+                "cer",
+                "substitutions",
+                "deletions",
+                "insertions",
+                "reference_units",
+            )
+        }
+        for i, wav in enumerate(audios):
+            try:
+                reference, language = self._sample_context(request, i)
+                if not reference.strip():
+                    raise ValueError("reference transcript is missing")
+                if wav is None or getattr(wav, "numel", lambda: 0)() == 0:
+                    raise ValueError("generated audio is empty")
+                transcript = self._transcribe(wav, sr, language)
+                selected_metric = metric_for_language(language, self._spec.cer_languages)
+                selected = score_edit_metric(
+                    reference,
+                    transcript,
+                    metric=selected_metric,
+                    language=language,
+                )
+                wer = score_edit_metric(reference, transcript, metric="wer", language=language)
+                cer = score_edit_metric(reference, transcript, metric="cer", language=language)
+                reward = wer_to_reward(float(selected["rate"]), wer_cap=self._spec.error_rate_cap)
+                rewards.append(reward)
+                successes.append(True)
+                errors.append(None)
+                details.append(
+                    {
+                        "status": "available",
+                        "language": language,
+                        "transcript": transcript,
+                        "selected": selected,
+                        "wer": wer,
+                        "cer": cer,
+                    }
+                )
+                components["selected_error_rate"].append(float(selected["rate"]))
+                components["wer"].append(float(wer["rate"]))
+                components["cer"].append(float(cer["rate"]))
+                for key in ("substitutions", "deletions", "insertions", "reference_units"):
+                    components[key].append(float(selected[key]))
+            except Exception as exc:
+                rewards.append(0.0)
+                successes.append(False)
+                errors.append(f"{type(exc).__name__}: {exc}")
+                details.append({"status": "failed", "error": errors[-1]})
+                for values in components.values():
+                    values.append(0.0)
+        return RewardResponse(
+            rewards=rewards,
+            component_rewards=components,
+            details=details,
+            successes=successes,
+            errors=errors,
+            compute_time=time.time() - start,
+        )
+
+    def _compute_model_rewards(self, request: RewardRequest) -> List[float]:
+        # ``compute_rewards`` is overridden to preserve transcript/edit details.
+        return list(self.compute_rewards(request).rewards)
+
+    def is_available(self) -> bool:
+        return self._asr is not None and not self._spec.dry_run
+
+    @property
+    def preferred_input_kind(self) -> str:
+        return self.input_kind
+
+
+@dataclass
+class TTSWerSpec(BaseRewardComponentSpec):
+    batch_size: int = 4
+    device: str = "auto"
+    asr_model_id: str = "openai/whisper-small"
+    error_rate_cap: float = 1.0
+    # Backward-compatible alias. If set, callers should keep it equal to
+    # ``error_rate_cap``; retained so old Hydra recipes do not fail parsing.
+    wer_cap: float | None = None
+    default_sample_rate: int = 24000
+    cer_languages: Tuple[str, ...] = ("zh", "yue", "ja", "ko")
+    pass_language_to_asr: bool = True
+    asr_language_map: Dict[str, str] = field(default_factory=dict)
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        if self.wer_cap is not None:
+            self.error_rate_cap = float(self.wer_cap)
+        if self.error_rate_cap <= 0:
+            raise ValueError("TTSWerSpec.error_rate_cap must be positive.")

--- a/unirl/reward/service.py
+++ b/unirl/reward/service.py
@@ -10,7 +10,7 @@ attached to the frontier Part, under DP-sharded distributed dispatch.
 from __future__ import annotations
 
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 
@@ -20,10 +20,70 @@ from unirl.types.primitives import Images, Texts, primitive_modality_key
 from unirl.types.reward import RewardRequest, RewardResponse
 from unirl.types.sample import Primitive, Sample, _part_with_field
 from unirl.types.sampling import ARSamplingParams
+from unirl.types.segments import SegmentStatus
 
 from .base import DifferentiableReward, RewardBackend
 
 logger = logging.getLogger(__name__)
+
+
+def _codec_statistics(tokens: torch.Tensor) -> Dict[str, Any]:
+    values = [int(value) for value in tokens.detach().cpu().view(-1).tolist()]
+    count = len(values)
+    if count == 0:
+        return {
+            "num_codec_tokens": 0,
+            "codec_unique_ratio": 0.0,
+            "codec_max_run_fraction": 1.0,
+            "codec_repetition_fraction": 1.0,
+        }
+    max_run = run = 1
+    for previous, current in zip(values, values[1:]):
+        run = run + 1 if current == previous else 1
+        max_run = max(max_run, run)
+    ngram_size = min(4, count)
+    ngrams = [tuple(values[i : i + ngram_size]) for i in range(count - ngram_size + 1)]
+    repeated = len(ngrams) - len(set(ngrams))
+    return {
+        "num_codec_tokens": count,
+        "codec_unique_ratio": len(set(values)) / count,
+        "codec_max_run_fraction": max_run / count,
+        "codec_repetition_fraction": repeated / len(ngrams) if ngrams else 0.0,
+        "last_codec_token_id": values[-1],
+    }
+
+
+def _frontier_rollout_metadata(frontier, index: int) -> Dict[str, Any]:
+    rollout: Dict[str, Any] = {}
+    status = frontier.status
+    if status is None and frontier.segment is not None:
+        status = getattr(frontier.segment, "status", None)
+    if status is not None and index < int(status.numel()):
+        status_value = int(status[index].item())
+        rollout["segment_status"] = SegmentStatus(status_value).name.lower()
+        rollout["has_eos"] = status_value == int(SegmentStatus.COMPLETED)
+        rollout["decode_failure"] = status_value == int(SegmentStatus.ABORTED)
+
+    segment = frontier.segment
+    if segment is not None:
+        tokens = getattr(segment, "tokens", None)
+        cu = getattr(segment, "cu_seqlens", None)
+        if tokens is not None and cu is not None and index + 1 < int(cu.numel()):
+            start, end = int(cu[index].item()), int(cu[index + 1].item())
+            sample_tokens = tokens[start:end]
+            rollout.update(_codec_statistics(sample_tokens))
+            behavior = frontier.conditions.get("behavior_sampling") if isinstance(frontier.conditions, dict) else None
+            eos_id = behavior.get("eos_token_id") if isinstance(behavior, dict) else None
+            if eos_id is not None:
+                rollout["has_eos"] = bool(sample_tokens.numel() and int(sample_tokens[-1].item()) == int(eos_id))
+
+    sampling_params = frontier.sampling_params
+    if isinstance(sampling_params, ARSamplingParams):
+        rollout["max_new_tokens"] = int(sampling_params.max_new_tokens)
+    audio_meta = frontier.primitive_metadata.get("audio", {})
+    if "decode_failure" in audio_meta:
+        rollout["decode_failure"] = bool(audio_meta["decode_failure"])
+    return rollout
 
 
 def _build_reward_request(sample: Sample, preferred_input_kind: str) -> RewardRequest:
@@ -49,7 +109,17 @@ def _build_reward_request(sample: Sample, preferred_input_kind: str) -> RewardRe
             f"{sorted(frontier.primitives)!r}; check the recipe's reward/model pairing."
         )
 
-    metadata = sample.root_metadata(-1)
+    root_metadata = sample.root_metadata(-1)
+    frontier_metadata: List[Dict[str, Any]] = list(frontier.metadata or [])
+    metadata: List[Dict[str, Any]] = []
+    for index in range(frontier.batch_size):
+        merged = dict(root_metadata[index] or {}) if index < len(root_metadata) else {}
+        if index < len(frontier_metadata):
+            merged.update(frontier_metadata[index] or {})
+        rollout = dict(merged.get("rollout") or {})
+        rollout.update(_frontier_rollout_metadata(frontier, index))
+        merged["rollout"] = rollout
+        metadata.append(merged)
     generated = dict(frontier.primitives)
     audio_sample_rate: Optional[int] = None
     audio_metadata = frontier.primitive_metadata.get("audio", {})
@@ -62,7 +132,7 @@ def _build_reward_request(sample: Sample, preferred_input_kind: str) -> RewardRe
         prompt_ids=[str(sid) for sid in frontier.sample_ids],
         sample_ids=list(frontier.sample_ids),
         group_ids=list(frontier.group_ids),
-        metadata=(metadata if any(m is not None for m in metadata) else None),
+        metadata=metadata,
     )
 
 
@@ -77,6 +147,11 @@ class RewardService(Remote):
         overlong_penalty_factor: float = 1.0,
     ) -> None:
         super().__init__()
+        if not bool(getattr(backend, "training_eligible", True)):
+            raise ValueError(
+                f"{type(backend).__name__} is diagnostic-only (dry_run/unavailable) and cannot be "
+                "registered with the training RewardService."
+            )
         self.backend = backend
         # How to score AR generations that hit max_new_tokens (sglang finish=="length"):
         #   "zero" — force reward 0 on truncated traces (anti-ramble; the default).
@@ -101,9 +176,9 @@ class RewardService(Remote):
     def preferred_input_kind(self) -> str:
         """The decoded media kind the backend consumes (image/video/text)."""
         kind = str(getattr(self.backend, "preferred_input_kind", "") or "").strip().lower()
-        if kind not in {"image", "video", "text"}:
+        if kind not in {"image", "video", "text", "audio"}:
             raise ValueError(
-                f"Reward backend must expose preferred_input_kind as 'image', 'video', or 'text'. Got {kind!r}."
+                f"Reward backend must expose preferred_input_kind as 'image', 'video', 'text', or 'audio'. Got {kind!r}."
             )
         return kind
 

--- a/unirl/rollout/engine/vllm_omni/adapters/__init__.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/__init__.py
@@ -1,4 +1,4 @@
-"""Adapter registry — importing this package registers all 10 modalities.
+"""Adapter registry — importing this package registers all supported modalities.
 
 Modality adapters are grouped by model family and composed from input/output
 sub-adapters (the binder constructs both in ``__init__`` and delegates the
@@ -9,6 +9,7 @@ two conversion verbs):
 - ``hv15`` — hv15_t2v
 - ``qwen_image`` — qwen_image_t2i
 - ``bagel`` — bagel_t2i
+- ``qwen3_omni`` — thinker-only generation and direct-TTS Talker generation
 
 ``dit`` holds the universal single-stage DiT skeletons
 (:class:`DitInputAdapter` / :class:`DitOutputAdapter`) the families derive
@@ -51,6 +52,11 @@ from unirl.rollout.engine.vllm_omni.adapters.qwen3_omni import (
     Qwen3OmniThinkerAdapter,
     Qwen3OmniThinkerInputAdapter,
 )
+from unirl.rollout.engine.vllm_omni.adapters.qwen3_omni_talker import (
+    Qwen3OmniTalkerAdapter,
+    Qwen3OmniTalkerInputAdapter,
+    Qwen3OmniTalkerOutputAdapter,
+)
 from unirl.rollout.engine.vllm_omni.adapters.qwen_image import (
     QwenImageGroupedInputAdapter,
     QwenImageInputAdapter,
@@ -82,6 +88,9 @@ __all__ = [
     "Hv15VideoOutputAdapter",
     "ModelAdapter",
     "QwenImageGroupedInputAdapter",
+    "Qwen3OmniTalkerAdapter",
+    "Qwen3OmniTalkerInputAdapter",
+    "Qwen3OmniTalkerOutputAdapter",
     "Qwen3OmniThinkerAdapter",
     "Qwen3OmniThinkerInputAdapter",
     "QwenImageInputAdapter",

--- a/unirl/rollout/engine/vllm_omni/adapters/base.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/base.py
@@ -107,6 +107,9 @@ class ModelAdapter(ABC):
     #: Re-push LoRA after wake via the byte-copy transport (TP>1 stages where
     #: the zero-copy handle crashes ranks 2..N; v1 wake branch).
     lora_copy_transport: bool = False
+    #: Optional stage allowlist for LoRA registration/activation. ``None``
+    #: preserves the historical all-stage behavior.
+    lora_stage_ids: Optional[Tuple[int, ...]] = None
 
     def __init__(
         self,

--- a/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py
@@ -576,4 +576,7 @@ class Qwen3OmniThinkerAdapter(ModelAdapter):
         return self.output_adapter.build(sample, per_request)
 
 
-__all__ = ["Qwen3OmniThinkerAdapter", "Qwen3OmniThinkerInputAdapter"]
+__all__ = [
+    "Qwen3OmniThinkerAdapter",
+    "Qwen3OmniThinkerInputAdapter",
+]

--- a/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni_talker.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni_talker.py
@@ -1,0 +1,592 @@
+"""Fail-closed Qwen3-Omni direct-TTS vLLM-Omni adapter."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+import torch
+
+from unirl.config.require import require
+from unirl.models.qwen3_omni.talker_conditions import Qwen3OmniTalkerConditions
+from unirl.models.qwen3_omni.talker_contract import AUDIO_SAMPLE_RATE, NUM_CODE_GROUPS
+from unirl.models.qwen3_omni.talker_sampling import (
+    TalkerSamplingConfig,
+    suppress_special_codec_ids,
+)
+from unirl.rollout.engine.vllm_omni.adapters.base import ModelAdapter, register_adapter
+from unirl.rollout.engine.vllm_omni.backends import (
+    STAGE_KIND_AR,
+    GenerateCall,
+    OmniRawResult,
+    StageSampling,
+)
+from unirl.rollout.engine.vllm_omni.capabilities import (
+    DIRECT_TTS_CONTRACT_VERSION,
+    require_direct_tts_runtime,
+)
+from unirl.types.conditions import TextTokenCondition
+from unirl.types.primitives import Audio, Audios, Texts
+from unirl.types.sample import Sample
+from unirl.types.sampling import ARSamplingParams
+from unirl.types.segments import SegmentStatus, TextSegment
+
+_TALKER_STAGE_ID = 0
+_CODE2WAV_STAGE_ID = 1
+_RAW_CONTRACT_KEY = "unirl_qwen3_omni_direct_tts"
+
+
+def build_direct_tts_prefix_ids(prompt_ids: Sequence[int], config: Any) -> List[int]:
+    """Mirror direct-TTS prefix ID construction without running Thinker."""
+
+    ids = [int(token_id) for token_id in prompt_ids]
+    starts = [index for index, token_id in enumerate(ids) if token_id == int(config.im_start_token_id)]
+    starts.append(len(ids))
+    if len(starts) < 3:
+        raise ValueError("direct-TTS prompt must contain ChatML user and assistant spans")
+
+    prefix: List[int] = []
+    saw_final_assistant = False
+    for span_index, (start, end) in enumerate(zip(starts, starts[1:])):
+        if start + 1 >= end:
+            raise ValueError("direct-TTS prompt contains an empty ChatML role span")
+        role = ids[start + 1]
+        if role == int(config.system_token_id):
+            continue
+        if role == int(config.user_token_id):
+            prefix.extend(ids[start:end])
+            continue
+        if role == int(config.assistant_token_id) and span_index == len(starts) - 2:
+            if end - start < 4:
+                raise ValueError("direct-TTS final assistant span is too short for the <audio> bootstrap")
+            # Official prefix: 3 text slots + 4 codec control slots + TTS BOS
+            # + first assistant content slot. talker_input_ids uses TTS PAD for
+            # all nine because the actual codec controls ride in embeddings.
+            prefix.extend([int(config.tts_pad_token_id)] * 9)
+            saw_final_assistant = True
+            continue
+        if role == int(config.assistant_token_id):
+            continue
+        raise ValueError(f"direct-TTS prompt has unsupported ChatML role token {role}")
+    if not saw_final_assistant or not prefix:
+        raise ValueError("direct-TTS prompt is missing the final assistant <audio> span")
+    return prefix
+
+
+@dataclass(frozen=True)
+class DirectTTSPreparedRequest:
+    prompt_ids: List[int]
+    speaker_id: int
+    prefix_ids: List[int]
+    behavior_sampling: Dict[str, Any]
+
+
+class Qwen3OmniTalkerInputAdapter:
+    """Build the patched runtime's direct prefix→Talker→Code2Wav request."""
+
+    def __init__(
+        self,
+        modality: str,
+        *,
+        model_path: str,
+        max_prompt_length: int = 2048,
+        system_instruction: Optional[str] = None,
+        default_speaker: str = "Ethan",
+        repetition_penalty: float = 1.05,
+        suppress_special_tokens: bool = True,
+    ) -> None:
+        from transformers import AutoConfig, AutoProcessor, AutoTokenizer
+
+        self.modality = modality
+        self.model_path = str(model_path)
+        self.max_prompt_length = int(max_prompt_length)
+        self.system_instruction = system_instruction or (
+            "You are a high-quality TTS model. Convert the user's text into natural speech audio."
+        )
+        self.default_speaker = str(default_speaker)
+        self.repetition_penalty = float(repetition_penalty)
+        self.suppress_special_tokens = bool(suppress_special_tokens)
+        self._processor = AutoProcessor.from_pretrained(self.model_path, trust_remote_code=True)
+        self._tokenizer = AutoTokenizer.from_pretrained(self.model_path, trust_remote_code=True)
+        self._config = AutoConfig.from_pretrained(self.model_path, trust_remote_code=True)
+        self._last_requests: List[DirectTTSPreparedRequest] = []
+
+    def _speaker_id(self, metadata: Any) -> int:
+        mapping = getattr(self._config.talker_config, "speaker_id", None) or {}
+        if isinstance(metadata, dict) and metadata.get("speaker_id") is not None:
+            speaker_id = int(metadata["speaker_id"])
+            if speaker_id not in {int(value) for value in mapping.values()}:
+                raise ValueError(
+                    f"Unknown Talker speaker_id {speaker_id}; known={sorted(mapping.values())}"
+                )
+            return speaker_id
+        speaker = (
+            str(metadata["speaker"])
+            if isinstance(metadata, dict) and metadata.get("speaker")
+            else self.default_speaker
+        )
+        speaker_id = mapping.get(speaker.lower())
+        if speaker_id is None:
+            raise ValueError(f"Unknown Talker speaker {speaker!r}; known={sorted(mapping)}")
+        return int(speaker_id)
+
+    def _prompt_ids(self, text: str) -> List[int]:
+        from unirl.models.qwen3_omni.talker_pipeline import build_tts_messages
+
+        messages = build_tts_messages(
+            text=str(text),
+            system_instruction=self.system_instruction,
+        )
+        ids = self._processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=False,
+            return_tensors=None,
+        )
+        if isinstance(ids, Mapping):
+            ids = ids.get("input_ids")
+        if isinstance(ids, torch.Tensor):
+            ids = ids.reshape(-1).tolist()
+        elif (
+            isinstance(ids, (list, tuple))
+            and len(ids) == 1
+            and isinstance(ids[0], (list, tuple))
+        ):
+            ids = ids[0]
+        if not isinstance(ids, (list, tuple)):
+            raise TypeError(f"direct-TTS chat template returned {type(ids).__name__}, expected token ids")
+        row = [int(token_id) for token_id in ids]
+        if not row:
+            raise ValueError("direct-TTS chat template returned no token ids")
+        if len(row) > self.max_prompt_length:
+            raise ValueError(
+                f"direct-TTS prompt produced {len(row)} tokens, exceeding "
+                f"max_prompt_length={self.max_prompt_length}; truncation would corrupt the prefix"
+            )
+        return row
+
+    def _behavior(self, ar: ARSamplingParams) -> TalkerSamplingConfig:
+        codec_cfg = self._config.talker_config
+        eos = int(codec_cfg.codec_eos_token_id)
+        if ar.stop_token_id is not None and int(ar.stop_token_id) != eos:
+            raise ValueError(
+                f"direct-TTS stop_token_id must be codec EOS {eos}, got {ar.stop_token_id}"
+            )
+        suppress = (
+            suppress_special_codec_ids(
+                vocab_size=int(codec_cfg.text_config.vocab_size),
+                codec_eos_token_id=eos,
+            )
+            if self.suppress_special_tokens
+            else ()
+        )
+        return TalkerSamplingConfig(
+            temperature=float(ar.temperature),
+            top_k=max(0, int(ar.top_k)),
+            top_p=float(ar.top_p),
+            repetition_penalty=self.repetition_penalty,
+            suppress_token_ids=tuple(suppress),
+            eos_token_id=eos,
+            do_sample=float(ar.temperature) > 0.0,
+        )
+
+    def build(self, sample: Sample) -> List[GenerateCall]:
+        frontier = sample.frontier_gen_part(ARSamplingParams)
+        ar = frontier.sampling_params
+        assert isinstance(ar, ARSamplingParams)
+        texts_prim = next((primitive for primitive in sample.conditioning() if isinstance(primitive, Texts)), None)
+        require(texts_prim is not None, "qwen3_omni_talker requires Texts conditioning")
+        texts = list(texts_prim.texts)
+        require(
+            len(texts) == len(frontier.sample_ids),
+            f"qwen3_omni_talker text count {len(texts)} != frontier {len(frontier.sample_ids)}",
+        )
+
+        behavior = self._behavior(ar)
+        behavior_dict = behavior.to_dict()
+        codec_vocab = int(self._config.talker_config.text_config.vocab_size)
+        suppressed = set(behavior.suppress_token_ids)
+        allowed = [
+            token_id
+            for token_id in range(codec_vocab)
+            if token_id not in suppressed
+        ]
+        metadata = sample.root_metadata(-1)
+        prompts: List[Dict[str, Any]] = []
+        self._last_requests = []
+        for index, text in enumerate(texts):
+            row_metadata = metadata[index] if metadata is not None and index < len(metadata) else None
+            prompt_ids = self._prompt_ids(text)
+            speaker_id = self._speaker_id(row_metadata)
+            prefix_ids = build_direct_tts_prefix_ids(prompt_ids, self._config)
+            prepared = DirectTTSPreparedRequest(
+                prompt_ids=prompt_ids,
+                speaker_id=speaker_id,
+                prefix_ids=prefix_ids,
+                behavior_sampling=dict(behavior_dict),
+            )
+            self._last_requests.append(prepared)
+            prompts.append(
+                {
+                    # The patched Talker stage replaces these placeholders with
+                    # the exact direct-TTS prefix carried below.
+                    "prompt_token_ids": [0] * len(prefix_ids),
+                    "additional_information": {
+                        _RAW_CONTRACT_KEY: {
+                            "contract_version": DIRECT_TTS_CONTRACT_VERSION,
+                            "prompt_input_ids": prompt_ids,
+                            "speaker_id": speaker_id,
+                            "prefix_ids": prefix_ids,
+                            "behavior_sampling": dict(behavior_dict),
+                        }
+                    },
+                }
+            )
+
+        talker_sampling = StageSampling(
+            kind=STAGE_KIND_AR,
+            kwargs={
+                "temperature": float(behavior.temperature),
+                "top_p": float(behavior.top_p),
+                "top_k": int(behavior.top_k) if behavior.top_k > 0 else -1,
+                "repetition_penalty": float(behavior.repetition_penalty),
+                "max_tokens": int(ar.max_new_tokens),
+                "stop_token_ids": [int(behavior.eos_token_id)],
+                "allowed_token_ids": allowed,
+                "detokenize": False,
+                "logprobs": 1,
+            },
+        )
+        code2wav_sampling = StageSampling(
+            kind=STAGE_KIND_AR,
+            kwargs={
+                "temperature": 0.0,
+                "top_p": 1.0,
+                "top_k": -1,
+                "max_tokens": 65536,
+            },
+        )
+        return [GenerateCall(prompts=prompts, sampling=[talker_sampling, code2wav_sampling])]
+
+
+def _contract_payload(output: OmniRawResult, *, label: str) -> Mapping[str, Any]:
+    custom = getattr(output, "custom_output", None)
+    if not isinstance(custom, Mapping):
+        raise RuntimeError(f"direct-TTS {label} output has no custom_output mapping")
+    payload = custom.get(_RAW_CONTRACT_KEY)
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(
+            f"direct-TTS {label} output lacks custom_output[{_RAW_CONTRACT_KEY!r}]"
+        )
+    if int(payload.get("contract_version", -1)) != DIRECT_TTS_CONTRACT_VERSION:
+        raise RuntimeError(
+            f"direct-TTS {label} output contract version "
+            f"{payload.get('contract_version')!r} != {DIRECT_TTS_CONTRACT_VERSION}"
+        )
+    return payload
+
+
+def _required(payload: Mapping[str, Any], key: str, *, label: str) -> Any:
+    if key not in payload:
+        raise RuntimeError(f"direct-TTS {label} contract is missing required field {key!r}")
+    return payload[key]
+
+
+def _sampled_processed_logprobs(completion: Any, token_ids: List[int]) -> List[float]:
+    raw = getattr(completion, "logprobs", None)
+    if not isinstance(raw, (list, tuple)) or len(raw) != len(token_ids):
+        raise RuntimeError(
+            "direct-TTS Talker requires one processed logprob map per layer0 token"
+        )
+    values: List[float] = []
+    for position, (token_id, token_map) in enumerate(zip(token_ids, raw)):
+        if not isinstance(token_map, Mapping):
+            raise RuntimeError(f"direct-TTS processed logprobs[{position}] is not a mapping")
+        entry = token_map.get(token_id)
+        if entry is None:
+            entry = token_map.get(str(token_id))
+        if entry is None:
+            raise RuntimeError(
+                f"direct-TTS processed logprobs[{position}] lacks sampled token {token_id}"
+            )
+        value = float(getattr(entry, "logprob", entry))
+        if not math.isfinite(value):
+            raise RuntimeError(f"direct-TTS processed logprob at position {position} is non-finite")
+        values.append(value)
+    return values
+
+
+class Qwen3OmniTalkerOutputAdapter:
+    """Strictly decode the patched runtime's two-stage raw-result contract."""
+
+    def __init__(self, modality: str, input_adapter: Qwen3OmniTalkerInputAdapter) -> None:
+        self.modality = modality
+        self.input_adapter = input_adapter
+
+    @staticmethod
+    def _stage(group: List[OmniRawResult], stage_id: int, label: str) -> OmniRawResult:
+        matches = [output for output in group if getattr(output, "stage_id", None) == stage_id]
+        if len(matches) != 1:
+            raise RuntimeError(
+                f"direct-TTS result requires exactly one {label} stage-{stage_id} output; "
+                f"got {len(matches)}"
+            )
+        return matches[0]
+
+    def _parse_one(
+        self,
+        group: List[OmniRawResult],
+        prepared: DirectTTSPreparedRequest,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        stage_ids = [getattr(output, "stage_id", None) for output in group]
+        if len(stage_ids) != 2 or set(stage_ids) != {_TALKER_STAGE_ID, _CODE2WAV_STAGE_ID}:
+            raise RuntimeError(
+                "direct-TTS output must contain only Talker stage 0 and "
+                f"Code2Wav stage 1; got stage_ids={stage_ids}"
+            )
+        talker_output = self._stage(group, _TALKER_STAGE_ID, "Talker")
+        audio_output = self._stage(group, _CODE2WAV_STAGE_ID, "Code2Wav")
+        if getattr(talker_output, "final_output_type", None) != "text":
+            raise RuntimeError("direct-TTS Talker output must be exposed as final_output_type='text'")
+        if getattr(audio_output, "final_output_type", None) != "audio":
+            raise RuntimeError("direct-TTS Code2Wav output must be final_output_type='audio'")
+        talker_payload = _contract_payload(talker_output, label="Talker")
+        audio_payload = _contract_payload(audio_output, label="Code2Wav")
+
+        request_output = getattr(talker_output, "request_output", None)
+        completions = getattr(request_output, "outputs", None)
+        if not isinstance(completions, (list, tuple)) or len(completions) != 1:
+            raise RuntimeError("direct-TTS Talker output requires exactly one vLLM completion")
+        completion = completions[0]
+        token_ids = [int(token_id) for token_id in (getattr(completion, "token_ids", None) or [])]
+        if not token_ids:
+            raise RuntimeError("direct-TTS Talker output returned no layer0 tokens")
+        processed_logps = _sampled_processed_logprobs(completion, token_ids)
+
+        echoed_tokens = [
+            int(token_id)
+            for token_id in _required(talker_payload, "layer0_token_ids", label="Talker")
+        ]
+        echoed_logps = [
+            float(value)
+            for value in _required(talker_payload, "processed_logprobs", label="Talker")
+        ]
+        if echoed_tokens != token_ids:
+            raise RuntimeError("direct-TTS custom layer0 tokens differ from vLLM completion tokens")
+        if len(echoed_logps) != len(processed_logps) or any(
+            not math.isclose(left, right, rel_tol=0.0, abs_tol=1e-6)
+            for left, right in zip(echoed_logps, processed_logps)
+        ):
+            raise RuntimeError("direct-TTS custom processed logprobs differ from vLLM completion logprobs")
+
+        residual = torch.as_tensor(
+            _required(talker_payload, "residual_codes", label="Talker"),
+            dtype=torch.long,
+        )
+        expected_shape = (NUM_CODE_GROUPS - 1, len(token_ids))
+        if residual.dim() != 2 or tuple(residual.shape) != expected_shape:
+            raise RuntimeError(
+                f"direct-TTS residual_codes expected {expected_shape}, got {tuple(residual.shape)}"
+            )
+        prefix_ids = [
+            int(token_id)
+            for token_id in _required(talker_payload, "prefix_ids", label="Talker")
+        ]
+        if prefix_ids != prepared.prefix_ids:
+            raise RuntimeError("direct-TTS engine prefix_ids differ from the driver-authored prefix")
+        if int(_required(talker_payload, "speaker_id", label="Talker")) != prepared.speaker_id:
+            raise RuntimeError("direct-TTS engine speaker_id differs from the request")
+        raw_behavior = _required(talker_payload, "behavior_sampling", label="Talker")
+        behavior = TalkerSamplingConfig.from_dict(dict(raw_behavior) if isinstance(raw_behavior, Mapping) else {})
+        if behavior.to_dict() != prepared.behavior_sampling:
+            raise RuntimeError("direct-TTS engine behavior_sampling differs from the request")
+
+        codec_eos = int(
+            _required(talker_payload, "codec_eos_token_id", label="Talker")
+        )
+        if codec_eos != behavior.eos_token_id:
+            raise RuntimeError("direct-TTS engine codec EOS differs from behavior_sampling")
+        eos_reached = _required(talker_payload, "eos_reached", label="Talker")
+        if not isinstance(eos_reached, bool):
+            raise RuntimeError("direct-TTS Talker output requires boolean eos_reached")
+        finish_reason = str(getattr(completion, "finish_reason", ""))
+        if eos_reached:
+            if codec_eos in token_ids[:-1] or token_ids[-1] != codec_eos or finish_reason != "stop":
+                raise RuntimeError("direct-TTS EOS/status contract is inconsistent")
+            status = int(SegmentStatus.COMPLETED)
+        elif finish_reason == "length":
+            if codec_eos in token_ids:
+                raise RuntimeError("direct-TTS length-truncated output contains codec EOS")
+            status = int(SegmentStatus.TRUNCATED)
+        elif finish_reason == "abort":
+            status = int(SegmentStatus.ABORTED)
+        else:
+            raise RuntimeError(f"direct-TTS unsupported finish_reason {finish_reason!r}")
+
+        if [
+            int(token_id)
+            for token_id in _required(audio_payload, "layer0_token_ids", label="Code2Wav")
+        ] != token_ids:
+            raise RuntimeError("Code2Wav source layer0 tokens differ from Talker output")
+        expected_frames = len(token_ids) - (1 if eos_reached else 0)
+        if int(
+            _required(audio_payload, "source_num_codec_frames", label="Code2Wav")
+        ) != expected_frames:
+            raise RuntimeError("Code2Wav source frame count is inconsistent with Talker EOS")
+        if int(_required(audio_payload, "sample_rate", label="Code2Wav")) != AUDIO_SAMPLE_RATE:
+            raise RuntimeError(
+                f"direct-TTS audio sample rate must be {AUDIO_SAMPLE_RATE}"
+            )
+        waveform = torch.as_tensor(
+            _required(audio_payload, "audio", label="Code2Wav"),
+            dtype=torch.float32,
+        ).reshape(-1)
+        if not bool(torch.isfinite(waveform).all()):
+            raise RuntimeError("direct-TTS Code2Wav output contains non-finite audio")
+        return (
+            torch.tensor(token_ids, dtype=torch.long),
+            torch.tensor(processed_logps, dtype=torch.float32),
+            residual.cpu(),
+            waveform.cpu(),
+            status,
+        )
+
+    def build(self, sample: Sample, per_request: List[List[OmniRawResult]]) -> Sample:
+        frontier = sample.frontier_gen_part(ARSamplingParams)
+        prepared = self.input_adapter._last_requests
+        require(
+            len(per_request) == len(prepared) == len(frontier.sample_ids),
+            "direct-TTS result/prepared/frontier batch sizes differ",
+        )
+
+        tokens: List[torch.Tensor] = []
+        logps: List[torch.Tensor] = []
+        residuals: List[torch.Tensor] = []
+        waveforms: List[torch.Tensor] = []
+        statuses: List[int] = []
+        for group, request in zip(per_request, prepared):
+            token, logp, residual, waveform, status = self._parse_one(group, request)
+            tokens.append(token)
+            logps.append(logp)
+            residuals.append(residual)
+            waveforms.append(waveform)
+            statuses.append(status)
+
+        max_prompt = max(len(request.prompt_ids) for request in prepared)
+        pad_id = int(getattr(self.input_adapter._tokenizer, "pad_token_id", None) or 0)
+        prompt_ids = []
+        prompt_masks = []
+        for request in prepared:
+            padding = max_prompt - len(request.prompt_ids)
+            prompt_ids.append([pad_id] * padding + request.prompt_ids)
+            prompt_masks.append([0] * padding + [1] * len(request.prompt_ids))
+        conditions = Qwen3OmniTalkerConditions(
+            prompt=TextTokenCondition(
+                input_ids=torch.tensor(prompt_ids, dtype=torch.long),
+                attention_mask=torch.tensor(prompt_masks, dtype=torch.long),
+            ),
+            speaker_ids=[request.speaker_id for request in prepared],
+            prefix_ids=[torch.tensor(request.prefix_ids, dtype=torch.long) for request in prepared],
+            residual_codes=residuals,
+            behavior_sampling=dict(prepared[0].behavior_sampling),
+        )
+        segment = TextSegment.pack(
+            tokens=tokens,
+            log_probs=logps,
+            status=torch.tensor(statuses, dtype=torch.long),
+        )
+        primitives: Dict[str, Any] = {
+            "audio": Audios.from_list([Audio(waveform=waveform) for waveform in waveforms])
+        }
+        texts_prim = next((primitive for primitive in sample.conditioning() if isinstance(primitive, Texts)), None)
+        if texts_prim is not None:
+            primitives["text"] = texts_prim
+        return sample.replace_frontier(
+            frontier.fill(
+                segment=segment,
+                primitives=primitives,
+                conditions=conditions.to_dict(),
+                primitive_metadata={"audio": {"sample_rate": AUDIO_SAMPLE_RATE}},
+                status=segment.status,
+            )
+        )
+
+
+@register_adapter("qwen3_omni_talker")
+class Qwen3OmniTalkerAdapter(ModelAdapter):
+    """Direct TTS only; refuses unpatched spoken-response runtimes."""
+
+    stage_yaml = "qwen3_omni_talker_tts_rl_1x4.yaml"
+    stage_yaml_source = "local"
+    omni_mode = None
+    needs_sigmas = False
+    needs_driver_tokenizer = False
+    ar_lora_passthrough = True
+    clear_cuda_visible = False
+    lora_copy_transport = True
+    lora_stage_ids = (_TALKER_STAGE_ID,)
+
+    def __init__(
+        self,
+        config: Any,
+        model_config: Any,
+        *,
+        strategy: Any = None,
+        tokenize_fn: Any = None,
+    ) -> None:
+        # This happens before backend spawn. The currently pinned upstream
+        # vLLM-Omni 0.20.0 intentionally fails here.
+        self.runtime_capability = require_direct_tts_runtime()
+        super().__init__(config, model_config, strategy=strategy, tokenize_fn=tokenize_fn)
+        self.input_adapter = Qwen3OmniTalkerInputAdapter(
+            self.modality,
+            model_path=str(config.model_path),
+            max_prompt_length=int(getattr(config, "max_prompt_length", 2048) or 2048),
+            system_instruction=(
+                getattr(model_config, "system_instruction", None)
+                if model_config is not None
+                else None
+            ),
+            default_speaker=(
+                str(getattr(model_config, "default_speaker", "Ethan"))
+                if model_config is not None
+                else "Ethan"
+            ),
+            repetition_penalty=float(
+                getattr(model_config, "repetition_penalty", 1.05)
+                if model_config is not None
+                else 1.05
+            ),
+            suppress_special_tokens=bool(
+                getattr(model_config, "suppress_special_tokens", True)
+                if model_config is not None
+                else True
+            ),
+        )
+        self.output_adapter = Qwen3OmniTalkerOutputAdapter(self.modality, self.input_adapter)
+
+    def schedule_policy(self) -> Any:
+        return None
+
+    def validate_request(self, sample: Sample) -> None:
+        sample.frontier_gen_part(ARSamplingParams)
+        require(
+            any(isinstance(primitive, Texts) for primitive in sample.conditioning()),
+            "qwen3_omni_talker requires Texts prompts",
+        )
+
+    def build_inputs(self, sample: Sample) -> List[GenerateCall]:
+        return self.input_adapter.build(sample)
+
+    def build_response(self, sample: Sample, per_request: List[List[OmniRawResult]]) -> Sample:
+        return self.output_adapter.build(sample, per_request)
+
+
+__all__ = [
+    "DirectTTSPreparedRequest",
+    "Qwen3OmniTalkerAdapter",
+    "Qwen3OmniTalkerInputAdapter",
+    "Qwen3OmniTalkerOutputAdapter",
+    "build_direct_tts_prefix_ids",
+]

--- a/unirl/rollout/engine/vllm_omni/backends/base.py
+++ b/unirl/rollout/engine/vllm_omni/backends/base.py
@@ -113,6 +113,10 @@ class OmniRawResult(Protocol):
       nested vLLM ``RequestOutput`` (``.outputs[0].token_ids`` / ``.logprobs``
       / ``.text``) — and ``prompt_token_ids`` (the sample's true, un-padded
       prompt; vLLM runs prompts per-request with no batch padding).
+      The capability-gated Qwen3-Omni direct-TTS path additionally requires
+      ``custom_output["unirl_qwen3_omni_direct_tts"]`` on both the Talker and
+      Code2Wav final outputs; its adapter validates every field and rejects
+      upstream spoken-response-only runtimes before spawn.
     - DiT stage (``"image"`` / ``"video"``): ``images`` (PIL list; per-prompt
       frame list for video), ``trajectory_latents`` ``[1, T+1, ...]`` (dense —
       every step recorded), ``trajectory_timesteps`` ``[T+1]`` (the field name
@@ -207,6 +211,7 @@ class Backend(Protocol):
         adapter_name: str,
         lora_tensors: Dict[str, Any],
         peft_config: Optional[dict],
+        stage_ids: Optional[List[int]],
     ) -> None: ...
     def set_lora_copy(
         self,
@@ -214,9 +219,16 @@ class Backend(Protocol):
         adapter_name: str,
         lora_tensors: Dict[str, Any],
         peft_config: Optional[dict],
+        stage_ids: Optional[List[int]],
     ) -> None: ...
     def param_checksums(self, *, names: List[str]) -> dict: ...
-    def lora_checksums(self, *, adapter_id: int, names: Optional[List[str]]) -> dict: ...
+    def lora_checksums(
+        self,
+        *,
+        adapter_id: int,
+        names: Optional[List[str]],
+        stage_ids: Optional[List[int]],
+    ) -> dict: ...
 
 
 __all__ = [

--- a/unirl/rollout/engine/vllm_omni/backends/native.py
+++ b/unirl/rollout/engine/vllm_omni/backends/native.py
@@ -419,6 +419,17 @@ class VLLMOmniBackend:
     def _stage_ids(self) -> List[int]:
         return list(range(self.num_stages()))
 
+    def _selected_stage_ids(self, stage_ids: Optional[Sequence[int]]) -> List[int]:
+        available = set(self._stage_ids())
+        selected = sorted(available if stage_ids is None else {int(stage_id) for stage_id in stage_ids})
+        invalid = sorted(set(selected) - available)
+        if invalid or not selected:
+            raise RuntimeError(
+                f"VLLMOmniBackend: invalid/empty stage allowlist {stage_ids!r}; "
+                f"available={sorted(available)}"
+            )
+        return selected
+
     # ------------------------------------------------------------------ #
     # Memory / lifecycle / health
     # ------------------------------------------------------------------ #
@@ -612,6 +623,7 @@ class VLLMOmniBackend:
         adapter_name: str,
         lora_tensors: Dict[str, Any],
         peft_config: Optional[dict],
+        stage_ids: Optional[List[int]] = None,
     ) -> None:
         """Zero-copy LoRA push via ``MultiprocessingSerializer`` shm handles.
 
@@ -633,7 +645,8 @@ class VLLMOmniBackend:
 
         omni = self._require_omni()
         lora_tensors = self._wrap_peft_envelope(lora_tensors)
-        self._remove_existing_lora(int(DIFFRL_LORA_INT_ID))
+        selected_stage_ids = self._selected_stage_ids(stage_ids)
+        self._remove_existing_lora(int(DIFFRL_LORA_INT_ID), stage_ids=selected_stage_ids)
 
         # Pass primitive fields, not an ``OmniTensorLoRARequest``: vllm's
         # msgspec wire encoder doesn't recognise our Struct subclass and
@@ -644,7 +657,7 @@ class VLLMOmniBackend:
             MultiprocessingSerializer,
         )
 
-        for sid in self._stage_ids():
+        for sid in selected_stage_ids:
             cloned = {
                 name: t.detach().clone() if isinstance(t, torch.Tensor) else t for name, t in lora_tensors.items()
             }
@@ -667,6 +680,7 @@ class VLLMOmniBackend:
         adapter_name: str,
         lora_tensors: Dict[str, Any],
         peft_config: Optional[dict],
+        stage_ids: Optional[List[int]] = None,
     ) -> None:
         """Byte-copy LoRA push (``torch.save`` + base64) — TP>1-broadcast-safe.
 
@@ -689,7 +703,8 @@ class VLLMOmniBackend:
 
         omni = self._require_omni()
         lora_tensors = self._wrap_peft_envelope(lora_tensors)
-        self._remove_existing_lora(int(DIFFRL_LORA_INT_ID))
+        selected_stage_ids = self._selected_stage_ids(stage_ids)
+        self._remove_existing_lora(int(DIFFRL_LORA_INT_ID), stage_ids=selected_stage_ids)
 
         cpu_tensors = {
             name: t.detach().to("cpu") if isinstance(t, torch.Tensor) else t for name, t in lora_tensors.items()
@@ -698,7 +713,7 @@ class VLLMOmniBackend:
         torch.save(cpu_tensors, buf)
         serialized = base64.b64encode(buf.getvalue()).decode("ascii")
 
-        for sid in self._stage_ids():
+        for sid in selected_stage_ids:
             omni.engine.collective_rpc(
                 method="set_lora_from_tensor_dict_copy",
                 args=(
@@ -726,7 +741,12 @@ class VLLMOmniBackend:
             return adapt_lora_for_vllm(lora_tensors)
         return lora_tensors
 
-    def _remove_existing_lora(self, adapter_id: int) -> None:
+    def _remove_existing_lora(
+        self,
+        adapter_id: int,
+        *,
+        stage_ids: Optional[Sequence[int]] = None,
+    ) -> None:
         """Drop the existing adapter on every stage before re-adding.
 
         Matches the receive-side ``_diffrl_load_bucket`` ordering.
@@ -734,7 +754,7 @@ class VLLMOmniBackend:
         call — subsequent failures still flow up via the add below.
         """
         omni = self._require_omni()
-        for sid in self._stage_ids():
+        for sid in self._selected_stage_ids(stage_ids):
             try:
                 omni.engine.collective_rpc(
                     method="remove_lora",
@@ -766,11 +786,17 @@ class VLLMOmniBackend:
             out[int(sid)] = results[0] if isinstance(results, list) and results else results
         return out
 
-    def lora_checksums(self, *, adapter_id: int, names: Optional[List[str]]) -> dict:
+    def lora_checksums(
+        self,
+        *,
+        adapter_id: int,
+        names: Optional[List[str]],
+        stage_ids: Optional[List[int]] = None,
+    ) -> dict:
         """Fan ``_diffrl_loaded_lora_checksums`` across stages and ranks."""
         omni = self._require_omni()
         out: dict = {}
-        for sid in self._stage_ids():
+        for sid in self._selected_stage_ids(stage_ids):
             results = omni.engine.collective_rpc(
                 method="_diffrl_loaded_lora_checksums",
                 args=(int(adapter_id), list(names) if names else None),

--- a/unirl/rollout/engine/vllm_omni/capabilities.py
+++ b/unirl/rollout/engine/vllm_omni/capabilities.py
@@ -1,0 +1,105 @@
+"""Fail-closed probes for optional vLLM-Omni runtime contracts."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Callable, FrozenSet
+
+DIRECT_TTS_CONTRACT_VERSION = 1
+DIRECT_TTS_RUNTIME_MODULE = "vllm_omni.model_executor.models.qwen3_omni.qwen3_omni"
+DIRECT_TTS_CAPABILITY_ATTR = "UNIRL_DIRECT_TTS_ROLLOUT_CAPABILITIES"
+DIRECT_TTS_REQUIRED_CAPABILITIES: FrozenSet[str] = frozenset(
+    {
+        "direct_tts_prefix_without_thinker_forward",
+        "layer0_processed_logprobs",
+        "residual_codes_15",
+        "prefix_ids_echo",
+        "speaker_id_echo",
+        "behavior_sampling_echo",
+        "codec_eos_status",
+        "code2wav_audio_24khz",
+    }
+)
+
+
+@dataclass(frozen=True)
+class DirectTTSRuntimeCapability:
+    engine_version: str
+    contract_version: int
+    capabilities: FrozenSet[str]
+
+
+def require_direct_tts_runtime(
+    *,
+    import_module: Callable[[str], object] = importlib.import_module,
+    distribution_version: Callable[[str], str] = metadata.version,
+) -> DirectTTSRuntimeCapability:
+    """Require the patched direct-TTS output contract before engine spawn.
+
+    Version numbers alone are deliberately insufficient: upstream vLLM-Omni
+    0.20.0 has Qwen3-Omni's spoken-response Thinker→Talker pipeline, but no
+    direct-TTS prefix input and no RL trajectory export. A compatible build
+    must advertise the exact contract on the Qwen3-Omni model module.
+    """
+
+    try:
+        engine_version = str(distribution_version("vllm-omni"))
+    except metadata.PackageNotFoundError as exc:
+        raise RuntimeError(
+            "qwen3_omni_talker requires a patched vllm-omni runtime; the "
+            "'vllm-omni' distribution is not installed. Upstream 0.20.0 is "
+            "not sufficient because it only exposes the spoken-response "
+            "Thinker→Talker handoff."
+        ) from exc
+
+    try:
+        module = import_module(DIRECT_TTS_RUNTIME_MODULE)
+    except (ImportError, ModuleNotFoundError) as exc:
+        raise RuntimeError(
+            "qwen3_omni_talker cannot import the Qwen3-Omni runtime module "
+            f"{DIRECT_TTS_RUNTIME_MODULE!r} from vllm-omni {engine_version}."
+        ) from exc
+
+    advertised = getattr(module, DIRECT_TTS_CAPABILITY_ATTR, None)
+    if not isinstance(advertised, dict):
+        raise RuntimeError(
+            f"vllm-omni {engine_version} lacks {DIRECT_TTS_CAPABILITY_ATTR}. "
+            "This build cannot provide direct-TTS prefix execution plus the "
+            "lossless layer0/residual/logprob/audio rollout contract; refusing "
+            "to start instead of falling back to spoken-response or fabricated data."
+        )
+    try:
+        contract_version = int(advertised["contract_version"])
+        capabilities = frozenset(str(value) for value in advertised["capabilities"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"vllm-omni {engine_version} advertises a malformed "
+            f"{DIRECT_TTS_CAPABILITY_ATTR} payload: {advertised!r}."
+        ) from exc
+    if contract_version != DIRECT_TTS_CONTRACT_VERSION:
+        raise RuntimeError(
+            f"vllm-omni {engine_version} direct-TTS contract version "
+            f"{contract_version} != required {DIRECT_TTS_CONTRACT_VERSION}."
+        )
+    missing = sorted(DIRECT_TTS_REQUIRED_CAPABILITIES - capabilities)
+    if missing:
+        raise RuntimeError(
+            f"vllm-omni {engine_version} direct-TTS runtime is missing required "
+            f"capabilities: {missing}."
+        )
+    return DirectTTSRuntimeCapability(
+        engine_version=engine_version,
+        contract_version=contract_version,
+        capabilities=capabilities,
+    )
+
+
+__all__ = [
+    "DIRECT_TTS_CAPABILITY_ATTR",
+    "DIRECT_TTS_CONTRACT_VERSION",
+    "DIRECT_TTS_REQUIRED_CAPABILITIES",
+    "DirectTTSRuntimeCapability",
+    "require_direct_tts_runtime",
+]

--- a/unirl/rollout/engine/vllm_omni/engine.py
+++ b/unirl/rollout/engine/vllm_omni/engine.py
@@ -113,6 +113,11 @@ class VLLMOmniRolloutEngine(BaseSingleTurnRolloutEngine):
             self._backend,
             uses_lora=bool(getattr(model_config, "use_lora", False)),
             lora_copy_transport=self.adapter.lora_copy_transport,
+            lora_stage_ids=(
+                list(self.adapter.lora_stage_ids)
+                if self.adapter.lora_stage_ids is not None
+                else None
+            ),
         )
 
     def _tokenize_prompt(self, text: str, *, task: str, sys_type: str) -> List[int]:
@@ -254,6 +259,14 @@ class VLLMOmniRolloutEngine(BaseSingleTurnRolloutEngine):
         stage YAML at boot). The IPC weight-sync handler needs this to skip
         orphan train ranks that exceed a stage's TP size."""
         return self._backend.tp_per_stage()
+
+    def lora_tp_per_stage(self) -> Dict[int, int]:
+        """Topology of stages on which this adapter permits LoRA."""
+        topology = self._backend.tp_per_stage()
+        allowed = self.adapter.lora_stage_ids
+        if allowed is None:
+            return topology
+        return {int(stage_id): topology[int(stage_id)] for stage_id in allowed}
 
     # ------------------------------------------------------------------ #
     # Weight sync — frozen base.py surface; thin forwards to the component.

--- a/unirl/rollout/engine/vllm_omni/stage_configs/qwen3_omni_talker_tts_rl_1x4.yaml
+++ b/unirl/rollout/engine/vllm_omni/stage_configs/qwen3_omni_talker_tts_rl_1x4.yaml
@@ -1,0 +1,87 @@
+# Qwen3-Omni direct-TTS rollout: prefix -> Talker(+frozen MTP) -> Code2Wav.
+#
+# This is NOT upstream's Thinker -> Talker spoken-response pipeline. Startup is
+# gated by capabilities.require_direct_tts_runtime(). Upstream vllm-omni 0.20.0
+# does not advertise the required v1 trajectory contract and must fail before
+# spawning. A compatible patched runtime must consume additional_information
+# ["unirl_qwen3_omni_direct_tts"] at the Talker stage and echo the complete
+# layer0/processed-logprob/residual/prefix/speaker/EOS contract on custom_output.
+stage_args:
+  - stage_id: 0
+    stage_type: llm
+    runtime:
+      devices: "0,1,2,3"
+    engine_args:
+      model_stage: talker
+      model_arch: Qwen3OmniMoeForConditionalGeneration
+      worker_type: ar
+      scheduler_cls: vllm_omni.core.sched.omni_ar_scheduler.OmniARScheduler
+      engine_output_type: latent
+      hf_config_name: talker_config
+
+      tensor_parallel_size: 4
+      distributed_executor_backend: "mp"
+
+      gpu_memory_utilization: 0.35
+      max_num_seqs: 32
+      max_num_batched_tokens: 16384
+      enable_chunked_prefill: true
+
+      dtype: bfloat16
+      load_format: safetensors
+      trust_remote_code: true
+      enable_prefix_caching: false
+      enforce_eager: false
+
+      enable_lora: true
+      max_lora_rank: 64
+      max_loras: 1
+
+      worker_extension_cls: unirl.rollout.engine.vllm_omni.worker.qwen3_omni_ar_extension.Qwen3OmniTalkerWeightSyncExtension
+
+      enable_sleep_mode: true
+      logprobs_mode: processed_logprobs
+      disable_log_stats: true
+    final_output: true
+    final_output_type: text
+    is_comprehension: false
+
+  - stage_id: 1
+    stage_type: llm
+    runtime:
+      devices: "0"
+    engine_args:
+      model_stage: code2wav
+      model_arch: Qwen3OmniMoeForConditionalGeneration
+      worker_type: generation
+      scheduler_cls: vllm_omni.core.sched.omni_generation_scheduler.OmniGenerationScheduler
+      engine_output_type: audio
+      # vLLM-Omni's Qwen3-Omni wrapper selects code2wav_config internally.
+      # The stage loader itself must receive the parent Thinker config.
+      hf_config_name: thinker_config
+
+      tensor_parallel_size: 1
+      distributed_executor_backend: "mp"
+      gpu_memory_utilization: 0.10
+      max_num_seqs: 32
+      max_num_batched_tokens: 1000000
+      enable_prefix_caching: false
+      async_scheduling: false
+      enforce_eager: true
+      trust_remote_code: true
+      enable_lora: false
+      enable_sleep_mode: true
+      disable_log_stats: true
+    engine_input_source: [0]
+    custom_process_input_func: vllm_omni.model_executor.stage_input_processors.qwen3_omni.talker2code2wav
+    final_output: true
+    final_output_type: audio
+    is_comprehension: false
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 65536
+      seed: 42
+      detokenize: true
+      repetition_penalty: 1.1

--- a/unirl/rollout/engine/vllm_omni/weight_sync.py
+++ b/unirl/rollout/engine/vllm_omni/weight_sync.py
@@ -40,6 +40,7 @@ class WeightSync:
         *,
         uses_lora: bool,
         lora_copy_transport: bool,
+        lora_stage_ids: Optional[List[int]] = None,
     ) -> None:
         self._backend = backend
         self._uses_lora = bool(uses_lora)
@@ -47,6 +48,7 @@ class WeightSync:
         # byte-copy transport (the zero-copy handle's one-shot fd pops after
         # the first consumer, crashing ranks 2..N).
         self._lora_copy_transport = bool(lora_copy_transport)
+        self._lora_stage_ids = None if lora_stage_ids is None else [int(stage_id) for stage_id in lora_stage_ids]
         #: An adapter has been pushed and should be active on generate.
         self._lora_loaded = False
         #: The runtime released its memory since the last push (sleep) — the
@@ -171,7 +173,12 @@ class WeightSync:
     ) -> None:
         """Hot-swap the adapter via the zero-copy shm-handle transport."""
         self._cache_lora(adapter_name, lora_tensors, peft_config)
-        self._backend.set_lora_handle(adapter_name=adapter_name, lora_tensors=lora_tensors, peft_config=peft_config)
+        self._backend.set_lora_handle(
+            adapter_name=adapter_name,
+            lora_tensors=lora_tensors,
+            peft_config=peft_config,
+            stage_ids=self._lora_stage_ids,
+        )
         self._lora_loaded = True
         self._weights_released = False
 
@@ -184,7 +191,12 @@ class WeightSync:
     ) -> None:
         """Hot-swap the adapter via the TP>1-safe byte-copy transport."""
         self._cache_lora(adapter_name, lora_tensors, peft_config)
-        self._backend.set_lora_copy(adapter_name=adapter_name, lora_tensors=lora_tensors, peft_config=peft_config)
+        self._backend.set_lora_copy(
+            adapter_name=adapter_name,
+            lora_tensors=lora_tensors,
+            peft_config=peft_config,
+            stage_ids=self._lora_stage_ids,
+        )
         self._lora_loaded = True
         self._weights_released = False
 
@@ -207,7 +219,11 @@ class WeightSync:
         return self._backend.param_checksums(names=list(names))
 
     def loaded_lora_checksums(self, *, adapter_id: int, names: Optional[List[str]] = None) -> dict:
-        return self._backend.lora_checksums(adapter_id=int(adapter_id), names=names)
+        return self._backend.lora_checksums(
+            adapter_id=int(adapter_id),
+            names=names,
+            stage_ids=self._lora_stage_ids,
+        )
 
     # ------------------------------------------------------------------ #
     # Weights-released event + the wake-time restore

--- a/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
+++ b/unirl/rollout/engine/vllm_omni/worker/ipc_receive_mixin.py
@@ -133,6 +133,9 @@ class BucketedIPCReceiveMixin:
     ) -> None:
         if peft_config and base_sync_done:
             tensors = dict(weights)
+            validator = getattr(self, "_diffrl_validate_lora_tensors", None)
+            if callable(validator):
+                validator(tensors)
             lora_request = OmniTensorLoRARequest(
                 lora_name=DIFFRL_LORA_NAME,
                 lora_int_id=DIFFRL_LORA_INT_ID,
@@ -278,6 +281,9 @@ class BucketedIPCReceiveMixin:
                 f"deserialised lora_tensors expected dict, got "
                 f"{type(lora_tensors).__name__}"
             )
+        validator = getattr(self, "_diffrl_validate_lora_tensors", None)
+        if callable(validator):
+            validator(lora_tensors)
         request = OmniTensorLoRARequest(
             lora_name=str(lora_name),
             lora_int_id=int(lora_int_id),
@@ -324,6 +330,9 @@ class BucketedIPCReceiveMixin:
                 f"deserialised lora_tensors expected dict, got "
                 f"{type(lora_tensors).__name__}"
             )
+        validator = getattr(self, "_diffrl_validate_lora_tensors", None)
+        if callable(validator):
+            validator(lora_tensors)
         from unirl.rollout.engine.vllm_omni.patches.runtime import (
             OmniTensorLoRARequest,
         )

--- a/unirl/rollout/engine/vllm_omni/worker/qwen3_omni_ar_extension.py
+++ b/unirl/rollout/engine/vllm_omni/worker/qwen3_omni_ar_extension.py
@@ -19,4 +19,22 @@ class Qwen3OmniARWeightSyncExtension(
     pass
 
 
-__all__ = ["Qwen3OmniARWeightSyncExtension"]
+class Qwen3OmniTalkerWeightSyncExtension(
+    BucketedIPCReceiveMixin,
+    NcclBroadcastReceiveMixin,
+):
+    """Talker-only receiver that rejects MTP/Thinker/Code2Wav LoRA keys."""
+
+    @staticmethod
+    def _diffrl_validate_lora_tensors(tensors) -> None:
+        from unirl.distributed.weight_sync.lora.qwen3_omni_talker import (
+            validate_talker_lora_keys,
+        )
+
+        validate_talker_lora_keys(tensors, engine_envelope=True)
+
+
+__all__ = [
+    "Qwen3OmniARWeightSyncExtension",
+    "Qwen3OmniTalkerWeightSyncExtension",
+]

--- a/unirl/train/backend/sharded_load.py
+++ b/unirl/train/backend/sharded_load.py
@@ -22,13 +22,18 @@ import logging
 import os
 import re
 from fnmatch import fnmatchcase
-from typing import Dict
+from typing import Dict, Optional
 
 import torch
 from torch import nn
 
 from unirl.train.backend.sharded_state import _build_state_dict_options, _current_rank
-from unirl.train.backend.veomni.ep.models.qwen3_moe import build_local_fused_block
+from unirl.train.backend.veomni.ep.models.qwen3_moe import (
+    build_local_fused_block,
+    fused_expert_kind,
+    is_fused_expert_param,
+    normalize_fused_param_name,
+)
 from unirl.train.backend.veomni.ep.placement import assign_local_block, ep_named_parameters
 
 logger = logging.getLogger(__name__)
@@ -63,7 +68,14 @@ def load_trainable_weights(
     """
     weights_path = getattr(bundle, "_transformer_weights_path", None)
     if weights_path is not None:
-        load_sharded(model, weights_path, device=device, strict=False)
+        # Composite HF checkpoints can keep the trainable root below a prefix
+        # (for example Qwen3-Omni stores the standalone Talker as ``talker.*``).
+        # The prefix is stripped while reading so the backend still loads the
+        # standalone module's native state-dict layout. Reading is prefix-aware,
+        # not a post-load filter, to avoid materializing unrelated checkpoint
+        # tensors on rank 0.
+        key_prefix = getattr(bundle, "_transformer_weights_key_prefix", None)
+        load_sharded(model, weights_path, device=device, strict=False, key_prefix=key_prefix)
         # Recover init-computed non-persistent buffers/attrs (RoPE inv_freq, sincos
         # tables, …) captured on the bundle before meta-init's `to_empty` clobbered
         # them and not carried by the checkpoint. Restoring here — in the shared
@@ -81,7 +93,10 @@ def load_trainable_weights(
         # and nothing learns; SGLang ties its own lm_head so old_logp is fine).
         # tie_weights() re-points lm_head.weight at the loaded embed_tokens.weight.
         retied = False
-        if getattr(getattr(model, "config", None), "tie_word_embeddings", False) and hasattr(model, "tie_weights"):
+        tied_keys = getattr(getattr(model, "module", model), "_tied_weights_keys", None)
+        if (
+            getattr(getattr(model, "config", None), "tie_word_embeddings", False) or tied_keys
+        ) and hasattr(model, "tie_weights"):
             model.tie_weights()
             retied = True
         logger.info(
@@ -121,6 +136,7 @@ def load_sharded(
     *,
     device: torch.device,
     strict: bool = False,
+    key_prefix: Optional[str] = None,
 ) -> None:
     """Materialize ``module`` from a (diffusers-layout) safetensors directory.
 
@@ -136,12 +152,21 @@ def load_sharded(
     # mmap'd ``get_slice`` and uses DTensor-native ``distribute_tensor`` to fill
     # its exact local shard. Non-EP models keep the rank-0-broadcast path verbatim.
     if hasattr(module, "_extra_parallel_param_groups"):
+        if key_prefix:
+            raise NotImplementedError(
+                "EP sliced loading does not yet support composite-checkpoint "
+                f"key_prefix={key_prefix!r}; use the FSDP backend for this bundle."
+            )
         if _module_has_meta_param(module):
             module.to_empty(device=device)
         _load_state_dict_ep_sliced(module, weights_dir, device=device, strict=strict)
         return
 
-    state_dict = _read_safetensors_dir(weights_dir) if _current_rank() == 0 else {}
+    state_dict = (
+        _read_safetensors_dir(weights_dir, key_prefix=key_prefix)
+        if _current_rank() == 0
+        else {}
+    )
     _load_state_dict_sharded(module, state_dict, device=device, strict=strict)
 
 
@@ -407,6 +432,7 @@ def _load_state_dict_sharded(
         # Align raw-checkpoint keys to the constructed model's key layout *before*
         # the LoRA base_layer hop, then guard against a silent no-load.
         state_dict = _remap_hf_checkpoint_keys(state_dict, module)
+        state_dict = _fuse_hf_expert_keys(state_dict, module)
         state_dict = _remap_lora_base_keys(state_dict, module)
         _assert_state_dict_covers_model(state_dict, module)
 
@@ -428,12 +454,66 @@ def _module_has_meta_param(module: nn.Module) -> bool:
     return any(p.is_meta for p in module.parameters(recurse=True))
 
 
-def _read_safetensors_dir(weights_dir: str) -> StateDict:
+def _fuse_hf_expert_keys(state_dict: StateDict, model: nn.Module) -> StateDict:
+    """Convert HF per-expert projections into this model's stacked tensors.
+
+    Qwen3-Omni checkpoints store ``experts.{e}.{gate,up,down}_proj.weight``
+    while the Transformers runtime uses ``experts.{gate_up,down}_proj`` 3-D
+    parameters. ``from_pretrained(strict=False)`` silently leaves those stacked
+    parameters uninitialized, so direct safetensors/FSDP loading must perform
+    the same explicit layout conversion used by the EP loader.
+    """
+    available = set(state_dict)
+    fused = 0
+    unwrapped = getattr(model, "module", model)
+
+    def get_tensor(key: str) -> torch.Tensor:
+        value = state_dict[key]
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"sharded_load: expert checkpoint value {key!r} is not a tensor")
+        return value
+
+    for name, parameter in unwrapped.named_parameters():
+        normalized = normalize_fused_param_name(name)
+        if normalized in state_dict or not is_fused_expert_param(normalized):
+            continue
+        block = build_local_fused_block(
+            fused_param_name=normalized,
+            expected_shape=tuple(parameter.shape),
+            ep_rank=0,
+            available_keys=available,
+            get_tensor=get_tensor,
+        )
+        if block is None:
+            continue
+        state_dict[normalized] = block
+        fused += 1
+
+        prefix = normalized.rsplit(".experts.", 1)[0]
+        num_experts = int(parameter.shape[0])
+        kind = fused_expert_kind(normalized)
+        projections = ("gate_proj", "up_proj") if kind == "gate_up" else ("down_proj",)
+        for expert in range(num_experts):
+            for projection in projections:
+                source = f"{prefix}.experts.{expert}.{projection}.weight"
+                state_dict.pop(source, None)
+                available.discard(source)
+
+    if fused:
+        logger.info("sharded_load: fused %d HF per-expert parameter blocks", fused)
+    return state_dict
+
+
+def _read_safetensors_dir(
+    weights_dir: str,
+    *,
+    key_prefix: Optional[str] = None,
+) -> StateDict:
     """Merge all ``*.safetensors`` shards in a directory.
 
     Loading every shard makes the index json unnecessary and covers both
     single-file and sharded checkpoints."""
-    from safetensors.torch import load_file
+    from safetensors import safe_open
 
     if not os.path.isdir(weights_dir):
         raise FileNotFoundError(
@@ -446,7 +526,31 @@ def _read_safetensors_dir(weights_dir: str) -> StateDict:
         raise FileNotFoundError(f"sharded_load: no *.safetensors files under {weights_dir!r}")
     state_dict: StateDict = {}
     for shard in shards:
-        state_dict.update(load_file(shard, device="cpu"))
+        # ``safe_open`` reads only selected tensors. This matters for composite
+        # checkpoints where Talker is much smaller than the sibling Thinker:
+        # loading a shard with ``load_file`` before filtering would transiently
+        # materialize the full Omni shard and defeat meta-init's memory contract.
+        with safe_open(shard, framework="pt", device="cpu") as handle:
+            for source_key in handle.keys():
+                if key_prefix is not None:
+                    if not source_key.startswith(key_prefix):
+                        continue
+                    target_key = source_key[len(key_prefix) :]
+                    if not target_key:
+                        continue
+                else:
+                    target_key = source_key
+                if target_key in state_dict:
+                    raise ValueError(
+                        f"sharded_load: duplicate target key {target_key!r} "
+                        f"after stripping prefix {key_prefix!r}"
+                    )
+                state_dict[target_key] = handle.get_tensor(source_key)
+    if key_prefix is not None and not state_dict:
+        raise ValueError(
+            f"sharded_load: no checkpoint tensors matched key prefix {key_prefix!r} "
+            f"under {weights_dir!r}"
+        )
     return state_dict
 
 
@@ -484,8 +588,21 @@ def _remap_hf_checkpoint_keys(state_dict: StateDict, model: nn.Module) -> StateD
         from torch.distributed.fsdp import FSDPModule
 
         if isinstance(unwrapped, FSDPModule):
-            hf_cls = type(unwrapped).__mro__[FSDPModule._orig_cls_mro_index]
-    except (ImportError, IndexError):
+            original_index = getattr(FSDPModule, "_orig_cls_mro_index", None)
+            if original_index is not None:
+                hf_cls = type(unwrapped).__mro__[int(original_index)]
+            else:
+                # Some torch releases no longer expose the private index.
+                # FSDP2 dynamically mixes FSDPModule into the original class;
+                # recover the first Transformers PreTrainedModel in that MRO.
+                hf_cls = next(
+                    cls
+                    for cls in type(unwrapped).__mro__
+                    if cls is not type(unwrapped)
+                    and issubclass(cls, PreTrainedModel)
+                    and cls is not PreTrainedModel
+                )
+    except (ImportError, IndexError, StopIteration):
         pass
     if not issubclass(hf_cls, PreTrainedModel):
         return state_dict
@@ -564,4 +681,10 @@ def _remap_lora_base_keys(state_dict: StateDict, model: nn.Module) -> StateDict:
     return remapped
 
 
-__all__ = ["load_trainable_weights", "load_sharded", "_load_state_dict_sharded", "StateDict"]
+__all__ = [
+    "load_trainable_weights",
+    "load_sharded",
+    "_load_state_dict_sharded",
+    "_read_safetensors_dir",
+    "StateDict",
+]

--- a/unirl/train/lora.py
+++ b/unirl/train/lora.py
@@ -68,6 +68,7 @@ def inject_lora(
         task_type=str(task_type),
     )
     inject_adapter_in_model(peft_cfg, model, adapter_name=adapter_name)
+    _enforce_model_lora_trainability_contract(model)
 
     if _current_rank() == 0:
         n_trainable = sum(1 for p in model.parameters() if p.requires_grad)
@@ -86,6 +87,40 @@ def inject_lora(
         )
 
     _stamp(model, partial(_reset_adapter, name=adapter_name))
+
+
+def _enforce_model_lora_trainability_contract(model: nn.Module) -> None:
+    """Apply optional model-owned freeze/validation markers after injection."""
+    if bool(getattr(model, "_unirl_freeze_mtp_after_lora", False)):
+        code_predictor = getattr(model, "code_predictor", None)
+        if code_predictor is None:
+            raise RuntimeError("Model requested post-LoRA MTP freezing but has no code_predictor")
+        code_predictor.requires_grad_(False)
+    if bool(getattr(model, "_unirl_freeze_embeddings_after_lora", False)):
+        get_embeddings = getattr(model, "get_input_embeddings", None)
+        if not callable(get_embeddings):
+            raise RuntimeError("Model requested post-LoRA embedding freezing but has no embedding accessor")
+        get_embeddings().requires_grad_(False)
+    if not bool(getattr(model, "_unirl_phase1_layer0_lora_only", False)):
+        return
+
+    named_parameters = list(model.named_parameters())
+    trainable = [name for name, parameter in named_parameters if parameter.requires_grad]
+    invalid = [
+        name
+        for name in trainable
+        if "lora_" not in name or name.startswith("code_predictor.") or ".code_predictor." in name
+    ]
+    mtp_lora = [
+        name
+        for name, _parameter in named_parameters
+        if "lora_" in name and (name.startswith("code_predictor.") or ".code_predictor." in name)
+    ]
+    if not trainable or invalid or mtp_lora:
+        raise RuntimeError(
+            "Phase-1 Talker trainability contract requires LoRA only outside MTP; "
+            f"trainable={trainable[:12]}, invalid={invalid[:12]}, mtp_lora={mtp_lora[:12]}"
+        )
 
 
 def _reset_adapter(model: nn.Module, *, name: str) -> None:

--- a/unirl/types/reward.py
+++ b/unirl/types/reward.py
@@ -130,6 +130,10 @@ class RewardResponse(Batch):
 
     rewards: List[float] = concat_field(default_factory=list)
     component_rewards: Dict[str, List[float]] = concat_field(default_factory=dict)
+    # Per-sample non-scalar diagnostics (for example ASR transcripts and raw
+    # edit counts). These are deliberately kept separate from
+    # ``component_rewards``: only the latter is attached as training tensors.
+    details: List[Dict[str, Any]] = concat_field(default_factory=list)
     successes: List[bool] = concat_field(default_factory=list)
     errors: List[Optional[str]] = concat_field(default_factory=list)
     compute_time: float = max_field(default=0.0)

--- a/unirl/utils/eval_talker_tts_baseline.py
+++ b/unirl/utils/eval_talker_tts_baseline.py
@@ -1,0 +1,488 @@
+"""Evaluate cached-code reconstruction ceiling and generated Talker speech.
+
+No metric has a heuristic fallback. Missing ASR, speaker, or MOS models either
+fail immediately (``--missing_metric_policy fail``) or are represented as
+``{"status": "unavailable", ...}`` in the output JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+
+from unirl.models.qwen3_omni.config import Qwen3OmniPipelineConfig
+from unirl.models.qwen3_omni.talker_bundle import Qwen3OmniTalkerBundle
+from unirl.models.qwen3_omni.talker_conditions import Qwen3OmniTalkerConditions
+from unirl.models.qwen3_omni.talker_contract import AUDIO_SAMPLE_RATE, NUM_CODE_GROUPS
+from unirl.models.qwen3_omni.talker_data import assert_fingerprint, fingerprint_sha, model_fingerprint
+from unirl.models.qwen3_omni.talker_pipeline import Qwen3OmniTalkerPipeline
+from unirl.reward.local.tts_wer import word_error_rate
+from unirl.types.primitives import Texts
+from unirl.types.sample import Part, Sample
+from unirl.types.sampling import ARSamplingParams
+
+
+def _char_error_rate(reference: str, hypothesis: str) -> float:
+    ref = list(reference)
+    hyp = list(hypothesis)
+    if not ref:
+        return 0.0 if not hyp else 1.0
+    previous = list(range(len(hyp) + 1))
+    for i, ref_char in enumerate(ref, 1):
+        current = [i]
+        for j, hyp_char in enumerate(hyp, 1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[j] + 1,
+                    previous[j - 1] + (ref_char != hyp_char),
+                )
+            )
+        previous = current
+    return float(previous[-1]) / float(len(ref))
+
+
+def _load_audio(path: str) -> tuple[torch.Tensor, int]:
+    import soundfile as sf
+
+    values, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    return torch.from_numpy(values).mean(dim=1), int(sample_rate)
+
+
+def _load_unirl_lora_checkpoint(bundle: Qwen3OmniTalkerBundle, checkpoint_path: str) -> Dict[str, Any]:
+    from unirl.train.lora import inject_lora
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    if not isinstance(checkpoint, dict):
+        raise TypeError(f"UniRL checkpoint must be a dict, got {type(checkpoint).__name__}")
+    policy = checkpoint.get("policy_state_dict")
+    config = checkpoint.get("lora_config")
+    if not isinstance(policy, dict) or not policy:
+        raise ValueError("UniRL checkpoint has no non-empty policy_state_dict")
+    if not isinstance(config, dict):
+        raise ValueError("UniRL checkpoint has no lora_config")
+    inject_lora(
+        bundle.talker,
+        rank=int(config["rank"]),
+        alpha=int(config["alpha"]),
+        target_modules=config["target_modules"],
+        exclude_modules=config.get("exclude_modules"),
+        dropout=float(config.get("dropout", 0.0)),
+        bias=str(config.get("bias", "none")),
+        task_type=str(config.get("task_type", "FEATURE_EXTRACTION")),
+    )
+    incompatible = bundle.talker.load_state_dict(policy, strict=False)
+    if incompatible.unexpected_keys:
+        raise RuntimeError(
+            f"Checkpoint contains unexpected Talker keys: {incompatible.unexpected_keys[:8]}"
+        )
+    model_keys = set(bundle.talker.state_dict())
+    missing_policy = sorted(set(policy) - model_keys)
+    if missing_policy:
+        raise RuntimeError(f"Checkpoint keys were not injected into Talker: {missing_policy[:8]}")
+    bundle.talker.requires_grad_(False)
+    bundle.talker.eval()
+    return {
+        "path": checkpoint_path,
+        "step": int(checkpoint.get("step", -1)),
+        "lora_tensors": len(policy),
+    }
+
+
+class _OptionalMetric:
+    def __init__(self, name: str, policy: str) -> None:
+        self.name = name
+        self.policy = policy
+        self.reason: Optional[str] = None
+
+    def unavailable(self, reason: str) -> None:
+        self.reason = reason
+        if self.policy == "fail":
+            raise RuntimeError(f"{self.name} unavailable: {reason}")
+
+    @property
+    def available(self) -> bool:
+        return self.reason is None
+
+
+class _ASR(_OptionalMetric):
+    def __init__(self, model_id: str, *, device: str, policy: str) -> None:
+        super().__init__("ASR WER/CER", policy)
+        self.pipeline = None
+        if not model_id:
+            self.unavailable("--asr_model_id was not provided")
+            return
+        try:
+            from transformers import pipeline
+
+            pipeline_device: Any = 0 if device.startswith("cuda") and torch.cuda.is_available() else -1
+            self.pipeline = pipeline("automatic-speech-recognition", model=model_id, device=pipeline_device)
+        except Exception as exc:
+            self.unavailable(f"failed to load {model_id!r}: {exc}")
+
+    def score(self, waveform: torch.Tensor, reference: str) -> Dict[str, Any]:
+        if not self.available or self.pipeline is None:
+            return {"transcript": None, "wer": None, "cer": None}
+        result = self.pipeline({"array": waveform.detach().float().cpu().numpy(), "sampling_rate": AUDIO_SAMPLE_RATE})
+        hypothesis = str(result.get("text", "") if isinstance(result, dict) else result).strip()
+        return {
+            "transcript": hypothesis,
+            "wer": word_error_rate(reference, hypothesis),
+            "cer": _char_error_rate(reference, hypothesis),
+        }
+
+
+class _SpeakerSIM(_OptionalMetric):
+    def __init__(self, model_id: str, *, device: str, policy: str) -> None:
+        super().__init__("speaker SIM", policy)
+        self.device = device
+        self.processor = self.model = None
+        if not model_id:
+            self.unavailable("--speaker_model_id was not provided")
+            return
+        try:
+            from transformers import AutoFeatureExtractor, AutoModel
+
+            self.processor = AutoFeatureExtractor.from_pretrained(model_id)
+            self.model = AutoModel.from_pretrained(model_id).to(device).eval()
+        except Exception as exc:
+            self.unavailable(f"failed to load {model_id!r}: {exc}")
+
+    def _embed(self, waveform: torch.Tensor, sample_rate: int) -> torch.Tensor:
+        assert self.processor is not None and self.model is not None
+        inputs = self.processor(
+            waveform.detach().float().cpu().numpy(),
+            sampling_rate=int(sample_rate),
+            return_tensors="pt",
+        )
+        inputs = {key: value.to(self.device) for key, value in inputs.items()}
+        with torch.no_grad():
+            hidden = self.model(**inputs).last_hidden_state.mean(dim=1).squeeze(0)
+        return torch.nn.functional.normalize(hidden.float(), dim=-1)
+
+    def score(self, waveform: torch.Tensor, reference_path: Optional[str]) -> Optional[float]:
+        if not self.available or not reference_path:
+            return None
+        reference, reference_rate = _load_audio(reference_path)
+        generated = self._embed(waveform, AUDIO_SAMPLE_RATE)
+        target = self._embed(reference, reference_rate)
+        return float(torch.dot(generated, target).clamp(-1.0, 1.0).item())
+
+
+class _MOS(_OptionalMetric):
+    def __init__(self, policy: str) -> None:
+        super().__init__("UTMOS", policy)
+        self.predictor = None
+        try:
+            import utmos  # type: ignore
+
+            self.predictor = utmos.Score()
+        except Exception as exc:
+            self.unavailable(f"utmos package/model failed to load: {exc}")
+
+    def score(self, waveform: torch.Tensor) -> Optional[float]:
+        if not self.available or self.predictor is None:
+            return None
+        return float(self.predictor.score(waveform.detach().float().cpu().numpy(), AUDIO_SAMPLE_RATE))
+
+
+def _metric_summary(rows: Sequence[Dict[str, Any]], key: str, metric: _OptionalMetric) -> Dict[str, Any]:
+    values = [float(row[key]) for row in rows if row.get(key) is not None]
+    if not metric.available:
+        return {"status": "unavailable", "reason": metric.reason, "n": 0, "mean": None}
+    if not values:
+        return {"status": "unavailable", "reason": f"no rows had inputs for {key}", "n": 0, "mean": None}
+    return {"status": "available", "n": len(values), "mean": sum(values) / len(values)}
+
+
+def _read_rows(path: str, max_samples: int) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            item = json.loads(line)
+            if not isinstance(item, dict):
+                raise TypeError(f"{path}:{line_number}: expected a JSON object")
+            rows.append(item)
+            if max_samples >= 0 and len(rows) >= max_samples:
+                break
+    if not rows:
+        raise ValueError(f"No eval rows found in {path}")
+    return rows
+
+
+def _validate_manifest_fingerprints(
+    rows: Sequence[Dict[str, Any]],
+    *,
+    model_path: str,
+    expected_codec_fingerprint: str,
+) -> tuple[Dict[str, Any], str]:
+    model_fp = model_fingerprint(model_path, kind="qwen3_omni_talker")
+    first_meta = rows[0].get("metadata") or {}
+    codec_sha = (
+        fingerprint_sha(expected_codec_fingerprint, field_name="expected_codec_fingerprint")
+        if expected_codec_fingerprint
+        else fingerprint_sha(first_meta.get("codec_fingerprint"), field_name="codec_fingerprint")
+    )
+    for index, row in enumerate(rows):
+        metadata = row.get("metadata") or {}
+        sample_id = str(row.get("sample_id", index))
+        assert_fingerprint(
+            metadata.get("talker_model_fingerprint"),
+            model_fp,
+            field_name="talker_model_fingerprint",
+            sample_id=sample_id,
+        )
+        assert_fingerprint(
+            metadata.get("codec_fingerprint"),
+            codec_sha,
+            field_name="codec_fingerprint",
+            sample_id=sample_id,
+        )
+    return model_fp, codec_sha
+
+
+def _score_audio(
+    waveform: torch.Tensor,
+    *,
+    transcript: str,
+    reference_path: Optional[str],
+    asr: _ASR,
+    speaker: _SpeakerSIM,
+    mos: _MOS,
+) -> Dict[str, Any]:
+    if waveform.numel() == 0 or not torch.isfinite(waveform).all():
+        raise ValueError("decoded waveform is empty or non-finite")
+    asr_scores = asr.score(waveform, transcript)
+    return {
+        **asr_scores,
+        "sim": speaker.score(waveform, reference_path),
+        "mos": mos.score(waveform),
+        "duration_s": float(waveform.numel()) / AUDIO_SAMPLE_RATE,
+    }
+
+
+def _aggregate(mode_rows: Sequence[Dict[str, Any]], *, asr: _ASR, speaker: _SpeakerSIM, mos: _MOS) -> Dict[str, Any]:
+    return {
+        "wer": _metric_summary(mode_rows, "wer", asr),
+        "cer": _metric_summary(mode_rows, "cer", asr),
+        "sim": _metric_summary(mode_rows, "sim", speaker),
+        "mos": _metric_summary(mode_rows, "mos", mos),
+        "decode_failure_rate": sum(bool(row["decode_failure"]) for row in mode_rows) / len(mode_rows),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--checkpoint", default="", help="Optional UniRL Talker LoRA checkpoint.pt")
+    parser.add_argument("--eval_jsonl", required=True)
+    parser.add_argument("--out_json", required=True)
+    parser.add_argument("--audio_out_dir", default="")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--max_samples", type=int, default=32)
+    parser.add_argument("--max_new_tokens", type=int, default=2048)
+    parser.add_argument("--temperature", type=float, default=0.9)
+    parser.add_argument("--top_p", type=float, default=1.0)
+    parser.add_argument("--top_k", type=int, default=50)
+    parser.add_argument("--asr_model_id", default="")
+    parser.add_argument("--speaker_model_id", default="")
+    parser.add_argument("--expected_codec_fingerprint", default="")
+    parser.add_argument("--missing_metric_policy", choices=("fail", "unavailable"), default="unavailable")
+    parser.add_argument("--seed", type=int, default=20260811)
+    args = parser.parse_args(argv)
+
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(args.seed)
+
+    rows = _read_rows(args.eval_jsonl, args.max_samples)
+    model_fp, codec_sha = _validate_manifest_fingerprints(
+        rows,
+        model_path=args.model_path,
+        expected_codec_fingerprint=args.expected_codec_fingerprint,
+    )
+    asr = _ASR(args.asr_model_id, device=args.device, policy=args.missing_metric_policy)
+    speaker_metric = _SpeakerSIM(
+        args.speaker_model_id,
+        device=args.device,
+        policy=args.missing_metric_policy,
+    )
+    mos = _MOS(args.missing_metric_policy)
+
+    config = Qwen3OmniPipelineConfig(
+        pretrained_model_ckpt_path=args.model_path,
+        model_precision="bf16",
+        device=args.device,
+        enable_talker=True,
+    )
+    bundle = Qwen3OmniTalkerBundle.from_config(config)
+    checkpoint_info = (
+        _load_unirl_lora_checkpoint(bundle, args.checkpoint)
+        if args.checkpoint
+        else None
+    )
+    pipeline = Qwen3OmniTalkerPipeline.from_bundle(bundle, decode_audio=True)
+    codec_eos = int(bundle.config.talker_config.codec_eos_token_id)
+
+    reconstruction_rows: List[Dict[str, Any]] = []
+    generation_rows: List[Dict[str, Any]] = []
+    audio_out_dir = Path(args.audio_out_dir) if args.audio_out_dir else None
+    if audio_out_dir is not None:
+        audio_out_dir.mkdir(parents=True, exist_ok=True)
+    for index, row in enumerate(rows):
+        sample_id = str(row.get("sample_id", index))
+        metadata = row.get("metadata") or {}
+        transcript = str(metadata["normalized_transcript"])
+        speaker_name = str(metadata["speaker"])
+        reference_path = metadata.get("audio_path")
+
+        reconstruction: Dict[str, Any] = {"sample_id": sample_id, "decode_failure": False}
+        try:
+            codes = torch.as_tensor(metadata["audio_codes"], dtype=torch.long)
+            length = int(metadata["audio_code_length"])
+            if codes.ndim != 2 or codes.shape[0] != NUM_CODE_GROUPS or not 0 < length <= codes.shape[1]:
+                raise ValueError(f"invalid cached codes shape/length: {tuple(codes.shape)}, {length}")
+            waveform = pipeline.ar.decode_codes_to_audio(
+                layer0_codes=[codes[0, :length]],
+                residual_codes=[codes[1:, :length]],
+            )[0]
+            reconstruction.update(
+                _score_audio(
+                    waveform,
+                    transcript=transcript,
+                    reference_path=reference_path,
+                    asr=asr,
+                    speaker=speaker_metric,
+                    mos=mos,
+                )
+            )
+            if audio_out_dir is not None:
+                import soundfile as sf
+
+                audio_path = audio_out_dir / f"{sample_id}.reconstruction.wav"
+                sf.write(audio_path, waveform.detach().float().cpu().numpy(), AUDIO_SAMPLE_RATE)
+                reconstruction["audio_path"] = str(audio_path)
+        except Exception as exc:
+            reconstruction.update(
+                {
+                    "decode_failure": True,
+                    "failure": f"{type(exc).__name__}: {exc}",
+                    "wer": None,
+                    "cer": None,
+                    "sim": None,
+                    "mos": None,
+                }
+            )
+        reconstruction_rows.append(reconstruction)
+
+        generated: Dict[str, Any] = {
+            "sample_id": sample_id,
+            "decode_failure": False,
+            "eos_failure": False,
+        }
+        try:
+            request = Sample(
+                parts=[
+                    Part.input(
+                        [sample_id],
+                        primitives={"text": Texts(texts=[transcript])},
+                        metadata=[{"speaker": speaker_name}],
+                    )
+                ]
+            ).fork(
+                1,
+                sampling_params=ARSamplingParams(
+                    max_new_tokens=args.max_new_tokens,
+                    temperature=args.temperature,
+                    top_p=args.top_p,
+                    top_k=args.top_k,
+                ),
+            )
+            output = pipeline.generate(request)
+            frontier = output.frontier_gen_part(ARSamplingParams)
+            if frontier.segment is None or frontier.segment.tokens is None:
+                raise ValueError("generation did not return layer-0 codec tokens")
+            tokens = frontier.segment.tokens
+            generated["num_codec_steps"] = int(tokens.numel())
+            generated["eos_failure"] = not bool(tokens.numel() and int(tokens[-1].item()) == codec_eos)
+            conditions = Qwen3OmniTalkerConditions.from_dict(frontier.conditions)
+            if conditions.residual_codes is None:
+                raise ValueError("generation did not return MTP residual codes")
+            audio = frontier.primitives.get("audio")
+            if audio is None:
+                raise ValueError("generation did not return decoded audio")
+            audio_items = audio.to_list()
+            if not audio_items:
+                raise ValueError("generation returned an empty audio batch")
+            waveform = audio_items[0].waveform
+            generated.update(
+                _score_audio(
+                    waveform,
+                    transcript=transcript,
+                    reference_path=reference_path,
+                    asr=asr,
+                    speaker=speaker_metric,
+                    mos=mos,
+                )
+            )
+            if audio_out_dir is not None:
+                import soundfile as sf
+
+                audio_path = audio_out_dir / f"{sample_id}.generated.wav"
+                sf.write(audio_path, waveform.detach().float().cpu().numpy(), AUDIO_SAMPLE_RATE)
+                generated["audio_path"] = str(audio_path)
+        except Exception as exc:
+            if "num_codec_steps" not in generated:
+                generated["eos_failure"] = True
+            generated.update(
+                {
+                    "decode_failure": True,
+                    "failure": f"{type(exc).__name__}: {exc}",
+                    "wer": None,
+                    "cer": None,
+                    "sim": None,
+                    "mos": None,
+                }
+            )
+        generation_rows.append(generated)
+
+    result = {
+        "n": len(rows),
+        "model_fingerprint": model_fp,
+        "codec_fingerprint": codec_sha,
+        "checkpoint": checkpoint_info,
+        "reconstruction_ceiling": {
+            "metrics": _aggregate(reconstruction_rows, asr=asr, speaker=speaker_metric, mos=mos),
+            "rows": reconstruction_rows,
+        },
+        "generation": {
+            "metrics": {
+                **_aggregate(generation_rows, asr=asr, speaker=speaker_metric, mos=mos),
+                "eos_failure_rate": sum(bool(row["eos_failure"]) for row in generation_rows) / len(generation_rows),
+            },
+            "rows": generation_rows,
+        },
+    }
+    output_path = Path(args.out_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_name(f".{output_path.name}.tmp.{os.getpid()}")
+    try:
+        tmp_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp_path, output_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    print(json.dumps({"n": len(rows), "output": str(output_path)}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/unirl/utils/prepare_talker_tts_data.py
+++ b/unirl/utils/prepare_talker_tts_data.py
@@ -1,0 +1,244 @@
+"""Build the *offline-only* Mimi target manifest consumed by Talker SFT.
+
+Every emitted SFT row contains mono 24 kHz Mimi codes with exact ``[16, T]``
+layout, the valid code length, normalized transcript metadata, and both Talker
+checkpoint and codec fingerprints.  Training never receives a waveform and
+therefore cannot silently run a different online encoder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from unirl.models.qwen3_omni.talker_contract import AUDIO_SAMPLE_RATE, NUM_CODE_GROUPS
+from unirl.models.qwen3_omni.talker_data import (
+    CODEC_DATA_SCHEMA,
+    codec_fingerprint,
+    model_fingerprint,
+)
+
+
+def normalize_transcript(text: str) -> str:
+    text = unicodedata.normalize("NFKC", str(text))
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _load_wav_mono_24k(path: str):
+    import soundfile as sf
+    import torch
+    import torchaudio
+
+    values, sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    waveform = torch.from_numpy(values.T.copy())
+    if waveform.ndim != 2 or waveform.shape[0] < 1:
+        raise ValueError(f"Audio {path!r} must decode to [channels, samples], got {tuple(waveform.shape)}")
+    waveform = waveform.float().mean(dim=0, keepdim=True)
+    if int(sample_rate) != AUDIO_SAMPLE_RATE:
+        waveform = torchaudio.functional.resample(waveform, int(sample_rate), AUDIO_SAMPLE_RATE)
+    waveform = waveform.squeeze(0).contiguous()
+    if waveform.numel() == 0 or not torch.isfinite(waveform).all():
+        raise ValueError(f"Audio {path!r} is empty or contains non-finite samples")
+    return waveform
+
+
+def _unwrap_audio_codes(encoded: Any):
+    import torch
+
+    codes = getattr(encoded, "audio_codes", encoded)
+    if isinstance(codes, (tuple, list)):
+        if not codes:
+            raise ValueError("Mimi encode returned an empty sequence")
+        codes = codes[0]
+    codes = torch.as_tensor(codes)
+    while codes.ndim > 2 and codes.shape[0] == 1:
+        codes = codes.squeeze(0)
+    if codes.ndim != 2:
+        raise ValueError(f"Mimi encode expected singleton batch dimensions then [Q, T], got {tuple(codes.shape)}")
+    return codes
+
+
+def _encode_mimi(wav, *, mimi, feature_extractor, device: str):
+    import torch
+
+    values = wav.detach().float().cpu().numpy()
+    inputs = feature_extractor(values, sampling_rate=AUDIO_SAMPLE_RATE, return_tensors="pt")
+    model_inputs = {
+        key: value.to(device)
+        for key, value in inputs.items()
+        if hasattr(value, "to") and key in {"input_values", "padding_mask"}
+    }
+    if "padding_mask" not in model_inputs and hasattr(inputs.get("attention_mask"), "to"):
+        model_inputs["padding_mask"] = inputs["attention_mask"].to(device)
+    if "input_values" not in model_inputs:
+        raise ValueError("Mimi feature extractor did not return input_values")
+    with torch.no_grad():
+        codes = _unwrap_audio_codes(mimi.encode(num_quantizers=NUM_CODE_GROUPS, **model_inputs)).detach().cpu().long()
+    if codes.shape[0] != NUM_CODE_GROUPS:
+        raise ValueError(
+            f"Mimi emitted {codes.shape[0]} quantizers; Talker SFT requires exactly {NUM_CODE_GROUPS}, "
+            "and will not truncate/pad incompatible codec targets."
+        )
+    if codes.shape[1] < 1:
+        raise ValueError("Mimi emitted an empty code timeline")
+    return codes
+
+
+def _extract_text_speaker_audio(
+    obj: Dict[str, Any],
+    *,
+    default_speaker: str,
+    default_language: str,
+) -> Tuple[str, str, str, Optional[str]]:
+    metadata = obj.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise TypeError("Input row metadata must be a dictionary")
+    speaker = str(obj.get("speaker") or metadata.get("speaker") or default_speaker).strip()
+    language = str(obj.get("language") or metadata.get("language") or default_language).strip()
+    audio = None
+    if obj.get("audios"):
+        audio = obj["audios"][0]
+    elif obj.get("audio"):
+        audio = obj["audio"]
+    text = obj.get("text") or obj.get("prompt")
+    if text is None and obj.get("messages"):
+        for m in obj["messages"]:
+            if m.get("role") == "user":
+                text = m.get("content")
+                break
+    if not text:
+        raise ValueError(f"Cannot extract text from {obj!r}")
+    normalized = normalize_transcript(str(text))
+    if not normalized:
+        raise ValueError("Transcript is empty after Unicode/whitespace normalization")
+    if not speaker or not language:
+        raise ValueError("speaker and language must be non-empty")
+    return normalized, speaker, language, (str(audio) if audio else None)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input_jsonl", required=True)
+    p.add_argument("--output_jsonl", required=True)
+    p.add_argument("--talker_model", required=True, help="Exact Qwen3-Omni checkpoint used for training")
+    p.add_argument("--talker_revision", default=None)
+    p.add_argument("--mimi_model", default="kyutai/mimi")
+    p.add_argument("--mimi_revision", default=None)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--max_samples", type=int, default=-1)
+    p.add_argument("--log_every", type=int, default=100)
+    p.add_argument("--default_speaker", default="Ethan")
+    p.add_argument("--default_language", default="und")
+    p.add_argument("--rl_prompts_only", action="store_true", help="Skip code encode; emit RL prompts only")
+    args = p.parse_args(argv)
+
+    talker_fp = model_fingerprint(
+        args.talker_model,
+        kind="qwen3_omni_talker",
+        revision=args.talker_revision,
+    )
+    codec_fp = codec_fingerprint(args.mimi_model, revision=args.mimi_revision)
+    mimi = feature_extractor = None
+    if not args.rl_prompts_only:
+        from transformers import AutoFeatureExtractor, MimiModel
+
+        feature_extractor = AutoFeatureExtractor.from_pretrained(
+            args.mimi_model,
+            revision=args.mimi_revision,
+        )
+        mimi = (
+            MimiModel.from_pretrained(
+                args.mimi_model,
+                revision=args.mimi_revision,
+            )
+            .to(args.device)
+            .eval()
+        )
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output_jsonl)) or ".", exist_ok=True)
+    output_path = Path(args.output_jsonl)
+    tmp_path = output_path.with_name(f".{output_path.name}.tmp.{os.getpid()}")
+    n = 0
+    try:
+        with open(args.input_jsonl, encoding="utf-8") as fin, tmp_path.open("w", encoding="utf-8") as fout:
+            for line_number, line in enumerate(fin, 1):
+                if not line.strip():
+                    continue
+                if args.max_samples >= 0 and n >= args.max_samples:
+                    break
+                try:
+                    obj = json.loads(line)
+                    text, speaker, language, audio = _extract_text_speaker_audio(
+                        obj,
+                        default_speaker=args.default_speaker,
+                        default_language=args.default_language,
+                    )
+                    if audio and not os.path.isabs(audio):
+                        audio = os.path.abspath(os.path.join(os.path.dirname(args.input_jsonl), audio))
+                    meta: Dict[str, Any] = {
+                        "codec_data_schema": CODEC_DATA_SCHEMA,
+                        "speaker": speaker,
+                        "language": language,
+                        "normalized_transcript": text,
+                        "talker_model_fingerprint": talker_fp,
+                        "codec_fingerprint": codec_fp,
+                    }
+                    if audio:
+                        meta["audio_path"] = audio
+                    if not args.rl_prompts_only:
+                        if not audio:
+                            raise ValueError("sample is missing an audio path")
+                        wav = _load_wav_mono_24k(audio)
+                        codes = _encode_mimi(
+                            wav,
+                            mimi=mimi,
+                            feature_extractor=feature_extractor,
+                            device=args.device,
+                        )
+                        meta["audio_codes"] = codes.tolist()
+                        meta["audio_code_length"] = int(codes.shape[1])
+                        meta["audio_num_samples_24k"] = int(wav.numel())
+                    out = {
+                        "sample_id": str(obj.get("sample_id") or f"tts-{n}"),
+                        "prompt": text,
+                        "metadata": meta,
+                    }
+                    fout.write(json.dumps(out, ensure_ascii=False, separators=(",", ":")) + "\n")
+                    n += 1
+                    if args.log_every > 0 and n % args.log_every == 0:
+                        print(
+                            json.dumps(
+                                {
+                                    "progress_rows": n,
+                                    "input": args.input_jsonl,
+                                    "output": args.output_jsonl,
+                                }
+                            ),
+                            flush=True,
+                        )
+                except Exception as exc:
+                    raise ValueError(f"{args.input_jsonl}:{line_number}: {exc}") from exc
+        os.replace(tmp_path, output_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    print(
+        json.dumps(
+            {
+                "rows": n,
+                "output": str(output_path),
+                "talker_model_fingerprint": talker_fp["sha256"],
+                "codec_fingerprint": codec_fp["sha256"],
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/unirl/utils/tts_reward_eval.py
+++ b/unirl/utils/tts_reward_eval.py
@@ -1,0 +1,202 @@
+"""Validate fixed TTS eval schemas and aggregate trustworthy reward results.
+
+This CPU-only tool does not load reward or generation models. It joins a fixed
+eval manifest with model-scored JSONL rows and emits overall plus stratified
+WER/CER/SIM/MOS, EOS/decode/anomaly rates, and reward distributions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, pstdev
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+TTS_EVAL_MANIFEST_SCHEMA = "unirl.tts_eval_manifest.v1"
+TTS_EVAL_RESULT_SCHEMA = "unirl.tts_eval_result.v1"
+LENGTH_BUCKETS = frozenset({"short", "medium", "long"})
+STRATIFICATION_FIELDS = ("language", "length_bucket", "contains_number", "speaker_id")
+
+
+def _require(row: Mapping[str, Any], key: str, expected_type: type, *, source: str) -> Any:
+    if key not in row:
+        raise ValueError(f"{source}: missing required field {key!r}")
+    value = row[key]
+    if not isinstance(value, expected_type) or (expected_type is str and not value.strip()):
+        raise TypeError(f"{source}: {key!r} must be a non-empty {expected_type.__name__}")
+    return value
+
+
+def validate_manifest_row(row: Mapping[str, Any], *, source: str = "manifest row") -> Dict[str, Any]:
+    if row.get("schema") != TTS_EVAL_MANIFEST_SCHEMA:
+        raise ValueError(f"{source}: schema must be {TTS_EVAL_MANIFEST_SCHEMA!r}")
+    normalized = dict(row)
+    _require(row, "sample_id", str, source=source)
+    _require(row, "text", str, source=source)
+    _require(row, "language", str, source=source)
+    _require(row, "speaker_id", str, source=source)
+    bucket = _require(row, "length_bucket", str, source=source)
+    if bucket not in LENGTH_BUCKETS:
+        raise ValueError(f"{source}: length_bucket must be one of {sorted(LENGTH_BUCKETS)}")
+    _require(row, "contains_number", bool, source=source)
+    if not row.get("ref_audio") and row.get("speaker_embedding") is None:
+        raise ValueError(f"{source}: ref_audio or speaker_embedding is required for speaker SIM")
+    return normalized
+
+
+def validate_result_row(row: Mapping[str, Any], *, source: str = "result row") -> Dict[str, Any]:
+    if row.get("schema") != TTS_EVAL_RESULT_SCHEMA:
+        raise ValueError(f"{source}: schema must be {TTS_EVAL_RESULT_SCHEMA!r}")
+    normalized = dict(row)
+    _require(row, "sample_id", str, source=source)
+    for key in ("has_eos", "decode_failure", "anomaly"):
+        _require(row, key, bool, source=source)
+    for key in ("wer", "cer", "sim", "mos", "reward"):
+        value = row.get(key)
+        if value is not None and (
+            isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value))
+        ):
+            raise TypeError(f"{source}: {key!r} must be finite numeric or null")
+    return normalized
+
+
+def read_jsonl(path: str, validator) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise TypeError(f"{path}:{line_number}: expected JSON object")
+            rows.append(validator(value, source=f"{path}:{line_number}"))
+    if not rows:
+        raise ValueError(f"{path}: no rows")
+    return rows
+
+
+def _numeric_summary(rows: Sequence[Mapping[str, Any]], key: str) -> Dict[str, Any]:
+    values = [float(row[key]) for row in rows if row.get(key) is not None]
+    if not values:
+        return {"status": "unavailable", "n": 0, "mean": None}
+    ordered = sorted(values)
+
+    def quantile(fraction: float) -> float:
+        position = fraction * (len(ordered) - 1)
+        lower = int(math.floor(position))
+        upper = int(math.ceil(position))
+        if lower == upper:
+            return ordered[lower]
+        weight = position - lower
+        return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+    return {
+        "status": "available",
+        "n": len(values),
+        "mean": mean(values),
+        "std": pstdev(values),
+        "min": ordered[0],
+        "p10": quantile(0.10),
+        "p50": quantile(0.50),
+        "p90": quantile(0.90),
+        "max": ordered[-1],
+    }
+
+
+def _summary(rows: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    count = len(rows)
+    return {
+        "n": count,
+        "wer": _numeric_summary(rows, "wer"),
+        "cer": _numeric_summary(rows, "cer"),
+        "sim": _numeric_summary(rows, "sim"),
+        "mos": _numeric_summary(rows, "mos"),
+        "reward_distribution": _numeric_summary(rows, "reward"),
+        "eos_failure_rate": sum(not bool(row["has_eos"]) for row in rows) / count,
+        "decode_failure_rate": sum(bool(row["decode_failure"]) for row in rows) / count,
+        "anomaly_rate": sum(bool(row["anomaly"]) for row in rows) / count,
+    }
+
+
+def aggregate_tts_eval(
+    manifest_rows: Sequence[Mapping[str, Any]],
+    result_rows: Sequence[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    manifest_by_id: Dict[str, Mapping[str, Any]] = {}
+    for row in manifest_rows:
+        sample_id = str(row["sample_id"])
+        if sample_id in manifest_by_id:
+            raise ValueError(f"duplicate manifest sample_id {sample_id!r}")
+        manifest_by_id[sample_id] = row
+    result_by_id: Dict[str, Mapping[str, Any]] = {}
+    for row in result_rows:
+        sample_id = str(row["sample_id"])
+        if sample_id in result_by_id:
+            raise ValueError(f"duplicate result sample_id {sample_id!r}")
+        result_by_id[sample_id] = row
+    missing = sorted(set(manifest_by_id) - set(result_by_id))
+    extra = sorted(set(result_by_id) - set(manifest_by_id))
+    if missing or extra:
+        raise ValueError(f"manifest/result sample mismatch: missing={missing[:5]}, extra={extra[:5]}")
+
+    joined: List[Dict[str, Any]] = []
+    for sample_id, manifest in manifest_by_id.items():
+        joined.append({**manifest, **result_by_id[sample_id], "sample_id": sample_id})
+
+    strata: Dict[str, Dict[str, Any]] = {}
+    for field in STRATIFICATION_FIELDS:
+        groups: Dict[str, List[Mapping[str, Any]]] = defaultdict(list)
+        for row in joined:
+            groups[str(row[field]).lower() if isinstance(row[field], bool) else str(row[field])].append(row)
+        strata[field] = {key: _summary(values) for key, values in sorted(groups.items())}
+    return {
+        "schema": "unirl.tts_eval_report.v1",
+        "overall": _summary(joined),
+        "stratified": strata,
+        "rows": joined,
+    }
+
+
+def _atomic_write_json(path: str, payload: Mapping[str, Any]) -> None:
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(temporary, output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--results", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+    manifest = read_jsonl(args.manifest, validate_manifest_row)
+    results = read_jsonl(args.results, validate_result_row)
+    report = aggregate_tts_eval(manifest, results)
+    _atomic_write_json(args.output, report)
+    print(json.dumps({"n": report["overall"]["n"], "output": args.output}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "LENGTH_BUCKETS",
+    "STRATIFICATION_FIELDS",
+    "TTS_EVAL_MANIFEST_SCHEMA",
+    "TTS_EVAL_RESULT_SCHEMA",
+    "aggregate_tts_eval",
+    "read_jsonl",
+    "validate_manifest_row",
+    "validate_result_row",
+]


### PR DESCRIPTION
Add lossless codec replay, SFT/RL recipes, fail-closed audio rewards, and standalone sharded loading so Talker can be trained without running the full Thinker.

## Summary

<!--
Explain what changed and why. Keep this focused on the reviewer-facing context,
not a file-by-file changelog.
-->

## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan

<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [ ] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
