### PR TITLE
fix(hunyuan-video): align SGLang and trainside rollouts

### DIFF
--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
@@ -122,10 +122,12 @@ rollout:
     tp_size: 1
     local_mode: true
     engine_kwargs:
-      # SGLang reads Hunyuan's transformer guidance from PipelineConfig rather
-      # than request guidance_scale. Pin both pipeline scalars to trainside
-      # instead of accepting its defaults (embedded_cfg_scale=6, flow_shift=7).
+      # SGLang ignores request guidance_scale and reads Hunyuan's transformer
+      # guidance from PipelineConfig, then multiplies by 1000 (same as trainside).
+      # Default embedded_cfg_scale=6 would emit 6000 instead of recipe 1.0 -> 1000.
       embedded_cfg_scale: ${sampling.guidance_scale}
+      # Pin scheduler shift to the recipe. UniRL-shipped sigmas remain the
+      # schedule source of truth; without this, Hunyuan's PipelineConfig default is 7.
       flow_shift: ${model_config.shift}
   model_config: ${model_config}
   strategy: ${strategy}

--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
@@ -69,6 +69,8 @@ backend:
   fsdp_cfg:
     _target_: unirl.train.configs.FSDPConfig
     param_dtype: bf16
+    # Keep LoRA optimizer masters in fp32 while forward compute stays bf16.
+    master_dtype: fp32
     cpu_offload: false
     mixed_precision: true
     fsdp_mode: full
@@ -119,6 +121,12 @@ rollout:
     num_gpus: 1
     tp_size: 1
     local_mode: true
+    engine_kwargs:
+      # SGLang reads Hunyuan's transformer guidance from PipelineConfig rather
+      # than request guidance_scale. Pin both pipeline scalars to trainside
+      # instead of accepting its defaults (embedded_cfg_scale=6, flow_shift=7).
+      embedded_cfg_scale: ${sampling.guidance_scale}
+      flow_shift: ${model_config.shift}
   model_config: ${model_config}
   strategy: ${strategy}
 

--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml
@@ -69,7 +69,6 @@ backend:
   fsdp_cfg:
     _target_: unirl.train.configs.FSDPConfig
     param_dtype: bf16
-    # Keep LoRA optimizer masters in fp32 while forward compute stays bf16.
     master_dtype: fp32
     cpu_offload: false
     mixed_precision: true
@@ -122,12 +121,8 @@ rollout:
     tp_size: 1
     local_mode: true
     engine_kwargs:
-      # SGLang ignores request guidance_scale and reads Hunyuan's transformer
-      # guidance from PipelineConfig, then multiplies by 1000 (same as trainside).
-      # Default embedded_cfg_scale=6 would emit 6000 instead of recipe 1.0 -> 1000.
+      # Hunyuan guidance is PipelineConfig.embedded_cfg_scale, not request guidance_scale.
       embedded_cfg_scale: ${sampling.guidance_scale}
-      # Pin scheduler shift to the recipe. UniRL-shipped sigmas remain the
-      # schedule source of truth; without this, Hunyuan's PipelineConfig default is 7.
       flow_shift: ${model_config.shift}
   model_config: ${model_config}
   strategy: ${strategy}

--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_trainside.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_trainside.yaml
@@ -67,7 +67,6 @@ backend:
   fsdp_cfg:
     _target_: unirl.train.configs.FSDPConfig
     param_dtype: bf16
-    # Keep LoRA optimizer masters in fp32 while forward compute stays bf16.
     master_dtype: fp32
     cpu_offload: false
     mixed_precision: true

--- a/examples/diffusion/hunyuan_video/hunyuan_video_t2v_trainside.yaml
+++ b/examples/diffusion/hunyuan_video/hunyuan_video_t2v_trainside.yaml
@@ -67,6 +67,8 @@ backend:
   fsdp_cfg:
     _target_: unirl.train.configs.FSDPConfig
     param_dtype: bf16
+    # Keep LoRA optimizer masters in fp32 while forward compute stays bf16.
+    master_dtype: fp32
     cpu_offload: false
     mixed_precision: true
     fsdp_mode: full

--- a/unirl/models/hunyuan_video/diffusion.py
+++ b/unirl/models/hunyuan_video/diffusion.py
@@ -9,7 +9,8 @@ import torch
 
 from unirl.models.types.diffusion import DiffusionStage, DiffusionStep
 from unirl.models.types.replay_result import ReplayResult
-from unirl.sde.kernels import StepStrategy
+from unirl.sde.kernels import GeneratorLike, StepStrategy
+from unirl.sde.noise import make_denoise_step_generators
 from unirl.types.sampling import DiffusionSamplingParams, compute_trajectory_positions
 from unirl.types.segments.latent import LatentSegment, make_video_segment
 from unirl.utils.dtypes import parse_torch_dtype
@@ -87,6 +88,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
         sigma: torch.Tensor,
         sigma_next: torch.Tensor,
         prev_sample: Optional[torch.Tensor] = None,
+        generator: GeneratorLike = None,
         sigma_max: float = 0.99,
         eta: float = 1.0,
         step_index: int = 0,
@@ -99,6 +101,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
             sigma_next=sigma_next,
             eta=eta,
             prev_sample=prev_sample,
+            generator=generator,
             sigma_max=sigma_max,
             step_index=step_index,
         )
@@ -114,6 +117,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
         sigma_next: torch.Tensor,
         guidance_scale: float,
         prev_sample: Optional[torch.Tensor] = None,
+        generator: GeneratorLike = None,
         sigma_max: float = 0.99,
         eta: float = 1.0,
         step_index: int = 0,
@@ -133,6 +137,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
             sigma=sigma,
             sigma_next=sigma_next,
             prev_sample=prev_sample,
+            generator=generator,
             sigma_max=sigma_max,
             eta=eta,
             step_index=step_index,
@@ -149,6 +154,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
         sigma_next: torch.Tensor,
         guidance_scale: float,
         prev_sample: Optional[torch.Tensor] = None,
+        generator: GeneratorLike = None,
         sigma_max: float = 0.99,
         eta: float = 1.0,
         step_index: int = 0,
@@ -163,6 +169,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
             sigma_next=sigma_next,
             guidance_scale=guidance_scale,
             prev_sample=prev_sample,
+            generator=generator,
             sigma_max=sigma_max,
             eta=eta,
             step_index=step_index,
@@ -236,8 +243,10 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
         schedule: torch.Tensor,
         params: DiffusionSamplingParams,
         initial_latents: Optional[torch.Tensor] = None,
+        denoise_seed_keys: Optional[List[str]] = None,
+        denoise_base_seed: int = 0,
     ) -> LatentSegment:
-        """Run full HunyuanVideo-1.0 T2V sampling."""
+        """Run HunyuanVideo-1.0 T2V sampling with optional deterministic per-step SDE generators."""
         from unirl.sde.noise import generate_latents
 
         if conditions.text_llama is None or conditions.text_llama.embeds is None:
@@ -245,6 +254,11 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
         prompt_embeds = conditions.text_llama.embeds
         device = prompt_embeds.device
         batch_size = int(prompt_embeds.shape[0])
+        if denoise_seed_keys is not None and len(denoise_seed_keys) != batch_size:
+            raise ValueError(
+                "HunyuanVideoDiffusionStage.diffuse: denoise_seed_keys length "
+                f"{len(denoise_seed_keys)} != batch size {batch_size}"
+            )
         T = int(params.num_inference_steps)
         if int(schedule.shape[0]) != T + 1:
             raise ValueError(f"HunyuanVideoDiffusionStage.diffuse: schedule length {schedule.shape[0]} != T+1={T + 1}")
@@ -303,6 +317,15 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
             sigma = schedule[i].to(device)
             sigma_next = schedule[i + 1].to(device)
             step_eta = float(params.eta) if i in sde_set else 0.0
+            step_generators = (
+                make_denoise_step_generators(
+                    base_seed=int(denoise_base_seed),
+                    step_index=i,
+                    sample_ids=[str(key) for key in denoise_seed_keys],
+                )
+                if step_eta > 0.0 and denoise_seed_keys is not None
+                else None
+            )
 
             with torch.no_grad(), autocast_ctx:
                 new_latents, log_prob, _ = self.step.step_with_logp(
@@ -314,6 +337,7 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
                     sigma_next=sigma_next,
                     guidance_scale=float(params.guidance_scale),
                     eta=step_eta,
+                    generator=step_generators,
                     sigma_max=sigma_max,
                     step_index=i,
                 )

--- a/unirl/models/hunyuan_video/diffusion.py
+++ b/unirl/models/hunyuan_video/diffusion.py
@@ -1,4 +1,4 @@
-"""HunyuanVideo-1.0 diffusion — 5D latents ``[B, C, T_lat, H_lat, W_lat]``; timestep and guidance both ``* 1000``."""
+"""HunyuanVideo-1.0 diffusion — 5D latents ``[B, C, T_lat, H_lat, W_lat]``; ``timestep = sigma * 1000``."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
         *,
         guidance_scale: float,
     ) -> torch.Tensor:
-        """Transformer forward on ``sample [B, C, T_lat, H_lat, W_lat]``; guidance is ``scale * 1000``, no CFG."""
+        """Transformer forward on ``sample [B, C, T_lat, H_lat, W_lat]``; guidance rides a ``[B]`` tensor, no CFG."""
         text_llama = conditions.text_llama
         pooled_clip = conditions.pooled_clip
         if text_llama is None or text_llama.embeds is None:
@@ -62,8 +62,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
             timestep = sigma
         timestep = timestep.to(device=device, dtype=dtype) * self.TIMESTEP_SCALE
 
-        # Same 1000x embedding as official HunyuanVideo and SGLang DenoisingStage.
-        guidance = torch.full((batch_size,), guidance_scale, device=device, dtype=dtype) * self.TIMESTEP_SCALE
+        guidance = torch.full((batch_size,), guidance_scale, device=device, dtype=dtype)
 
         hidden_states = sample.to(dtype)
 
@@ -247,7 +246,7 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
         denoise_seed_keys: Optional[List[str]] = None,
         denoise_base_seed: int = 0,
     ) -> LatentSegment:
-        """Run HunyuanVideo-1.0 T2V sampling with optional deterministic per-step SDE generators."""
+        """Run full HunyuanVideo-1.0 T2V sampling."""
         from unirl.sde.noise import generate_latents
 
         if conditions.text_llama is None or conditions.text_llama.embeds is None:
@@ -255,11 +254,6 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
         prompt_embeds = conditions.text_llama.embeds
         device = prompt_embeds.device
         batch_size = int(prompt_embeds.shape[0])
-        if denoise_seed_keys is not None and len(denoise_seed_keys) != batch_size:
-            raise ValueError(
-                "HunyuanVideoDiffusionStage.diffuse: denoise_seed_keys length "
-                f"{len(denoise_seed_keys)} != batch size {batch_size}"
-            )
         T = int(params.num_inference_steps)
         if int(schedule.shape[0]) != T + 1:
             raise ValueError(f"HunyuanVideoDiffusionStage.diffuse: schedule length {schedule.shape[0]} != T+1={T + 1}")
@@ -322,7 +316,7 @@ class HunyuanVideoDiffusionStage(DiffusionStage[HunyuanVideoConditions]):
                 make_denoise_step_generators(
                     base_seed=int(denoise_base_seed),
                     step_index=i,
-                    sample_ids=[str(key) for key in denoise_seed_keys],
+                    sample_ids=denoise_seed_keys,
                 )
                 if step_eta > 0.0 and denoise_seed_keys is not None
                 else None

--- a/unirl/models/hunyuan_video/diffusion.py
+++ b/unirl/models/hunyuan_video/diffusion.py
@@ -1,4 +1,4 @@
-"""HunyuanVideo-1.0 diffusion — 5D latents ``[B, C, T_lat, H_lat, W_lat]``; ``timestep = sigma * 1000``."""
+"""HunyuanVideo-1.0 diffusion — 5D latents ``[B, C, T_lat, H_lat, W_lat]``; timestep and guidance both ``* 1000``."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
         *,
         guidance_scale: float,
     ) -> torch.Tensor:
-        """Transformer forward on ``sample [B, C, T_lat, H_lat, W_lat]``; guidance rides a ``[B]`` tensor, no CFG."""
+        """Transformer forward on ``sample [B, C, T_lat, H_lat, W_lat]``; guidance is ``scale * 1000``, no CFG."""
         text_llama = conditions.text_llama
         pooled_clip = conditions.pooled_clip
         if text_llama is None or text_llama.embeds is None:
@@ -62,7 +62,8 @@ class HunyuanVideoDiffusionStep(DiffusionStep[HunyuanVideoBundle, HunyuanVideoCo
             timestep = sigma
         timestep = timestep.to(device=device, dtype=dtype) * self.TIMESTEP_SCALE
 
-        guidance = torch.full((batch_size,), guidance_scale, device=device, dtype=dtype)
+        # Same 1000x embedding as official HunyuanVideo and SGLang DenoisingStage.
+        guidance = torch.full((batch_size,), guidance_scale, device=device, dtype=dtype) * self.TIMESTEP_SCALE
 
         hidden_states = sample.to(dtype)
 

--- a/unirl/models/hunyuan_video/pipeline.py
+++ b/unirl/models/hunyuan_video/pipeline.py
@@ -170,7 +170,7 @@ class HunyuanVideoPipeline(Pipeline):
             schedule=schedule,
             params=params,
             initial_latents=initial_latents,
-            denoise_seed_keys=list(frontier.sample_ids) if initial_latents is not None else None,
+            denoise_seed_keys=frontier.sample_ids if initial_latents is not None else None,
             denoise_base_seed=int(params.seed) if params.seed is not None else 0,
         )
         videos = self.vae_decode.decode(latent_seg)

--- a/unirl/models/hunyuan_video/pipeline.py
+++ b/unirl/models/hunyuan_video/pipeline.py
@@ -165,7 +165,14 @@ class HunyuanVideoPipeline(Pipeline):
 
         initial_latents = NoiseRecipe.from_sample(sample).resolve()
 
-        latent_seg = self.diffusion.diffuse(hv_conds, schedule=schedule, params=params, initial_latents=initial_latents)
+        latent_seg = self.diffusion.diffuse(
+            hv_conds,
+            schedule=schedule,
+            params=params,
+            initial_latents=initial_latents,
+            denoise_seed_keys=list(frontier.sample_ids) if initial_latents is not None else None,
+            denoise_base_seed=int(params.seed) if params.seed is not None else 0,
+        )
         videos = self.vae_decode.decode(latent_seg)
 
         filled = frontier.fill(segment=latent_seg, primitives={"video": videos}, conditions=hv_conds.to_dict())

--- a/unirl/rollout/engine/sglang_diffusion/backends/native.py
+++ b/unirl/rollout/engine/sglang_diffusion/backends/native.py
@@ -99,13 +99,19 @@ class SGLangBackend:
         *,
         local_mode: bool,
     ) -> "SGLangBackend":
-        """Filter intent against ServerArgs, build the generator, return the backend."""
+        """Resolve ServerArgs and model PipelineConfig intent, then build the generator."""
         rt = _import_sglang_runtime()
-        allowed = {f.name for f in dataclasses.fields(rt["ServerArgs"])}
-        server_kwargs = {k: v for k, v in server_intent.items() if k in allowed}
+        server_args_cls = rt["ServerArgs"]
+        # from_dict routes model-specific intent such as guidance and flow shift into PipelineConfig.
+        from_dict = getattr(server_args_cls, "from_dict", None)
+        if callable(from_dict):
+            server_args = from_dict(dict(server_intent))
+        else:
+            allowed = {f.name for f in dataclasses.fields(server_args_cls)}
+            server_kwargs = {k: v for k, v in server_intent.items() if k in allowed}
+            server_args = server_args_cls.from_kwargs(**server_kwargs)
 
-        disable_autocast = server_kwargs.get("disable_autocast")
-        server_args = rt["ServerArgs"].from_kwargs(**server_kwargs)
+        disable_autocast = server_intent.get("disable_autocast")
         if disable_autocast is not None:
             server_args.disable_autocast = disable_autocast
 

--- a/unirl/rollout/engine/sglang_diffusion/backends/native.py
+++ b/unirl/rollout/engine/sglang_diffusion/backends/native.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 import logging
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -101,22 +100,8 @@ class SGLangBackend:
     ) -> "SGLangBackend":
         """Resolve ServerArgs and model PipelineConfig intent, then build the generator."""
         rt = _import_sglang_runtime()
-        server_args_cls = rt["ServerArgs"]
-        # Global ServerArgs resolver for every model family. from_dict keeps
-        # PipelineConfig fields that live in server_intent / engine_kwargs
-        # (Hunyuan embedded_cfg_scale, flow_shift, ...). Filtering to ServerArgs
-        # fields first then calling from_kwargs drops those keys silently.
-        from_dict = getattr(server_args_cls, "from_dict", None)
-        if callable(from_dict):
-            server_args = from_dict(dict(server_intent))
-        else:
-            allowed = {f.name for f in dataclasses.fields(server_args_cls)}
-            server_kwargs = {k: v for k, v in server_intent.items() if k in allowed}
-            server_args = server_args_cls.from_kwargs(**server_kwargs)
-
-        disable_autocast = server_intent.get("disable_autocast")
-        if disable_autocast is not None:
-            server_args.disable_autocast = disable_autocast
+        # from_dict keeps PipelineConfig keys; filtering to ServerArgs fields drops them.
+        server_args = rt["ServerArgs"].from_dict(dict(server_intent))
 
         generator = rt["DiffGenerator"].from_pretrained(
             server_args=server_args,

--- a/unirl/rollout/engine/sglang_diffusion/backends/native.py
+++ b/unirl/rollout/engine/sglang_diffusion/backends/native.py
@@ -102,7 +102,10 @@ class SGLangBackend:
         """Resolve ServerArgs and model PipelineConfig intent, then build the generator."""
         rt = _import_sglang_runtime()
         server_args_cls = rt["ServerArgs"]
-        # from_dict routes model-specific intent such as guidance and flow shift into PipelineConfig.
+        # Global ServerArgs resolver for every model family. from_dict keeps
+        # PipelineConfig fields that live in server_intent / engine_kwargs
+        # (Hunyuan embedded_cfg_scale, flow_shift, ...). Filtering to ServerArgs
+        # fields first then calling from_kwargs drops those keys silently.
         from_dict = getattr(server_args_cls, "from_dict", None)
         if callable(from_dict):
             server_args = from_dict(dict(server_intent))


### PR DESCRIPTION
## Summary

HunyuanVideo's trainside and SGLang recipes used the same visible sampling values but did not execute the same numerical path:

- SGLang filtered rollout intent to `ServerArgs` fields before construction, so Hunyuan's pipeline-only `embedded_cfg_scale` and `flow_shift` were dropped and silently fell back to 6/7 instead of the recipe's 1/5. Route intent through SGLang's `ServerArgs.from_dict` so model `PipelineConfig` fields are preserved.
- Trainside sampling consumed rank-local SDE noise while SGLang derived it per sample and denoising step. Pass the same sample IDs and base seed through Hunyuan's trainside diffusion stage.
- Both bf16-loaded recipes now keep trainable LoRA masters in fp32, while forward compute remains bf16.

The existing `TensorWeightSync + lora_merged` path and `old_logp_source: rollout` recipe are intentionally preserved.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files examples/diffusion/hunyuan_video/hunyuan_video_t2v_sglang.yaml examples/diffusion/hunyuan_video/hunyuan_video_t2v_trainside.yaml unirl/models/hunyuan_video/diffusion.py unirl/models/hunyuan_video/pipeline.py unirl/rollout/engine/sglang_diffusion/backends/native.py` — passed.
- `python lint/check_docstring_lines.py` and `python lint/check_recipe_targets.py` — passed.
- Hydra config composition on commit `0b7b0f0`:
  - `python -m unirl.train_diffusion --config-name=diffusion/hunyuan_video/hunyuan_video_t2v_sglang --cfg job --resolve` — passed; resolved `master_dtype=fp32`, `embedded_cfg_scale=1.0`, `flow_shift=5.0`, and `old_logp_source=rollout`.
  - `python -m unirl.train_diffusion --config-name=diffusion/hunyuan_video/hunyuan_video_t2v_trainside --cfg job --resolve` — passed; resolved `master_dtype=fp32`.
- Temporary CPU contract harness on commit `0b7b0f0` — passed. It covers generator forwarding through `step`/`step_with_logp`, per-sample/per-step trainside SDE seeds, seed-count validation, SGLang `PipelineConfig` routing, and the older-runtime fallback. The one-off harness is not committed per repository policy.
- Paired 125-rollout validation: `hunyuanvideo-community/HunyuanVideo`, PickScore prompts, one node / 8 NVIDIA H20 GPUs per run, LoRA rank 64, 1280x720x5, 10 denoising steps, four SDE steps, and `torch_sdpa` for SGLang:
  - [trainside fp32-master reference](https://wandb.ai/leviking98z-zhejiang-university/tmp/runs/hvtsfp32m-8c42b8c)
  - [SGLang lora-merged + rollout-anchor candidate](https://wandb.ai/leviking98z-zhejiang-university/tmp/runs/hvsgmroll32-14e0003)
  - Across steps 1–125, SGLang minus trainside mean reward was `-0.002381`, RMSE was `0.008345`, and correlation was `0.965214`. The original historical pair had RMSE `0.038154` and correlation `0.353175` over the same window.
  - The long run used the functionally equivalent ablation commit `14e0003` with its optional fixed padding disabled. The exact PR commit was then rebased onto current `main` and covered by the composition and CPU contract checks above.

## Compatibility / Risk

The recipe change adds fp32 storage only for trainable LoRA masters; forward mixed precision remains bf16. Deterministic trainside SDE generators are enabled only when the driver supplied initial noise, matching the SGLang path; `disable_driver_xt` retains the previous engine-local RNG behavior. Current SGLang builds use `ServerArgs.from_dict`; older builds without it retain the previous filtered `from_kwargs` path.

## Reviewer Notes

This PR deliberately does not add online-LoRA sync, replay anchoring, fixed text padding, or gradient clipping. The 125-step matrix showed the existing lora-merged + rollout-anchor recipe was the best late-window match.

Duplicate-work check: no open PR or issue covers HunyuanVideo trainside/SGLang reward-curve parity; issue #127 is the general Video RL roadmap. AI assistance was used; the full diff, config composition, contract harness, and long-window metrics were reviewed before publication.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
