### PR TITLE
feat(types): canonical agent-trace format and typed tool calls

### DIFF
--- a/unirl/models/types/conversations.py
+++ b/unirl/models/types/conversations.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+from unirl.types.agent_trace import system_instruction_wins
 from unirl.types.primitives import Images
 from unirl.types.sample import Turn
 
@@ -35,9 +36,11 @@ Conversation = List[Dict[str, Any]]
 
 
 def system_prefix(system_instruction: Optional[str], roles: List[str]) -> Conversation:
-    """The config ``system_instruction`` as a leading message, unless the trajectory
-    already carries an explicit ``system`` turn (which wins)."""
-    if system_instruction and "system" not in roles:
+    """The Turn-dialect form of the one system rule (see
+    :func:`unirl.types.agent_trace.system_instruction_wins`): the config
+    ``system_instruction`` leads unless the trajectory carries its own ``system``
+    turn."""
+    if system_instruction_wins(system_instruction, roles):
         return [{"role": "system", "content": system_instruction}]
     return []
 
@@ -67,14 +70,31 @@ def build_text_messages(
     Transposes :meth:`Sample.text_conditioning` (turn-major, frontier-aligned) into
     one message list per frontier sample. Degenerates to a single ``user`` message
     when no roles are set, so it is byte-identical on single-turn workloads.
+
+    Structured agent channels ride through when present: a turn's
+    :attr:`Turn.tool_calls` rows emit OpenAI-style ``tool_calls`` entries (dict
+    ``arguments`` — the HF template form), a calls-only turn emits
+    ``content: None``, and a tool turn emits ``tool_call_id`` / ``name``. Plain
+    chat turns emit exactly ``{"role", "content"}``.
     """
     if not turns:
         return []
     roles = [t.role for t in turns]
-    cols = [t.content.texts for t in turns]
+    cols = [t.content.texts if t.content is not None else None for t in turns]
     prefix = system_prefix(system_instruction, roles)
-    n_rows = len(turns[0].content)
-    return [prefix + [{"role": roles[j], "content": cols[j][row]} for j in range(len(turns))] for row in range(n_rows)]
+    n_rows = next(len(t.content if t.content is not None else t.tool_calls) for t in turns)
+
+    def _message(j: int, row: int) -> Dict[str, Any]:
+        message: Dict[str, Any] = {"role": roles[j], "content": cols[j][row] if cols[j] is not None else None}
+        calls = turns[j].tool_calls.rows[row] if turns[j].tool_calls is not None else []
+        if calls:
+            message["tool_calls"] = [call.to_message_entry() for call in calls]
+        for key, channel in (("tool_call_id", turns[j].tool_call_ids), ("name", turns[j].tool_names)):
+            if channel is not None and channel[row] is not None:
+                message[key] = channel[row]
+        return message
+
+    return [prefix + [_message(j, row) for j in range(len(turns))] for row in range(n_rows)]
 
 
 def build_vision_messages(

--- a/unirl/types/agent_trace.py
+++ b/unirl/types/agent_trace.py
@@ -1,0 +1,179 @@
+"""The canonical external conversation format: OpenAI-style messages.
+
+Manifests and converted agent traces are
+``{"messages": [{role, content|null, tool_calls}], "tools": [...]}`` — the
+trainer-facing shape OpenAI/Azure fine-tuning, HF ``apply_chat_template``, TRL,
+axolotl, LLaMA-Factory and verl all speak. Per-source converters
+(``datasets/<name>/convert_*.py``) may accept anything; what they *emit* is this
+schema, unextended, with RL metadata (rewards, outcome labels, trace ids) as
+sibling fields next to ``messages`` rather than inside it.
+
+This module owns the *format*: normalization and the messages → :class:`Turn`
+parse. Rendering ``Turn`` s back into model-consumable messages is the job of
+``unirl.models.types.conversations`` (and of a model package when only one model
+consumes that dialect) — format lives with the types, rendering lives with the
+models.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+from unirl.types.media import MediaRef, MediaRefs, SUPPORTED_MEDIA_MODALITIES
+from unirl.types.primitives import Texts
+from unirl.types.sample import TURN_ROLES, Turn
+from unirl.types.tool_calls import ToolCall, ToolCalls
+
+Message = Dict[str, Any]
+
+
+def system_instruction_wins(system_instruction: Any, roles: Sequence[str]) -> bool:
+    """The one system rule: the config default applies unless the data carries a
+    ``system`` turn, which wins.
+
+    Both dialects go through this predicate — :func:`ensure_system_message` for
+    message histories and ``conversations.system_prefix`` for ``Turn`` lists — so
+    the precedence is defined once. A path that wants "data is the sole source of
+    truth" leaves ``system_instruction`` unset in the recipe; it is never a code
+    branch.
+    """
+    return bool(system_instruction) and "system" not in roles
+
+
+def ensure_system_message(messages: Sequence[Message], system_instruction: Any) -> List[Message]:
+    """Prepend the config ``system_instruction`` unless the history has its own."""
+    out = list(messages)
+    if system_instruction_wins(system_instruction, [m.get("role") for m in out]):
+        return [{"role": "system", "content": system_instruction}, *out]
+    return out
+
+
+def normalize_tool_arguments(messages: Sequence[Message]) -> List[Message]:
+    """Normalize every assistant ``tool_calls`` entry to dict ``arguments``.
+
+    OpenAI serializes ``function.arguments`` as a JSON-encoded string; HF chat
+    templates expect a dict and mis-render the string form (the transformers docs
+    warn about exactly this). Run this once at manifest ingest so trace data from
+    either dialect renders identically. Messages without calls pass through
+    unchanged (same object).
+    """
+    out: List[Message] = []
+    for message in messages:
+        calls = message.get("tool_calls")
+        if not calls:
+            out.append(message)
+            continue
+        normalized = [ToolCall.from_message_entry(entry, context="normalize_tool_arguments") for entry in calls]
+        rebuilt = dict(message)
+        rebuilt["tool_calls"] = [call.to_message_entry() for call in normalized]
+        out.append(rebuilt)
+    return out
+
+
+def _media_ref_from_part(part: Message, *, context: str) -> MediaRef:
+    """One content part → prompt ``MediaRef``, tolerant of the common dialects.
+
+    Accepts ``{"type": X, X: uri}`` (canonical / Qwen), ``{"type": X, "url"|"path":
+    uri}`` (HF), and ``{"type": "image_url", "image_url": {"url": uri}}`` (OpenAI).
+    Re-rendering emits the canonical first form.
+    """
+    ptype = part.get("type")
+    if ptype == "image_url":
+        uri = (part.get("image_url") or {}).get("url")
+        if not uri:
+            raise ValueError(f"{context}: image_url part carries no url: {part!r}.")
+        return MediaRef(modality="image", role="prompt", uri=uri)
+    if ptype in SUPPORTED_MEDIA_MODALITIES:
+        uri = part.get(ptype) or part.get("url") or part.get("path")
+        if not isinstance(uri, str) or not uri:
+            raise ValueError(f"{context}: {ptype} part carries no usable URI: {part!r}.")
+        return MediaRef(modality=ptype, role="prompt", uri=uri)
+    raise ValueError(f"{context}: unsupported content part type {ptype!r}.")
+
+
+def turns_from_messages(messages: Sequence[Message]) -> List[Turn]:
+    """One OpenAI-style message history → batch-1 :class:`Turn` list.
+
+    The manifest half of the round trip whose render half lives with the model
+    dialects. Supported content: strings, ``None`` (calls-only assistant), and
+    content-part lists carrying URI media parts plus at most one text part; parts
+    normalize to canonical media-before-text order, so parse→render→parse is
+    stable in canonical form (it does not preserve arbitrary input part order).
+
+    ``Turn`` carries one primitive, so a message with both media and text becomes
+    two turns; the renderer fuses them back by consecutive role. A ``tool``
+    message is the one case where that is lossy — its ``tool_call_id`` belongs to
+    the whole message, and the renderer never fuses tool turns (each result keeps
+    its own pairing) — so a media-bearing tool result raises instead of silently
+    dropping the link. Representing it needs composite ``Turn`` content, which is
+    a typed-representation change, not a parser workaround.
+    """
+    turns: List[Turn] = []
+    for i, message in enumerate(messages):
+        role = message.get("role")
+        if role not in TURN_ROLES:
+            raise ValueError(f"turns_from_messages: message {i} role {role!r} not in {TURN_ROLES}.")
+        content = message.get("content")
+        raw_calls = message.get("tool_calls") or []
+        if raw_calls and role != "assistant":
+            raise ValueError(f"turns_from_messages: message {i} ({role}) carries tool_calls; only assistant may.")
+        calls = [ToolCall.from_message_entry(entry, context=f"turns_from_messages[{i}]") for entry in raw_calls]
+        tool_calls = ToolCalls.from_rows([calls]) if calls else None
+        call_id = message.get("tool_call_id")
+        name = message.get("name")
+        pairing = {
+            "tool_call_ids": [call_id] if role == "tool" and call_id is not None else None,
+            "tool_names": [name] if role == "tool" and name is not None else None,
+        }
+
+        if isinstance(content, list):
+            text_parts = [p for p in content if isinstance(p, dict) and p.get("type") == "text"]
+            media_parts = [p for p in content if isinstance(p, dict) and p.get("type") != "text"]
+            if len(text_parts) > 1:
+                raise ValueError(
+                    f"turns_from_messages: message {i} has {len(text_parts)} text parts; one message "
+                    "carries at most one text part — join the texts in the converter."
+                )
+            if media_parts and role == "tool":
+                raise NotImplementedError(
+                    f"turns_from_messages: message {i} is a tool result carrying media parts. A Turn holds "
+                    "one primitive, so this would split into two turns and the tool_call_id link would be "
+                    "lost on the media half; composite Turn content is required first."
+                )
+            refs = [_media_ref_from_part(p, context=f"turns_from_messages[{i}]") for p in media_parts]
+            if not refs and not text_parts and not calls:
+                raise ValueError(f"turns_from_messages: message {i} ({role}) has an empty content-part list.")
+            if refs:
+                turns.append(Turn(role=role, content=MediaRefs.from_rows([refs])))
+            if text_parts or calls:
+                text = text_parts[0]["text"] if text_parts else None
+                turns.append(
+                    Turn(
+                        role=role,
+                        content=Texts(texts=[text]) if text is not None else None,
+                        tool_calls=tool_calls,
+                        **pairing,
+                    )
+                )
+            continue
+
+        if content is None:
+            if not calls:
+                raise ValueError(f"turns_from_messages: message {i} ({role}) has neither content nor tool_calls.")
+            turns.append(Turn(role=role, content=None, tool_calls=tool_calls))
+            continue
+        if not isinstance(content, str):
+            raise TypeError(
+                f"turns_from_messages: message {i} content must be str/None/list, got {type(content).__name__}."
+            )
+        turns.append(Turn(role=role, content=Texts(texts=[content]), tool_calls=tool_calls, **pairing))
+    return turns
+
+
+__all__ = [
+    "Message",
+    "ensure_system_message",
+    "normalize_tool_arguments",
+    "system_instruction_wins",
+    "turns_from_messages",
+]

--- a/unirl/types/primitives.py
+++ b/unirl/types/primitives.py
@@ -53,6 +53,7 @@ import torch
 
 from unirl.distributed.tensor.batch import Batch, FieldKind, concat_field, field, packed_field
 from unirl.types.media import MediaRefs
+from unirl.types.tool_calls import ToolCalls
 
 
 @dataclass
@@ -341,14 +342,15 @@ def _cumsum(values: List[int]) -> List[int]:
     return out
 
 
-PrimitiveValue = Union[Texts, Images, Videos, Audios, MediaRefs]
+PrimitiveValue = Union[Texts, Images, Videos, Audios, MediaRefs, ToolCalls]
 
 
 def primitive_modality_key(prim: PrimitiveValue) -> str:
     """Map a batched primitive to its modality slot key.
 
     ``Texts -> "text"``, ``Images -> "image"``, ``Videos -> "video"``,
-    ``Audios -> "audio"``, ``MediaRefs -> "media"`` — the keying convention shared by
+    ``Audios -> "audio"``, ``MediaRefs -> "media"``, ``ToolCalls -> "tool_calls"``
+    — the keying convention shared by
     ``RewardRequest.primitives`` / ``generated`` and the slots
     :meth:`Sample.conditioning` surfaces. Inverse of a backend's
     ``preferred_input_kind``.
@@ -363,6 +365,8 @@ def primitive_modality_key(prim: PrimitiveValue) -> str:
         return "audio"
     if isinstance(prim, MediaRefs):
         return "media"
+    if isinstance(prim, ToolCalls):
+        return "tool_calls"
     raise TypeError(f"primitive_modality_key: unknown primitive type {type(prim).__name__!r}")
 
 
@@ -378,6 +382,7 @@ __all__ = [
     "TextAndVideo",
     "Texts",
     "PrimitiveValue",
+    "ToolCalls",
     "Video",
     "Videos",
     "primitive_modality_key",

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from dataclasses import fields as dc_fields
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 
 import torch
 
@@ -45,6 +45,7 @@ from unirl.types.primitives import Images, PrimitiveValue, Texts, primitive_moda
 from unirl.types.sample_id import ancestor_id, child_id, parent_id
 from unirl.types.sampling import BaseSamplingParams
 from unirl.types.segments import Segment, TextSegment
+from unirl.types.tool_calls import ToolCalls
 from unirl.utils.shard_balance import lpt_shard_permutation, shard_token_spread
 
 logger = logging.getLogger(__name__)
@@ -66,10 +67,35 @@ class Turn:
     can be rendered into an LLM/VLM conversation. A plain return type (not a
     :class:`Batch`): ``content`` is already a batched primitive (one row per
     frontier sample).
+
+    Structured agent-trace channels (all optional; absent on plain chat turns):
+    ``tool_calls`` carries the assistant turn's structured calls (row-aligned,
+    from the part's ``"tool_calls"`` primitive); ``content`` is ``None`` only
+    for a calls-only assistant turn (OpenAI's null-content case). On a
+    ``tool``-role turn, ``tool_call_ids`` / ``tool_names`` pair each row's
+    result with the call that produced it (from ``Part.metadata[r]``).
     """
 
     role: str
-    content: Primitive
+    content: Optional[Primitive]
+    tool_calls: Optional["ToolCalls"] = None
+    tool_call_ids: Optional[List[Optional[str]]] = None
+    tool_names: Optional[List[Optional[str]]] = None
+
+    def __post_init__(self) -> None:
+        if self.role not in TURN_ROLES:
+            raise ValueError(f"Turn.role must be one of {TURN_ROLES}, got {self.role!r}.")
+        if self.content is None and self.tool_calls is None:
+            raise ValueError(f"Turn({self.role!r}) carries neither content nor tool_calls.")
+        if self.tool_calls is not None and self.role != "assistant":
+            raise ValueError(f"Turn.tool_calls is assistant-only; got role={self.role!r}.")
+        for name, value in (("tool_call_ids", self.tool_call_ids), ("tool_names", self.tool_names)):
+            if value is not None and self.role != "tool":
+                raise ValueError(f"Turn.{name} is tool-role-only; got role={self.role!r}.")
+        rows = [len(v) for v in (self.content, self.tool_calls) if v is not None]
+        rows += [len(v) for v in (self.tool_call_ids, self.tool_names) if v is not None]
+        if len(set(rows)) > 1:
+            raise ValueError(f"Turn({self.role!r}) channels disagree on batch size: {rows}.")
 
 
 @dataclass
@@ -143,7 +169,13 @@ class Part(Batch):
 
     @classmethod
     def concat(cls, items: Sequence["Part"]) -> "Part":
-        """Concat batch rows while requiring identical shared primitive metadata."""
+        """Concat batch rows while requiring identical shared primitive metadata.
+
+        ``metadata`` semantics: an empty list means "no per-row annotations", so
+        when some shards carry row-aligned metadata (e.g. ``observe`` tool-call
+        pairing) and others carry the empty default, the empty ones are padded
+        with ``{}`` rows — otherwise the generic list-concat rejects the mix.
+        """
         if items:
             expected = items[0].primitive_metadata
             mismatched = [i for i, item in enumerate(items[1:], start=1) if item.primitive_metadata != expected]
@@ -152,6 +184,11 @@ class Part(Batch):
                     "Part.concat: primitive_metadata must be identical across shards; "
                     f"mismatched item indices {mismatched}."
                 )
+            if any(item.metadata for item in items) and any(not item.metadata for item in items):
+                items = [
+                    item if item.metadata else _part_with_field(item, "metadata", [{} for _ in item.sample_ids])
+                    for item in items
+                ]
         return super().concat(items)
 
     @classmethod
@@ -186,7 +223,13 @@ class Part(Batch):
             role=role,
         )
 
-    def input_child(self, primitives: PrimitiveMap, *, role: Optional[str] = None) -> "Part":
+    def input_child(
+        self,
+        primitives: PrimitiveMap,
+        *,
+        role: Optional[str] = None,
+        metadata: Optional[List[Dict[str, Any]]] = None,
+    ) -> "Part":
         """A branch-1 *input* child carrying additional conditioning primitives.
 
         Multi-input multimodal (e.g. image+text → image) usually puts each
@@ -195,14 +238,19 @@ class Part(Batch):
         None because it generates nothing. Chaining keeps only the head a root,
         so the Sample stays valid and
         :meth:`Sample.conditioning` surfaces every input primitive in turn order
-        (root → …). See ``unirl/types/README.md``.
+        (root → …). See ``unirl/types/README.md``. ``metadata`` optionally
+        carries per-row annotations (e.g. ``tool_call_id`` pairing on an
+        observation) and must be row-aligned to the parent.
         """
         if not self.sample_ids:
             raise ValueError("Part.input_child: parent has no sample_ids")
+        if metadata is not None and len(metadata) != len(self.sample_ids):
+            raise ValueError(f"Part.input_child: metadata rows {len(metadata)} != parent batch {len(self.sample_ids)}.")
         return Part(
             sample_ids=[child_id(pid, 0) for pid in self.sample_ids],
             primitives=dict(primitives),
             role=role,
+            metadata=list(metadata) if metadata is not None else [],
         )
 
     @property
@@ -767,7 +815,14 @@ class Sample(Batch):
         )
         return type(self)(parts=[*self.parts, child], reward_compute_s=self.reward_compute_s)
 
-    def observe(self, observation: Primitive, *, role: str = "tool") -> "Sample":
+    def observe(
+        self,
+        observation: Primitive,
+        *,
+        role: str = "tool",
+        tool_call_id: Optional[Union[str, List[Optional[str]]]] = None,
+        tool_name: Optional[Union[str, List[Optional[str]]]] = None,
+    ) -> "Sample":
         """Append an observation as a branch-1, mask-0 *input* Part off the frontier.
 
         The world-response half of an agentic turn (``unirl/rollout/env/README.md``): the
@@ -780,11 +835,46 @@ class Sample(Batch):
         ``role`` tags the observation's conversation turn for role-aware rendering
         (:meth:`Part.resolved_role`), defaulting to ``"tool"`` — the agentic world-response is a
         tool result, so the chat template wraps it as a ``<tool_response>``. A non-tool world
-        (e.g. a user simulator) can pass ``role="user"``.
+        (e.g. a user simulator) can pass ``role="user"``. ``tool_call_id`` / ``tool_name``
+        optionally pair the result with the structured call that produced it (OpenAI
+        ``tool_call_id`` convention); they ride in ``Part.metadata`` and surface on the
+        turn's :attr:`Turn.tool_call_ids` / :attr:`Turn.tool_names`. Rows of a batched
+        frontier are independent trajectories with distinct call ids, so a bare string is
+        only accepted at batch 1 — batched observations must pass row-aligned lists.
         """
         if not self.parts:
             raise ValueError("Sample.observe: no parts to observe from (empty Sample)")
-        obs_part = self.parts[-1].input_child({primitive_modality_key(observation): observation}, role=role)
+        batch = len(self.parts[-1].sample_ids)
+
+        def _rows(value: Optional[Union[str, List[Optional[str]]]], label: str) -> Optional[List[Optional[str]]]:
+            if value is None:
+                return None
+            if isinstance(value, str):
+                if batch != 1:
+                    raise ValueError(
+                        f"Sample.observe: scalar {label} with frontier batch {batch}; rows are independent "
+                        "trajectories with distinct call ids — pass a row-aligned list."
+                    )
+                return [value]
+            if len(value) != batch:
+                raise ValueError(f"Sample.observe: {label} rows {len(value)} != frontier batch {batch}.")
+            return list(value)
+
+        ids = _rows(tool_call_id, "tool_call_id")
+        names = _rows(tool_name, "tool_name")
+        metadata: Optional[List[Dict[str, Any]]] = None
+        if ids is not None or names is not None:
+            metadata = []
+            for r in range(batch):
+                row: Dict[str, Any] = {}
+                if ids is not None and ids[r] is not None:
+                    row["tool_call_id"] = ids[r]
+                if names is not None and names[r] is not None:
+                    row["tool_name"] = names[r]
+                metadata.append(row)
+        obs_part = self.parts[-1].input_child(
+            {primitive_modality_key(observation): observation}, role=role, metadata=metadata
+        )
         return type(self)(parts=[*self.parts, obs_part], reward_compute_s=self.reward_compute_s)
 
     def propagate_rewards(self, op: Literal["mean", "max", "sum"] = "mean") -> "Sample":
@@ -838,7 +928,12 @@ class Sample(Batch):
         the frontier's samples, climbed one level per step via ``parent_id``; each
         level's rows are looked up by id (position-independent). Ancestors with
         no populated ``primitives`` are skipped; for a non-frontier part's turns
-        (replay), call this on ``parts[:i+1]``."""
+        (replay), call this on ``parts[:i+1]``.
+
+        Structured agent channels: a part's ``"tool_calls"`` primitive attaches to
+        its text Turn (or a content-``None`` Turn when the assistant made calls
+        without text); a ``tool``-role part's ``metadata[r]["tool_call_id"]``
+        surfaces as :attr:`Turn.tool_call_ids`."""
         if not self.parts:
             return []
         frontier = self.parts[-1]
@@ -856,12 +951,38 @@ class Sample(Batch):
                 raise ValueError(
                     f"Sample.turns: ancestor id {e.args[0]!r} not found in part {anc}; lineage chain is malformed."
                 ) from None
-            for key in reversed(PRIMITIVE_MODALITY_ORDER):
+            role = part.resolved_role()
+            rows_tensor = torch.tensor(rows, dtype=torch.long)
+            tool_calls = part.primitives.get("tool_calls")
+            selected_calls = tool_calls.select(rows_tensor) if tool_calls is not None else None
+            tool_call_ids: Optional[List[Optional[str]]] = None
+            tool_names: Optional[List[Optional[str]]] = None
+            if role == "tool" and len(part.metadata) == len(part.sample_ids):
+                ids = [(part.metadata[r] or {}).get("tool_call_id") for r in rows]
+                names = [(part.metadata[r] or {}).get("tool_name") for r in rows]
+                if any(i is not None for i in ids):
+                    tool_call_ids = ids
+                if any(n is not None for n in names):
+                    tool_names = names
+            part_turns: List[Turn] = []
+            for key in PRIMITIVE_MODALITY_ORDER:
                 primitive = part.primitives.get(key)
                 if primitive is None:
                     continue
-                content = primitive.select(torch.tensor(rows, dtype=torch.long))
-                out.append(Turn(role=part.resolved_role(), content=content))
+                content = primitive.select(rows_tensor)
+                part_turns.append(
+                    Turn(
+                        role=role,
+                        content=content,
+                        tool_calls=selected_calls if key == "text" else None,
+                        tool_call_ids=tool_call_ids,
+                        tool_names=tool_names,
+                    )
+                )
+            if selected_calls is not None and not any(t.tool_calls is not None for t in part_turns):
+                # Calls-only assistant part (OpenAI null-content): surface the calls anyway.
+                part_turns.append(Turn(role=role, content=None, tool_calls=selected_calls))
+            out.extend(reversed(part_turns))
             if part.is_root:
                 break
             active_ids = [parent_id(aid) for aid in active_ids]
@@ -874,8 +995,9 @@ class Sample(Batch):
         ancestor's raw primitives, row-aligned to the frontier's
         samples, in chronological order (root → frontier-parent). The role-stripped
         view of :meth:`turns` — the bare-primitive escape unified models consume
-        (replay: call on ``parts[:i+1]``)."""
-        return [t.content for t in self.turns()]
+        (replay: call on ``parts[:i+1]``). Calls-only turns (``content is None``)
+        carry no raw primitive and are skipped."""
+        return [t.content for t in self.turns() if t.content is not None]
 
     def prompt_media_refs(self) -> Optional[MediaRefs]:
         """Return typed URI prompt-media refs from the root input Part, if any.
@@ -915,8 +1037,16 @@ class Sample(Batch):
 
     def text_conditioning(self) -> List[Turn]:
         """LLM render: the trajectory as an all-text conversation. Fails loud on
-        any non-text turn — this consumer has no image channel."""
+        any non-text turn — this consumer has no image channel — and on
+        calls-only turns (the wire render carries tool calls inline in the
+        assistant text; structured-only turns come from manifest conversion and
+        belong to the messages render, ``build_text_messages``)."""
         ts = self.turns()
+        if any(t.content is None for t in ts):
+            raise ValueError(
+                "Sample.text_conditioning: trajectory has a calls-only turn (content=None); "
+                "the wire render requires inline-text tool calls."
+            )
         non_text = [primitive_modality_key(t.content) for t in ts if not isinstance(t.content, Texts)]
         if non_text:
             raise ValueError(f"Sample.text_conditioning: the LLM path requires all-text turns; got non-text {non_text}")
@@ -929,11 +1059,15 @@ class Sample(Batch):
         modality."""
         ts = self.turns()
         images = [t.content for t in ts if isinstance(t.content, Images)]
-        extra = [primitive_modality_key(t.content) for t in ts if not isinstance(t.content, (Texts, Images))]
+        extra = [
+            primitive_modality_key(t.content) if t.content is not None else "tool_calls-only"
+            for t in ts
+            if not isinstance(t.content, (Texts, Images))
+        ]
         if extra or not images:
             raise ValueError(
                 f"Sample.vision_conditioning: requires text+image turns only; got "
-                f"{[primitive_modality_key(t.content) for t in ts]}"
+                f"{[primitive_modality_key(t.content) if t.content is not None else 'tool_calls-only' for t in ts]}"
             )
         return ts, images
 

--- a/unirl/types/tool_calls.py
+++ b/unirl/types/tool_calls.py
@@ -1,0 +1,127 @@
+"""Typed structured tool calls for agent trajectories.
+
+The canonical on-disk/interchange shape for tool calls is the OpenAI messages
+convention (assistant message ``tool_calls`` entries; ``tool`` role results
+paired by ``tool_call_id``). This module is the typed internal counterpart:
+``ToolCalls`` rides on a :class:`~unirl.types.sample.Part` under the
+``"tool_calls"`` primitive key and surfaces on the part's assistant
+:class:`~unirl.types.sample.Turn`, so an agent's calls are typed data rather
+than regex over rendered text. (``Turn`` is a read-only view over a ``Sample``;
+:func:`unirl.types.agent_trace.turns_from_messages` parses a manifest history
+into turns — there is no messages → ``Sample`` constructor.)
+
+``arguments`` is ALWAYS a dict internally. OpenAI serializes
+``function.arguments`` as a JSON-encoded string while HF chat templates expect
+a dict (transformers docs warn the string form mis-renders); ingest normalizes
+via :meth:`ToolCall.from_message_entry`, and :meth:`ToolCall.to_message_entry`
+re-emits the dict form that ``apply_chat_template`` consumes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from unirl.distributed.tensor.batch import Batch, concat_field
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """One structured function call: ``id`` pairs it with its tool-role result."""
+
+    name: str
+    # Excluded from __hash__ (dicts are unhashable); equality still compares it,
+    # so equal calls keep equal hashes and set/dict dedup of parallel calls works.
+    arguments: Dict[str, Any] = field(default_factory=dict, hash=False)
+    id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError(f"ToolCall.name must be a non-empty string, got {self.name!r}.")
+        if not isinstance(self.arguments, dict):
+            raise TypeError(
+                f"ToolCall.arguments must be a dict (normalize JSON strings at ingest), "
+                f"got {type(self.arguments).__name__}."
+            )
+        if self.id is not None and not isinstance(self.id, str):
+            raise TypeError(f"ToolCall.id must be a string or None, got {type(self.id).__name__}.")
+
+    @classmethod
+    def from_message_entry(cls, entry: Dict[str, Any], *, context: str = "ToolCall") -> "ToolCall":
+        """Parse one OpenAI-style ``tool_calls`` entry, normalizing arguments to a dict.
+
+        Accepts both the nested ``{"id", "type": "function", "function": {"name",
+        "arguments"}}`` shape and a flat ``{"id", "name", "arguments"}`` shape;
+        ``arguments`` may be a dict or a JSON-encoded string (the OpenAI wire form).
+        """
+        if not isinstance(entry, dict):
+            raise TypeError(f"{context}: tool_calls entries must be dicts, got {type(entry).__name__}.")
+        if "function" in entry and not isinstance(entry["function"], dict):
+            raise TypeError(
+                f"{context}: tool_calls entry 'function' must be a dict, got {type(entry['function']).__name__}."
+            )
+        fn = entry.get("function") if isinstance(entry.get("function"), dict) else entry
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{context}: tool_calls entry missing function name: {entry!r}.")
+        arguments = fn.get("arguments", {})
+        if isinstance(arguments, str):
+            text = arguments.strip() or "{}"
+            try:
+                arguments = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{context}: tool call {name!r} arguments is not valid JSON: {text!r}.") from exc
+        if not isinstance(arguments, dict):
+            raise TypeError(
+                f"{context}: tool call {name!r} arguments must decode to an object, got {type(arguments).__name__}."
+            )
+        call_id = entry.get("id")
+        return cls(name=name, arguments=arguments, id=str(call_id) if call_id is not None else None)
+
+    def to_message_entry(self) -> Dict[str, Any]:
+        """The OpenAI-style ``tool_calls`` entry, with dict ``arguments`` (HF template form)."""
+        entry: Dict[str, Any] = {"type": "function", "function": {"name": self.name, "arguments": self.arguments}}
+        if self.id is not None:
+            entry["id"] = self.id
+        return entry
+
+
+@dataclass
+class ToolCalls(Batch):
+    """Batch-aligned sparse structured tool calls (mirror of :class:`MediaRefs`).
+
+    ``rows[i]`` is the ordered list of calls the assistant made for sample ``i``
+    (empty row = no call; multiple entries = parallel calls). Sparsity stays
+    inside each row so CONCAT selection, slicing, and transport remain
+    row-aligned under the rectangular :class:`Batch` contract.
+
+    Builder contract (shared by every ``Part.primitives`` key): same-position
+    parts that get concatenated must agree on key presence. A builder whose
+    batches can mix call-free and calling samples attaches ``ToolCalls`` with
+    empty rows unconditionally rather than only when calls exist.
+    """
+
+    rows: List[List[ToolCall]] = concat_field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        normalized: List[List[ToolCall]] = []
+        for row, calls in enumerate(self.rows):
+            if not isinstance(calls, (list, tuple)):
+                raise TypeError(f"ToolCalls.rows[{row}] must be a list of ToolCall values.")
+            values = list(calls)
+            invalid = [type(call).__name__ for call in values if not isinstance(call, ToolCall)]
+            if invalid:
+                raise TypeError(f"ToolCalls.rows[{row}] contains non-ToolCall values: {invalid}.")
+            normalized.append(values)
+        self.rows = normalized
+
+    @classmethod
+    def from_rows(cls, rows: List[List[ToolCall]]) -> "ToolCalls":
+        return cls(rows=[list(row) for row in rows])
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+
+__all__ = ["ToolCall", "ToolCalls"]


### PR DESCRIPTION
## Summary

**Draft — deliberately not mergeable yet.** This is the agent-trace framework extracted out of #357 after review, held until a real ingest consumes it (the #352 direction). Landing it earlier would have produced exactly the state we do not want: docs claiming one canonical path while SFT still hands raw messages to the tokenizer, rollout carries tool calls as inline text, and the new API has no consumer.

The bar this must clear before it leaves draft: a real entry point, a real consumer, the critical path actually going through it, invariants held by the owner, and no parallel path still working.

What it contains:
- **`unirl/types/tool_calls.py`** — `ToolCall` / `ToolCalls`, a MediaRefs-style sparse-rows `Batch` primitive under the `tool_calls` key, so parallel assistant calls are typed data instead of regex over rendered text.
- **`unirl/types/agent_trace.py`** (new module) — the canonical external format: `normalize_tool_arguments` (OpenAI's JSON-string `arguments` → the dict form HF templates need), `ensure_system_message`, and `turns_from_messages`, which accepts all three common content-part dialects (canonical `{type: X, X: uri}`, HF `url|path`, OpenAI `image_url`). Format lives with the types; rendering stays with the models — so a future `unirl/data` consumer does not depend on `unirl/models`.
- **`Turn` channels + invariants** — the canonical type now enforces role membership, calls-are-assistant-only, pairing-is-tool-only, and batch-size agreement itself, instead of trusting each entry point.
- **`Sample.observe(tool_call_id=, tool_name=)`** — row-aligned result↔call pairing; `build_text_messages` emits the structured channels when present and stays byte-identical for plain chat turns; `system_prefix` delegates to the single precedence rule in `agent_trace`.

**Review fixes already carried in:** a tool result carrying media used to lose its `tool_call_id` silently (a `Turn` holds one primitive, so it split into two turns and the renderer never fuses tool turns) — it now raises, because representing it needs composite `Turn` content rather than a parser workaround; and the `ToolCalls` docstring no longer claims a `messages ↔ Sample` round trip that does not exist (`Turn` is a read-only view; there is no messages → `Sample` constructor).

## Related Issue

Blocked on a real ingest path — see #352.

## Test Plan

CPU harnesses against this branch:
- Round trip: messages (parallel calls, both `arguments` dialects, tool role with `tool_call_id`+`name`, calls-only assistant, system-in-data vs config) → `turns_from_messages` → `build_text_messages` → messages, exact modulo intended normalization.
- `build_text_messages` on plain turns emits exactly `{role,content}` (byte-identical to before).
- `Turn` invariants: 5/5 malformed shapes rejected (bad role, empty turn, calls on non-assistant, pairing on non-tool, batch mismatch); valid calls-only and tool shapes accepted.
- Regression for the fixed defect: a media-bearing tool result now raises `NotImplementedError` instead of silently dropping `tool_call_id`.
- Sample level: structured calls on a filled part + `observe(tool_call_id=, tool_name=)` → `turns()` pairing → rendered `{role:tool,content:...,tool_call_id:...,name:...}`.
- Import sweep incl. sglang utils, env/harness, trainer, `data/sft` → OK. `pre-commit` over the diff → all hooks Passed.

## Compatibility / Risk

Nothing on a live path changes while this is a draft. The open design questions to settle **with** the consumer, not before it:
1. Tool-result linkage currently rides in the generic `Part.metadata` (string keys) and forced a `Part.concat` metadata-padding rule; a typed field or primitive would keep protocol semantics out of the generic batching mechanism.
2. Composite `Turn` content (ordered multi-part) is what a multimodal tool result and true intra-message interleave actually need; today they fail loud.
3. The URI-media render is model-local in #357 by design; it moves to the shared layer when this path becomes its second real consumer.

## Reviewer Notes

AI-assisted (Claude Code). Split out of #357 on review feedback (thanks — the round-trip defect was real and is fixed here). Please do not merge until the ingest lands; the point of the split is that "canonical" describes the running system, not the intent.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.