### PR TITLE
fix(bagel): pin the validated AC order for EditReward trainside; write down the BAGEL RL contracts

### DIFF
--- a/examples/diffusion/bagel/bagel_editreward.yaml
+++ b/examples/diffusion/bagel/bagel_editreward.yaml
@@ -95,6 +95,7 @@ backend:
     fsdp_mode: full
     reshard_after_forward: true
     activation_checkpointing: true     # 7B + multi-step replay + dual-CFG forwards: required
+    ac_wrap_order: inside              # the composition the it2i differentiable-replay smoke validated (see unirl/models/bagel/README.md)
     use_torch_compile: false
     root_wrap: false                   # vendored BAGEL calls embed_tokens/lm_head outside a root forward
   optimizer_cfg:

--- a/unirl/models/bagel/README.md
+++ b/unirl/models/bagel/README.md
@@ -1,0 +1,61 @@
+# BAGEL
+
+> **Where it fits:** the BAGEL-7B-MoT model bundle. `pipeline.py` is trainside
+> rollout, `diffusion.py` is the replay stage the trainer scores/backprops
+> through, `rl_ops.py` is the single home for every helper both of those (and
+> the vLLM-Omni worker) must share, `conditions.py` carries what replay needs
+> across the Part boundary. Full map: [`../../README.md`](../../README.md).
+
+## Why rl_ops is the only home for prefill helpers
+
+Rollout earns the reward under one conditioning; replay takes the gradient
+under another only if the two prefill differently — a mismatch **no importance
+ratio corrects**, and nothing crashes: the curve just quietly degrades. So the
+source-image transforms and the VAE/ViT/text prefill exist exactly once
+(`build_image_transforms`, `resize_input_image`, `update_context_image`,
+`update_context_text`), and trainside rollout (`BagelPipeline`), trainer replay
+(`BagelDiffusionStage`), and the vLLM-Omni worker (`RLBagelPipeline`) all call
+them. Do not fork these paths; extend them in place.
+
+## Gotchas
+
+- **Source images are VAE-encoded by posterior MEAN, not by sampling**
+  (`rl_ops._encode_vae_posterior_mean`). Sampling would draw different noise at
+  rollout and at replay-rebuild, breaking the ratio unfixably. Consequence:
+  since #304 this also holds for trainside it2i rollout — conditioning is
+  deterministic where the vendored `AutoEncoder.encode` used to sample. The
+  `bagel_editreward.yaml` curve was re-baselined for this (see that PR's run);
+  pre-#304 curves are not comparable step-for-step.
+- **it2i grad replay rebuilds the source contexts through the CURRENT LoRA
+  weights on every replay** (`_resolve_single` bypasses stored contexts when
+  grads are enabled and `conditions.input_images` is non-empty). That is the
+  point — stored contexts go stale across optimizer updates — but it costs a
+  full image+text prefill per replay, and the prefill runs under activation
+  checkpointing. `ac_wrap_order: inside` is the composition the it2i smoke
+  validated; both EditReward recipes pin it. A recipe that enables
+  `activation_checkpointing` on an image-conditioned BAGEL path without that
+  pin is running an unvalidated composition.
+- **Packed-inference prefill must run in eval dispatch.** Every navit module
+  routes `forward_train` vs `forward_inference` on `self.training`, and the
+  train stack leaves the model in train mode; `rl_ops.inference_dispatch_scope`
+  forces eval for the rebuild. `forward_flow` deliberately restores mode
+  asymmetrically — it stays in eval while grads are pending so a later
+  `backward()`'s checkpoint recompute also fires in eval. Keep that asymmetry.
+- **`force_rebuild` refuses prompt-only conditions** (`_resolve_single`
+  requires `input_images`). Stored contexts may bake in text the raw prompt
+  cannot reproduce — t2ti stores `init + system + think + prompt` — so a forced
+  rebuild there would silently recondition the caller (UniGRPO's `v_ref`).
+  Only image-conditioned conditions carry raw material that reproduces the
+  stored layout.
+- **ViT transform stride must equal the SigLIP patch size (14)**
+  (`BAGEL_VIT_TRANSFORM_GEOMETRY`). `patchify` asserts `h % patch_size == 0`;
+  flow_grpo ships stride 7 (half a patch), which crashes non-square inputs.
+- **The vendored `prepare_vae_images` / `prepare_vit_images` build CPU
+  tensors** and the bundle's VAE carries no accelerate hooks, so
+  `rl_ops.update_context_image` moves `padded_images` and the packed index
+  tensors to the bundle device before the cache update. Dropping those moves
+  "works" on trainside colocate and fails only cross-process.
+- **Trainside rollout does not strip `<|im_start|>` / `<|im_end|>` from
+  prompts; the worker and the grad rebuild do.** Identical behavior for any
+  normal prompt; a dataset instruction literally wrapped in those markers would
+  condition trainside rollout and its grad replay on different token sequences.

--- a/unirl/rollout/engine/vllm_omni/pipelines/bagel/README.md
+++ b/unirl/rollout/engine/vllm_omni/pipelines/bagel/README.md
@@ -1,0 +1,39 @@
+# BAGEL worker pipeline (vLLM-Omni)
+
+> **Where it fits:** the worker-side RL pipeline loaded into vLLM-Omni's DiT
+> worker via `custom_pipeline_args`. It taps the trajectory (SDE scheduler,
+> noise, σ echo) and, for it2i, builds the editing KV contexts itself. The
+> trainer-side twin of every prefill it runs lives in
+> [`unirl/models/bagel/rl_ops.py`](../../../../../models/bagel/README.md) —
+> read that README's one-home rule first.
+
+## Gotchas
+
+All verified against the pinned vllm-omni tag in `pyproject.toml`; re-verify
+each on any engine bump.
+
+- **it2i must inject KV and bypass upstream's img2img branch entirely**
+  (`_inject_it2i_contexts`; upstream skips ALL of its own prefill once
+  `sampling_params.past_key_values` is set). Letting upstream's branch run
+  would (1) override the output canvas with the resized SOURCE dims — the
+  driver authored x_T for the requested height/width, so the noise tap's shape
+  check fails — and (2) preprocess the source with a stride-`latent_downsample`
+  resize plus a fixed 980x980 `SiglipImageProcessor` squash (~4x the ViT
+  tokens, aspect ratio dropped) instead of the vendored navit transforms the
+  trainer replays with. That is a rollout/replay conditioning mismatch no
+  importance ratio can correct.
+- **`ropes` must ride `kv_metadata`.** An image block advances `kv_lens` by
+  `num_img_tokens + 2` but rope by ONE (the whole block shares a single
+  position). Upstream's `ropes = [seq_len]` fallback coincides for text-only
+  t2i and is off by thousands for image-bearing contexts.
+- **Repoint the request at a SHALLOW COPY of its sampling params before
+  writing KV into them.** Omni shares one params object across the requests of
+  a generate call; writing in place leaks this request's caches into its
+  siblings.
+- **Packed rollout is t2i-only.** Upstream's grouped `generate_image` is cfg=1
+  t2i; `_is_batchable_t2i` here and the adapter's `_is_packable_t2i` both
+  reject image-bearing requests, so it2i runs one request per sample. Keep the
+  two gates in agreement.
+- **`kv_metadata["image_shape"]` carries the REQUESTED canvas**, not the
+  source image's dims — the driver's x_T recipe and the σ echo are authored
+  for it.


### PR DESCRIPTION
## Summary

- Pin `ac_wrap_order: inside` in `examples/diffusion/bagel/bagel_editreward.yaml`. #304 activated differentiable it2i context rebuild on the trainside replay path, and `inside` is the AC composition its smoke validated; the recipe was silently running the default `outside`, an unvalidated composition.
- Disclose the trainside re-baseline #304 implied for this recipe: source images are now VAE-encoded by posterior MEAN (the vendored `AutoEncoder.encode` used to sample), and grad replay rebuilds the source contexts through the current LoRA weights every replay. Curves are not step-for-step comparable with pre-#304 runs; the validation run below is the new baseline.
- Migrate the load-bearing contracts that #304's docstring collapse deleted into `unirl/models/bagel/README.md` (new) and `unirl/rollout/engine/vllm_omni/pipelines/bagel/README.md` (new): the one-home prefill rule, posterior-mean determinism, dispatch/AC composition, `force_rebuild` refusal semantics, upstream img2img divergence, ropes and shallow-copy wire contracts.

## Related Issue

N/A — follow-up to #304.

## Test Plan

- `python -m unirl.train_diffusion --config-name=diffusion/bagel/bagel_editreward --cfg job --resolve` composes clean.
- `uvx --from pre-commit pre-commit run` on the changed files: all hooks pass (recipe targets, docstring, yaml).
- **Re-validation long run: DONE, curve aligned** — `bagel_editreward.yaml` at this HEAD on 8x NVIDIA H20 96GB, BAGEL-7B-MoT + EditReward-MiMo-VL-7B (rank-affine child), 225 rollouts x 8 prompts x 8 samples, 2 updates/rollout. Training reward +0.720 -> +1.469 (first-25 vs last-25, monotone); eval (eta=0) 1.1185 -> 1.5719. Converted to the reference's pre-fix `mean(reward, log-sigma)` scale: -0.99 start / -0.66 at step ~160 / -0.62 tail vs the reference's ~-1.1 / -0.598 / -0.4..-0.6 band. Zero errors, zero OOM, peak HBM 89.9 GiB. Full numbers in the run comment below.

## Compatibility / Risk

- `ac_wrap_order: inside` changes this recipe's FSDP2 AC wrapping order; it is the order the stacked it2i consumer validated and recompute re-enters sharding hooks there. No other recipe is touched.
- The README additions are documentation only.

## Reviewer Notes

- The re-baseline being disclosed here happened at #304-merge time via code, not via this PR; this PR makes it visible and validated.
- AI-assisted; diff reviewed. No overlapping open PR touches these files.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.

