### PR TITLE
refactor(qwen3_omni): localize the omni chat render; share the two multi-consumer composition helpers

### DIFF
--- a/unirl/models/README.md
+++ b/unirl/models/README.md
@@ -84,3 +84,23 @@ it is the authoritative bundle / pipeline / stage / conditions contract.
   it's `None`; never build the σ tensor inside `generate`.
 - **CFG empty-negative differs per model** (SD3 `""`, Qwen-Image `" "`) — use the
   model's canonical upstream value or the rollout/replay ratio drifts off 1.0.
+
+
+## Conversation composition
+
+`unirl/models/types/conversations.py` holds the transpose helpers with more than
+one model consumer: `build_text_messages` (qwen3, qwen3_5),
+`build_vision_messages` (qwen_vl, qwen3_5), and the two composition rules both
+use — `system_prefix` and `group_consecutive_roles`. The sglang wire render
+imports those two rather than keeping private copies, so the rules have one
+definition.
+
+- **One system rule:** the config `system_instruction` is a default; an explicit
+  `system` turn in the data wins. A path that wants "data is the sole source of
+  truth" leaves `system_instruction` unset in the recipe — not a code branch.
+- **A render with one model consumer stays in that model's package** and imports
+  the shared rules (Qwen3-Omni's URI-media render lives in
+  `unirl/models/qwen3_omni/media.py`, next to the media contract it enforces). It
+  moves into the shared layer when a second consumer actually exists.
+- Model chat stages own *encoding* — chat template, processor, Bagel splits —
+  never the composition rules.

--- a/unirl/models/qwen3_omni/chat_template.py
+++ b/unirl/models/qwen3_omni/chat_template.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch
 
-from unirl.models.types.conversations import build_omni_messages
 from unirl.types.conditions import TextTokenCondition
 from unirl.types.media import MediaRefs
 from unirl.types.primitives import Texts
@@ -14,7 +13,7 @@ from unirl.types.sample import Turn
 
 from .bundle import Qwen3OmniBundle
 from .conditions import Qwen3OmniARConditions
-from .media import omni_processor_media_kwargs, prepare_omni_media
+from .media import build_omni_messages, omni_processor_media_kwargs, prepare_omni_media
 
 Qwen3OmniChatInput = Union[List[Turn], Texts]
 

--- a/unirl/models/qwen3_omni/media.py
+++ b/unirl/models/qwen3_omni/media.py
@@ -1,14 +1,90 @@
-"""Shared media helpers for Qwen3-Omni prompt processing."""
+"""Shared media helpers and the prompt-media contract for Qwen3-Omni."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import PIL.Image
 
+from unirl.models.types.conversations import Conversation, group_consecutive_roles, system_prefix
+from unirl.types.media import MediaRefs
+from unirl.types.primitives import Texts
+from unirl.types.sample import Turn
+
 from .video import limit_video_frames, sample_video_frames_pyav
+
+
+def build_omni_messages(
+    turns: List[Turn],
+    system_instruction: Optional[str] = None,
+) -> List[Conversation]:
+    """Render the trajectory as Qwen3-Omni chat conversations, one per frontier row.
+
+    Qwen3-Omni's prompt-media contract: media rides as URI-backed ``MediaRefs`` and
+    each ref becomes a ``{"type": modality, modality: uri}`` content part (the
+    serving side decodes the file), with at most one prompt input per modality per
+    row. Decoded frame/waveform primitives are rejected so tensors cannot bypass the
+    URI contract.
+
+    Both parity sides call this: the HF trainside chat stage and the vLLM-Omni
+    rollout adapter, so replay and rollout compose the same messages. The transpose
+    rules it builds on (:func:`system_prefix`, :func:`group_consecutive_roles`) are
+    shared with the text/vision renders.
+    """
+    if not turns:
+        return []
+    unsupported = [type(turn.content).__name__ for turn in turns if not isinstance(turn.content, (Texts, MediaRefs))]
+    if unsupported:
+        raise ValueError(
+            "build_omni_messages: Qwen3-Omni prompt media must be URI-backed MediaRefs; "
+            f"unsupported turn content: {unsupported}."
+        )
+
+    n_rows = len(turns[0].content)
+    mismatched = [i for i, turn in enumerate(turns) if len(turn.content) != n_rows]
+    if mismatched:
+        raise ValueError(
+            f"build_omni_messages: frontier-aligned turns must share batch size {n_rows}; "
+            f"mismatched turn indices {mismatched}."
+        )
+
+    roles = [turn.role for turn in turns]
+    role_groups = group_consecutive_roles(roles)
+    prefix = system_prefix(system_instruction, roles)
+    columns: List[List[Any]] = [
+        list(turn.content.texts) if isinstance(turn.content, Texts) else [list(refs) for refs in turn.content.rows]
+        for turn in turns
+    ]
+
+    conversations: List[Conversation] = []
+    for row in range(n_rows):
+        messages: Conversation = list(prefix)
+        seen_modalities: set[str] = set()
+        for role, indices in role_groups:
+            media_blocks: List[Dict[str, Any]] = []
+            text_blocks: List[Dict[str, Any]] = []
+            for index in indices:
+                value = columns[index][row]
+                if isinstance(turns[index].content, Texts):
+                    text_blocks.append({"type": "text", "text": value})
+                    continue
+                for ref in value:
+                    if ref.role != "prompt":
+                        raise ValueError(
+                            f"build_omni_messages: row {row} MediaRefs only supports role='prompt', got {ref.role!r}."
+                        )
+                    if ref.modality in seen_modalities:
+                        raise ValueError(
+                            f"build_omni_messages: row {row} has more than one {ref.modality} prompt input."
+                        )
+                    seen_modalities.add(ref.modality)
+                    media_blocks.append({"type": ref.modality, ref.modality: ref.uri})
+            if media_blocks or text_blocks:
+                messages.append({"role": role, "content": media_blocks + text_blocks})
+        conversations.append(messages)
+    return conversations
 
 
 def load_audio_pyav(path: str, target_sr: int = 16000) -> Optional[np.ndarray]:
@@ -210,6 +286,7 @@ def prepare_omni_media(
 
 
 __all__ = [
+    "build_omni_messages",
     "PreparedOmniMedia",
     "extract_audio_from_video_pyav",
     "load_audio_pyav",

--- a/unirl/models/qwen3_omni/pipeline.py
+++ b/unirl/models/qwen3_omni/pipeline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from unirl.models.types.conversations import build_omni_messages
 from unirl.models.types.pipeline import Pipeline
 from unirl.types.primitives import Texts
 from unirl.types.sample import Sample, Turn
@@ -15,6 +14,7 @@ from .bundle import Qwen3OmniBundle
 from .chat_template import Qwen3OmniChatTemplateStage
 from .conditions import Qwen3OmniARConditions
 from .config import Qwen3OmniPipelineConfig
+from .media import build_omni_messages
 
 
 class Qwen3OmniPipeline(Pipeline):

--- a/unirl/models/types/conversations.py
+++ b/unirl/models/types/conversations.py
@@ -9,45 +9,32 @@ Unlike the sglang engine's equivalent (``rollout/engine/sglang/utils/conversatio
 which de-expands the ``*n`` wire fan-out), the trainside embeds **every** frontier
 sample per-row — so there is NO de-expand here; one conversation per row.
 
-Pure (only :mod:`unirl.types`): no tokenizer, no processor, no engine. The trainside
-cannot import the sglang engine's helper (sglang is an optional dependency whose
-package import pulls the backend), so the small transpose is mirrored here.
+Pure (only :mod:`unirl.types`): no tokenizer, no processor, no engine.
+
+Two renders live here because both have several model consumers: string content
+(:func:`build_text_messages` — qwen3, qwen3_5) and inline-PIL parts
+(:func:`build_vision_messages` — qwen_vl, qwen3_5). They share two composition
+rules, :func:`system_prefix` (the config ``system_instruction`` is a default; an
+explicit ``system`` turn in the data wins) and :func:`group_consecutive_roles`,
+which the sglang wire render now imports instead of mirroring byte-identical
+private copies.
+
+A render with a single model consumer stays in that model's package (Qwen3-Omni's
+URI-media render lives in ``unirl.models.qwen3_omni.media``); it moves here when a
+second consumer actually exists, not before.
 """
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
-from unirl.types.media import MediaRef, MediaRefs
-from unirl.types.primitives import Audios, Images, Texts, Videos
+from unirl.types.primitives import Images
 from unirl.types.sample import Turn
 
 Conversation = List[Dict[str, Any]]
 
 
-def _uri_videos_to_media_refs(videos: Videos, *, context: str) -> MediaRefs:
-    """Compat shim: URI-backed ``Videos`` → sparse ``MediaRefs``.
-
-    Decoded frame tensors remain unsupported for Qwen3-Omni prompts.
-    """
-    if videos.uris is None:
-        raise ValueError(
-            f"{context}: decoded Videos frames are unsupported for Qwen3-Omni prompts; "
-            "use URI-backed MediaRefs (or deprecated Videos.from_uris)."
-        )
-    if videos.frames is not None:
-        raise ValueError(f"{context}: Videos cannot carry both frames and uris for Qwen3-Omni prompts.")
-    rows: List[List[MediaRef]] = []
-    for uri in videos.uris:
-        if uri is None or (isinstance(uri, str) and not uri.strip()):
-            rows.append([])
-            continue
-        rows.append([MediaRef(modality="video", role="prompt", uri=uri)])
-    return MediaRefs.from_rows(rows)
-
-
-def _system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conversation:
+def system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conversation:
     """The config ``system_instruction`` as a leading message, unless the trajectory
     already carries an explicit ``system`` turn (which wins)."""
     if system_instruction and "system" not in roles:
@@ -55,7 +42,7 @@ def _system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conve
     return []
 
 
-def _group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
+def group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
     """Group consecutive turn indices that share a role → ``[(role, [idx…]), …]``.
 
     Multi-input modalities ride as separate same-role turns (e.g. it2i is a text
@@ -85,7 +72,7 @@ def build_text_messages(
         return []
     roles = [t.role for t in turns]
     cols = [t.content.texts for t in turns]
-    prefix = _system_prefix(system_instruction, roles)
+    prefix = system_prefix(system_instruction, roles)
     n_rows = len(turns[0].content)
     return [prefix + [{"role": roles[j], "content": cols[j][row]} for j in range(len(turns))] for row in range(n_rows)]
 
@@ -107,8 +94,8 @@ def build_vision_messages(
     roles = [t.role for t in turns]
     is_image = [isinstance(t.content, Images) for t in turns]
     cols = [t.content.to_pils() if im else t.content.texts for t, im in zip(turns, is_image)]
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
+    role_groups = group_consecutive_roles(roles)
+    prefix = system_prefix(system_instruction, roles)
     n_rows = len(turns[0].content)
 
     conversations: List[Conversation] = []
@@ -127,175 +114,10 @@ def build_vision_messages(
     return conversations
 
 
-def _video_rows(videos: Videos) -> List[Any]:
-    """Return one URI or packed-frame tensor per row of a ``Videos`` batch."""
-    if videos.uris is not None:
-        if videos.frames is not None:
-            raise ValueError("build_video_messages: Videos cannot carry both uris and packed frames.")
-        if len(videos.uris) != len(videos):
-            raise ValueError(f"build_video_messages: video URI count {len(videos.uris)} != video batch {len(videos)}.")
-        return list(videos.uris)
-
-    rows = videos.to_list()
-    if len(rows) != len(videos):
-        raise ValueError("build_video_messages: Videos carries neither batch-aligned uris nor valid packed frames.")
-    return [row.frames for row in rows]
-
-
-def build_video_messages(
-    turns: List[Turn],
-    system_instruction: Optional[str] = None,
-) -> List[Conversation]:
-    """One text+optional-video conversation per frontier row.
-
-    Qwen3-Omni's current agentic contract permits one persistent source-video
-    turn plus arbitrary role-aware text turns. Consecutive same-role turns are
-    fused, with the video block placed before text blocks so the initial
-    ``text input Part -> video input child`` dataset shape renders to the
-    checkpoint's canonical ``[video, text]`` user message.
-    """
-    if not turns:
-        return []
-
-    unsupported = [type(turn.content).__name__ for turn in turns if not isinstance(turn.content, (Texts, Videos))]
-    if unsupported:
-        raise ValueError(
-            f"build_video_messages: Qwen3-Omni requires text/video turns only; got unsupported content {unsupported}."
-        )
-
-    video_turns = sum(isinstance(turn.content, Videos) for turn in turns)
-    if video_turns > 1:
-        raise ValueError(
-            "build_video_messages: Qwen3-Omni currently supports at most one persistent "
-            f"source-video turn per trajectory, got {video_turns}."
-        )
-
-    roles = [turn.role for turn in turns]
-    is_video = [isinstance(turn.content, Videos) for turn in turns]
-    cols = [_video_rows(turn.content) if video else list(turn.content.texts) for turn, video in zip(turns, is_video)]
-    n_rows = len(turns[0].content)
-    mismatched = [i for i, turn in enumerate(turns) if len(turn.content) != n_rows]
-    if mismatched:
-        raise ValueError(
-            f"build_video_messages: frontier-aligned turns must share batch size {n_rows}; "
-            f"mismatched turn indices {mismatched}."
-        )
-
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
-    conversations: List[Conversation] = []
-    for row in range(n_rows):
-        messages: Conversation = list(prefix)
-        for role, indices in role_groups:
-            video_blocks: List[Dict[str, Any]] = []
-            text_blocks: List[Dict[str, Any]] = []
-            for index in indices:
-                if is_video[index]:
-                    video_blocks.append({"type": "video", "video": cols[index][row]})
-                else:
-                    text_blocks.append({"type": "text", "text": cols[index][row]})
-            messages.append({"role": role, "content": video_blocks + text_blocks})
-        conversations.append(messages)
-    return conversations
-
-
-def build_omni_messages(
-    turns: List[Turn],
-    system_instruction: Optional[str] = None,
-) -> List[Conversation]:
-    """Render typed Qwen3-Omni text/image/audio/video conversations per row.
-
-    Canonical prompt media is ``MediaRefs``. URI-backed ``Videos.from_uris`` is
-    accepted as a temporary compatibility shim and normalized to video
-    ``MediaRef`` rows; decoded ``Images`` / ``Videos`` / ``Audios`` remain
-    rejected so waveform and frame tensors cannot bypass the URI contract.
-    """
-    if not turns:
-        return []
-    decoded = [
-        type(turn.content).__name__
-        for turn in turns
-        if isinstance(turn.content, (Images, Audios))
-        or (isinstance(turn.content, Videos) and turn.content.uris is None)
-    ]
-    if decoded:
-        raise ValueError(
-            "build_omni_messages: Qwen3-Omni prompt media must use URI-backed MediaRefs; "
-            f"decoded primitive inputs are unsupported: {decoded}."
-        )
-    supported = (Texts, MediaRefs, Videos)
-    unsupported = [type(turn.content).__name__ for turn in turns if not isinstance(turn.content, supported)]
-    if unsupported:
-        raise ValueError(f"build_omni_messages: unsupported turn content {unsupported}.")
-
-    n_rows = len(turns[0].content)
-    mismatched = [i for i, turn in enumerate(turns) if len(turn.content) != n_rows]
-    if mismatched:
-        raise ValueError(
-            f"build_omni_messages: frontier-aligned turns must share batch size {n_rows}; "
-            f"mismatched turn indices {mismatched}."
-        )
-
-    roles = [turn.role for turn in turns]
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
-    columns: List[List[Any]] = []
-    for turn in turns:
-        if isinstance(turn.content, Texts):
-            columns.append(list(turn.content.texts))
-        elif isinstance(turn.content, MediaRefs):
-            columns.append([list(refs) for refs in turn.content.rows])
-        elif isinstance(turn.content, Videos):
-            warnings.warn(
-                "build_omni_messages: URI-backed Videos prompt inputs are deprecated; "
-                "migrate to Part.primitives['media'] = MediaRefs.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            columns.append(
-                [list(refs) for refs in _uri_videos_to_media_refs(turn.content, context="build_omni_messages").rows]
-            )
-        else:  # pragma: no cover - guarded by the supported-type check above.
-            raise AssertionError(type(turn.content).__name__)
-
-    conversations: List[Conversation] = []
-    for row in range(n_rows):
-        messages: Conversation = list(prefix)
-        seen_modalities: set[str] = set()
-        for role, indices in role_groups:
-            media_blocks: List[Dict[str, Any]] = []
-            text_blocks: List[Dict[str, Any]] = []
-            for index in indices:
-                content = turns[index].content
-                value = columns[index][row]
-                if isinstance(content, Texts):
-                    text_blocks.append({"type": "text", "text": value})
-                else:
-                    for ref in value:
-                        if ref.role != "prompt":
-                            raise ValueError(
-                                f"build_omni_messages: row {row} MediaRefs only supports role='prompt', "
-                                f"got {ref.role!r}."
-                            )
-                        modality = ref.modality
-                        if modality not in {"image", "audio", "video"}:
-                            raise ValueError(f"build_omni_messages: unsupported prompt media modality {modality!r}.")
-                        if modality in seen_modalities:
-                            raise ValueError(
-                                f"build_omni_messages: row {row} has more than one {modality} prompt input."
-                            )
-                        seen_modalities.add(modality)
-                        media_blocks.append({"type": modality, modality: ref.uri})
-            if media_blocks or text_blocks:
-                messages.append({"role": role, "content": media_blocks + text_blocks})
-        conversations.append(messages)
-    return conversations
-
-
 __all__ = [
     "Conversation",
     "build_text_messages",
-    "build_omni_messages",
-    "build_video_messages",
     "build_vision_messages",
+    "group_consecutive_roles",
+    "system_prefix",
 ]

--- a/unirl/rollout/engine/sglang/utils/conversations.py
+++ b/unirl/rollout/engine/sglang/utils/conversations.py
@@ -7,15 +7,19 @@ row per frontier sample (``P`` prompts × ``n`` fan-out = ``P*n`` rows). These
 helpers transpose that into ``P`` per-sample message lists and de-expand the
 ``*n`` fan-out back to the unique conversations the backend fans out server-side.
 
-Pure (only :mod:`unirl.types`): no tokenizer, no processor, no engine state — so
-the message-shape logic unit-tests with canned ``Sample``s. The *model-specific*
-encode (``apply_chat_template`` / processor) stays in the adapter.
+Pure (no tokenizer, no processor, no engine state) — so the message-shape
+logic unit-tests with canned ``Sample``s. The *model-specific* encode
+(``apply_chat_template`` / processor) stays in the adapter. Composition rules
+(system precedence, role fusion) are imported from the single composition
+layer, :mod:`unirl.models.types.conversations`; only the wire-specific ``*n``
+de-expand lives here.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
+from unirl.models.types.conversations import group_consecutive_roles, system_prefix
 from unirl.types.primitives import Images
 from unirl.types.sample import Sample
 
@@ -54,30 +58,6 @@ def unique_group_indices(group_ids: List[str]) -> Tuple[List[int], int]:
     return rep_indices, next(iter(k_values))
 
 
-def _group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
-    """Group consecutive turn indices that share a role → ``[(role, [idx…]), …]``.
-
-    Multi-input modalities ride as separate same-role turns (e.g. it2i is a text
-    ``user`` turn + an image ``user`` turn); a chat message holds one role, so
-    consecutive same-role turns fuse into one message.
-    """
-    groups: List[Tuple[str, List[int]]] = []
-    for j, role in enumerate(roles):
-        if groups and groups[-1][0] == role:
-            groups[-1][1].append(j)
-        else:
-            groups.append((role, [j]))
-    return groups
-
-
-def _system_prefix(system_instruction: Any, roles: List[str]) -> Conversation:
-    """The config ``system_instruction`` as a leading message, unless the
-    trajectory already carries an explicit ``system`` turn (which wins)."""
-    if system_instruction and "system" not in roles:
-        return [{"role": "system", "content": system_instruction}]
-    return []
-
-
 def build_text_conversations(
     sample: Sample,
     system_instruction: Any = None,
@@ -93,7 +73,7 @@ def build_text_conversations(
     rep, k = unique_group_indices(sample.parts[-1].group_ids)
     roles = [t.role for t in turns]
     cols = [t.content.texts for t in turns]
-    prefix = _system_prefix(system_instruction, roles)
+    prefix = system_prefix(system_instruction, roles)
 
     conversations = [prefix + [{"role": roles[j], "content": cols[j][row]} for j in range(len(turns))] for row in rep]
     return conversations, k
@@ -117,8 +97,8 @@ def build_vision_conversations(
     roles = [t.role for t in turns]
     is_image = [isinstance(t.content, Images) for t in turns]
     cols = [t.content.to_pils() if im else t.content.texts for t, im in zip(turns, is_image)]
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
+    role_groups = group_consecutive_roles(roles)
+    prefix = system_prefix(system_instruction, roles)
 
     conversations: List[Conversation] = []
     images_list: List[List[Any]] = []

--- a/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/qwen3_omni.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, List, Optional
 import torch
 
 from unirl.config.require import require
-from unirl.models.qwen3_omni.media import omni_processor_media_kwargs, prepare_omni_media
-from unirl.models.types.conversations import build_omni_messages
+from unirl.models.qwen3_omni.media import build_omni_messages, omni_processor_media_kwargs, prepare_omni_media
 from unirl.rollout.engine.vllm_omni.adapters.base import ModelAdapter, register_adapter
 from unirl.rollout.engine.vllm_omni.adapters.hi3 import Hi3TextOutputAdapter
 from unirl.rollout.engine.vllm_omni.backends import (

--- a/unirl/types/README.md
+++ b/unirl/types/README.md
@@ -177,7 +177,6 @@ Those decoded modality keys remain the contract for **condition** media
 (diffusion / V2V / image-edit): loaded `Images` / `Videos` tensors with
 `role="condition"`.
 
-`build_omni_messages` still accepts deprecated URI-backed `Videos.from_uris`
-and normalizes them to video `MediaRef` rows; migrate callers to `MediaRefs`.
-Waveform `Audios` and decoded frame `Videos` / `Images` stay rejected for
-Omni prompts.
+`build_omni_messages` (`unirl/models/qwen3_omni/media.py`) accepts `MediaRefs`
+prompt media only; waveform `Audios` and decoded frame `Videos` / `Images` are
+rejected for Omni prompts.

--- a/unirl/types/primitives.py
+++ b/unirl/types/primitives.py
@@ -248,8 +248,6 @@ class Videos(Batch):
 
     frames: torch.Tensor = field(kind=FieldKind.PACKED, default=None)
 
-    uris: Optional[List[str]] = concat_field(default=None)
-
     @property
     def cu_frames(self) -> Optional[torch.Tensor]:
         """Per-sample cumulative frame offsets — alias for :attr:`cu_seqlens`.
@@ -285,13 +283,6 @@ class Videos(Batch):
             frames_list = resized
         return cls.pack(frames=frames_list)
 
-    @classmethod
-    def from_uris(cls, uris: List[str]) -> "Videos":
-        """Build frame-less videos carrying batch-aligned source paths."""
-        if not uris:
-            raise ValueError("Cannot build Videos from an empty uris list")
-        return cls(uris=list(uris))
-
     def to_list(self) -> List[Video]:
         cu = self.cu_seqlens
         if cu is None or self.frames is None:
@@ -300,9 +291,7 @@ class Videos(Batch):
 
     def __len__(self) -> int:
         cu = self.cu_seqlens
-        if cu is not None:
-            return int(cu.shape[0]) - 1
-        return len(self.uris) if self.uris is not None else 0
+        return int(cu.shape[0]) - 1 if cu is not None else 0
 
 
 @dataclass
@@ -355,7 +344,7 @@ def _cumsum(values: List[int]) -> List[int]:
 PrimitiveValue = Union[Texts, Images, Videos, Audios, MediaRefs]
 
 
-def primitive_modality_key(prim: Texts | Images | Videos | Audios | MediaRefs) -> str:
+def primitive_modality_key(prim: PrimitiveValue) -> str:
     """Map a batched primitive to its modality slot key.
 
     ``Texts -> "text"``, ``Images -> "image"``, ``Videos -> "video"``,


### PR DESCRIPTION
## Summary

Qwen3-Omni's conversation render carried the model's own prompt-media contract — URI-only `MediaRefs`, one prompt input per modality per row, error strings naming the model — inside `unirl/models/types/conversations.py`, the contract layer every model package depends on, while being consumed only by the qwen3_omni package and its vLLM-Omni adapter. It moves into `unirl/models/qwen3_omni/media.py`, next to the media contract it enforces and the decode helpers both parity sides already import, so the HF trainside stage and the rollout adapter still compose messages from one function.

The shared layer keeps only what several models actually consume today: `build_text_messages` (qwen3, qwen3_5), `build_vision_messages` (qwen_vl, qwen3_5), and the two composition rules both use — `system_prefix` and `group_consecutive_roles`, now public. **The sglang wire render imports those two instead of keeping byte-identical private copies** kept in sync by cross-referencing docstrings; that mirror is retired. A render with a single model consumer stays in that model's package and moves to the shared layer when a second consumer actually exists.

Dead compatibility paths removed along the way:
- `build_video_messages` + its private `_video_rows` helper — zero consumers since #306 superseded them.
- The deprecated URI-backed `Videos` prompt path: `_uri_videos_to_media_refs`, the `Videos` branch and its `DeprecationWarning`, plus `Videos.uris` and `Videos.from_uris` themselves (`from_uris` was the field's only constructor and nothing called it, so the whole field was dead).
- An unreachable modality re-check (`MediaRef.__post_init__` already validates modality at construction, and the two literal sets were identical).

**Scope note.** An earlier revision of this branch also carried a canonical agent-trace framework (typed `ToolCall`/`ToolCalls`, tool channels on `Turn`, `turns_from_messages` / `normalize_tool_arguments` / `ensure_system_message`). Review pointed out it had **no production consumer** — SFT still hands raw messages to the tokenizer — so "canonical" described an intent, not the running system, and a verified round-trip defect in the unconsumed half confirmed the risk. That work is extracted and will land with its real ingest path (alongside #352) rather than ahead of it. What remains here is only code that is on a live path today.

## Related Issue

N/A (architecture-audit follow-up)

## Test Plan

- **Byte-identity harness** against the pre-move `build_omni_messages` (loaded from `main` side by side with the moved one), all matching: text+audio with `system_instruction`; text+video without; **multiple text turns inside one role run**; multi-row batches; data-side `system` turn beating the config default; multi-turn role fusion; empty media rows; text-only. Error parity too: condition-role `MediaRef`, duplicate modality per row, batch-size mismatch — same exception type in both.
- Import sweep over the moved/edited modules plus the sglang adapters, vLLM-Omni adapter, `data/sft`, `train/sft/track_builder`, `rollout/env/tool_environment` → OK.
- sglang wire render (`build_text_conversations`) on a canned `Sample`: unchanged output and fan-out `k`.
- After rebasing onto current `main`: `Qwen3OmniPipeline.extra_input_primitives == ("media",)` still holds (the #358 contract), and the byte-identity harness re-run clean.
- `SKIP=no-commit-to-branch pre-commit run --from-ref origin/main --to-ref HEAD` → all hooks Passed.

## Compatibility / Risk

No recipe changes and no behavior change on any live path — the omni render is byte-identical, the wire render is unchanged, and the removed paths had zero producers. Out-of-tree callers of `unirl.models.types.conversations.build_omni_messages` / `build_video_messages`, or of `Videos.from_uris`, would need the new location (deliberate: repo-internal APIs get no compatibility shims).

## Reviewer Notes

AI-assisted (Claude Code), per-line reviewed. Rewritten after review feedback: the branch was rebuilt from `main` so the diff is only the retained work; the extracted agent-trace framework is preserved and will be proposed separately with its consumer. Duplicate-work check: #352 touches `data/sft.py` and the qwen_vl/bagel chat stages (untouched here); #355 is Talker-side.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.