### PR TITLE
docs: state droid100's torch requirement and list dataset-prep in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,6 +32,11 @@ uv pip install -e ".[sglang,train,infer]" --prerelease=allow
 | `infer` | `accelerate` | HunyuanImage3 and similar models |
 | `eval` | `torchvision`, `easyocr` | OCR-based reward components |
 | `dev` | `pytest`, `ruff`, `pre-commit` | Local development |
+| `dataset-prep` | `datasets`, `pandas`, `pyarrow`, PyAV | Cooking a dataset with a converter under [`datasets/`](datasets/README.md) |
+
+`dataset-prep` is independent of the engine extras — it carries no torch, so cooking in a
+bare venv works for every converter except `datasets/droid100/`, which needs torch as well
+(any engine extra supplies it; a plain `uv pip install torch` is enough for CPU-only prep).
 
 For development tools (lint and tests):
 

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -24,6 +24,11 @@ The converters need a few libraries the framework itself does not (`datasets`, `
 pip install -e '.[dataset-prep]'
 ```
 
+That covers every converter here except [`droid100/`](droid100/README.md), which also needs
+**torch** (it resizes clips and writes `.pt` tensors). The extra deliberately does not carry
+torch: torch enters through exactly one engine extra, which is what lets each engine pin its
+own CUDA stack. Any engine extra supplies it, or `pip install torch` for CPU-only prep.
+
 Installing `unirl` at all is only strictly required for the converters that import it
 (`sft_manifests/prepare_sft_agent.py`, `searchgen/prepare_sft.py`), but the extra is the
 simplest way to get the rest. Training does not need it.

--- a/datasets/droid100/README.md
+++ b/datasets/droid100/README.md
@@ -27,6 +27,12 @@ Needs the converter dependencies (`pip install -e '.[dataset-prep]'`, see
 `pandas` and decodes video with `av`. Both are required lazily, so a missing one exits with
 the package to install rather than a traceback.
 
+**Also needs torch**, which `dataset-prep` does not carry (torch enters through an engine
+extra so each engine can pin its own CUDA stack). This prep resizes clips and writes `.pt`
+tensors, so in a bare `dataset-prep` venv it fails at import with
+`ModuleNotFoundError: No module named 'torch'`. Any engine extra supplies it; `pip install
+torch` is enough for CPU-only prep. It is the only converter here with this requirement.
+
 ```bash
 python datasets/droid100/prepare_droid100.py --root datasets/droid100_debug
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,12 @@ dev = [
 # LeRobot droid100 prep reads parquet metadata with pandas and decodes video with
 # av. The av bound matches the sglang/vllm extras so installing both cannot
 # conflict.
+#
+# torch is deliberately NOT here even though droid100 imports it (clip resize +
+# .pt writes): adding it would put a second torch declaration outside the engine
+# extras, and pinning exactly one is what lets each engine carry its own CUDA
+# stack. droid100 is the only converter that needs it; datasets/droid100/README.md
+# says so, and every other converter runs in a bare dataset-prep venv.
 dataset-prep = [
   "datasets>=2.14",
   "pandas>=2",


### PR DESCRIPTION
## Summary

Follow-up to #375, fixing one thing it got wrong.

The `dataset-prep` extra #375 added is presented in `datasets/README.md` as everything a
converter needs. It is not, for one of them: `datasets/droid100/prepare_droid100.py` imports
`torch` at module level (clip resize via `interpolate`, and `torch.save` for the `.pt` tensors
the Cosmos3 track builder reads), and `torch` is deliberately absent from the base dependencies
— it enters through exactly one engine extra, which is what lets each engine pin its own CUDA
stack. So the documented path

```bash
pip install -e '.[dataset-prep]'
python datasets/droid100/prepare_droid100.py --root datasets/droid100_debug
```

ends at `ModuleNotFoundError: No module named 'torch'`.

Fixed in the docs, not by adding `torch` to the extra: a second torch declaration outside the
engine extras is exactly what that pinning scheme avoids. `datasets/README.md`,
`datasets/droid100/README.md` and the extra's own comment in `pyproject.toml` now say droid100
additionally needs torch, that any engine extra supplies it, and that it is the only converter
with that requirement.

`INSTALL.md`'s **Extras** table enumerates every extra and had no `dataset-prep` row, so a
reader following the canonical install doc could not discover the extra at all. That row is the
other half of the same gap and is added here.

Docs and one comment only — no code, no dependency changes.

## Related Issue

N/A — follow-up to #375.

## Test Plan

- **Reproduced the failure** under an import hook that blocks `torch`, simulating a venv
  installed with exactly `.[dataset-prep]`, and confirmed the blast radius is one converter:

  ```
  datasets/droid100/prepare_droid100.py       FAILS -> ImportError: No module named 'torch'
  datasets/geo3k_mc/prepare_geo3k_mc.py       OK (--help works)
  datasets/sft_manifests/prepare_sft_text.py  OK (--help works)
  ```

  Cross-checked against the manifest: `torch` appears in `pyproject.toml` only inside the
  `sglang`/`vllm` extras (and `[tool.uv.extra-build-dependencies]`), never in base.
- **Dependency set re-derived** across all 15 converters by AST scan plus a grep for the
  string-based `_require()` helper `droid100` uses (an import scan alone misses `pandas` and
  `av`). Union is `PIL`, `datasets`, `huggingface_hub`, `numpy`, `pandas`, `pyarrow`, `torch`,
  `transformers`, `av` — all covered by base + `dataset-prep` except `torch`.
- `SKIP=no-commit-to-branch pre-commit run --all-files` → all hooks **Passed**, including
  `core-dependency-directions` and `check-docstring-lines`.
- `pyproject.toml` parses; all four `dataset-prep` requirements are valid PEP 508 and the `av`
  bound still matches the `sglang`/`vllm` extras.
- Repo-wide markdown check: **149** relative links across 55 files resolve, files and anchors.

## Compatibility / Risk

N/A — documentation and one TOML comment. No dependency, config, or code change; no install
that works today stops working.

## Reviewer Notes

- Deliberately **not** adding `torch` to `dataset-prep`. It would resolve (a bare `torch` is
  compatible with the engines' `==2.11.0+cuXXX` pins), but it puts a second torch declaration
  outside the engine extras and invites a plain PyPI CUDA wheel on a `.[dataset-prep]`-only
  install. The base-deps comment calls that pinning out explicitly; this respects it.
- Also considered and **not** done: routing droid100's `torch` import through the `_require()`
  helper it already uses for `pandas`/`av`, which would turn the traceback into
  `prepare_droid100 needs 'torch' (pip install torch)`. That is an error-message improvement,
  not a correctness fix — the docs are what were wrong. Easy to add if a reviewer prefers it.
- Found while auditing the merged result of #361 + #375. Four other gaps surfaced in that audit
  and are **not** fixed here, because none of them breaks anything and bundling them would make
  this a grab-bag: `unirl/tools/` is absent from the Module Map, the "Where new code goes"
  table, and `check_core_dependencies.py`'s `RULES` (so that package is unguarded); the merge
  dropped #361's "older modules … remain staged migration candidates" caveat from
  `unirl/utils/README.md`, which now asserts the ownership rule unconditionally while
  `wandb_logger`, `memory_monitor`, `shard_balance` and `profiling` still have a single owner
  each; `datasets/pickscore/` has a converter but no README (and a `prpocess.py` filename
  typo); and the root `README.md` never mentions `datasets/`. Happy to take any of them in a
  separate PR.
- AI assistance: written with Claude Code; the failure was reproduced rather than inferred, and
  every changed line is documentation. Duplicate-work check: no open PR touches `INSTALL.md`,
  `pyproject.toml`'s extras, or `datasets/**/README.md`.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
