### PR TITLE
fix(veomni): preserve rank-local EP checkpoint blocks

### DIFF
--- a/unirl/train/backend/veomni/ep/placement.py
+++ b/unirl/train/backend/veomni/ep/placement.py
@@ -2,11 +2,44 @@
 
 from __future__ import annotations
 
+import os
 from typing import Tuple
 
 import torch
 import torch.distributed as dist
 from torch import nn
+
+
+def _verify_rank_local_block(block: torch.Tensor, mesh) -> None:
+    """Fail when a DTensor mesh does not hold the same logical local block."""
+    if os.environ.get("UNIRL_VERIFY_EP_LOCAL_BLOCKS", "0").strip().lower() not in ("1", "true", "yes"):
+        return
+    if not dist.is_initialized() or mesh.size() <= 1:
+        return
+
+    import hashlib
+
+    data = block.detach().contiguous().cpu()
+    digest = hashlib.sha256()
+    digest.update(str(data.dtype).encode())
+    digest.update(str(tuple(data.shape)).encode())
+    digest.update(data.view(torch.uint8).flatten().numpy().tobytes())
+    local = {
+        "rank": dist.get_rank(),
+        "checksum": digest.hexdigest()[:16],
+        "shape": tuple(block.shape),
+        "dtype": str(block.dtype),
+    }
+    for group in mesh.get_all_groups():
+        gathered = [None] * dist.get_world_size(group)
+        dist.all_gather_object(gathered, local, group=group)
+        checksums = {item["checksum"] for item in gathered}
+        if len(checksums) != 1:
+            raise RuntimeError(
+                "EP placement: ranks in one DTensor mesh must provide the same "
+                "logical EP-local block before FSDP sharding; "
+                f"got {gathered}."
+            )
 
 
 def has_ep_params(model: nn.Module) -> bool:
@@ -64,7 +97,7 @@ def gather_stacked_expert_block(
 
 
 def assign_local_block(param: torch.Tensor, block: torch.Tensor) -> None:
-    """Copy a full local EP block into a plain tensor or its DTensor shard."""
+    """Copy a full EP-local block already replicated across its FSDP mesh."""
     try:
         from torch.distributed.tensor import DTensor, distribute_tensor
     except ImportError:  # pragma: no cover - older torch
@@ -72,7 +105,11 @@ def assign_local_block(param: torch.Tensor, block: torch.Tensor) -> None:
 
     with torch.no_grad():
         if isinstance(param, DTensor):
-            sharded = distribute_tensor(block, param.device_mesh, param.placements)
+            # Every rank in param.device_mesh must hold the same logical block;
+            # each EP rank has a separate FSDP mesh. Avoid a redundant source-rank
+            # scatter and shard the already-local block in place.
+            _verify_rank_local_block(block, param.device_mesh)
+            sharded = distribute_tensor(block, param.device_mesh, param.placements, src_data_rank=None)
             param.to_local().copy_(sharded.to_local())
         else:
             param.copy_(block)


### PR DESCRIPTION
## Summary

<!--
Explain what changed and why. Keep this focused on the reviewer-facing context,
not a file-by-file changelog.
-->
Preserve independently loaded rank-local expert blocks when assigning VeOmni
expert-parallel checkpoint tensors.
                                             
The EP checkpoint loader reads or reconstructs a different local expert block on
each EP rank. `assign_local_block()` previously passed those blocks to
`distribute_tensor()` with its default `src_data_rank=0` behavior. This treats
rank 0 as the source of truth and scatters rank 0's input across the DTensor
mesh, discarding the independently loaded blocks on the other EP ranks.
           
Set `src_data_rank=None` so each rank constructs its DTensor shard from its own
local checkpoint block.

## Related Issue

<!--
Use "Fixes #123", "Closes #123", or "N/A" if there is no associated issue.
-->

## Test Plan

<!--
List the exact commands or jobs you ran, or write "Not run; reason: ...".
For training or rollout changes, include the model, recipe, hardware, GPU count,
and dataset/checkpoint details that make the validation reproducible.

Examples:
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `pytest`
- Hydra config validation:
  `python -m unirl.train_diffusion --config-name=<domain>/<recipe> --cfg job --resolve`
- Training / rollout smoke test:
- Not run; reason:
-->

## Compatibility / Risk

<!--
Mention config changes, checkpoint compatibility, data format changes, API changes,
GPU/resource requirement changes, migrations, risky areas, or write "N/A".
-->

## Reviewer Notes

<!--
Call out follow-up work, known limitations, AI assistance, duplicate-work checks,
or anything reviewers should inspect first. Use "N/A" if there is nothing special.
-->

## Checklist

- [ ] I reviewed the changed code and removed unrelated/generated artifacts.
- [ ] I updated tests, docs, and configs where needed, or explained why not.
