### PR TITLE
fix(algorithms): respect text loss masks

### DIFF
--- a/unirl/algorithms/grpo.py
+++ b/unirl/algorithms/grpo.py
@@ -101,18 +101,30 @@ class GRPO(StageAlgorithm):
             clip_range_high=clip_high,
         )
 
+        mask: Optional[torch.Tensor] = None
         if segment.loss_mask is not None:
             mask = segment.loss_mask.to(dtype=loss_per_elem.dtype, device=loss_per_elem.device)
             loss_per_elem = loss_per_elem * mask
 
-        if self.loss_agg_mode in ("seq-mean-token-sum-norm", "seq-mean-token-mean") and segment.lengths is not None:
+        if self.loss_agg_mode in ("seq-mean-token-sum-norm", "seq-mean-token-mean"):
             parts = torch.split(loss_per_elem, segment.lengths.tolist())
-            if self.loss_agg_mode == "seq-mean-token-sum-norm":
-                loss = torch.stack([p.sum() for p in parts]).mean() / float(self.horizon)
-            else:  # seq-mean-token-mean — guard 0-length responses (mean of empty = NaN)
-                loss = torch.stack([p.mean() if p.numel() else p.new_zeros(()) for p in parts]).mean()
-        else:
+            if mask is None:
+                if self.loss_agg_mode == "seq-mean-token-sum-norm":
+                    loss = torch.stack([p.sum() for p in parts]).mean() / float(self.horizon)
+                else:
+                    loss = torch.stack([p.mean() if p.numel() else p.new_zeros(()) for p in parts]).mean()
+            else:
+                mask_parts = torch.split(mask, segment.lengths.tolist())
+                valid_parts = [(p, float(m.sum().item())) for p, m in zip(parts, mask_parts) if bool(m.any())]
+                if self.loss_agg_mode == "seq-mean-token-sum-norm":
+                    per_seq = [p.sum() / float(self.horizon) for p, _ in valid_parts]
+                else:
+                    per_seq = [p.sum() / weight for p, weight in valid_parts]
+                loss = torch.stack(per_seq).mean() if per_seq else loss_per_elem.sum() * 0.0
+        elif mask is None:
             loss = loss_per_elem.mean()
+        else:
+            loss = loss_per_elem.sum() / mask.sum().clamp(min=1)
         (loss * loss_scale).backward()
 
         metrics: Dict[str, Any] = {

--- a/unirl/algorithms/grpo.py
+++ b/unirl/algorithms/grpo.py
@@ -101,6 +101,10 @@ class GRPO(StageAlgorithm):
             clip_range_high=clip_high,
         )
 
+        if segment.loss_mask is not None:
+            mask = segment.loss_mask.to(dtype=loss_per_elem.dtype, device=loss_per_elem.device)
+            loss_per_elem = loss_per_elem * mask
+
         if self.loss_agg_mode in ("seq-mean-token-sum-norm", "seq-mean-token-mean") and segment.lengths is not None:
             parts = torch.split(loss_per_elem, segment.lengths.tolist())
             if self.loss_agg_mode == "seq-mean-token-sum-norm":

--- a/unirl/algorithms/gspo.py
+++ b/unirl/algorithms/gspo.py
@@ -123,7 +123,13 @@ class GSPO(StageAlgorithm):
             else _resolve_clip_range_from_schedule(self.clip_range_high, self.clip_schedule, training_progress)
         )
 
-        seq_new, seq_old, seq_adv = self._reduce_to_sequences(new_logp, old_logp, advantages, segment.lengths)
+        seq_new, seq_old, seq_adv = self._reduce_to_sequences(
+            new_logp,
+            old_logp,
+            advantages,
+            segment.lengths,
+            loss_mask=segment.loss_mask,
+        )
         if seq_new.numel() == 0:
             return AlgorithmStepResult(loss=0.0, metrics={}, num_steps_or_tokens=0, has_backward=False)
 
@@ -161,6 +167,8 @@ class GSPO(StageAlgorithm):
         old_logp: torch.Tensor,
         advantages: torch.Tensor,
         lengths: torch.Tensor,
+        *,
+        loss_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Reduce packed per-token log-probs to one length-normalized value per sequence via a segment-sum."""
         device = new_logp.device
@@ -169,8 +177,18 @@ class GSPO(StageAlgorithm):
         if int(advantages.shape[0]) != num_seqs:
             raise ValueError(f"GSPO: advantages batch={int(advantages.shape[0])} != sequences={num_seqs}")
 
+        if loss_mask is not None:
+            mask = loss_mask.to(dtype=new_logp.dtype, device=device)
+            new_logp = new_logp * mask
+            old_logp = old_logp * mask
+
         seg_ids = torch.repeat_interleave(torch.arange(num_seqs, device=device), lengths)
-        denom = lengths.to(new_logp.dtype).clamp(min=1)
+
+        if loss_mask is not None:
+            denom = new_logp.new_zeros(num_seqs).index_add(0, seg_ids, mask).clamp(min=1)
+        else:
+            denom = lengths.to(new_logp.dtype).clamp(min=1)
+
         seq_new = new_logp.new_zeros(num_seqs).index_add(0, seg_ids, new_logp) / denom
         seq_old = old_logp.new_zeros(num_seqs).index_add(0, seg_ids, old_logp) / denom
         seq_adv = advantages.detach().to(dtype=new_logp.dtype, device=device)

--- a/unirl/algorithms/gspo.py
+++ b/unirl/algorithms/gspo.py
@@ -177,23 +177,22 @@ class GSPO(StageAlgorithm):
         if int(advantages.shape[0]) != num_seqs:
             raise ValueError(f"GSPO: advantages batch={int(advantages.shape[0])} != sequences={num_seqs}")
 
+        seg_ids = torch.repeat_interleave(torch.arange(num_seqs, device=device), lengths)
         if loss_mask is not None:
             mask = loss_mask.to(dtype=new_logp.dtype, device=device)
             new_logp = new_logp * mask
             old_logp = old_logp * mask
-
-        seg_ids = torch.repeat_interleave(torch.arange(num_seqs, device=device), lengths)
-
-        if loss_mask is not None:
-            denom = new_logp.new_zeros(num_seqs).index_add(0, seg_ids, mask).clamp(min=1)
+            denom = new_logp.new_zeros(num_seqs).index_add(0, seg_ids, mask)
+            valid = denom > 0
         else:
-            denom = lengths.to(new_logp.dtype).clamp(min=1)
+            denom = lengths.to(new_logp.dtype)
+            valid = lengths > 0
 
+        denom = denom.clamp(min=1)
         seq_new = new_logp.new_zeros(num_seqs).index_add(0, seg_ids, new_logp) / denom
         seq_old = old_logp.new_zeros(num_seqs).index_add(0, seg_ids, old_logp) / denom
         seq_adv = advantages.detach().to(dtype=new_logp.dtype, device=device)
 
-        valid = lengths > 0
         if bool(valid.all()):
             return seq_new, seq_old, seq_adv
         return seq_new[valid], seq_old[valid], seq_adv[valid]

--- a/unirl/types/segments/text.py
+++ b/unirl/types/segments/text.py
@@ -23,7 +23,6 @@ class TextSegment(Segment):
     log_probs: Optional[torch.Tensor] = packed_field(default=None)
     rollout_log_probs: Optional[torch.Tensor] = packed_field(default=None)
     loss_mask: Optional[torch.Tensor] = packed_field(default=None)
-    rollout_log_probs: Optional[torch.Tensor] = packed_field(default=None)
     values: Optional[torch.Tensor] = packed_field(default=None)
     returns: Optional[torch.Tensor] = packed_field(default=None)
     token_advantages: Optional[torch.Tensor] = packed_field(default=None)


### PR DESCRIPTION
## Summary

Respect `TextSegment.loss_mask` in GRPO and GSPO loss computation so masked text tokens do not contribute to policy loss values, gradients, or reduction denominators. Fully masked sequences are excluded, and the duplicate `rollout_log_probs` declaration is removed from `TextSegment`.

## Related Issue

N/A

## Test Plan

- `pre-commit run --all-files`
- Local smoke checks for all GRPO aggregation modes, an all-masked GRPO batch, and GSPO fully-masked sequence filtering (no test files included in this PR).

## Compatibility / Risk

No config, checkpoint, data format, or public API changes expected. Risk is limited to masked-token loss aggregation in GRPO/GSPO.

## Reviewer Notes

GRPO now normalizes token means by active mask weight. GSPO uses masked sequence log-prob means and excludes sequences with no active tokens.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.