### PR TITLE
fix(trainer): share model-blind AR preflight with async trainer

### DIFF
--- a/unirl/models/qwen3_5/validation.py
+++ b/unirl/models/qwen3_5/validation.py
@@ -50,12 +50,12 @@ def _require_version(distribution: str, minimum: Version, *, reason: str) -> Non
         raise RuntimeError(f"Qwen3.5 {reason} requires {distribution}>={minimum} (installed: {installed}).")
 
 
-def is_qwen3_5_pipeline_config(pipeline_cfg: Any) -> bool:
+def _is_qwen3_5_pipeline_config(pipeline_cfg: Any) -> bool:
     """Whether a Hydra pipeline config targets the Qwen3.5 package."""
     return "unirl.models.qwen3_5." in _target(pipeline_cfg)
 
 
-def validate_qwen3_5_training_contract(
+def validate_training_contract(
     *,
     pipeline_cfg: Any,
     backend_cfg: Any,
@@ -68,7 +68,7 @@ def validate_qwen3_5_training_contract(
     so prompt-policy and dependency mistakes fail before allocating GPUs.
     Other model families are untouched.
     """
-    if not is_qwen3_5_pipeline_config(pipeline_cfg):
+    if not _is_qwen3_5_pipeline_config(pipeline_cfg):
         return
 
     backend_target = _target(backend_cfg)
@@ -145,7 +145,4 @@ def validate_qwen3_5_training_contract(
     )
 
 
-# Generic hook name the AR trainers dispatch to (see unirl.trainer.ar.ar_preflight).
-validate_training_contract = validate_qwen3_5_training_contract
-
-__all__ = ["is_qwen3_5_pipeline_config", "validate_qwen3_5_training_contract", "validate_training_contract"]
+__all__ = ["validate_training_contract"]

--- a/unirl/models/qwen3_5/validation.py
+++ b/unirl/models/qwen3_5/validation.py
@@ -145,4 +145,7 @@ def validate_qwen3_5_training_contract(
     )
 
 
-__all__ = ["is_qwen3_5_pipeline_config", "validate_qwen3_5_training_contract"]
+# Generic hook name the AR trainers dispatch to (see unirl.trainer.ar.ar_preflight).
+validate_training_contract = validate_qwen3_5_training_contract
+
+__all__ = ["is_qwen3_5_pipeline_config", "validate_qwen3_5_training_contract", "validate_training_contract"]

--- a/unirl/models/qwen3_omni/pipeline.py
+++ b/unirl/models/qwen3_omni/pipeline.py
@@ -26,6 +26,11 @@ class Qwen3OmniPipeline(Pipeline):
     conditions are written back to that frontier for per-turn replay.
     """
 
+    # URI-backed MediaRefs are an Omni prompt-input channel; the AR trainers
+    # read this declaration (unirl.trainer.ar.ar_preflight) instead of
+    # special-casing the model.
+    extra_input_primitives = ("media",)
+
     def __init__(
         self,
         *,

--- a/unirl/trainer/ar.py
+++ b/unirl/trainer/ar.py
@@ -1,17 +1,18 @@
+import importlib
+import importlib.util
 import inspect
 import logging
 import math
 import time
 from contextlib import contextmanager, nullcontext
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Dict, Iterator, Optional, Set, Tuple
 
 import torch
-from hydra.utils import instantiate
+from hydra.utils import get_object, instantiate
 from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
 from unirl.distributed.tensor import hydrate
-from unirl.models.qwen3_5.validation import validate_qwen3_5_training_contract
 from unirl.train.stack import TrainStepResult
 from unirl.trainer.base import BaseTrainer, build_sampling_dict, prepare_input_sample
 from unirl.types.sample import Sample
@@ -22,6 +23,46 @@ from unirl.utils.hydra import parse_hydra_cfg, remote_hydra
 logger = logging.getLogger(__name__)
 
 _ROLLOUT_SHUTDOWN_TIMEOUT_S = 60.0
+
+
+def ar_preflight(
+    *,
+    pipeline_cfg: DictConfig,
+    backend_cfg: DictConfig,
+    rollout_cfg: DictConfig,
+    stack_cfg: DictConfig,
+) -> Set[str]:
+    """Model-blind pre-flight shared by :class:`ARTrainer` and ``AsyncARTrainer``.
+
+    Runs on the driver before any model or rollout actor is created. Dispatches
+    the optional fail-fast contract check a model package declares as
+    ``unirl.models.<pkg>.validation.validate_training_contract`` (so the trainer
+    never imports a concrete model family), then returns the prompt-input
+    primitives the pipeline accepts: the decoded ``text``/``image``/``video``
+    contract plus whatever the pipeline class opts into via its
+    ``extra_input_primitives`` attribute (e.g. Omni's URI-backed ``media``
+    channel) — a miswired dataset then fails at request build instead of
+    silently dropping inputs.
+    """
+    target = str(pipeline_cfg.get("_target_", "") or "")
+    parts = target.split(".")
+    if target.startswith("unirl.models.") and len(parts) > 3:
+        validation_module = f"unirl.models.{parts[2]}.validation"
+        if importlib.util.find_spec(validation_module) is not None:
+            validate = getattr(importlib.import_module(validation_module), "validate_training_contract", None)
+            if validate is not None:
+                validate(
+                    pipeline_cfg=pipeline_cfg,
+                    backend_cfg=backend_cfg,
+                    rollout_cfg=rollout_cfg,
+                    stack_cfg=stack_cfg,
+                )
+    allowed: Set[str] = {"text", "image", "video"}
+    if target:
+        resolved = get_object(target)
+        pipeline_cls = resolved if isinstance(resolved, type) else getattr(resolved, "__self__", None)
+        allowed.update(getattr(pipeline_cls, "extra_input_primitives", ()))
+    return allowed
 
 
 class ARTrainer(BaseTrainer):
@@ -67,20 +108,13 @@ class ARTrainer(BaseTrainer):
         rollout_anchor_device: Optional[int] = None,
         enable_fsdp_offload: bool = True,
     ) -> None:
-        validate_qwen3_5_training_contract(
+        self._allowed_input_primitives = ar_preflight(
             pipeline_cfg=pipeline_cfg,
             backend_cfg=backend_cfg,
             rollout_cfg=rollout_cfg,
             stack_cfg=stack_cfg,
         )
         super().__init__(cfg=cfg, logging_cfg=logging_cfg)
-        # ``media`` (URI-backed MediaRefs) is an Omni prompt-input channel.
-        # Keep other AR models on the decoded image/video contract so a miswired
-        # dataset fails at request build instead of silently dropping media.
-        self._allowed_input_primitives = {"text", "image", "video"}
-        pipeline_target = str(pipeline_cfg.get("_target_", ""))
-        if "qwen3_omni" in pipeline_target:
-            self._allowed_input_primitives.add("media")
         self.batch_size = batch_size
         self.adv_normalization_scope = adv_normalization_scope
         self.normalize_adv_by_std = normalize_adv_by_std

--- a/unirl/trainer/async_ar.py
+++ b/unirl/trainer/async_ar.py
@@ -15,9 +15,8 @@ from omegaconf import DictConfig
 
 from unirl.distributed.group.placement import placement, remote
 from unirl.distributed.tensor import hydrate
-from unirl.models.qwen3_5.validation import validate_qwen3_5_training_contract
 from unirl.train.stack import TrainStepResult
-from unirl.trainer.ar import ARTrainer
+from unirl.trainer.ar import ARTrainer, ar_preflight
 from unirl.trainer.async_rollout import AsyncRolloutTrainerMixin, training_version_metrics
 from unirl.trainer.base import BaseTrainer, build_sampling_dict
 from unirl.types.sample import Sample
@@ -72,7 +71,7 @@ class AsyncARTrainer(AsyncRolloutTrainerMixin, ARTrainer):
         max_inflight: int = 1,
         weight_sync_interval: int = 1,
     ) -> None:
-        validate_qwen3_5_training_contract(
+        self._allowed_input_primitives = ar_preflight(
             pipeline_cfg=pipeline_cfg,
             backend_cfg=backend_cfg,
             rollout_cfg=rollout_cfg,


### PR DESCRIPTION
## Summary

Unify AR trainer pre-flight checks behind one model-blind helper and fix the async trainer's missing input-primitive initialization.

- Add `ar_preflight()` and call it from both `ARTrainer` and `AsyncARTrainer` before actors are created.
- Discover optional model-specific validation through `unirl.models.<package>.validation.validate_training_contract`, removing the trainer's direct dependency on Qwen3.5.
- Rename the Qwen3.5 validator to that generic hook name while keeping its validation behavior unchanged.
- Let pipeline classes declare additional accepted prompt primitives. `Qwen3OmniPipeline` declares `("media",)`, replacing the trainer's `"qwen3_omni"` target-string special case.
- Initialize `_allowed_input_primitives` in `AsyncARTrainer`. It intentionally skips `ARTrainer.__init__` but inherits `_build_request_sample`, so the previous code raised `AttributeError` on the first async dispatch.

Stacked on #357; retarget this PR to `main` after #357 merges.

## Related Issues

Follow-up to #174 and #306; no issue is closed directly.

## Test Plan

- Smoke-tested `ar_preflight()` with the shipped Qwen3, Qwen-VL, and Qwen3-Omni `from_bundle` targets.
  - Standard AR pipelines resolve `text`, `image`, and `video`.
  - Qwen3-Omni additionally resolves `media`.
- Verified all shipped Qwen3-Omni AR recipes use `Qwen3OmniPipeline.from_bundle`, whose bound classmethod resolves back to the declaring pipeline class.
- Verified Qwen3.5 dispatches through `validate_training_contract` and that the removed validator names have no remaining repository consumers.
- GitHub lint and CodeQL checks pass.

## Compatibility / Risk

- No recipe changes; accepted input primitives are unchanged for every shipped AR pipeline.
- Qwen3-Omni keeps its existing `media` input behavior, now declared by the pipeline rather than inferred from its target string.
- The Qwen3.5 validator's old internal names are removed. Out-of-tree imports must use `validate_training_contract`.
- Pre-flight now resolves the configured pipeline target on the driver. Invalid targets fail before GPU actors are allocated.

## Reviewer Notes

- `AsyncARTrainer` deliberately bypasses `ARTrainer.__init__` for its two-slab placement, so both constructors must call the shared pre-flight helper explicitly.
- Hydra targets may name either a pipeline class or a bound classmethod such as `from_bundle`; the helper uses the same `get_object`/`__self__` resolution pattern as the diffusion trainer.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.