### PR TITLE
feat(types): canonical agent-trace path — structured tool calls, one composition layer

### DIFF
--- a/unirl/models/README.md
+++ b/unirl/models/README.md
@@ -84,3 +84,34 @@ it is the authoritative bundle / pipeline / stage / conditions contract.
   it's `None`; never build the σ tensor inside `generate`.
 - **CFG empty-negative differs per model** (SD3 `""`, Qwen-Image `" "`) — use the
   model's canonical upstream value or the rollout/replay ratio drifts off 1.0.
+
+## Conversation composition and the canonical trace format
+
+Multi-turn / agent conversation data has one canonical external format and one
+composition layer; every path (rollout render, replay, trace SFT) goes through
+them.
+
+- **Canonical external format: OpenAI-style messages.** Manifests and converted
+  agent traces are `{"messages": [{role, content|null, tool_calls}], "tools":
+  [...]}` — the industry trainer-facing shape (OpenAI/HF/TRL). Per-source
+  converters (`datasets/<name>/convert_*.py`) may accept anything; what they
+  *emit* is this schema, unextended. RL metadata (rewards, outcome labels,
+  trace ids) rides as sibling fields next to `messages`, never inside it.
+  `tool_calls.function.arguments` is normalized to a **dict** at ingest
+  (`normalize_tool_arguments`) — HF chat templates mis-render the OpenAI
+  JSON-string dialect.
+- **One composition layer: `unirl/models/types/conversations.py`.** Rules that
+  decide how a conversation is assembled — system-instruction precedence, role
+  fusion, structured tool-call emission — live there and only there (Turn-based
+  and message-based dialects side by side; the sglang wire render imports the
+  same helpers). Model chat stages own *encoding* (chat template / processor /
+  Bagel splits), never composition rules.
+- **One system rule, zero stances:** the config `system_instruction` is a
+  default; an explicit `system` turn in the data wins. A path that wants
+  "data is the sole source of truth" leaves `system_instruction` unset in the
+  recipe — never adds a code branch.
+- **Structured tool calls are typed, not regex.** An assistant part carries
+  `unirl.types.tool_calls.ToolCalls` under the `"tool_calls"` primitive key; a tool
+  result pairs back via `Sample.observe(..., tool_call_id=...)`. `Sample.turns()`
+  surfaces both on the `Turn`, and `build_text_messages` /
+  `turns_from_messages` round-trip them to and from OpenAI messages.

--- a/unirl/models/qwen3_omni/conversations.py
+++ b/unirl/models/qwen3_omni/conversations.py
@@ -13,8 +13,8 @@ from typing import Any, Dict, List, Optional
 
 from unirl.models.types.conversations import (
     Conversation,
-    _group_consecutive_roles,
-    _system_prefix,
+    group_consecutive_roles,
+    system_prefix,
 )
 from unirl.types.media import MediaRef, MediaRefs
 from unirl.types.primitives import Audios, Images, Texts, Videos
@@ -80,8 +80,8 @@ def build_omni_messages(
         )
 
     roles = [turn.role for turn in turns]
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
+    role_groups = group_consecutive_roles(roles)
+    prefix = system_prefix(system_instruction, roles)
     columns: List[List[Any]] = []
     for turn in turns:
         if isinstance(turn.content, Texts):

--- a/unirl/models/types/conversations.py
+++ b/unirl/models/types/conversations.py
@@ -9,22 +9,40 @@ Unlike the sglang engine's equivalent (``rollout/engine/sglang/utils/conversatio
 which de-expands the ``*n`` wire fan-out), the trainside embeds **every** frontier
 sample per-row — so there is NO de-expand here; one conversation per row.
 
-Pure (only :mod:`unirl.types`): no tokenizer, no processor, no engine. The trainside
-cannot import the sglang engine's helper (sglang is an optional dependency whose
-package import pulls the backend), so the small transpose is mirrored here.
+Pure (only :mod:`unirl.types`): no tokenizer, no processor, no engine.
+
+**This module is the repo's single conversation-composition layer.** Rules that
+decide how a conversation is assembled — the system-instruction precedence, role
+fusion, structured tool-call emission, message normalization — live here and
+ONLY here, in two dialects: Turn-based helpers (rollout/replay trajectories) and
+message-based helpers (OpenAI-style manifests / agent traces). Per-model chat
+stages own the *encoding* of a composed conversation (chat template, processor,
+Bagel splits), never the composition rules. The sglang wire render
+(``rollout/engine/sglang/utils/conversations.py``) imports these helpers too.
+
+The one system rule, both dialects: **the config ``system_instruction`` is a
+default; an explicit ``system`` turn in the data wins.** Paths that want
+"data is the sole source of truth" (e.g. faithful trace SFT) express that by
+not setting ``system_instruction`` in the recipe — never by a code branch.
+
+The canonical external format for conversation data is the OpenAI messages
+shape (``{"messages": [{role, content|null, tool_calls}], "tools": [...]}``);
+``tool_calls.function.arguments`` is normalized to a dict at ingest
+(:func:`normalize_tool_arguments`) because HF chat templates expect dicts.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from unirl.types.primitives import Images
-from unirl.types.sample import Turn
+from unirl.types.primitives import Images, Texts
+from unirl.types.sample import TURN_ROLES, Turn
+from unirl.types.tool_calls import ToolCall, ToolCalls
 
 Conversation = List[Dict[str, Any]]
 
 
-def _system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conversation:
+def system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conversation:
     """The config ``system_instruction`` as a leading message, unless the trajectory
     already carries an explicit ``system`` turn (which wins)."""
     if system_instruction and "system" not in roles:
@@ -32,7 +50,7 @@ def _system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conve
     return []
 
 
-def _group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
+def group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
     """Group consecutive turn indices that share a role → ``[(role, [idx…]), …]``.
 
     Multi-input modalities ride as separate same-role turns (e.g. it2i is a text
@@ -48,6 +66,15 @@ def _group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
     return groups
 
 
+def _turn_batch_size(turns: List[Turn]) -> int:
+    for t in turns:
+        if t.content is not None:
+            return len(t.content)
+        if t.tool_calls is not None:
+            return len(t.tool_calls)
+    raise ValueError("conversations: every turn is empty (no content, no tool_calls).")
+
+
 def build_text_messages(
     turns: List[Turn],
     system_instruction: Optional[str] = None,
@@ -57,14 +84,34 @@ def build_text_messages(
     Transposes :meth:`Sample.text_conditioning` (turn-major, frontier-aligned) into
     one message list per frontier sample. Degenerates to a single ``user`` message
     when no roles are set, so it is byte-identical on single-turn workloads.
+
+    Structured agent channels ride through: a turn's :attr:`Turn.tool_calls`
+    rows emit OpenAI-style ``tool_calls`` entries (dict ``arguments`` — the HF
+    template form) on the assistant message, a calls-only turn emits
+    ``content: None``, and a tool turn's :attr:`Turn.tool_call_ids` emits
+    ``tool_call_id``. Plain chat turns emit exactly ``{"role", "content"}``.
     """
     if not turns:
         return []
     roles = [t.role for t in turns]
-    cols = [t.content.texts for t in turns]
-    prefix = _system_prefix(system_instruction, roles)
-    n_rows = len(turns[0].content)
-    return [prefix + [{"role": roles[j], "content": cols[j][row]} for j in range(len(turns))] for row in range(n_rows)]
+    cols = [t.content.texts if t.content is not None else None for t in turns]
+    prefix = system_prefix(system_instruction, roles)
+    n_rows = _turn_batch_size(turns)
+
+    def _message(j: int, row: int) -> Dict[str, Any]:
+        message: Dict[str, Any] = {"role": roles[j], "content": cols[j][row] if cols[j] is not None else None}
+        calls = turns[j].tool_calls.rows[row] if turns[j].tool_calls is not None else []
+        if calls:
+            message["tool_calls"] = [call.to_message_entry() for call in calls]
+        ids = turns[j].tool_call_ids
+        if ids is not None and ids[row] is not None:
+            message["tool_call_id"] = ids[row]
+        names = turns[j].tool_names
+        if names is not None and names[row] is not None:
+            message["name"] = names[row]
+        return message
+
+    return [prefix + [_message(j, row) for j in range(len(turns))] for row in range(n_rows)]
 
 
 def build_vision_messages(
@@ -81,11 +128,16 @@ def build_vision_messages(
     """
     if not turns:
         return []
+    if any(t.content is None for t in turns):
+        raise ValueError(
+            "build_vision_messages: calls-only turns (content=None) are unsupported on the "
+            "vision render; structured tool calls currently render via build_text_messages."
+        )
     roles = [t.role for t in turns]
     is_image = [isinstance(t.content, Images) for t in turns]
     cols = [t.content.to_pils() if im else t.content.texts for t, im in zip(turns, is_image)]
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
+    role_groups = group_consecutive_roles(roles)
+    prefix = system_prefix(system_instruction, roles)
     n_rows = len(turns[0].content)
 
     conversations: List[Conversation] = []
@@ -104,8 +156,102 @@ def build_vision_messages(
     return conversations
 
 
+def ensure_system_message(
+    messages: Sequence[Dict[str, Any]],
+    system_instruction: Optional[str],
+) -> List[Dict[str, Any]]:
+    """The message-dialect twin of :func:`system_prefix` — same one rule.
+
+    Prepends the config ``system_instruction`` as a leading ``system`` message
+    unless the history already carries an explicit ``system`` message (which
+    wins). Returns a new list; never mutates ``messages``.
+    """
+    out = list(messages)
+    if system_instruction and not any(m.get("role") == "system" for m in out):
+        return [{"role": "system", "content": system_instruction}, *out]
+    return out
+
+
+def normalize_tool_arguments(messages: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Normalize every assistant ``tool_calls`` entry to dict ``arguments``.
+
+    OpenAI serializes ``function.arguments`` as a JSON-encoded string; HF chat
+    templates expect a dict and mis-render the string form (transformers docs
+    warn about this explicitly). Call this once at manifest ingest so trace
+    data from either dialect renders identically. Returns new message dicts
+    where normalization applies; non-assistant / call-free messages pass
+    through unchanged.
+    """
+    out: List[Dict[str, Any]] = []
+    for message in messages:
+        calls = message.get("tool_calls")
+        if not calls:
+            out.append(message)
+            continue
+        normalized = [ToolCall.from_message_entry(entry, context="normalize_tool_arguments") for entry in calls]
+        rebuilt = dict(message)
+        rebuilt["tool_calls"] = [call.to_message_entry() for call in normalized]
+        out.append(rebuilt)
+    return out
+
+
+def turns_from_messages(messages: Sequence[Dict[str, Any]]) -> List[Turn]:
+    """One OpenAI-style message history → batch-1 :class:`Turn` list.
+
+    The manifest→trajectory half of the round trip whose other half is
+    :func:`build_text_messages`, so an SFT path over trace manifests can render
+    through exactly the same composition code as rollout. Supported today:
+    string (or ``None``) content, assistant ``tool_calls`` (either arguments
+    dialect — normalized to dicts), and ``tool``-role ``tool_call_id`` pairing.
+    Content-part lists (interleaved media) are not yet representable as Turns
+    and raise.
+    """
+    turns: List[Turn] = []
+    for i, message in enumerate(messages):
+        role = message.get("role")
+        if role not in TURN_ROLES:
+            raise ValueError(f"turns_from_messages: message {i} role {role!r} not in {TURN_ROLES}.")
+        content = message.get("content")
+        raw_calls = message.get("tool_calls") or []
+        if raw_calls and role != "assistant":
+            raise ValueError(f"turns_from_messages: message {i} ({role}) carries tool_calls; only assistant may.")
+        calls = [ToolCall.from_message_entry(entry, context=f"turns_from_messages[{i}]") for entry in raw_calls]
+        tool_calls = ToolCalls.from_rows([calls]) if calls else None
+        if isinstance(content, list):
+            raise NotImplementedError(
+                f"turns_from_messages: message {i} has content-part list; interleaved media "
+                "parts are not yet representable as Turns (text/tool histories only)."
+            )
+        if content is None:
+            if not calls:
+                raise ValueError(f"turns_from_messages: message {i} ({role}) has neither content nor tool_calls.")
+            turns.append(Turn(role=role, content=None, tool_calls=tool_calls))
+            continue
+        if not isinstance(content, str):
+            raise TypeError(
+                f"turns_from_messages: message {i} content must be str/None/list, got {type(content).__name__}."
+            )
+        call_id = message.get("tool_call_id")
+        name = message.get("name")
+        turns.append(
+            Turn(
+                role=role,
+                content=Texts(texts=[content]),
+                tool_calls=tool_calls,
+                tool_call_ids=[call_id] if role == "tool" and call_id is not None else None,
+                tool_names=[name] if role == "tool" and name is not None else None,
+            )
+        )
+    return turns
+
+
 __all__ = [
     "Conversation",
     "build_text_messages",
     "build_vision_messages",
+    "ensure_system_message",
+    "group_consecutive_roles",
+    "normalize_tool_arguments",
+    "system_prefix",
+    "turns_from_messages",
 ]

--- a/unirl/rollout/engine/sglang/utils/conversations.py
+++ b/unirl/rollout/engine/sglang/utils/conversations.py
@@ -7,15 +7,19 @@ row per frontier sample (``P`` prompts × ``n`` fan-out = ``P*n`` rows). These
 helpers transpose that into ``P`` per-sample message lists and de-expand the
 ``*n`` fan-out back to the unique conversations the backend fans out server-side.
 
-Pure (only :mod:`unirl.types`): no tokenizer, no processor, no engine state — so
-the message-shape logic unit-tests with canned ``Sample``s. The *model-specific*
-encode (``apply_chat_template`` / processor) stays in the adapter.
+Pure (no tokenizer, no processor, no engine state) — so the message-shape
+logic unit-tests with canned ``Sample``s. The *model-specific* encode
+(``apply_chat_template`` / processor) stays in the adapter. Composition rules
+(system precedence, role fusion) are imported from the single composition
+layer, :mod:`unirl.models.types.conversations`; only the wire-specific ``*n``
+de-expand lives here.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple
 
+from unirl.models.types.conversations import group_consecutive_roles, system_prefix
 from unirl.types.primitives import Images
 from unirl.types.sample import Sample
 
@@ -54,30 +58,6 @@ def unique_group_indices(group_ids: List[str]) -> Tuple[List[int], int]:
     return rep_indices, next(iter(k_values))
 
 
-def _group_consecutive_roles(roles: List[str]) -> List[Tuple[str, List[int]]]:
-    """Group consecutive turn indices that share a role → ``[(role, [idx…]), …]``.
-
-    Multi-input modalities ride as separate same-role turns (e.g. it2i is a text
-    ``user`` turn + an image ``user`` turn); a chat message holds one role, so
-    consecutive same-role turns fuse into one message.
-    """
-    groups: List[Tuple[str, List[int]]] = []
-    for j, role in enumerate(roles):
-        if groups and groups[-1][0] == role:
-            groups[-1][1].append(j)
-        else:
-            groups.append((role, [j]))
-    return groups
-
-
-def _system_prefix(system_instruction: Any, roles: List[str]) -> Conversation:
-    """The config ``system_instruction`` as a leading message, unless the
-    trajectory already carries an explicit ``system`` turn (which wins)."""
-    if system_instruction and "system" not in roles:
-        return [{"role": "system", "content": system_instruction}]
-    return []
-
-
 def build_text_conversations(
     sample: Sample,
     system_instruction: Any = None,
@@ -93,7 +73,7 @@ def build_text_conversations(
     rep, k = unique_group_indices(sample.parts[-1].group_ids)
     roles = [t.role for t in turns]
     cols = [t.content.texts for t in turns]
-    prefix = _system_prefix(system_instruction, roles)
+    prefix = system_prefix(system_instruction, roles)
 
     conversations = [prefix + [{"role": roles[j], "content": cols[j][row]} for j in range(len(turns))] for row in rep]
     return conversations, k
@@ -117,8 +97,8 @@ def build_vision_conversations(
     roles = [t.role for t in turns]
     is_image = [isinstance(t.content, Images) for t in turns]
     cols = [t.content.to_pils() if im else t.content.texts for t, im in zip(turns, is_image)]
-    role_groups = _group_consecutive_roles(roles)
-    prefix = _system_prefix(system_instruction, roles)
+    role_groups = group_consecutive_roles(roles)
+    prefix = system_prefix(system_instruction, roles)
 
     conversations: List[Conversation] = []
     images_list: List[List[Any]] = []

--- a/unirl/types/primitives.py
+++ b/unirl/types/primitives.py
@@ -53,6 +53,7 @@ import torch
 
 from unirl.distributed.tensor.batch import Batch, FieldKind, concat_field, field, packed_field
 from unirl.types.media import MediaRefs
+from unirl.types.tool_calls import ToolCalls
 
 
 @dataclass
@@ -352,14 +353,15 @@ def _cumsum(values: List[int]) -> List[int]:
     return out
 
 
-PrimitiveValue = Union[Texts, Images, Videos, Audios, MediaRefs]
+PrimitiveValue = Union[Texts, Images, Videos, Audios, MediaRefs, ToolCalls]
 
 
-def primitive_modality_key(prim: Texts | Images | Videos | Audios | MediaRefs) -> str:
+def primitive_modality_key(prim: PrimitiveValue) -> str:
     """Map a batched primitive to its modality slot key.
 
     ``Texts -> "text"``, ``Images -> "image"``, ``Videos -> "video"``,
-    ``Audios -> "audio"``, ``MediaRefs -> "media"`` — the keying convention shared by
+    ``Audios -> "audio"``, ``MediaRefs -> "media"``, ``ToolCalls -> "tool_calls"``
+    — the keying convention shared by
     ``RewardRequest.primitives`` / ``generated`` and the slots
     :meth:`Sample.conditioning` surfaces. Inverse of a backend's
     ``preferred_input_kind``.
@@ -374,6 +376,8 @@ def primitive_modality_key(prim: Texts | Images | Videos | Audios | MediaRefs) -
         return "audio"
     if isinstance(prim, MediaRefs):
         return "media"
+    if isinstance(prim, ToolCalls):
+        return "tool_calls"
     raise TypeError(f"primitive_modality_key: unknown primitive type {type(prim).__name__!r}")
 
 
@@ -389,6 +393,7 @@ __all__ = [
     "TextAndVideo",
     "Texts",
     "PrimitiveValue",
+    "ToolCalls",
     "Video",
     "Videos",
     "primitive_modality_key",

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from dataclasses import fields as dc_fields
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 
 import torch
 
@@ -45,6 +45,7 @@ from unirl.types.primitives import Images, PrimitiveValue, Texts, primitive_moda
 from unirl.types.sample_id import ancestor_id, child_id, parent_id
 from unirl.types.sampling import BaseSamplingParams
 from unirl.types.segments import Segment, TextSegment
+from unirl.types.tool_calls import ToolCalls
 from unirl.utils.shard_balance import lpt_shard_permutation, shard_token_spread
 
 logger = logging.getLogger(__name__)
@@ -66,10 +67,20 @@ class Turn:
     can be rendered into an LLM/VLM conversation. A plain return type (not a
     :class:`Batch`): ``content`` is already a batched primitive (one row per
     frontier sample).
+
+    Structured agent-trace channels (all optional; absent on plain chat turns):
+    ``tool_calls`` carries the assistant turn's structured calls (row-aligned,
+    from the part's ``"tool_calls"`` primitive); ``content`` is ``None`` only
+    for a calls-only assistant turn (OpenAI's null-content case). On a
+    ``tool``-role turn, ``tool_call_ids`` / ``tool_names`` pair each row's
+    result with the call that produced it (from ``Part.metadata[r]``).
     """
 
     role: str
-    content: Primitive
+    content: Optional[Primitive]
+    tool_calls: Optional["ToolCalls"] = None
+    tool_call_ids: Optional[List[Optional[str]]] = None
+    tool_names: Optional[List[Optional[str]]] = None
 
 
 @dataclass
@@ -143,7 +154,13 @@ class Part(Batch):
 
     @classmethod
     def concat(cls, items: Sequence["Part"]) -> "Part":
-        """Concat batch rows while requiring identical shared primitive metadata."""
+        """Concat batch rows while requiring identical shared primitive metadata.
+
+        ``metadata`` semantics: an empty list means "no per-row annotations", so
+        when some shards carry row-aligned metadata (e.g. ``observe`` tool-call
+        pairing) and others carry the empty default, the empty ones are padded
+        with ``{}`` rows — otherwise the generic list-concat rejects the mix.
+        """
         if items:
             expected = items[0].primitive_metadata
             mismatched = [i for i, item in enumerate(items[1:], start=1) if item.primitive_metadata != expected]
@@ -152,6 +169,11 @@ class Part(Batch):
                     "Part.concat: primitive_metadata must be identical across shards; "
                     f"mismatched item indices {mismatched}."
                 )
+            if any(item.metadata for item in items) and any(not item.metadata for item in items):
+                items = [
+                    item if item.metadata else _part_with_field(item, "metadata", [{} for _ in item.sample_ids])
+                    for item in items
+                ]
         return super().concat(items)
 
     @classmethod
@@ -186,7 +208,13 @@ class Part(Batch):
             role=role,
         )
 
-    def input_child(self, primitives: PrimitiveMap, *, role: Optional[str] = None) -> "Part":
+    def input_child(
+        self,
+        primitives: PrimitiveMap,
+        *,
+        role: Optional[str] = None,
+        metadata: Optional[List[Dict[str, Any]]] = None,
+    ) -> "Part":
         """A branch-1 *input* child carrying additional conditioning primitives.
 
         Multi-input multimodal (e.g. image+text → image) usually puts each
@@ -195,14 +223,19 @@ class Part(Batch):
         None because it generates nothing. Chaining keeps only the head a root,
         so the Sample stays valid and
         :meth:`Sample.conditioning` surfaces every input primitive in turn order
-        (root → …). See ``unirl/types/README.md``.
+        (root → …). See ``unirl/types/README.md``. ``metadata`` optionally
+        carries per-row annotations (e.g. ``tool_call_id`` pairing on an
+        observation) and must be row-aligned to the parent.
         """
         if not self.sample_ids:
             raise ValueError("Part.input_child: parent has no sample_ids")
+        if metadata is not None and len(metadata) != len(self.sample_ids):
+            raise ValueError(f"Part.input_child: metadata rows {len(metadata)} != parent batch {len(self.sample_ids)}.")
         return Part(
             sample_ids=[child_id(pid, 0) for pid in self.sample_ids],
             primitives=dict(primitives),
             role=role,
+            metadata=list(metadata) if metadata is not None else [],
         )
 
     @property
@@ -767,7 +800,14 @@ class Sample(Batch):
         )
         return type(self)(parts=[*self.parts, child], reward_compute_s=self.reward_compute_s)
 
-    def observe(self, observation: Primitive, *, role: str = "tool") -> "Sample":
+    def observe(
+        self,
+        observation: Primitive,
+        *,
+        role: str = "tool",
+        tool_call_id: Optional[Union[str, List[Optional[str]]]] = None,
+        tool_name: Optional[Union[str, List[Optional[str]]]] = None,
+    ) -> "Sample":
         """Append an observation as a branch-1, mask-0 *input* Part off the frontier.
 
         The world-response half of an agentic turn (``unirl/rollout/env/README.md``): the
@@ -780,11 +820,46 @@ class Sample(Batch):
         ``role`` tags the observation's conversation turn for role-aware rendering
         (:meth:`Part.resolved_role`), defaulting to ``"tool"`` — the agentic world-response is a
         tool result, so the chat template wraps it as a ``<tool_response>``. A non-tool world
-        (e.g. a user simulator) can pass ``role="user"``.
+        (e.g. a user simulator) can pass ``role="user"``. ``tool_call_id`` / ``tool_name``
+        optionally pair the result with the structured call that produced it (OpenAI
+        ``tool_call_id`` convention); they ride in ``Part.metadata`` and surface on the
+        turn's :attr:`Turn.tool_call_ids` / :attr:`Turn.tool_names`. Rows of a batched
+        frontier are independent trajectories with distinct call ids, so a bare string is
+        only accepted at batch 1 — batched observations must pass row-aligned lists.
         """
         if not self.parts:
             raise ValueError("Sample.observe: no parts to observe from (empty Sample)")
-        obs_part = self.parts[-1].input_child({primitive_modality_key(observation): observation}, role=role)
+        batch = len(self.parts[-1].sample_ids)
+
+        def _rows(value: Optional[Union[str, List[Optional[str]]]], label: str) -> Optional[List[Optional[str]]]:
+            if value is None:
+                return None
+            if isinstance(value, str):
+                if batch != 1:
+                    raise ValueError(
+                        f"Sample.observe: scalar {label} with frontier batch {batch}; rows are independent "
+                        "trajectories with distinct call ids — pass a row-aligned list."
+                    )
+                return [value]
+            if len(value) != batch:
+                raise ValueError(f"Sample.observe: {label} rows {len(value)} != frontier batch {batch}.")
+            return list(value)
+
+        ids = _rows(tool_call_id, "tool_call_id")
+        names = _rows(tool_name, "tool_name")
+        metadata: Optional[List[Dict[str, Any]]] = None
+        if ids is not None or names is not None:
+            metadata = []
+            for r in range(batch):
+                row: Dict[str, Any] = {}
+                if ids is not None and ids[r] is not None:
+                    row["tool_call_id"] = ids[r]
+                if names is not None and names[r] is not None:
+                    row["tool_name"] = names[r]
+                metadata.append(row)
+        obs_part = self.parts[-1].input_child(
+            {primitive_modality_key(observation): observation}, role=role, metadata=metadata
+        )
         return type(self)(parts=[*self.parts, obs_part], reward_compute_s=self.reward_compute_s)
 
     def propagate_rewards(self, op: Literal["mean", "max", "sum"] = "mean") -> "Sample":
@@ -838,7 +913,12 @@ class Sample(Batch):
         the frontier's samples, climbed one level per step via ``parent_id``; each
         level's rows are looked up by id (position-independent). Ancestors with
         no populated ``primitives`` are skipped; for a non-frontier part's turns
-        (replay), call this on ``parts[:i+1]``."""
+        (replay), call this on ``parts[:i+1]``.
+
+        Structured agent channels: a part's ``"tool_calls"`` primitive attaches to
+        its text Turn (or a content-``None`` Turn when the assistant made calls
+        without text); a ``tool``-role part's ``metadata[r]["tool_call_id"]``
+        surfaces as :attr:`Turn.tool_call_ids`."""
         if not self.parts:
             return []
         frontier = self.parts[-1]
@@ -856,12 +936,38 @@ class Sample(Batch):
                 raise ValueError(
                     f"Sample.turns: ancestor id {e.args[0]!r} not found in part {anc}; lineage chain is malformed."
                 ) from None
-            for key in reversed(PRIMITIVE_MODALITY_ORDER):
+            role = part.resolved_role()
+            rows_tensor = torch.tensor(rows, dtype=torch.long)
+            tool_calls = part.primitives.get("tool_calls")
+            selected_calls = tool_calls.select(rows_tensor) if tool_calls is not None else None
+            tool_call_ids: Optional[List[Optional[str]]] = None
+            tool_names: Optional[List[Optional[str]]] = None
+            if role == "tool" and len(part.metadata) == len(part.sample_ids):
+                ids = [(part.metadata[r] or {}).get("tool_call_id") for r in rows]
+                names = [(part.metadata[r] or {}).get("tool_name") for r in rows]
+                if any(i is not None for i in ids):
+                    tool_call_ids = ids
+                if any(n is not None for n in names):
+                    tool_names = names
+            part_turns: List[Turn] = []
+            for key in PRIMITIVE_MODALITY_ORDER:
                 primitive = part.primitives.get(key)
                 if primitive is None:
                     continue
-                content = primitive.select(torch.tensor(rows, dtype=torch.long))
-                out.append(Turn(role=part.resolved_role(), content=content))
+                content = primitive.select(rows_tensor)
+                part_turns.append(
+                    Turn(
+                        role=role,
+                        content=content,
+                        tool_calls=selected_calls if key == "text" else None,
+                        tool_call_ids=tool_call_ids,
+                        tool_names=tool_names,
+                    )
+                )
+            if selected_calls is not None and not any(t.tool_calls is not None for t in part_turns):
+                # Calls-only assistant part (OpenAI null-content): surface the calls anyway.
+                part_turns.append(Turn(role=role, content=None, tool_calls=selected_calls))
+            out.extend(reversed(part_turns))
             if part.is_root:
                 break
             active_ids = [parent_id(aid) for aid in active_ids]
@@ -874,8 +980,9 @@ class Sample(Batch):
         ancestor's raw primitives, row-aligned to the frontier's
         samples, in chronological order (root → frontier-parent). The role-stripped
         view of :meth:`turns` — the bare-primitive escape unified models consume
-        (replay: call on ``parts[:i+1]``)."""
-        return [t.content for t in self.turns()]
+        (replay: call on ``parts[:i+1]``). Calls-only turns (``content is None``)
+        carry no raw primitive and are skipped."""
+        return [t.content for t in self.turns() if t.content is not None]
 
     def prompt_media_refs(self) -> Optional[MediaRefs]:
         """Return typed URI prompt-media refs from the root input Part, if any.
@@ -915,8 +1022,16 @@ class Sample(Batch):
 
     def text_conditioning(self) -> List[Turn]:
         """LLM render: the trajectory as an all-text conversation. Fails loud on
-        any non-text turn — this consumer has no image channel."""
+        any non-text turn — this consumer has no image channel — and on
+        calls-only turns (the wire render carries tool calls inline in the
+        assistant text; structured-only turns come from manifest conversion and
+        belong to the messages render, ``build_text_messages``)."""
         ts = self.turns()
+        if any(t.content is None for t in ts):
+            raise ValueError(
+                "Sample.text_conditioning: trajectory has a calls-only turn (content=None); "
+                "the wire render requires inline-text tool calls."
+            )
         non_text = [primitive_modality_key(t.content) for t in ts if not isinstance(t.content, Texts)]
         if non_text:
             raise ValueError(f"Sample.text_conditioning: the LLM path requires all-text turns; got non-text {non_text}")
@@ -929,11 +1044,15 @@ class Sample(Batch):
         modality."""
         ts = self.turns()
         images = [t.content for t in ts if isinstance(t.content, Images)]
-        extra = [primitive_modality_key(t.content) for t in ts if not isinstance(t.content, (Texts, Images))]
+        extra = [
+            primitive_modality_key(t.content) if t.content is not None else "tool_calls-only"
+            for t in ts
+            if not isinstance(t.content, (Texts, Images))
+        ]
         if extra or not images:
             raise ValueError(
                 f"Sample.vision_conditioning: requires text+image turns only; got "
-                f"{[primitive_modality_key(t.content) for t in ts]}"
+                f"{[primitive_modality_key(t.content) if t.content is not None else 'tool_calls-only' for t in ts]}"
             )
         return ts, images
 

--- a/unirl/types/tool_calls.py
+++ b/unirl/types/tool_calls.py
@@ -1,0 +1,125 @@
+"""Typed structured tool calls for agent trajectories.
+
+The canonical on-disk/interchange shape for tool calls is the OpenAI messages
+convention (assistant message ``tool_calls`` entries; ``tool`` role results
+paired by ``tool_call_id``). This module is the typed internal counterpart:
+``ToolCalls`` rides on a :class:`~unirl.types.sample.Part` under the
+``"tool_calls"`` primitive key and surfaces on the part's assistant
+:class:`~unirl.types.sample.Turn`, so a full agent trace round-trips
+messages ↔ ``Sample`` without regex over rendered text.
+
+``arguments`` is ALWAYS a dict internally. OpenAI serializes
+``function.arguments`` as a JSON-encoded string while HF chat templates expect
+a dict (transformers docs warn the string form mis-renders); ingest normalizes
+via :meth:`ToolCall.from_message_entry`, and :meth:`ToolCall.to_message_entry`
+re-emits the dict form that ``apply_chat_template`` consumes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from unirl.distributed.tensor.batch import Batch, concat_field
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """One structured function call: ``id`` pairs it with its tool-role result."""
+
+    name: str
+    # Excluded from __hash__ (dicts are unhashable); equality still compares it,
+    # so equal calls keep equal hashes and set/dict dedup of parallel calls works.
+    arguments: Dict[str, Any] = field(default_factory=dict, hash=False)
+    id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError(f"ToolCall.name must be a non-empty string, got {self.name!r}.")
+        if not isinstance(self.arguments, dict):
+            raise TypeError(
+                f"ToolCall.arguments must be a dict (normalize JSON strings at ingest), "
+                f"got {type(self.arguments).__name__}."
+            )
+        if self.id is not None and not isinstance(self.id, str):
+            raise TypeError(f"ToolCall.id must be a string or None, got {type(self.id).__name__}.")
+
+    @classmethod
+    def from_message_entry(cls, entry: Dict[str, Any], *, context: str = "ToolCall") -> "ToolCall":
+        """Parse one OpenAI-style ``tool_calls`` entry, normalizing arguments to a dict.
+
+        Accepts both the nested ``{"id", "type": "function", "function": {"name",
+        "arguments"}}`` shape and a flat ``{"id", "name", "arguments"}`` shape;
+        ``arguments`` may be a dict or a JSON-encoded string (the OpenAI wire form).
+        """
+        if not isinstance(entry, dict):
+            raise TypeError(f"{context}: tool_calls entries must be dicts, got {type(entry).__name__}.")
+        if "function" in entry and not isinstance(entry["function"], dict):
+            raise TypeError(
+                f"{context}: tool_calls entry 'function' must be a dict, got {type(entry['function']).__name__}."
+            )
+        fn = entry.get("function") if isinstance(entry.get("function"), dict) else entry
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{context}: tool_calls entry missing function name: {entry!r}.")
+        arguments = fn.get("arguments", {})
+        if isinstance(arguments, str):
+            text = arguments.strip() or "{}"
+            try:
+                arguments = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{context}: tool call {name!r} arguments is not valid JSON: {text!r}.") from exc
+        if not isinstance(arguments, dict):
+            raise TypeError(
+                f"{context}: tool call {name!r} arguments must decode to an object, got {type(arguments).__name__}."
+            )
+        call_id = entry.get("id")
+        return cls(name=name, arguments=arguments, id=str(call_id) if call_id is not None else None)
+
+    def to_message_entry(self) -> Dict[str, Any]:
+        """The OpenAI-style ``tool_calls`` entry, with dict ``arguments`` (HF template form)."""
+        entry: Dict[str, Any] = {"type": "function", "function": {"name": self.name, "arguments": self.arguments}}
+        if self.id is not None:
+            entry["id"] = self.id
+        return entry
+
+
+@dataclass
+class ToolCalls(Batch):
+    """Batch-aligned sparse structured tool calls (mirror of :class:`MediaRefs`).
+
+    ``rows[i]`` is the ordered list of calls the assistant made for sample ``i``
+    (empty row = no call; multiple entries = parallel calls). Sparsity stays
+    inside each row so CONCAT selection, slicing, and transport remain
+    row-aligned under the rectangular :class:`Batch` contract.
+
+    Builder contract (shared by every ``Part.primitives`` key): same-position
+    parts that get concatenated must agree on key presence. A builder whose
+    batches can mix call-free and calling samples attaches ``ToolCalls`` with
+    empty rows unconditionally rather than only when calls exist.
+    """
+
+    rows: List[List[ToolCall]] = concat_field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        normalized: List[List[ToolCall]] = []
+        for row, calls in enumerate(self.rows):
+            if not isinstance(calls, (list, tuple)):
+                raise TypeError(f"ToolCalls.rows[{row}] must be a list of ToolCall values.")
+            values = list(calls)
+            invalid = [type(call).__name__ for call in values if not isinstance(call, ToolCall)]
+            if invalid:
+                raise TypeError(f"ToolCalls.rows[{row}] contains non-ToolCall values: {invalid}.")
+            normalized.append(values)
+        self.rows = normalized
+
+    @classmethod
+    def from_rows(cls, rows: List[List[ToolCall]]) -> "ToolCalls":
+        return cls(rows=[list(row) for row in rows])
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+
+__all__ = ["ToolCall", "ToolCalls"]


### PR DESCRIPTION
## Summary

Lands the agreed unification (audit follow-up, discussed with the maintainer): agent traces and plain single/multi-turn chat share **one canonical external format, one internal representation, and one composition layer**; per-model chat stages keep only encoding. Stacked on #357 (same file); retarget to `main` after #357 merges.

**Canonical external format (declared + normalized).** OpenAI-style `messages`+`tools` is the trainer-facing industry standard (OpenAI/Azure fine-tuning, HF `apply_chat_template`, TRL, axolotl, LLaMA-Factory, verl) and `unirl/data/sft.py` already speaks it. `unirl/models/README.md` now states the house rules: per-source converters customize freely but emit this schema unextended; RL metadata rides as sibling fields; `function.arguments` normalizes to a **dict** at ingest (`normalize_tool_arguments`) — HF templates mis-render the OpenAI JSON-string dialect (documented transformers warning).

**Structured tool calls in the trajectory type** — closes the two gaps that forced agent SFT (#352) to bypass `Turn`s: no structured call channel (inline `<tool_call>` text + regex re-parse) and unrepresentable parallel calls. New `unirl/types/tool_calls.py`: `ToolCall` (arguments always dict; loud ingest errors on malformed entries) + `ToolCalls`, a MediaRefs-style sparse-rows Batch primitive under the `"tool_calls"` key. `Sample.observe(tool_call_id=, tool_name=)` pairs results with calls via `Part.metadata` (row-aligned lists; bare string only at batch 1 — rows are independent trajectories); `Sample.turns()` surfaces `Turn.tool_calls` / `tool_call_ids` / `tool_names` and OpenAI's calls-only null-content assistant turn (`Turn.content: Optional`).

**One composition layer** (`unirl/models/types/conversations.py`). `system_prefix` / `group_consecutive_roles` go public; the **sglang wire render now imports them instead of keeping byte-identical private copies** (docstring-sync mirror retired). Message-dialect twins land beside the Turn-dialect helpers: `ensure_system_message` (same one rule: config is a default, data wins — stance differences are recipe config, not code branches), `normalize_tool_arguments`, `turns_from_messages` (messages → batch-1 Turns), so trace SFT can render through exactly the code path rollout uses. `build_text_messages` emits structured `tool_calls`/`tool_call_id`/`name`/null-content; plain chat turns emit byte-identical `{'role','content'}`.

**Deliberately unchanged:** the live agentic rollout keeps tool calls inline in assistant text (`sigma_verify`-class parity concern — switching the wire render to structured emission changes rollout prompt bytes and needs GPU validation as its own decision). `data/sft.py` wiring of `normalize_tool_arguments` is a one-line follow-up after #352 lands (that PR rewrites `normalize_supervised_example`; not colliding).

## Related Issue

N/A (audit follow-up; complements #352's agent-SFT seam)

## Test Plan

CPU harnesses, all run against this branch (commands + outputs preserved in the working notes):

- Round-trip: messages (parallel calls, both arguments dialects, tool role with `tool_call_id`+`name`, null-content assistant, system-in-data vs config) → `turns_from_messages` → `build_text_messages` → messages: exact modulo intended normalization; system rule verified both dialects.
- Byte-identity: `build_text_messages` on plain turns emits exactly `{'role','content'}`; sglang `build_text_conversations`/`build_vision_conversations` outputs unchanged on canned `Sample`s.
- Sample-level: batched (2-row) trajectory with distinct per-row calls → `turns()` row-aligns calls/ids; calls-only part surfaces with `content=None`; `conditioning()` skips it; `text_conditioning` fails loud on it.
- Transport: `ToolCalls` through `Batch` select/concat/slice; `Sample.concat` of mixed (pairing-metadata vs plain) trajectories — the empty-metadata shards pad with `{}` rows (new `Part.concat` normalization).
- Adversarial review (multi-agent, 3 lenses + per-finding skeptical verification, every finding live-reproduced): 9 findings → 5 fixed in this PR (scalar `tool_call_id` broadcast mispairing on batch>1 → row-aligned lists required; `str(None)` name coercion → loud ingest error; `None` metadata row crash in `turns()` → guarded; frozen `ToolCall` advertising broken hashability → `arguments` excluded from hash; write-only `tool_name` channel → plumbed through Turn/render/parse). Remaining verified-latent: mixed key-presence concat is the pre-existing contract shared by every primitive (image/media behave identically) — documented as the builder contract in `ToolCalls`' docstring instead of special-casing generic Batch machinery.
- `SKIP=no-commit-to-branch pre-commit run --from-ref audit/omni-conversations-localize --to-ref HEAD` → all hooks Passed; full import sweep incl. sglang adapters, env/harness, data/sft OK.

## Compatibility / Risk

No recipe changes; no rollout behavior change (wire renders byte-identical; live tool-call path untouched). New surface: `Turn` gains optional fields (positional `Turn(role, content)` construction unchanged); `unirl.types.primitives.PrimitiveValue` union widens. `Part.concat` gains metadata presence-normalization (`[]` ≡ no annotations). Consumers assuming `Turn.content` is never `None` were swept: none outside the guarded conditioning paths.

## Reviewer Notes

AI-assisted (Claude Code), per-line reviewed; duplicate-work check done — #352 touches `data/sft.py`/chat stages (deliberately avoided here), #355 is Talker-side. Design rationale (industry-format research + the 6-site system-rule archaeology) available on request. Suggested review order: `types/tool_calls.py` → `types/sample.py` → `models/types/conversations.py` → sglang dedup → README.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.