### PR TITLE
feat(sp): adaptive dynamic Ulysses sequence parallelism

### DIFF
--- a/unirl/train/backend/fsdp/backend.py
+++ b/unirl/train/backend/fsdp/backend.py
@@ -50,6 +50,12 @@ class FSDPBackend(BaseFSDP2Backend):
         super().__init__()
         self._check_lora_exclusivity(lora_cfg, ema_lora_cfg)
 
+        # This backend is single-track and has no sequence parallelism; reject SP knobs instead of ignoring them.
+        if int(getattr(fsdp_cfg, "sp_size", 1) or 1) > 1 or getattr(fsdp_cfg, "dynamic_sp", False):
+            raise NotImplementedError(
+                "FSDPBackend: sequence parallelism (sp_size>1 / dynamic_sp) is unsupported; use the VeOmni backend."
+            )
+
         self._bundle = bundle
         self._rank = int(rank)
         self._device = device if device is not None else torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/unirl/train/backend/veomni/backend.py
+++ b/unirl/train/backend/veomni/backend.py
@@ -79,6 +79,8 @@ class VeOmniBackend(BaseFSDP2Backend):
         self._sp_size = int(getattr(fsdp_cfg, "sp_size", 1) or 1)
         if world % self._sp_size != 0:
             raise ValueError(f"VeOmniBackend: world_size {world} not divisible by sp_size {self._sp_size}")
+        # Dynamic SP picks a per-microbatch Ulysses degree <= sp_size at runtime; no planner is wired yet.
+        self._sp_planner = _resolve_sp_planner(getattr(fsdp_cfg, "dynamic_sp", False))
         # ep_size > 1 requires get_parallel_plan() for fused expert tensors.
         self._ep_size = _validate_ep_size(getattr(fsdp_cfg, "ep_size", 1), world_size=world)
         extra_parallel_kwargs = (
@@ -219,6 +221,15 @@ def _validate_fsdp_cfg(fsdp_cfg: FSDPConfig) -> None:
         raise ValueError("VeOmniBackend: cpu_offload=true unsupported in v1 (use FSDPBackend).")
     if not fsdp_cfg.mixed_precision:
         raise ValueError("VeOmniBackend: mixed_precision=false unsupported in v1 (bf16-parity mode is fixed).")
+
+
+def _resolve_sp_planner(dynamic_sp: object):
+    """Return a per-microbatch Ulysses planner when dynamic_sp is set, else None (static sp_size)."""
+    if not dynamic_sp:
+        return None
+    raise NotImplementedError(
+        "VeOmniBackend: dynamic_sp is set but no SequenceParallelPlanner is wired yet; set dynamic_sp=false."
+    )
 
 
 def _validate_ep_size(value: object, *, world_size: int) -> int:

--- a/unirl/train/backend/veomni/sp/planner.py
+++ b/unirl/train/backend/veomni/sp/planner.py
@@ -1,0 +1,18 @@
+"""Abstract planner for adaptive (dynamic) Ulysses sequence parallelism."""
+
+from __future__ import annotations
+
+import abc
+from collections.abc import Sequence
+
+
+class SequenceParallelPlanner(abc.ABC):
+    """Chooses a per-microbatch Ulysses degree from runtime sequence lengths."""
+
+    @abc.abstractmethod
+    def plan(self, seq_lens: Sequence[int], sp_max: int) -> list[int]:
+        """Per-microbatch Ulysses degree (each a divisor of ``sp_max``), aligned to ``seq_lens``."""
+        raise NotImplementedError
+
+
+__all__ = ["SequenceParallelPlanner"]

--- a/unirl/train/configs.py
+++ b/unirl/train/configs.py
@@ -102,7 +102,9 @@ class FSDPConfig:
     root_wrap: bool = True
     checkpoint_format: str = "torch"
     checkpoint_async: bool = False
+    # Ulysses degree. When dynamic_sp is set, this is the ceiling and the per-microbatch degree is chosen at runtime.
     sp_size: int = 1
+    dynamic_sp: bool = False
     ep_size: int = 1
 
 


### PR DESCRIPTION
# feat(sp): adaptive dynamic 2D (Ulysses × Ring) sequence parallelism

## Summary

### Motivation

Real training data is long-tailed in sequence length: the vast majority of sequences are short (< 8k), but rare super-long outliers exist. Those outliers dictate memory pressure, so today we must configure a large, **fixed** SP/CP degree for the whole run. Running short sequences at that fixed degree over-shards them — wasting communication and compute. We want to **adapt the sequence-parallel degree to each sequence's length at runtime.**

The second axis is the *kind* of sequence parallelism. Modern models trend toward **fewer KV heads**, which caps the Ulysses degree — beyond `num_kv_heads` you must shard with Ring. But Ring has higher communication cost than Ulysses and degrades FlashAttention kernel efficiency. Per USP, Ulysses wins when heads are plentiful; Ring is needed once you hit the head wall. Neither is universally right.

### Positioning

Existing dynamic SP/CP work adapts a **single** strategy's degree:

- **FlexSP** (ASPLOS'25) — MILP-based SP-group partition + sequence assignment; **pure Ulysses**.
- **FlexUlysses** (ICLR'26) — per-sequence Ulysses degree + hierarchical device groups; **pure Ulysses** (hits the head wall).
- **ByteScale** (SIGCOMM'25) — dynamic DP×CP mesh + data-aware sharding + selective offloading; **pure Ring**.
- **Megatron Dynamic-CP** — per-sequence local CP size; **pure Ring** (or pure Ulysses, not mixed).
- **LoongTrain** — 2D Ulysses × Ring, but **static** `d_hp × d_cp`, fixed sequence length, no runtime selection.

**None treat the 2D decomposition of the parallel degree across Ulysses and Ring as a runtime decision variable.** Our contribution:

> **FlexUlysses = adaptive but pure Ulysses (head wall). LoongTrain = 2D but static. Ours = adaptive 2D Ulysses × Ring** — choosing the `(sp_ulysses, sp_ring)` split per sequence/microbatch from sequence length, model head count, and cluster bandwidth tiers, jointly optimizing communication and compute.

### Design

**1. Config surface.** `FSDPConfig.sp_size` becomes the total SP ceiling; `dynamic_sp` opts into runtime selection. A planner selector chooses how the ceiling is decomposed into Ulysses × Ring per microbatch.

**2. Planner (decision engine).** `SequenceParallelPlanner.plan(seq_lens, sp_max) -> list[SPCPPlan]` maps the batch's runtime sequence lengths to a per-microbatch `(ulysses_degree, ring_degree)` split. The selection rule combines:
- **Sequence length** — short sequences take degree 1 (no sharding); longer ones scale up only as far as memory requires.
- **Head budget** — Ulysses degree is capped at the KV-head count (optionally raised toward query-head count via GQA KV-replication, à la LoongTrain, at the cost of redundant KV compute/comm); the remaining degree spills into Ring.
- **Bandwidth tiers** — prefer Ulysses (all-to-all) within high-bandwidth domains (intra-node NVLink), Ring (P2P) across lower-bandwidth domains (inter-node), mirroring LoongTrain's Double-Ring intuition.

**3. Bucketing & dispatch.** Sequences are grouped by chosen `(ulysses, ring)` degree into buckets, following the FlexUlysses hierarchical-device-group / highest-sharding-first pattern to avoid cross-group communication deadlock (a rank may belong to multiple SP groups).

**4. Backend integration.** The VeOmni backend constructs the 2D SP sub-mesh (`ulysses × ring`) and threads the per-microbatch plan into the parallel state and the SP patchers in `sp/` (both the AR causal-LM Ulysses path and, newly, a Ring/context-parallel attention path). The plain single-track `FSDPBackend` has no SP and rejects SP knobs outright.

## Test Plan

- Static-parity: existing `sp_size=N` Ulysses recipe — logprob + FSDP grad parity vs `sp_size=1` (the current backend invariant), must remain unchanged.
- Dynamic path (once landed): per-microbatch degree selection over a synthetic long-tailed length distribution; assert (a) short sequences get degree 1, (b) the longest fits without OOM, (c) chosen splits respect the head-count cap, (d) end-to-end loss/logprob parity vs the equivalent static run.
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`.
- Training smoke test on Qwen3 (recipe/hardware/GPU count TBD) comparing throughput and step time against the fixed-degree baseline.
- Current commit: all changed files parse (`ast.parse`); no wired runtime path beyond the fail-closed guard on `dynamic_sp=true`.

## Compatibility / Risk

- **Config**: additive; `dynamic_sp` defaults to `false`, `sp_size` static semantics preserved.
- **Behavior**: none at default. Opting into `dynamic_sp` (or `sp_size>1` on plain FSDP) fails closed until the implementation lands.
- **Numerics**: dynamic degree selection must preserve attention numerics per microbatch — the parity tests above gate this.
- No checkpoint or data-format changes.

## Reviewer Notes

- **This is a draft.** Please review the *plan* and the planner interface shape first — everything downstream depends on the `plan(...)` contract.
- Open question: should `plan(...)` take `num_heads` / bandwidth-tier as call args or planner-construction params? Currently minimal (`seq_lens, sp_max`); will extend as (1) lands.
- Open question from the survey: USP's own numbers show Ring beating Ulysses at 128k — worth validating whether the 2D sweet spot holds on our models/cluster before over-investing in the Ring path.
- AI-assisted; duplicate-work check: no open PR touches SP-degree plumbing or adds an SP planner.
