### PR TITLE
perf(qwen_image): skip unused tokenizer load

### DIFF
--- a/unirl/models/qwen_image/bundle.py
+++ b/unirl/models/qwen_image/bundle.py
@@ -27,7 +27,7 @@ class QwenImageBundle(Bundle):
         transformer: nn.Module,
         vae: Optional[nn.Module],
         text_encoder: Optional[nn.Module],
-        tokenizer: Any,
+        tokenizer: Optional[Any],
         scheduler: Any,
         dtype: torch.dtype,
         device: torch.device,
@@ -104,6 +104,7 @@ class QwenImageBundle(Bundle):
             vae.requires_grad_(False)
 
         text_encoder = None
+        tokenizer = None
         if config.load_text_encoder:
             text_encoder = (
                 Qwen2_5_VLForConditionalGeneration.from_pretrained(
@@ -113,8 +114,7 @@ class QwenImageBundle(Bundle):
                 .eval()
             )
             text_encoder.requires_grad_(False)
-
-        tokenizer = Qwen2Tokenizer.from_pretrained(text_encoder_path, subfolder="tokenizer")
+            tokenizer = Qwen2Tokenizer.from_pretrained(text_encoder_path, subfolder="tokenizer")
 
         scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(path, subfolder="scheduler")
 


### PR DESCRIPTION
## Summary

Skip loading the Qwen Image tokenizer when load_text_encoder=False. The tokenizer is only used by the text-embedding stage, which is absent on that path; load_text_encoder=True behavior is unchanged.

## Related Issue

Fixes #241.

## Test Plan

- SKIP=no-commit-to-branch uvx pre-commit run --files unirl/models/qwen_image/bundle.py --show-diff-on-failure — all applicable hooks passed.
- Disposable in-memory fake-loader harness — verified Qwen Image and Edit-Plus skip both tokenizer and text-encoder loads when disabled and preserve the existing paths and arguments when enabled.

## Compatibility / Risk

No configuration, checkpoint, data-format, or public API changes. The bundle tokenizer is now None only on the existing no-text-encoder path.

## Reviewer Notes

No overlapping open PR modifies this bundle or addresses #241. AI assistance was used; the complete diff and validation results were reviewed before publication.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
