### PR TITLE
fix(rollout): separate transfer and policy versions

### DIFF
--- a/unirl/rollout/engine/fastvideo/engine.py
+++ b/unirl/rollout/engine/fastvideo/engine.py
@@ -181,6 +181,7 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         )
 
         self._version = 0
+        self._weight_update_calls = 0
         self._generate_lock = threading.Lock()
         self._shutdown_lock = threading.Lock()
         self._shutdown_requested = False
@@ -620,7 +621,7 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             require(self._generator is not None, "fastvideo engine is offloaded/not initialized")
             self._generator.update_transformer_weights_from_path(checkpoint_path)
             self._last_weights_path = checkpoint_path
-            self._version += 1
+            self._weight_update_calls += 1
             logger.info("fastvideo transformer weights updated from %s", checkpoint_path)
 
 

--- a/unirl/rollout/engine/sglang/engine.py
+++ b/unirl/rollout/engine/sglang/engine.py
@@ -152,6 +152,7 @@ class SGLangRolloutEngine(BaseRolloutEngine):
         )
 
         self._version = 0
+        self._weight_update_calls = 0
 
     def _prepare_generation(self, sample: Sample) -> Any:
         require(
@@ -282,7 +283,7 @@ class SGLangRolloutEngine(BaseRolloutEngine):
             load_format=load_format,
             flush_cache=flush_cache,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def init_weights_update_group(
         self,
@@ -329,7 +330,7 @@ class SGLangRolloutEngine(BaseRolloutEngine):
             group_name=group_name,
             flush_cache=flush_cache,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def destroy_weights_update_group(
         self,

--- a/unirl/rollout/engine/sglang_diffusion/engine.py
+++ b/unirl/rollout/engine/sglang_diffusion/engine.py
@@ -98,6 +98,7 @@ class SGLangDiffusionRolloutEngine(BaseRolloutEngine):
         self.schedule_policy = self.adapter.schedule_policy()
 
         self._version = 0
+        self._weight_update_calls = 0
         self._generate_lock = threading.Lock()
         self._shutdown_lock = threading.Lock()
         self._shutdown_requested = False
@@ -236,7 +237,7 @@ class SGLangDiffusionRolloutEngine(BaseRolloutEngine):
             load_format=load_format,
             flush_cache=flush_cache,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def init_weights_update_group(
         self,
@@ -279,7 +280,7 @@ class SGLangDiffusionRolloutEngine(BaseRolloutEngine):
             target_modules=target_modules,
             flush_cache=flush_cache,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def destroy_weights_update_group(
         self,

--- a/unirl/rollout/engine/vllm_omni/engine.py
+++ b/unirl/rollout/engine/vllm_omni/engine.py
@@ -38,6 +38,7 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
     ) -> None:
         self.cfg = config
         self._version = 0
+        self._weight_update_calls = 0
         self._generate_lock = threading.Lock()
         self._shutdown_lock = threading.Lock()
         self._shutdown_requested = False
@@ -256,7 +257,7 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
             use_shm=use_shm,
             replica_rank=replica_rank,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def init_weights_update_group(
         self,
@@ -299,7 +300,7 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
             target_modules=target_modules,
             flush_cache=flush_cache,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def destroy_weights_update_group(
         self,
@@ -326,7 +327,7 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
             load_format=load_format,
             flush_cache=flush_cache,
         )
-        self._version += 1
+        self._weight_update_calls += 1
 
     def set_lora_from_tensors(
         self,


### PR DESCRIPTION
## Summary

Keep receiver-local transfer counts separate from the trainer policy version stamped on rollout output. Successful weight transfers increment `_weight_update_calls`, leaving `_version` to the publication contract.

Rebased onto `c8af5d6` and included the checkpoint-engine IPC receiver added in #225. Its successful update previously changed published version 7 to 8; it now preserves 7 and counts one transfer.

## Related Issue

Fixes #324.

## Test Plan

- `python3 ../review-followup-2026-09-20/check_unirl_receivers.py .` — disposable CPU harness discovers and executes all 15 concrete/forwarding `update_weights_from_*` methods from the checkout with stubbed transport backends. All 30 success/failure cases pass, plus three-bucket counting, non-TP-zero no-ops, and checkpoint-engine poisoned-retry checks. The same harness failed on the rebased code before the one-line IPC fix (`_version=8`, expected 7).
- `SKIP=no-commit-to-branch uvx pre-commit run --files unirl/rollout/engine/fastvideo/engine.py unirl/rollout/engine/sglang/engine.py unirl/rollout/engine/sglang_diffusion/engine.py unirl/rollout/engine/vllm_omni/engine.py --show-diff-on-failure` — all applicable hooks pass.
- No new GPU/model run locally. The reviewer's separate H20/SGLang tensor-path result is not included as locally performed validation.

## Compatibility / Risk

No configuration or public API changes. Existing publication ordering, checkpoint-engine failure poisoning, and native vLLM publication remain unchanged. CPU checks exercise the receiver method bodies, not real transport implementations.

## Reviewer Notes

AI-assisted.

## Checklist

- [x] Full diff checked for unrelated/generated artifacts.
- [x] Relevant validation completed and limitations documented above.
