### PR TITLE
docs: fix stale extension guides and document engine anatomy

### DIFF
--- a/.claude/skills/development/add-model-bundle/SKILL.md
+++ b/.claude/skills/development/add-model-bundle/SKILL.md
@@ -146,15 +146,15 @@ For causal-LM or multimodal AR paths:
 
 ## What To Verify
 
-There is no committed test tree (removed by policy in #99/#267 — do not recreate it under any name). Instead, write **one-off verification harnesses** in a scratch directory outside the repo, run them, and quote the exact commands plus results in the PR's Test Plan (per the CLAUDE.md verification-harness rule). Prefer small CPU harnesses with fakes or monkeypatches rather than loading real checkpoints.
-
-Cover the same targets the old test suite did:
+Follow the `CLAUDE.md` verification-harness rule: run small, uncommitted CPU
+harnesses with fakes or monkeypatches and quote the commands and results in the
+PR's Test Plan.
 
 - **Conditions**: `from_dict` / `to_dict` round trips, optional slots, wrong-typed slot errors, and missing required slot errors.
 - **Diffusion step**: CFG batching (uncond+cond in one transformer call), timestep scaling, masks, vision kwargs, and private transformer kwargs, using fake transformers.
 - **Pipeline wiring**: construct fake stages, call `generate(sample)`, and assert lineage preservation, generation-Part conditions/segment/primitives, and pinned-sigma validation (`generate` must raise when `params.sigmas is None`).
 - **AR models**: generation and replay token/log-prob alignment on a tiny fake model.
-- **Recipe resolution**: the recipe-target pre-commit hook validates `_target_` dotpaths; run `SKIP=no-commit-to-branch pre-commit run --from-ref main --to-ref HEAD` before publishing.
+- **Recipe/config wiring**: instantiate added configs and recipes with lightweight fakes and verify their `_target_` paths resolve.
 
 ## Review Before Finishing
 

--- a/.claude/skills/development/add-model-bundle/SKILL.md
+++ b/.claude/skills/development/add-model-bundle/SKILL.md
@@ -144,24 +144,17 @@ For causal-LM or multimodal AR paths:
 - Expose `trainable_module()` when training-side LoRA/FSDP injection needs the wrapped transformer root.
 - Use `ARSamplingParams` for common generation controls and a package-specific params dataclass only for model-specific knobs.
 
-## Tests To Add
+## What To Verify
 
-Prefer small CPU tests with fakes or monkeypatches rather than loading real checkpoints:
+There is no committed test tree (removed by policy in #99/#267 — do not recreate it under any name). Instead, write **one-off verification harnesses** in a scratch directory outside the repo, run them, and quote the exact commands plus results in the PR's Test Plan (per the CLAUDE.md verification-harness rule). Prefer small CPU harnesses with fakes or monkeypatches rather than loading real checkpoints.
 
-- `tests/models/test_<model>_conditions.py`: `from_dict` / `to_dict` round trips, optional slots, wrong-typed slot errors, and missing required slot errors. Follow `tests/models/test_sd3_conditions.py` and `tests/models/test_hunyuan_image3_conditions.py`.
-- `tests/models/test_<model>_diffusion_step_<topic>.py`: CFG batching, timestep scaling, masks, vision kwargs, and private transformer kwargs using fakes. Follow the WAN21 diffusion-step tests.
-- `tests/models/test_<model>_pipeline.py` when pipeline wiring changed: construct fake stages, call `generate(sample)`, and assert lineage preservation, generation-Part conditions/segment/primitives, and pinned-sigma validation.
-- AR models: add or adapt `tests/test_qwen3_ar_stage.py`-style tests for generation and replay alignment.
-- Shared condition or stage behavior: update `tests/types/test_conditions.py` or `tests/models/test_stages.py` only when shared contracts changed.
-- Config registration and instantiation: use the patterns in `tests/config/test_config_registration.py` and `tests/config/test_config_instantiate.py` when adding Hydra config behavior.
+Cover the same targets the old test suite did:
 
-Run targeted tests first, then broaden if shared condition, stage, or pipeline behavior changed:
-
-```bash
-pytest tests/models/test_<model>_conditions.py tests/models/test_<model>_diffusion_step_*.py tests/models/test_stages.py tests/types/test_conditions.py
-```
-
-Adjust the command to real files before running. If the model is AR-only or pipeline-only, replace diffusion-step tests with the relevant AR or pipeline tests.
+- **Conditions**: `from_dict` / `to_dict` round trips, optional slots, wrong-typed slot errors, and missing required slot errors.
+- **Diffusion step**: CFG batching (uncond+cond in one transformer call), timestep scaling, masks, vision kwargs, and private transformer kwargs, using fake transformers.
+- **Pipeline wiring**: construct fake stages, call `generate(sample)`, and assert lineage preservation, generation-Part conditions/segment/primitives, and pinned-sigma validation (`generate` must raise when `params.sigmas is None`).
+- **AR models**: generation and replay token/log-prob alignment on a tiny fake model.
+- **Recipe resolution**: the recipe-target pre-commit hook validates `_target_` dotpaths; run `SKIP=no-commit-to-branch pre-commit run --from-ref main --to-ref HEAD` before publishing.
 
 ## Review Before Finishing
 

--- a/unirl/README.md
+++ b/unirl/README.md
@@ -41,7 +41,7 @@ As source, the package falls into four groups:
 | `trainer/` | Training lifecycle (`base.py` plus domain trainers and `AgenticTrainer`): owns placement, builds workers, and runs the rollout→reward→advantage→train loop |
 | `config/` | `require` + `validate_*` cross-component validators over the flat Hydra recipe (instantiation itself is `_target_`-driven, not in this module) |
 | `distributed/` | Ray worker base (`Remote`) + placement/dispatch (`group/`), tensor transport (`tensor/`), and weight sync (`weight_sync/`) |
-| `rollout/` | Rollout engine contracts and implementations (`engine/`: trainside, sglang, sglang_diffusion, vllm_omni, composed) |
+| `rollout/` | Rollout engine contracts and implementations (`engine/`: trainside, sglang, sglang_diffusion, vllm_omni, fastvideo, composed, agentic) |
 | `train/` | Train stack: `TrainStack`, FSDP backend, LoRA/DiffusionNFT/mirror injection, EMA shadow, optimizer/lr |
 | `algorithms/` | Per-track loss algorithms (GRPO, DiffusionNFT, FlowDPPO, DRPO) |
 | `models/` | Per-model bundles, pipelines, stages, conditions; text/vision/vae helpers |

--- a/unirl/rollout/README.md
+++ b/unirl/rollout/README.md
@@ -45,13 +45,18 @@ wrong objective.
   AR and diffusion Parts.
 - **The engines.** `trainside` (in-process — the train actor's pipeline *is* the
   sampler), `sglang_diffusion` (dedicated diffusion), `sglang` (dedicated AR), `vllm_omni`
-  (dedicated; HI3 / SD3 / HunyuanVideo), `fastvideo` (dedicated accelerated video
+  (dedicated; BAGEL / HI3 / SD3 / HunyuanVideo), `fastvideo` (dedicated accelerated video
   sampling), and `composed` (chains an AR child + a
   diffusion child for prompt enhancement) are the six single-turn engines.
   `agentic` wraps one of them with an environment to produce multi-turn
-  trajectories. Each diffusion engine consumes the Part's pinned sigmas verbatim,
-  while initial-noise construction is engine-specific. `forward_batch_size` bounds
-  peak memory by slicing the Sample and concatenating the results.
+  trajectories. Each diffusion engine consumes the Part's pinned sigmas verbatim
+  and reads the same driver-authored `NoiseRecipe` (`../types/noise_recipe.py`),
+  but realizes it differently: `trainside`, `sglang_diffusion` and `vllm_omni`
+  resolve the recipe to an `x_T` tensor, so those three start a rollout from
+  bit-identical noise; `fastvideo` cannot accept a tensor and instead derives
+  per-sample seeds from the recipe's noise-group ids, so its noise matches only
+  in grouping, not bit-for-bit. `forward_batch_size` bounds peak memory by
+  slicing the Sample and concatenating the results.
 - **Deployment modes:** *direct sampling* — the trainside engine, no `sync:`, the
   ratio is 1 on the first update; *separate* — a dedicated engine on its own GPUs
   plus a `sync:` block; *colocate* — a dedicated engine sharing GPUs with train,

--- a/unirl/rollout/README.md
+++ b/unirl/rollout/README.md
@@ -45,8 +45,9 @@ wrong objective.
   AR and diffusion Parts.
 - **The engines.** `trainside` (in-process — the train actor's pipeline *is* the
   sampler), `sglang_diffusion` (dedicated diffusion), `sglang` (dedicated AR), `vllm_omni`
-  (dedicated; HI3 / SD3 / HunyuanVideo), and `composed` (chains an AR child + a
-  diffusion child for prompt enhancement) are the five single-turn engines.
+  (dedicated; HI3 / SD3 / HunyuanVideo), `fastvideo` (in-process accelerated video
+  sampling), and `composed` (chains an AR child + a
+  diffusion child for prompt enhancement) are the six single-turn engines.
   `agentic` wraps one of them with an environment to produce multi-turn
   trajectories. Each diffusion engine consumes the Part's pinned sigmas verbatim,
   and dedicated engines regenerate `x_T` from the recipe, so two engines start a
@@ -75,6 +76,36 @@ concurrent callers if it should serve as an agentic inner, else serialized
 internally — and dispatch `generate` with `DP_SCATTER`). A dedicated engine also
 implements its weight-receive method and a matching `sync:` handler in
 `../distributed/weight_sync`.
+
+## Engine anatomy, and adding a model to an existing engine
+
+Engine dirs come in two tiers. **Local engines** (`trainside`, `fastvideo`,
+`composed`, `agentic`) are just `config.py` + `engine.py`. **Dedicated-server
+engines** (`sglang`, `sglang_diffusion`, `vllm_omni`) share a standard anatomy:
+`config.py` + `engine.py` + `adapters/` (per-model wire-format translation) +
+`backends/` (server process management) + `utils/` + `weight_sync.py`, plus a
+runtime-patch dir for the pinned upstream (`sglang_diffusion/_patches/`,
+`vllm_omni/patches/` — the naming difference is historical; don't churn it).
+`vllm_omni` additionally carries worker-subprocess code (`pipelines/`, `worker/`,
+`stage_configs/`).
+
+Model onboarding is per-engine, and the adapter file is usually **not** the whole
+change surface:
+
+- **`sglang` (AR/VLM):** add `adapters/<model>.py` overriding `TextAdapter` steps,
+  register with `@register_adapter("<model_family>")`, and import it in
+  `adapters/__init__.py` (registration fires on import).
+- **`sglang_diffusion`:** the same adapter + registration + `adapters/__init__.py`
+  import, **plus** — if the model's conditions add new tensor fields that must
+  cross the wire — an entry in `_COND_FIELDS` in `_patches/patch_conditions.py`
+  (the transport allowlist; forgetting it silently drops the field), and hijack
+  wiring in `_patches/hijack.py` if the model needs a new upstream patch. Every
+  model onboarded so far has touched shared `_patches/` files; expect reviewers to
+  check those edits against the pinned upstream source.
+- **`vllm_omni`:** an `adapters/<family>.py` binder (keyed by modality), a
+  worker-side `pipelines/<model>/pipeline.py` (worker-subprocess-only imports), a
+  `stage_configs/<model>_*_rl.yaml`, and — if the AR/DiT worker needs new
+  behavior — a `worker/` extension or a `patches/compat_<model>.py`.
 
 ## Gotchas
 

--- a/unirl/rollout/README.md
+++ b/unirl/rollout/README.md
@@ -45,14 +45,13 @@ wrong objective.
   AR and diffusion Parts.
 - **The engines.** `trainside` (in-process — the train actor's pipeline *is* the
   sampler), `sglang_diffusion` (dedicated diffusion), `sglang` (dedicated AR), `vllm_omni`
-  (dedicated; HI3 / SD3 / HunyuanVideo), `fastvideo` (in-process accelerated video
+  (dedicated; HI3 / SD3 / HunyuanVideo), `fastvideo` (dedicated accelerated video
   sampling), and `composed` (chains an AR child + a
   diffusion child for prompt enhancement) are the six single-turn engines.
   `agentic` wraps one of them with an environment to produce multi-turn
   trajectories. Each diffusion engine consumes the Part's pinned sigmas verbatim,
-  and dedicated engines regenerate `x_T` from the recipe, so two engines start a
-  rollout from the same noise. `forward_batch_size` bounds peak memory by slicing
-  the Sample and concatenating the results.
+  while initial-noise construction is engine-specific. `forward_batch_size` bounds
+  peak memory by slicing the Sample and concatenating the results.
 - **Deployment modes:** *direct sampling* — the trainside engine, no `sync:`, the
   ratio is 1 on the first update; *separate* — a dedicated engine on its own GPUs
   plus a `sync:` block; *colocate* — a dedicated engine sharing GPUs with train,
@@ -79,36 +78,33 @@ implements its weight-receive method and a matching `sync:` handler in
 
 ## Engine anatomy, and adding a model to an existing engine
 
-Engine dirs come in two tiers. **Local engines** (`trainside`, `fastvideo`,
-`composed`, `agentic`) are just `config.py` + `engine.py`. **Dedicated-server
-engines** (`sglang`, `sglang_diffusion`, `vllm_omni`) share a standard anatomy:
-`config.py` + `engine.py` + `adapters/` (per-model wire-format translation) +
-`backends/` (server process management) + `utils/` + `weight_sync.py`, plus a
+Engine dirs use two layouts. The compact engines (`trainside`, `fastvideo`,
+`composed`, `agentic`) contain `config.py` + `engine.py`. Server-backed engines
+(`sglang`, `sglang_diffusion`, `vllm_omni`) also carry `adapters/`
+(per-family/modality wire-format translation), `backends/` (server process
+management), `utils/`, `weight_sync.py`, and a
 runtime-patch dir for the pinned upstream (`sglang_diffusion/_patches/`,
-`vllm_omni/patches/` — the naming difference is historical; don't churn it).
-`vllm_omni` additionally carries worker-subprocess code (`pipelines/`, `worker/`,
-`stage_configs/`).
+`vllm_omni/patches/`). `vllm_omni` additionally carries worker-subprocess code
+(`pipelines/`, `worker/`) and stage boot configs (`stage_configs/`).
 
 Model onboarding is per-engine, and the adapter file is usually **not** the whole
 change surface:
 
-- **`sglang` (AR/VLM):** add `adapters/<model>.py` extending `TextLMAdapter`
-  (text-only) or `VLMAdapter` (multimodal), register it with
-  `@register_adapter("<model_family>")`, and import it in `adapters/__init__.py`
-  (registration fires on import).
-- **`sglang_diffusion`:** the same adapter + registration + `adapters/__init__.py`
-  import, **plus** — if the model's conditions add new tensor fields that must
-  cross the wire — an entry in `_COND_FIELDS` in `_patches/patch_conditions.py`
-  (the transport allowlist; forgetting it silently drops the field), and hijack
-  wiring in `_patches/hijack.py` if the model needs a new upstream patch. When
-  onboarding touches shared `_patches/` files, reviewers should check those edits
-  against the pinned upstream source.
+- **`sglang` (AR/VLM):** onboarding is normally config-only: text models use the
+  `text` adapter, while `image_token` selects `vlm`. Add and register a new adapter
+  only for a genuinely new wire shape, extending `TextLMAdapter` or `VLMAdapter`
+  and importing it in `adapters/__init__.py`.
+- **`sglang_diffusion`:** add `adapters/<family>.py` extending `ImageAdapter` or
+  `VideoAdapter`, register it by `model_family`, and import it in
+  `adapters/__init__.py`. New condition fields that cross the wire also need an
+  entry in `_COND_FIELDS` and either `_POS_MAP` / `_NEG_MAP` or an explicit copy
+  branch in `_copy_conditions`; add `_patches/hijack.py` wiring only when the
+  model needs a new upstream patch.
 - **`vllm_omni`:** add an `adapters/<family>.py` binder (keyed by modality),
-  register it, import it in `adapters/__init__.py`, and add a
-  `stage_configs/<model>_*_rl.yaml`. DiT families additionally need a worker-side
-  `pipelines/<model>/pipeline.py` (worker-subprocess-only imports); if the AR/DiT
-  worker needs new behavior, add a `worker/` extension or
-  `patches/compat_<model>.py`.
+  register it, import it in `adapters/__init__.py`, and add the appropriate boot
+  YAML under `stage_configs/`. DiT families additionally need a worker-side
+  `pipelines/<model>/pipeline.py`; if the AR/DiT worker needs new behavior, add a
+  `worker/` extension or `patches/compat_<model>.py`.
 
 ## Gotchas
 

--- a/unirl/rollout/README.md
+++ b/unirl/rollout/README.md
@@ -92,20 +92,23 @@ runtime-patch dir for the pinned upstream (`sglang_diffusion/_patches/`,
 Model onboarding is per-engine, and the adapter file is usually **not** the whole
 change surface:
 
-- **`sglang` (AR/VLM):** add `adapters/<model>.py` overriding `TextAdapter` steps,
-  register with `@register_adapter("<model_family>")`, and import it in
-  `adapters/__init__.py` (registration fires on import).
+- **`sglang` (AR/VLM):** add `adapters/<model>.py` extending `TextLMAdapter`
+  (text-only) or `VLMAdapter` (multimodal), register it with
+  `@register_adapter("<model_family>")`, and import it in `adapters/__init__.py`
+  (registration fires on import).
 - **`sglang_diffusion`:** the same adapter + registration + `adapters/__init__.py`
   import, **plus** — if the model's conditions add new tensor fields that must
   cross the wire — an entry in `_COND_FIELDS` in `_patches/patch_conditions.py`
   (the transport allowlist; forgetting it silently drops the field), and hijack
-  wiring in `_patches/hijack.py` if the model needs a new upstream patch. Every
-  model onboarded so far has touched shared `_patches/` files; expect reviewers to
-  check those edits against the pinned upstream source.
-- **`vllm_omni`:** an `adapters/<family>.py` binder (keyed by modality), a
-  worker-side `pipelines/<model>/pipeline.py` (worker-subprocess-only imports), a
-  `stage_configs/<model>_*_rl.yaml`, and — if the AR/DiT worker needs new
-  behavior — a `worker/` extension or a `patches/compat_<model>.py`.
+  wiring in `_patches/hijack.py` if the model needs a new upstream patch. When
+  onboarding touches shared `_patches/` files, reviewers should check those edits
+  against the pinned upstream source.
+- **`vllm_omni`:** add an `adapters/<family>.py` binder (keyed by modality),
+  register it, import it in `adapters/__init__.py`, and add a
+  `stage_configs/<model>_*_rl.yaml`. DiT families additionally need a worker-side
+  `pipelines/<model>/pipeline.py` (worker-subprocess-only imports); if the AR/DiT
+  worker needs new behavior, add a `worker/` extension or
+  `patches/compat_<model>.py`.
 
 ## Gotchas
 

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -29,7 +29,7 @@ knows nothing about DTensor sharding or wrap topology.
 
 ## How it works
 
-- **`FSDPBackend`** (`backend/fsdp.py`) holds the FSDP2-wrapped module
+- **`FSDPBackend`** (`backend/fsdp/backend.py`) holds the FSDP2-wrapped module
   (`bundle.<trainable_attr>`, default `transformer`), the optimizer, scheduler, and
   EMA (when configured). Structural injection (`inject_lora` / `inject_nft` /
   `inject_mirror`) happens once at construction, *before* `fsdp_wrap`.
@@ -40,19 +40,21 @@ knows nothing about DTensor sharding or wrap topology.
   `train_track`: move the segment onto device → `prepare_segment` (freeze π_old
   once) → `num_updates_per_batch` optimizer steps over disjoint mini-batches, each a
   micro-batch loop of `compute_loss_and_backward`. The mini/micro slicing comes from
-  one source, `_optimizer_step_slices`, shared with `prepare_segment` — so when an
-  algorithm replays its anchor, it's recomputed at the *exact* geometry training
-  uses, which is what pins the on-policy PPO ratio to 1 under bf16's batch-shape
-  sensitivity. `AgenticTrainer` uses the same interface after concatenating every
+  one source — the injected `micro_planner` (`stack/planner/`; `CountPlanner` by
+  default, `TokenBudgetPlanner` for token packing) — shared with `prepare_segment`,
+  so when an algorithm replays its anchor, it's recomputed at the *exact* geometry
+  training uses, which is what pins the on-policy PPO ratio to 1 under bf16's
+  batch-shape sensitivity. `AgenticTrainer` uses the same interface after concatenating every
   successful trajectory's generated assistant turns.
 - **`UnifiedModelTrainStack`** (`unified_model_stack.py`) drives two algorithms
   (`ar` + `image`) backward-accumulating into one shared optimizer step on one
   shared backbone (HunyuanImage3).
 
-**Extending it:** a new structural injection mode is an `inject_<mode>` in
-`inject.py` (called before `fsdp_wrap`) plus a config in `configs.py`; a new
-optimizer or LR schedule is a branch in `factories.py` plus fields on
-`OptimizerConfig`/`LrSchedulerConfig`; a multi-update-capable algorithm sets
+**Extending it:** a new structural injection mode is an `inject_<mode>` next to
+the existing ones — `inject_lora` in `lora.py`, `inject_nft` / `inject_mirror` in
+`ema.py` — (called before `fsdp_wrap`) plus a config in `configs.py`; a new
+optimizer or LR schedule is a branch in `optim.py` plus fields on
+`OptimizerConfig`/`LrSchedulerConfig` in `backend/base.py`; a multi-update-capable algorithm sets
 `supports_multi_update = True` and declares `anchor_fields` (see
 `../algorithms/README.md`).
 

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -44,17 +44,17 @@ knows nothing about DTensor sharding or wrap topology.
   default, `TokenBudgetPlanner` for token packing) — shared with `prepare_segment`,
   so when an algorithm replays its anchor, it's recomputed at the *exact* geometry
   training uses, which is what pins the on-policy PPO ratio to 1 under bf16's
-  batch-shape sensitivity. `AgenticTrainer` uses the same interface after concatenating every
-  successful trajectory's generated assistant turns.
+  batch-shape sensitivity. `AgenticTrainer` uses the same interface after
+  concatenating every successful trajectory's generated assistant turns.
 - **`UnifiedModelTrainStack`** (`unified_model_stack.py`) drives two algorithms
   (`ar` + `image`) backward-accumulating into one shared optimizer step on one
   shared backbone (HunyuanImage3).
 
-**Extending it:** a new structural injection mode is an `inject_<mode>` next to
-the existing ones — `inject_lora` in `lora.py`, `inject_nft` / `inject_mirror` in
-`ema.py` — (called before `fsdp_wrap`) plus a config in `configs.py`; a new
-optimizer or LR schedule is a branch in `optim.py` plus fields on
-`OptimizerConfig`/`LrSchedulerConfig` in `backend/base.py`; a multi-update-capable algorithm sets
+**Extending it:** a new structural injection mode is an `inject_<mode>` alongside
+`inject_lora` (`lora.py`) and `inject_nft` / `inject_mirror` (`ema.py`), called
+before `fsdp_wrap`, plus a config in `configs.py`; a new optimizer or LR schedule
+is a branch in `optim.py` plus fields on `OptimizerConfig` / `LrSchedulerConfig`
+in `backend/base.py`; a multi-update-capable algorithm sets
 `supports_multi_update = True` and declares `anchor_fields` (see
 `../algorithms/README.md`).
 

--- a/unirl/utils/prepare_dapo_math.py
+++ b/unirl/utils/prepare_dapo_math.py
@@ -18,7 +18,7 @@ that format so the recipe is reproducible without any private cache:
   - eval  : AIME 2024 + AIME 2025 (the paper's avg@16 benchmark), concatenated.
 
 Usage:
-  python scripts/prepare_dapo_math.py --out-dir data/dapo_math
+  python -m unirl.utils.prepare_dapo_math --out-dir data/dapo_math
   # → data/dapo_math/train.jsonl  (+ aime_eval.jsonl)
 
   DATA_PATH=data/dapo_math/train.jsonl EVAL_DATA_PATH=data/dapo_math/aime_eval.jsonl \


### PR DESCRIPTION
## Summary

Fix stale high-traffic extension guidance and align it with the current tree.

- Update `unirl/train/readme.md` to point at the real FSDP backend, structural-injection, optimizer, scheduler, and MicroPlanner implementations.
- Correct the rollout engine census and shared-noise invariant, including FastVideo's seed-based realization and the current BAGEL-capable vLLM-Omni surface.
- Document the real per-engine model-onboarding touchpoints for SGLang, SGLang Diffusion, and vLLM-Omni.
- Replace removed `tests/`-tree guidance in the model-bundle skill with the repository's one-off verification-harness policy.
- Fix the DAPO preparation command to use the importable module path.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --from-ref origin/main --to-ref HEAD --show-diff-on-failure` — all hooks passed after rebasing onto current `main`.
- Cross-checked every referenced file, symbol, engine directory, adapter registry, noise path, and planner against the rebased tree.

## Compatibility / Risk

N/A — documentation-only, apart from correcting one help-string command.

## Reviewer Notes

AI-assisted; the full diff was reviewed after rebasing onto current `main`. Duplicate-work check done: #361 owns the broader core-boundary and dataset-placement rules, which are intentionally not claimed here.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
