### PR TITLE
fix(sampling): separate xT and denoising noise identities

### DIFF
--- a/unirl/models/hunyuan_video10/pipeline.py
+++ b/unirl/models/hunyuan_video10/pipeline.py
@@ -165,15 +165,16 @@ class HunyuanVideo10Pipeline(Pipeline):
         hv_conds = self.build_conditions(texts)
         schedule = params.sigmas.to(self.bundle.device)
 
-        initial_latents = NoiseRecipe.from_sample(sample).resolve()
+        noise_recipe = NoiseRecipe.from_sample(sample)
+        initial_latents = noise_recipe.resolve()
 
         latent_seg = self.diffusion.diffuse(
             hv_conds,
             schedule=schedule,
             params=params,
             initial_latents=initial_latents,
-            denoise_seed_keys=frontier.sample_ids if initial_latents is not None else None,
-            denoise_base_seed=int(params.seed) if params.seed is not None else 0,
+            denoise_seed_keys=noise_recipe.denoise_seed_keys or None,
+            denoise_base_seed=noise_recipe.base_seed,
         )
         videos = self.vae_decode.decode(latent_seg)
 

--- a/unirl/models/ltx2/diffusion.py
+++ b/unirl/models/ltx2/diffusion.py
@@ -274,6 +274,16 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
                     if step_eta > 0.0 and denoise_seed_keys is not None
                     else None
                 )
+                audio_step_generators = (
+                    make_denoise_step_generators(
+                        base_seed=int(denoise_base_seed),
+                        step_index=step_idx,
+                        sample_ids=[str(key) for key in denoise_seed_keys],
+                        salt="audio",
+                    )
+                    if step_eta > 0.0 and self._audio_in_policy and denoise_seed_keys is not None
+                    else None
+                )
 
                 video_pred, audio_pred = self.step_kernel.predict_noise(
                     self.bundle,
@@ -307,6 +317,7 @@ class LTX2DiffusionStage(DiffusionStage[LTX2Conditions]):
                     sigma=sigma,
                     sigma_next=sigma_next,
                     eta=audio_eta,
+                    generator=audio_step_generators,
                     sigma_max=sigma_max,
                     step_index=step_idx,
                 )

--- a/unirl/models/ltx2/pipeline.py
+++ b/unirl/models/ltx2/pipeline.py
@@ -234,8 +234,8 @@ class LTX2Pipeline(Pipeline):
             initial_latents=initial_latents,
             initial_audio_latents=initial_audio_latents,
             sde_indices=sde_indices,
-            denoise_seed_keys=[str(sample_id) for sample_id in sample.sample_ids],
-            denoise_base_seed=int(params.seed) if params.seed is not None else 0,
+            denoise_seed_keys=video_recipe.denoise_seed_keys or None,
+            denoise_base_seed=video_recipe.base_seed,
         )
 
         _, latent_t, latent_h, latent_w = self.latent_shape(model_config=self.config, sampling_spec=params)

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_denoising.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_denoising.py
@@ -15,6 +15,8 @@ def _make_step_generators(
     step_index: int,
     device: torch.device,
     denoise_seeds: list[str],
+    *,
+    salt: str = "",
 ) -> list[torch.Generator]:
     """Per-sample deterministic CPU generators for one SDE step."""
     del device
@@ -22,6 +24,7 @@ def _make_step_generators(
         base_seed=int(base_seed),
         step_index=int(step_index),
         sample_ids=[str(seed_key) for seed_key in denoise_seeds],
+        salt=salt,
     )
 
 

--- a/unirl/rollout/engine/sglang_diffusion/_patches/patch_ltx2_rollout_sde.py
+++ b/unirl/rollout/engine/sglang_diffusion/_patches/patch_ltx2_rollout_sde.py
@@ -201,23 +201,38 @@ def _patch_sde_logprob_bridge() -> None:
 
         def _run_denoising_step(self, ctx, step, batch, server_args):
             sched = getattr(ctx, "scheduler", None)
-            gen = None
+            audio_sched = getattr(ctx, "audio_scheduler", None)
+            video_gen = None
+            audio_gen = None
             denoise_seeds = getattr(batch, "denoise_seeds", None)
             if getattr(batch, "rollout", False) and denoise_seeds is not None:
                 base_seed = _resolve_base_seed(batch)
                 if base_seed is not None:
-                    gen = _make_step_generators(
+                    video_gen = _make_step_generators(
                         base_seed, int(step.step_index), ctx.latents.device, list(denoise_seeds)
+                    )
+                    audio_gen = _make_step_generators(
+                        base_seed,
+                        int(step.step_index),
+                        ctx.latents.device,
+                        list(denoise_seeds),
+                        salt="audio",
                     )
             if sched is not None:
                 sched._unirl_rollout_batch = batch
-                sched._unirl_rollout_generator = gen
+                sched._unirl_rollout_generator = video_gen
+            if audio_sched is not None:
+                audio_sched._unirl_rollout_batch = batch
+                audio_sched._unirl_rollout_generator = audio_gen
             try:
                 return orig_stage_step(self, ctx, step, batch, server_args)
             finally:
                 if sched is not None:
                     sched._unirl_rollout_batch = None
                     sched._unirl_rollout_generator = None
+                if audio_sched is not None:
+                    audio_sched._unirl_rollout_batch = None
+                    audio_sched._unirl_rollout_generator = None
 
         _run_denoising_step._unirl_ltx2_rollout_sde = True  # type: ignore[attr-defined]
         LTX2DenoisingStage._run_denoising_step = _run_denoising_step

--- a/unirl/rollout/engine/sglang_diffusion/adapters/image.py
+++ b/unirl/rollout/engine/sglang_diffusion/adapters/image.py
@@ -8,6 +8,7 @@ from unirl.config.require import require
 from unirl.rollout.engine.sglang_diffusion import utils
 from unirl.rollout.engine.sglang_diffusion.adapters.base import ModelAdapter
 from unirl.rollout.engine.sglang_diffusion.backends import RawResult
+from unirl.types.noise_recipe import NoiseRecipe
 from unirl.types.primitives import Texts, primitive_modality_key
 from unirl.types.sample import Sample
 from unirl.types.sampling import DiffusionSamplingParams, is_forward_process
@@ -85,11 +86,11 @@ class ImageAdapter(ModelAdapter):
             if float(diffusion.guidance_scale) > 1.0 and neg_prompt is not None:
                 kwargs["return_negative_prompt_embeds"] = True
 
-        # Key per-step SDE noise by sample ID to preserve within-group exploration.
+        noise_recipe = NoiseRecipe.from_sample(sample)
         if initial_noise is not None:
             kwargs["initial_noise"] = initial_noise
-            if gen_part.sample_ids:
-                kwargs["denoise_seeds"] = [str(sid) for sid in gen_part.sample_ids]
+        if noise_recipe.denoise_seed_keys:
+            kwargs["denoise_seeds"] = noise_recipe.denoise_seed_keys
 
         # RawResult must use dit_trajectory; trajectory_latents omits x_T and is not output-sliced.
         kwargs["rollout"] = True

--- a/unirl/sde/noise.py
+++ b/unirl/sde/noise.py
@@ -12,17 +12,20 @@ MAX_TORCH_SEED = (1 << 63) - 1
 PROMPT_SEED_PREFIX = "prompt:"
 
 
-def make_prompt_seed_group_id(prompt: str, sample_ordinal: int = 0) -> str:
-    """Encode prompt content and a sibling-sample ordinal into an eval noise group id."""
+def make_prompt_seed_group_id(
+    prompt: str,
+    sample_ordinal: int = 0,
+    *,
+    prompt_id: Optional[str] = None,
+) -> str:
+    """Encode stable prompt identity and sibling ordinal into an eval noise group id."""
     ordinal = int(sample_ordinal)
     if ordinal < 0:
         raise ValueError(f"sample_ordinal must be non-negative, got {ordinal}")
-    payload = json.dumps(
-        {"prompt": str(prompt), "sample": ordinal},
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
+    fields = {"prompt": str(prompt), "sample": ordinal}
+    if prompt_id is not None:
+        fields["prompt_id"] = str(prompt_id)
+    payload = json.dumps(fields, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return f"{PROMPT_SEED_PREFIX}{payload}"
 
 
@@ -32,6 +35,7 @@ def _derive_group_seed(base_seed: int, group_id: str) -> int:
     if gid.startswith(PROMPT_SEED_PREFIX):
         payload = gid[len(PROMPT_SEED_PREFIX) :]
         sample_ordinal = 0
+        prompt_id = None
         try:
             decoded = json.loads(payload)
         except json.JSONDecodeError:
@@ -40,19 +44,22 @@ def _derive_group_seed(base_seed: int, group_id: str) -> int:
             if not isinstance(decoded, dict) or not isinstance(decoded.get("prompt"), str):
                 raise ValueError(f"invalid prompt-seed group id: {gid!r}")
             prompt = decoded["prompt"]
+            prompt_id = decoded.get("prompt_id")
             sample_ordinal = int(decoded.get("sample", 0))
             if sample_ordinal < 0:
                 raise ValueError(f"invalid prompt-seed sample ordinal: {sample_ordinal}")
-        digest = hashlib.sha256(prompt.encode("utf-8")).digest()
+        seed_key = prompt if prompt_id is None else f"{prompt}\0{prompt_id}"
+        digest = hashlib.sha256(seed_key.encode("utf-8")).digest()
         return (int(base_seed) + int.from_bytes(digest[:4], "big") + sample_ordinal) % (2**31)
     payload = f"{int(base_seed)}::{gid}".encode("utf-8")
     digest = hashlib.blake2b(payload, digest_size=8).digest()
     return int.from_bytes(digest, byteorder="big", signed=False) % (MAX_TORCH_SEED + 1)
 
 
-def derive_denoise_step_seed(base_seed: int, step_index: int, sample_id: str) -> int:
+def derive_denoise_step_seed(base_seed: int, step_index: int, sample_id: str, *, salt: str = "") -> int:
     """Derive the cross-engine per-sample, per-step SDE-noise seed."""
-    payload = (f"{int(base_seed)}::step::{int(step_index)}::sample::{str(sample_id)}").encode("utf-8")
+    seed_key = f"{sample_id}::{salt}" if salt else str(sample_id)
+    payload = (f"{int(base_seed)}::step::{int(step_index)}::sample::{seed_key}").encode("utf-8")
     digest = hashlib.blake2b(payload, digest_size=8).digest()
     return int.from_bytes(digest, byteorder="big", signed=False) % MAX_TORCH_SEED
 
@@ -62,8 +69,9 @@ def make_denoise_step_generators(
     base_seed: int,
     step_index: int,
     sample_ids: List[str],
+    salt: str = "",
 ) -> List[torch.Generator]:
-    """Build deterministic CPU generators for one SDE transition."""
+    """Build deterministic CPU generators for one SDE transition and namespace."""
     generators: List[torch.Generator] = []
     for sample_id in sample_ids:
         generator = torch.Generator(device="cpu")
@@ -72,6 +80,7 @@ def make_denoise_step_generators(
                 base_seed=int(base_seed),
                 step_index=int(step_index),
                 sample_id=str(sample_id),
+                salt=salt,
             )
         )
         generators.append(generator)

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -561,6 +561,7 @@ class DiffusionTrainer(BaseTrainer):
     ) -> Sample:
         """Turn a data source batch into a request :class:`Sample`."""
         sp = sampling if sampling is not None else self.sampling_params
+        eval_prompt_ids = list(inputs.parts[0].sample_ids) if sampling is not None else []
         noise_latent_shape = self._eval_noise_latent_shape if sampling is not None else self._noise_latent_shape
         diffusion = sp.get("diffusion")
         sde_indices = diffusion.resolve_sde_indices(rollout_id)
@@ -577,7 +578,7 @@ class DiffusionTrainer(BaseTrainer):
         samples_per_prompt = total_samples_per_prompt(sp)
         request = request.fork(samples_per_prompt, sampling_params=diffusion)
 
-        if sampling is not None and noise_latent_shape is not None:
+        if sampling is not None:
             from unirl.sde.noise import make_prompt_seed_group_id
 
             texts = next((value for value in request.conditioning() if isinstance(value, Texts)), None)
@@ -588,10 +589,18 @@ class DiffusionTrainer(BaseTrainer):
                     f"sample count {len(request.parts[-1].sample_ids)}."
                 )
             noise_group_ids = [
-                make_prompt_seed_group_id(text, sample_ordinal=index % samples_per_prompt)
+                make_prompt_seed_group_id(
+                    text,
+                    sample_ordinal=index % samples_per_prompt,
+                    prompt_id=eval_prompt_ids[index // samples_per_prompt],
+                )
                 for index, text in enumerate(texts.texts)
             ]
-            frontier = dataclasses.replace(request.parts[-1], init_noise_group_ids=noise_group_ids)
+            frontier = dataclasses.replace(
+                request.parts[-1],
+                init_noise_group_ids=noise_group_ids if noise_latent_shape is not None else [],
+                denoise_seed_keys=noise_group_ids,
+            )
             request = request.with_parts([*request.parts[:-1], frontier])
         return request
 

--- a/unirl/types/README.md
+++ b/unirl/types/README.md
@@ -56,6 +56,7 @@ it is not inferred from `sampling_params.samples_per_prompt`.
 | `sigmas` | `DiffusionSamplingParams.sigmas` on the diffusion generation part |
 | `metadata` | Root input `Part.metadata`; use `Sample.root_metadata(part_index)` to align it with descendants |
 | `init_noise_group_ids` | Derived from generated `sample_ids` / `group_ids` by `NoiseRecipe.from_sample(...)`; deterministic eval may override them on the gen `Part` |
+| `denoise_seed_keys` | Per-sample SDE-noise identities derived by `NoiseRecipe.from_sample(...)`; deterministic eval may override them independently from x_T sharing |
 | `init_noise_latent_shape` | `DiffusionSamplingParams.init_noise_latent_shape` |
 
 ### `RolloutResp` and `RolloutTrack`

--- a/unirl/types/noise_recipe.py
+++ b/unirl/types/noise_recipe.py
@@ -1,4 +1,4 @@
-"""``NoiseRecipe`` — the normalized, engine-agnostic x_T recipe."""
+"""``NoiseRecipe`` — normalized, engine-agnostic diffusion noise identity."""
 
 from __future__ import annotations
 
@@ -10,21 +10,28 @@ import torch
 
 @dataclass
 class NoiseRecipe:
-    """Normalized x_T recipe consumed by every engine (see module docstring)."""
+    """Driver-authored identities for initial and per-step diffusion noise."""
 
     noise_group_ids: List[str] = field(default_factory=list)
+    denoise_seed_keys: List[str] = field(default_factory=list)
     base_seed: int = 0
     latent_shape: Optional[Tuple[int, ...]] = None
     initial_latents: Optional[torch.Tensor] = None
 
     def for_batch(self, batch_size: int, *, latent_shape: Optional[Tuple[int, ...]] = None) -> "NoiseRecipe":
         """Specialize this (per-sample) recipe to a concrete ``batch_size``-row engine call, returning a NEW recipe."""
-        gids = self.noise_group_ids
-        if gids and len(gids) != batch_size:
-            gids = gids[:batch_size] if len(gids) >= batch_size else [gids[i % len(gids)] for i in range(batch_size)]
+
+        def align(keys: List[str]) -> List[str]:
+            if not keys or len(keys) == batch_size:
+                return list(keys)
+            return (
+                list(keys[:batch_size]) if len(keys) >= batch_size else [keys[i % len(keys)] for i in range(batch_size)]
+            )
+
         return replace(
             self,
-            noise_group_ids=gids,
+            noise_group_ids=align(self.noise_group_ids),
+            denoise_seed_keys=align(self.denoise_seed_keys),
             latent_shape=latent_shape if latent_shape is not None else self.latent_shape,
         )
 
@@ -58,19 +65,20 @@ class NoiseRecipe:
         """Build a recipe from a request ``Sample`` (its gen frontier part)."""
         gen = sample.parts[-1]
         diffusion = gen.sampling_params
-        if bool(getattr(diffusion, "disable_driver_xt", False)):
-            return cls()
         seg = gen.segment
-        explicit_keys = list(getattr(gen, "init_noise_group_ids", None) or [])
+        disable_xt = bool(getattr(diffusion, "disable_driver_xt", False))
+        explicit_xt_keys = list(getattr(gen, "init_noise_group_ids", None) or [])
         share = bool(getattr(diffusion, "init_same_noise", False)) if diffusion is not None else False
-        keys = explicit_keys or (gen.group_ids if share else list(gen.sample_ids))
+        xt_keys = [] if disable_xt else explicit_xt_keys or (gen.group_ids if share else list(gen.sample_ids))
+        denoise_keys = list(getattr(gen, "denoise_seed_keys", None) or gen.sample_ids)
         shape = getattr(diffusion, "init_noise_latent_shape", None) if diffusion is not None else None
         seed = int(diffusion.seed) if diffusion is not None and getattr(diffusion, "seed", None) is not None else 0
         return cls(
-            noise_group_ids=[str(k) for k in keys],
+            noise_group_ids=[str(k) for k in xt_keys],
+            denoise_seed_keys=[str(k) for k in denoise_keys],
             base_seed=seed,
             latent_shape=tuple(shape) if shape else None,
-            initial_latents=getattr(seg, "initial_latents", None) if seg is not None else None,
+            initial_latents=None if disable_xt or seg is None else getattr(seg, "initial_latents", None),
         )
 
 

--- a/unirl/types/sample.py
+++ b/unirl/types/sample.py
@@ -75,6 +75,7 @@ class Part(Batch):
     output_version: Optional[int] = shared_field(default=None)
     harness_status: Optional[str] = shared_field(default=None)
     init_noise_group_ids: List[str] = concat_field(default_factory=list)
+    denoise_seed_keys: List[str] = concat_field(default_factory=list)
 
     def __post_init__(self) -> None:
         expected_batch = len(self.sample_ids)
@@ -109,6 +110,11 @@ class Part(Batch):
             raise ValueError(
                 "Part.init_noise_group_ids must be empty or aligned with sample_ids; "
                 f"got {len(self.init_noise_group_ids)} keys for {expected_batch} samples."
+            )
+        if self.denoise_seed_keys and len(self.denoise_seed_keys) != expected_batch:
+            raise ValueError(
+                "Part.denoise_seed_keys must be empty or aligned with sample_ids; "
+                f"got {len(self.denoise_seed_keys)} keys for {expected_batch} samples."
             )
 
     @classmethod


### PR DESCRIPTION
## Summary

Separate initial-latent (`x_T`) identity from per-step SDE denoising identity in the driver-authored noise recipe.

- keep `init_same_noise` sharing limited to `x_T` while preserving per-sample denoising exploration;
- propagate denoising seed keys through trainside HunyuanVideo 1.0/LTX-2 and SGLang diffusion paths;
- namespace LTX-2 video and audio SDE noise independently; and
- make deterministic eval keys stable for duplicate prompt text by including the source row ID and sibling ordinal.

Empty `denoise_seed_keys` remain backward compatible by falling back to generated sample IDs.

## Related Issue

N/A

## Test Plan

- `pre-commit run --files <all 11 changed files>` — passed all applicable hooks.
- `ruff check <changed Python files>` — passed.
- `ruff format --check <changed Python files>` — passed.
- `python -m py_compile <changed Python files>` — passed.
- `python lint/check_docstring_lines.py` — passed (`3228` docstrings checked).
- `python lint/check_core_dependencies.py` — passed.
- `python lint/check_recipe_targets.py` — passed (`2496` recipe targets checked).
- One-off CPU Torch harness in the project environment verified same-key/same-step reproducibility, sibling/step separation, video/audio namespace separation, shared `x_T` with independent denoising keys, `disable_driver_xt` preserving denoising keys, and `Part.slice`/`Part.concat` alignment.
- One-off harness against pinned `sglang==0.5.12.post1` verified that the LTX-2 bridge forwards separate per-sample video/audio generators to both schedulers and clears temporary scheduler state afterward.

## Compatibility / Risk

- Adds an optional batch-aligned `Part.denoise_seed_keys` field. Empty values preserve the previous sample-ID behavior.
- Existing initial-noise recipes and checkpoint formats are unchanged.
- Deterministic eval noise for duplicate prompt strings now also depends on the stable source row ID.

## Reviewer Notes

Duplicate-work check: open PR #390 directly passes sample IDs for one HunyuanVideo-1.5/vLLM-Omni path; this PR instead defines the general request/recipe contract and consumes it across trainside and SGLang paths. No other open PR was found for `NoiseRecipe` or denoising seed identity.

AI assistance was used. The full diff and reported validation output were reviewed before publication.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
