### PR TITLE
fix(reward): inject nested T2AV scorers and require prompt-video alignment

### DIFF
--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -12,8 +12,9 @@
 #   - clap           (audio-text alignment, LAION CLAP; zero extra deps)
 # ImageBind (audio-video alignment) is also available as an inner scorer but is
 # NOT enabled here: it requires the facebookresearch/ImageBind package and is
-# CC-BY-NC-SA 4.0 (NonCommercial). To enable, add `imagebind: <weight>` to the
-# composite weights (and install the package).
+# CC-BY-NC-SA 4.0 (NonCommercial). To enable it, nest an ImageBind scorer with
+# mode: text_video or all; audio_video does not relate the prompt to the video,
+# so the composite rejects that mode unless another scorer supplies this term.
 #
 # With audio_joint_sde=true, audio is part of the SDE policy AND now receives a
 # direct reward signal, so it is optimized toward prompt alignment (not just
@@ -120,17 +121,26 @@ reward:
   _target_: unirl.reward.service.RewardService
   backend:
     _target_: unirl.reward.local.t2av_composite.T2AVCompositeScorer
-    base_device: cuda
     config:
       _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
-      batch_size: 4
-      device: auto
-      # Inner scorer name -> blend weight. videopickscore reads the video,
-      # clap reads the parallel audio side-channel. To add audio-video
-      # alignment, install ImageBind and add `imagebind: <w>` here.
       weights:
         videopickscore: 0.5
         clap: 0.5
+      scorers:
+        videopickscore:
+          _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+          base_device: cuda
+          config:
+            _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+            batch_size: 4
+            device: auto
+        clap:
+          _target_: unirl.reward.local.clap.CLAPRewardScorer
+          base_device: cuda
+          config:
+            _target_: unirl.reward.local.clap.CLAPSpec
+            batch_size: 4
+            device: auto
 
 algorithm:
   _target_: unirl.algorithms.flowgrpo.FlowGRPO

--- a/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
+++ b/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
@@ -3,7 +3,7 @@
 #
 # Against the sibling `minimax_h3_t2va_trainside.yaml` (Flow-GRPO, 768x768):
 # a forward-process objective, 256x384, all 10 transitions trained, and a reward
-# that scores audio/video agreement rather than a single frame.
+# that scores audio/video agreement plus prompt alignment rather than one frame.
 #
 # Launch (1 node x 8 GPUs):
 #   bash examples/run_experiment_multinode_taiji.sh diffusion/minimax_h3/minimax_h3_t2va_nft
@@ -133,11 +133,8 @@ reward:
   _target_: unirl.reward.service.RewardService
   backend:
     _target_: unirl.reward.local.t2av_composite.T2AVCompositeScorer
-    base_device: cuda
     config:
       _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
-      device: auto
-      batch_size: 2
       # Summed raw, not renormalised. The imagebind package loads its checkpoint
       # from a RELATIVE ./.checkpoints/imagebind_huge.pth.
       #
@@ -145,6 +142,29 @@ reward:
       weights:
         clap: 1.0
         imagebind: 1.0
+      scorers:
+        clap:
+          _target_: unirl.reward.local.clap.CLAPRewardScorer
+          base_device: cuda
+          config:
+            _target_: unirl.reward.local.clap.CLAPSpec
+            batch_size: 2
+            device: auto
+        imagebind:
+          _target_: unirl.reward.local.imagebind.ImageBindRewardScorer
+          base_device: cuda
+          config:
+            _target_: unirl.reward.local.imagebind.ImageBindSpec
+            batch_size: 2
+            device: auto
+            # Include prompt-video alignment; audio_video alone rewards the
+            # measured black/silent collapse.
+            mode: all
+            # Keep ImageBind's default mix explicit so the objective is visible.
+            weights:
+              audio_video: 0.5
+              text_audio: 0.25
+              text_video: 0.25
 
 algorithm:
   _target_: unirl.algorithms.diffusionnft.DiffusionNFT

--- a/examples/diffusion/minimax_h3/minimax_h3_t2va_trainside.yaml
+++ b/examples/diffusion/minimax_h3/minimax_h3_t2va_trainside.yaml
@@ -183,12 +183,8 @@ reward:
   _target_: unirl.reward.service.RewardService
   backend:
     _target_: unirl.reward.local.t2av_composite.T2AVCompositeScorer
-    base_device: cpu
     config:
       _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
-      device: cpu
-      batch_size: 2
-      frame_selection: middle
       # videopickscore scores the middle frame (image-text alignment), and
       # clap scores generated-audio-vs-text. Neither measures motion or A/V
       # sync; the only real sync scorer is imagebind, which is CC-BY-NC-SA and
@@ -196,6 +192,22 @@ reward:
       weights:
         videopickscore: 0.5
         clap: 0.5
+      scorers:
+        videopickscore:
+          _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+          base_device: cpu
+          config:
+            _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+            batch_size: 2
+            device: cpu
+            frame_selection: middle
+        clap:
+          _target_: unirl.reward.local.clap.CLAPRewardScorer
+          base_device: cpu
+          config:
+            _target_: unirl.reward.local.clap.CLAPSpec
+            batch_size: 2
+            device: cpu
 
 algorithm:
   _target_: unirl.algorithms.flowgrpo.FlowGRPO

--- a/unirl/reward/base.py
+++ b/unirl/reward/base.py
@@ -55,6 +55,15 @@ class RewardBackend(ABC):
 
 
 @runtime_checkable
+class PromptVideoReward(Protocol):
+    """Optional capability for rewards that score prompt-to-video alignment."""
+
+    def covers_prompt_video(self) -> bool:
+        """Whether the configured reward gives prompt-to-video alignment positive weight."""
+        ...
+
+
+@runtime_checkable
 class DifferentiableReward(Protocol):
     """Optional capability: in-process ``nn.Module`` rewards returning a grad-carrying score tensor for ReFL."""
 
@@ -75,5 +84,6 @@ class BaseRewardComponentSpec(ABC):
 __all__ = [
     "BaseRewardComponentSpec",
     "DifferentiableReward",
+    "PromptVideoReward",
     "RewardBackend",
 ]

--- a/unirl/reward/local/imagebind.py
+++ b/unirl/reward/local/imagebind.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import math
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import torch
@@ -39,21 +40,39 @@ _IB_VISION_SIZE = 224
 _IB_VISION_MEAN = (0.48145466, 0.4578275, 0.40821073)
 _IB_VISION_STD = (0.26862954, 0.26130258, 0.27577711)
 
+_IMAGEBIND_MODES = ("audio_video", "text_audio", "text_video", "all")
+_IMAGEBIND_DEFAULT_WEIGHTS = {"audio_video": 0.5, "text_audio": 0.25, "text_video": 0.25}
+
 
 class ImageBindRewardScorer(LocalRewardBackend):
     """Audio-video / audio-text alignment reward using Meta ImageBind."""
 
     canonical_model_name = "imagebind"
     input_kind = "video"
-    DEFAULT_MODE = "audio_video"
 
     def __init__(self, *, config: "ImageBindSpec", base_device: str) -> None:
-        self._mode = str(config.mode or self.DEFAULT_MODE)
-        self._weights = dict(config.weights or {"audio_video": 0.5, "text_audio": 0.25, "text_video": 0.25})
+        self._mode = config.mode
+        if self._mode not in _IMAGEBIND_MODES:
+            raise ValueError(f"ImageBindSpec.mode must be one of {_IMAGEBIND_MODES}; got {config.mode!r}.")
+        self._weights = dict(config.weights or _IMAGEBIND_DEFAULT_WEIGHTS)
+        if self._mode == "all":
+            if set(self._weights) != set(_IMAGEBIND_DEFAULT_WEIGHTS):
+                raise ValueError(
+                    f"ImageBindSpec.weights must contain exactly {sorted(_IMAGEBIND_DEFAULT_WEIGHTS)} "
+                    f"for mode='all'; got {sorted(self._weights)}."
+                )
+            if any(
+                not isinstance(weight, (int, float)) or not math.isfinite(weight) for weight in self._weights.values()
+            ):
+                raise ValueError("ImageBindSpec.weights values must be finite numbers.")
+            self._weights = {name: float(weight) for name, weight in self._weights.items()}
         super().__init__(
             device=resolve_device(config.device, base_device),
             batch_size=config.batch_size,
         )
+
+    def covers_prompt_video(self) -> bool:
+        return self._mode == "text_video" or (self._mode == "all" and self._weights["text_video"] > 0.0)
 
     def _load_model(self) -> None:
         warnings.warn(_IMAGEBIND_LICENSE_WARNING, stacklevel=2)
@@ -226,13 +245,11 @@ class ImageBindRewardScorer(LocalRewardBackend):
             return cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
         if self._mode == "text_video":
             return cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
-        if self._mode == "all":
-            w = self._weights
-            av = cos(embeddings[ModalityType.AUDIO], embeddings[ModalityType.VISION])
-            ta = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
-            tv = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
-            return w["audio_video"] * av + w["text_audio"] * ta + w["text_video"] * tv
-        raise ValueError(f"Unknown ImageBind mode {self._mode!r}; expected audio_video|text_audio|text_video|all.")
+        w = self._weights
+        av = cos(embeddings[ModalityType.AUDIO], embeddings[ModalityType.VISION])
+        ta = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.AUDIO])
+        tv = cos(embeddings[ModalityType.TEXT], embeddings[ModalityType.VISION])
+        return w["audio_video"] * av + w["text_audio"] * ta + w["text_video"] * tv
 
 
 @dataclass
@@ -242,4 +259,4 @@ class ImageBindSpec(BaseRewardComponentSpec):
     batch_size: int = 8
     device: str = "auto"
     mode: str = "audio_video"
-    weights: Optional[Dict[str, float]] = field(default=None)
+    weights: Optional[Dict[str, float]] = None

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -31,7 +31,7 @@ class T2AVCompositeScorer(RewardBackend):
             import dataclasses
 
             # Propagate only fields BOTH the composite and the inner spec declare.
-            shared = ("device", "batch_size", "frame_selection")
+            shared = ("device", "batch_size", "frame_selection", "mode")
             overrides = {f: getattr(config, f) for f in shared if hasattr(inner_spec, f) and hasattr(config, f)}
             if overrides:
                 inner_spec = dataclasses.replace(inner_spec, **overrides)
@@ -101,4 +101,9 @@ class T2AVCompositeSpec(BaseRewardComponentSpec):
     # keeps the historical behaviour; "middle" avoids scoring a blank opening
     # frame on clips that fade or reveal in.
     frame_selection: str = "first"
+    # Forwarded to inner scorers that declare it (imagebind only). Defaults to
+    # ImageBindSpec's own default so existing recipes are unaffected; set "all"
+    # to include the text terms, without which nothing scored here relates the
+    # prompt to the video.
+    mode: str = "audio_video"
     weights: Dict[str, float] = field(default_factory=lambda: {"videopickscore": 0.5, "clap": 0.5})

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -2,40 +2,72 @@
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List
 
-from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
+from unirl.reward.base import BaseRewardComponentSpec, PromptVideoReward, RewardBackend
 from unirl.types.reward import RewardRequest, RewardResponse
 
-from .registry import resolve_builtin_reward_scorer_class, resolve_builtin_reward_spec_class
+
+def _require_prompt_video_term(weights: Dict[str, float], scorers: Dict[str, RewardBackend]) -> None:
+    coverage = {
+        name: isinstance(scorer, PromptVideoReward) and scorer.covers_prompt_video() for name, scorer in scorers.items()
+    }
+    if any(weights[name] > 0.0 and coverage[name] for name in scorers):
+        return
+    details = ", ".join(f"{name}(weight={weights[name]}, covers_prompt_video={coverage[name]})" for name in weights)
+    raise ValueError(
+        "T2AVCompositeScorer: no positive-weight inner scorer relates the prompt to the video. "
+        f"Current mix: {details}. "
+        "Add videopickscore / videoalign, or set scorers.imagebind.config.mode to "
+        "'text_video' or 'all'. clap and imagebind mode='audio_video' do not cover this."
+    )
 
 
 class T2AVCompositeScorer(RewardBackend):
-    """Weighted blend of inner reward scorers for T2AV (video + audio)."""
+    """Weighted blend of Hydra-instantiated inner reward scorers for T2AV."""
 
     input_kind = "video"
 
-    def __init__(self, *, config: "T2AVCompositeSpec", base_device: str) -> None:
-        super().__init__(model_name="t2av_composite", batch_size=config.batch_size)
-        self.weights: Dict[str, float] = dict(config.weights or {})
-        if not self.weights:
+    def __init__(self, *, config: "T2AVCompositeSpec", base_device: str = "auto") -> None:
+        super().__init__(model_name="t2av_composite")
+        del base_device
+        if not config.weights:
             raise ValueError("T2AVCompositeScorer requires a non-empty `weights` dict (scorer_name -> weight).")
+        if not config.scorers:
+            raise ValueError("T2AVCompositeScorer requires a non-empty `scorers` mapping (name -> RewardBackend).")
 
-        self._scorers: Dict[str, RewardBackend] = {}
-        for name in self.weights:
-            inner_cls = resolve_builtin_reward_scorer_class(name)
-            inner_spec_cls = resolve_builtin_reward_spec_class(name)
-            inner_spec = inner_spec_cls()
-            import dataclasses
+        weights = dict(config.weights)
+        if any(not isinstance(weight, (int, float)) or not math.isfinite(weight) for weight in weights.values()):
+            raise ValueError("T2AVCompositeScorer: weights must be finite numbers.")
+        self.weights = {name: float(weight) for name, weight in weights.items()}
 
-            # Propagate only fields BOTH the composite and the inner spec declare.
-            shared = ("device", "batch_size", "frame_selection", "mode")
-            overrides = {f: getattr(config, f) for f in shared if hasattr(inner_spec, f) and hasattr(config, f)}
-            if overrides:
-                inner_spec = dataclasses.replace(inner_spec, **overrides)
-            self._scorers[name] = inner_cls(config=inner_spec, base_device=base_device)
+        for name, scorer in config.scorers.items():
+            if not isinstance(scorer, RewardBackend):
+                raise TypeError(
+                    f"T2AVCompositeScorer: scorers[{name!r}] is {type(scorer).__name__}, not a "
+                    "RewardBackend — each entry needs its own `_target_` for Hydra to instantiate."
+                )
+            input_kind = scorer.preferred_input_kind
+            if input_kind != self.input_kind:
+                raise ValueError(
+                    f"T2AVCompositeScorer: scorers[{name!r}] consumes {input_kind!r}, expected {self.input_kind!r}."
+                )
+
+        weight_names = set(self.weights)
+        scorer_names = set(config.scorers)
+        if weight_names != scorer_names:
+            missing = sorted(weight_names - scorer_names)
+            extra = sorted(scorer_names - weight_names)
+            raise ValueError(
+                "T2AVCompositeScorer: `weights` and `scorers` must use the same keys "
+                f"(weights missing scorers={missing}, scorers missing weights={extra})."
+            )
+
+        self._scorers: Dict[str, RewardBackend] = dict(config.scorers)
+        _require_prompt_video_term(self.weights, self._scorers)
 
     def compute_rewards(self, request: RewardRequest) -> RewardResponse:
         start = time.time()
@@ -47,14 +79,17 @@ class T2AVCompositeScorer(RewardBackend):
             total = torch.zeros(bs, dtype=torch.float32)
             for name, scorer in self._scorers.items():
                 resp = scorer.compute_rewards(request)
-                comp = torch.tensor(list(resp.rewards), dtype=torch.float32)
+                comp = torch.tensor(resp.rewards, dtype=torch.float32)
                 if comp.numel() != bs:
                     raise RuntimeError(
                         f"T2AVCompositeScorer: inner scorer {name!r} returned {comp.numel()} rewards "
                         f"for a batch of {bs}."
                     )
+                if resp.successes and not all(resp.successes):
+                    error = next((error for error in (resp.errors or []) if error), "unknown inner error")
+                    raise RuntimeError(f"T2AVCompositeScorer: inner scorer {name!r} failed: {error}")
                 component_rewards[name] = comp.tolist()
-                total = total + float(self.weights[name]) * comp
+                total = total + self.weights[name] * comp
 
             return RewardResponse(
                 rewards=total.tolist(),
@@ -71,9 +106,8 @@ class T2AVCompositeScorer(RewardBackend):
                 compute_time=time.time() - start,
             )
 
-    @property
-    def preferred_input_kind(self) -> str:
-        return self.input_kind
+    def covers_prompt_video(self) -> bool:
+        return True
 
     def is_available(self) -> bool:
         return all(s.is_available() for s in self._scorers.values())
@@ -95,15 +129,8 @@ class T2AVCompositeScorer(RewardBackend):
 class T2AVCompositeSpec(BaseRewardComponentSpec):
     """Typed config for the T2AV composite reward."""
 
-    batch_size: int = 8
-    device: str = "auto"
-    # Forwarded to inner scorers that declare it (videopickscore). "first"
-    # keeps the historical behaviour; "middle" avoids scoring a blank opening
-    # frame on clips that fade or reveal in.
-    frame_selection: str = "first"
-    # Forwarded to inner scorers that declare it (imagebind only). Defaults to
-    # ImageBindSpec's own default so existing recipes are unaffected; set "all"
-    # to include the text terms, without which nothing scored here relates the
-    # prompt to the video.
-    mode: str = "audio_video"
-    weights: Dict[str, float] = field(default_factory=lambda: {"videopickscore": 0.5, "clap": 0.5})
+    weights: Dict[str, float] = field(default_factory=dict)
+    scorers: Dict[str, RewardBackend] = field(default_factory=dict)
+
+
+__all__ = ["T2AVCompositeScorer", "T2AVCompositeSpec"]

--- a/unirl/reward/local/video_clip_delta.py
+++ b/unirl/reward/local/video_clip_delta.py
@@ -31,6 +31,9 @@ class VideoCLIPDeltaScorer(PickScoreRewardScorer):
         self.source_sim_floor = float(getattr(config, "source_sim_floor", 0.3))
         super().__init__(config=config, base_device=base_device)
 
+    def covers_prompt_video(self) -> bool:
+        return True
+
     @staticmethod
     def _sample_frames_pil(video: "Video", k: int) -> list["Image.Image"]:
         """K evenly-spaced frames of a per-sample ``Video`` (frames ``[T, C, H, W]``)."""

--- a/unirl/reward/local/video_pickscore.py
+++ b/unirl/reward/local/video_pickscore.py
@@ -33,6 +33,9 @@ class VideoPickScoreScorer(PickScoreRewardScorer):
                 f"VideoPickScoreSpec.frame_selection must be 'first' or 'middle'; got {self.frame_selection!r}"
             )
 
+    def covers_prompt_video(self) -> bool:
+        return True
+
     @staticmethod
     def _extract_frame(video: torch.Tensor, which: str = "first") -> "Image.Image":
         """Extract one frame of a channel-first video tensor."""

--- a/unirl/reward/local/videoalign.py
+++ b/unirl/reward/local/videoalign.py
@@ -607,6 +607,9 @@ class VideoAlignRewardScorer(LocalRewardBackend):
         self._mq_coef = float(getattr(config, "mq_coef", 1.0))
         self._ta_coef = float(getattr(config, "ta_coef", 1.0))
 
+    def covers_prompt_video(self) -> bool:
+        return self._ta_coef > 0.0
+
     def _load_model(self) -> None:
         os.environ.setdefault("FORCE_QWENVL_VIDEO_READER", "decord")
         checkpoint_path = self.model_kwargs.get("checkpoint_path") or os.environ.get("VIDEOALIGN_CKPT")


### PR DESCRIPTION
## Summary

`T2AVCompositeScorer` rebuilt every inner spec from defaults and forwarded a hardcoded field allow-list. Inner-only fields such as `ImageBindSpec.mode` were unreachable, leaving ImageBind at `audio_video`. Combined with CLAP (prompt↔audio only), that gives a T2AV objective with no prompt↔video term and permits the measured black/silent collapse.

The composite now receives Hydra-instantiated backends under `scorers`, matching `PerDomainRewardScorer`; registry lookup, inner-spec reconstruction, and field forwarding are gone. Prompt-video support is an optional `PromptVideoReward` protocol instead of a method on every reward backend.

The composite rejects mismatched scorer/weight names, non-backend or non-video scorers, nonnumeric/nonfinite outer weights, inner scorer failures, and mixes without a positive-weight prompt-video term. ImageBind now validates `mode` and validates its three finite `mode: all` weights locally.

All three in-tree T2AV recipes use nested scorers. MiniMax-H3 NFT selects `mode: all` and writes ImageBind's current internal weights explicitly so the objective is reviewable.

## Related Issue

Follow-up: #423 tracks capability validation before eager inner-model loading. Interacts with #403: a weights-only ImageBind + CLAP recipe must migrate to nested scorers and select `text_video` or `all`.

## Test Plan

- Full pre-push hook suite — pass (YAML, AST, Ruff, recipe targets, dependency boundaries, one-line docstrings)
- `PYTHONPATH=. python3 /tmp/verify_t2av_nested.py` — pass:
  - nested blending and inherited `preferred_input_kind`
  - absent, zero, negative, and nonfinite prompt-video coverage rejected
  - mismatched keys, non-backend entries, and incompatible media kind rejected
  - inner `successes=False` propagates as composite failure
  - strict ImageBind mode validation and complete all-mode weights
  - positive internal ImageBind/VideoAlign alignment coefficients
- `PYTHONPATH=. python3 /tmp/verify_t2av_hydra.py` — all three T2AV recipes instantiate with model loading stubbed; H3 NFT reaches ImageBind `mode: all`
- Hydra `--cfg job --resolve` composition for all three recipes — pass (`PRETRAINED_MODEL=/tmp/dummy` for H3)
- End-to-end GPU rollout: Not run; this changes reward construction and the H3 NFT objective. A fresh run is required before reusing old `audio_video` measurements as training evidence.

## Compatibility / Risk

Breaking T2AV configuration: weights-only composites no longer construct scorers implicitly; every weight needs a matching nested backend. In-tree recipes are migrated. The constructor still accepts `base_device` for the common backend/factory contract, but inner scorers own device configuration. The now-inert composite `batch_size` field was removed.

H3 NFT ImageBind changes from `audio_video` to `all`, so its old reward measurements do not describe the new recipe. Internal weights remain ImageBind's existing 0.5 / 0.25 / 0.25 defaults; this PR does not invent a new unmeasured mix.

## Reviewer Notes

- Validation is limited to cheap structural/numeric invariants. Scorer-specific mode/weight validation stays in ImageBind; the composite does not encode scorer business rules or impose subjective reward thresholds.
- The guard runs after Hydra constructs inner backends. Because local backends load eagerly, it prevents training but not model-loading cost; #423 tracks a shared two-phase lifecycle.
- Rebased onto current `main`; unrelated diff removed.
- AI-assisted follow-up; collapse measurements in the original report are from celve.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
