### PR TITLE
chore(ci): drop @xshrz from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,10 +40,10 @@
 /unirl/train/                           @CjhHa1 @celve @haonan3
 /unirl/train/backend/                   @celve @zzhuoxin1508 @CjhHa1
 /unirl/train/stack/                     @leviking98z-rgb @haonan3
-/unirl/train/sft/                       @haonan3 @xshrz
+/unirl/train/sft/                       @haonan3 @celve
 /unirl/train/unified_model_stack.py     @Ideny42 @zzhuoxin1508
 /unirl/trainer/                         @celve @Ideny42 @CjhHa1
-/unirl/train_sft.py                     @haonan3 @xshrz
+/unirl/train_sft.py                     @haonan3 @celve
 /unirl/train_pe.py                      @Jayce-Ping @Ideny42
 /unirl/train_unified_model.py           @Ideny42 @zzhuoxin1508
 
@@ -55,13 +55,13 @@
 /unirl/models/                          @celve @CjhHa1 @haonan3
 /unirl/models/bagel/                    @celve @Ideny42 @heguangxin
 /unirl/models/ltx2/                     @KemingWu @leviking98z-rgb
-/unirl/models/z_image/                  @xshrz @celve
-/unirl/models/wan22_v2v/                @xshrz @celve
+/unirl/models/z_image/                  @CjhHa1 @celve
+/unirl/models/wan22_v2v/                @CjhHa1 @celve
 /unirl/models/pe/                       @Jayce-Ping @celve
 /unirl/models/qwen3/                    @celve @haonan3
 /unirl/models/qwen_vl/                  @haonan3 @celve
 /unirl/models/qwen3_omni/               @CjhHa1 @zzhuoxin1508
-/unirl/models/qwen_image_edit_plus/     @CjhHa1 @xshrz
+/unirl/models/qwen_image_edit_plus/     @CjhHa1 @celve
 
 # --- reward ----------------------------------------------------------------
 /unirl/reward/                          @KemingWu @Zcchill @haonan3
@@ -72,7 +72,7 @@
 /unirl/config/                          @celve @haonan3
 /unirl/utils/                           @zzhuoxin1508 @haonan3
 /unirl/tools/                           @CjhHa1 @zzhuoxin1508
-/unirl/data/                            @haonan3 @xshrz
+/unirl/data/                            @haonan3 @celve
 
 # --- data and benchmarks ---------------------------------------------------
 /datasets/                              @KemingWu @haonan3
@@ -80,7 +80,7 @@
 
 # --- recipes ---------------------------------------------------------------
 /examples/                              @celve @leviking98z-rgb @haonan3
-/examples/sft/                          @haonan3 @xshrz
+/examples/sft/                          @haonan3 @celve
 /examples/pe/                           @Jayce-Ping @celve
 /examples/unified_model/                @zzhuoxin1508 @Ideny42
 


### PR DESCRIPTION
## Summary

Removes `@xshrz` from the seven CODEOWNERS rules that still named him, so GitHub stops auto-requesting a departed teammate on SFT, z-image, wan22 v2v, qwen-image-edit-plus, and data PRs.

Each rule still names two remaining maintainers (the documented minimum after the author is excluded): `@xshrz` is replaced by `@celve` where he was not already listed, and by `@CjhHa1` where `@celve` already was. Specific path ownership is otherwise unchanged.

Write access is a GitHub collaborator setting, not this file. It has already been revoked on `Tencent-Hunyuan/UniRL`, so `@xshrz` no longer has `push` and is no longer treated as internal.

## Related Issue

N/A

## Test Plan

- `pre-commit run --files .github/CODEOWNERS` — all applicable hooks passed (`check for merge conflicts`, `trim trailing whitespace`, `fix end of files`, `don't commit to branch`, `experimental-tier boundaries hold`; language-specific hooks skipped, no matching files).
- `git grep -n xshrz -- .github/CODEOWNERS` — no remaining matches.
- `gh api repos/Tencent-Hunyuan/UniRL/codeowners/errors?ref=refs/pull/396/head` — `{"errors":[]}`.
- `gh api repos/Tencent-Hunyuan/UniRL/collaborators/xshrz/permission` — `role_name` is now `read` (`push: false`), the public-repo default.

## Compatibility / Risk

No code, config, checkpoint, or data-format impact. The only behavioral change is reviewer routing on the seven paths above: `@xshrz` is no longer requested; `@celve` or `@CjhHa1` is requested instead.

## Reviewer Notes

AI-assisted (Cursor); the diff is seven owner-name substitutions and has been reviewed. Duplicate-work check: no open PR targeting CODEOWNERS ownership (`gh search prs --repo Tencent-Hunyuan/UniRL --state open CODEOWNERS` only returned the unrelated issue-forms PR).

Existing open PRs that already requested `@xshrz` (#343, #351, #355, #383) keep that pending request until it is dismissed; new requests will not be created after this merges.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.