### PR TITLE
feat(diffusionnft): implement the reference-model KL penalty

### DIFF
--- a/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
+++ b/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
@@ -154,7 +154,7 @@ algorithm:
     path: unirl.models.minimax_h3.conditions.MiniMaxH3Conditions
   params: ${sampling}
   beta: 0.1
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   # Read the rollout's own 10-transition schedule and train on all of it; Flow-GRPO

--- a/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
+++ b/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
@@ -163,8 +163,8 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 1.0
-  # A reference-model KL term would cost a third forward per timestep and is not
-  # implemented; the algorithm rejects kl_coef > 0.
+  # kl_coef > 0 anchors the policy to the LoRA-disabled base with a third no_grad
+  # forward per trained timestep; see unirl/algorithms/README.md. Default off.
   kl_coef: 0.0
 
 stack:

--- a/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
+++ b/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
@@ -163,9 +163,9 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 1.0
-  # kl_coef > 0 anchors the policy to the LoRA-disabled base with a third no_grad
+  # ref_deviation_coef > 0 anchors the policy to the LoRA-disabled base with a third no_grad
   # forward per trained timestep; see unirl/algorithms/README.md. Default off.
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
+++ b/examples/diffusion/minimax_h3/minimax_h3_t2va_nft.yaml
@@ -154,7 +154,7 @@ algorithm:
     path: unirl.models.minimax_h3.conditions.MiniMaxH3Conditions
   params: ${sampling}
   beta: 0.1
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   # Read the rollout's own 10-transition schedule and train on all of it; Flow-GRPO

--- a/examples/diffusion/qwen_image/qwen_image_nft.yaml
+++ b/examples/diffusion/qwen_image/qwen_image_nft.yaml
@@ -119,7 +119,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/qwen_image/qwen_image_nft.yaml
+++ b/examples/diffusion/qwen_image/qwen_image_nft.yaml
@@ -126,7 +126,7 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 0.99
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/qwen_image/qwen_image_nft.yaml
+++ b/examples/diffusion/qwen_image/qwen_image_nft.yaml
@@ -119,7 +119,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
@@ -176,7 +176,7 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 0.2
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
@@ -169,7 +169,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft.yaml
@@ -169,7 +169,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
@@ -224,7 +224,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
@@ -231,7 +231,7 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 0.2
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
+++ b/examples/diffusion/qwen_image_edit_plus/qwen_image_edit_plus_nft_sglang.yaml
@@ -224,7 +224,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/sd3/sd3_nft.yaml
+++ b/examples/diffusion/sd3/sd3_nft.yaml
@@ -115,7 +115,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/sd3/sd3_nft.yaml
+++ b/examples/diffusion/sd3/sd3_nft.yaml
@@ -115,7 +115,7 @@ algorithm:
   params: ${sampling}
   # DiffusionNFT loss hyperparameters (v1 algorithm.algorithms.diffusion block).
   beta: 1.0
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/sd3/sd3_nft.yaml
+++ b/examples/diffusion/sd3/sd3_nft.yaml
@@ -122,7 +122,7 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 0.99
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/sd3/sd3_nft_reward_service.yaml
+++ b/examples/diffusion/sd3/sd3_nft_reward_service.yaml
@@ -112,7 +112,7 @@ algorithm:
     path: unirl.models.sd3.conditions.SD3Conditions
   params: ${sampling}
   beta: 1.0
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/sd3/sd3_nft_reward_service.yaml
+++ b/examples/diffusion/sd3/sd3_nft_reward_service.yaml
@@ -119,7 +119,7 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 0.99
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/sd3/sd3_nft_reward_service.yaml
+++ b/examples/diffusion/sd3/sd3_nft_reward_service.yaml
@@ -112,7 +112,7 @@ algorithm:
     path: unirl.models.sd3.conditions.SD3Conditions
   params: ${sampling}
   beta: 1.0
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/sd3/sd3_nft_sglang.yaml
+++ b/examples/diffusion/sd3/sd3_nft_sglang.yaml
@@ -131,7 +131,7 @@ algorithm:
     path: unirl.models.sd3.conditions.SD3Conditions
   params: ${sampling}
   beta: 1.0
-  adv_clip_max: 5.0
+  adv_sat_std: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/examples/diffusion/sd3/sd3_nft_sglang.yaml
+++ b/examples/diffusion/sd3/sd3_nft_sglang.yaml
@@ -138,7 +138,7 @@ algorithm:
   shuffle_train_timesteps: true
   apply_time_shift_in_loss: false
   training_timestep_fraction: 0.99
-  kl_coef: 0.0
+  ref_deviation_coef: 0.0
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/diffusion/sd3/sd3_nft_sglang.yaml
+++ b/examples/diffusion/sd3/sd3_nft_sglang.yaml
@@ -131,7 +131,7 @@ algorithm:
     path: unirl.models.sd3.conditions.SD3Conditions
   params: ${sampling}
   beta: 1.0
-  adv_sat_std: 5.0
+  adv_std_saturate: 5.0
   adv_mode: raw
   use_adaptive_weight: true
   train_timestep_mode: all

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -102,11 +102,14 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   `kl_coef > 0` run settles at a lower proxy reward than a `kl_coef = 0` one; budget steps for that
   rather than reading the trade off the timing alone. `kl_coef=0` returns a `None` reference before
   any of that, so it stays bit-identical to a build without the term.
-- **`ref_kl_loss` is the raw mean-difference², not the σ-normalized KL** — DiffusionNFT trains on a
-  freshly noised `xt` rather than the rollout trajectory, so it has no `stage.replay` step indices
-  and no `segment.sigmas` to normalize by, and takes `((new_pred - ref_pred)**2).mean()` on the
-  velocity prediction instead. That is the `add_kl_coefficient=false` variant minus the `/2`, so the
-  number is **not** comparable to FlowGRPO/FlowDPPO's `kl_ref_mean`, which carries
+- **`ref_prediction_deviation` is the raw mean-difference², not the σ-normalized KL** — the metric
+  is named for what it measures rather than for `kl_coef`, which weighs it: the penalty is
+  `((new_pred - ref_pred)**2).mean()`, the same formula as the neighbouring `prediction_deviation`
+  with the anchor swapped from the EMA shadow to the LoRA-disabled base, so the two share a scale
+  and can be read side by side as drift-from-shadow against drift-from-base. DiffusionNFT trains on
+  a freshly noised `xt` rather than the rollout trajectory, so it has no `stage.replay` step indices
+  and no `segment.sigmas` to normalize by. That leaves the `add_kl_coefficient=false` variant minus
+  the `/2`, so the number is **not** comparable to FlowGRPO/FlowDPPO's `kl_ref_mean`, which carries
   `_gaussian_kl_div`'s `/(2σ²)`. Measuring on the prediction rather than the reconstructed `x0`
   drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
   instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -93,3 +93,20 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   distribution; when unset it silently falls back to the `ARSamplingParams` default,
   *not* the engine's actual temperature, biasing every ratio with no raise. Watch
   `rollout_replay_logp_absdiff_mean` — it should be ~0 on an on-policy step.
+- **DiffusionNFT's `kl_coef > 0` anchors to the LoRA-disabled base, not the EMA shadow** — the
+  shadow tracks the policy by construction, so anchoring to it would bound no drift. The reference
+  is a third `predict_noise_at_step` per trained timestep, on top of the trainable and shadow ones;
+  it runs under `no_grad` and needs no backward (~+24% train phase rather than +50%), and under
+  `train_timestep_mode: all` it is paid once per timestep in the K-loop. `kl_coef=0` returns a
+  `None` reference before any of that, so it stays bit-identical to a build without the term.
+- **`ref_kl_loss` is the raw mean-difference², not the σ-normalized KL** — DiffusionNFT trains on a
+  freshly noised `xt` rather than the rollout trajectory, so it has no `stage.replay` step indices
+  and no `segment.sigmas` to normalize by, and takes `((new_pred - ref_pred)**2).mean()` on the
+  velocity prediction instead. That is the `add_kl_coefficient=false` variant minus the `/2`, so the
+  number is **not** comparable to FlowGRPO/FlowDPPO's `kl_ref_mean`, which carries
+  `_gaussian_kl_div`'s `/(2σ²)`. Measuring on the prediction rather than the reconstructed `x0`
+  drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
+  instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises
+  it several-fold). Also note `kl_coef` weighs a policy term already scaled by `adv_clip_max`, so
+  the effective relative strength is `kl_coef / adv_clip_max` and re-tuning the clip re-tunes the
+  penalty.

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -97,8 +97,11 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   shadow tracks the policy by construction, so anchoring to it would bound no drift. The reference
   is a third `predict_noise_at_step` per trained timestep, on top of the trainable and shadow ones;
   it runs under `no_grad` and needs no backward (~+24% train phase rather than +50%), and under
-  `train_timestep_mode: all` it is paid once per timestep in the K-loop. `kl_coef=0` returns a
-  `None` reference before any of that, so it stays bit-identical to a build without the term.
+  `train_timestep_mode: all` it is paid once per timestep in the K-loop. That wall-clock number is
+  not the whole cost — the penalty competes with the reward gradient, so at equal step count a
+  `kl_coef > 0` run settles at a lower proxy reward than a `kl_coef = 0` one; budget steps for that
+  rather than reading the trade off the timing alone. `kl_coef=0` returns a `None` reference before
+  any of that, so it stays bit-identical to a build without the term.
 - **`ref_kl_loss` is the raw mean-difference², not the σ-normalized KL** — DiffusionNFT trains on a
   freshly noised `xt` rather than the rollout trajectory, so it has no `stage.replay` step indices
   and no `segment.sigmas` to normalize by, and takes `((new_pred - ref_pred)**2).mean()` on the

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -108,11 +108,24 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   with the anchor swapped from the EMA shadow to the LoRA-disabled base, so the two share a scale
   and can be read side by side as drift-from-shadow against drift-from-base. DiffusionNFT trains on
   a freshly noised `xt` rather than the rollout trajectory, so it has no `stage.replay` step indices
-  and no `segment.sigmas` to normalize by. That leaves the `add_kl_coefficient=false` variant minus
-  the `/2`, so the number is **not** comparable to FlowGRPO/FlowDPPO's `kl_ref_mean`, which carries
+  to hand `_transition_sigma`. `segment.sigmas` is present (`train_timestep_mode: all` requires it)
+  and so is `t_batch`, so a time weight is available if one is ever wanted; what is absent is the SDE
+  transition std itself, because every NFT recipe runs `eta: 0.0` and that std vanishes with `eta` —
+  the same trap the DiffusionOPD bullet above raises on. That leaves the `add_kl_coefficient=false`
+  variant minus the `/2`, so the number is **not** comparable to FlowGRPO/FlowDPPO's `kl_ref_mean`, which carries
   `_gaussian_kl_div`'s `/(2σ²)`. Measuring on the prediction rather than the reconstructed `x0`
   drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
   instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises
   it several-fold). Also note `kl_coef` weighs a policy term already scaled by `adv_clip_max`, so
   the effective relative strength is `kl_coef / adv_clip_max` and re-tuning the clip re-tunes the
   penalty.
+- **The reference penalty is uninformative while the adapter delta is sub-ULP** — both operands come
+  straight out of a bf16 forward, and standard LoRA init (`B=0`) starts the delta at exactly zero.
+  Below roughly 2 bf16 ULP (RMS delta ≲ 0.01 against O(1) predictions) the difference is mostly
+  quantization noise: measured gradient-direction cosine against the fp32 answer is 0.52 at RMS
+  1e-3 and 0.97 at 1e-2. At the deviations these runs actually reach (0.008 → 0.057, i.e. 23 → 61
+  ULP) bf16 costs nothing measurable — 1.00x error, cosine 0.9999 — so the term is sound once the
+  adapter has moved, and merely inert before that. Upcasting inside the penalty does not change
+  this: the operands are already rounded when the forward returns them. DiffusionOPD's
+  `fp32 before squaring` is not the same situation — it upcasts scheduler-computed
+  `prev_sample_means`, not raw network output.

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -117,19 +117,27 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
   instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises
   it several-fold).
-- **`ref_deviation_coef / adv_clip_max` is a base-anchor-to-shadow-anchor ratio, not an accident** —
-  `total = adv_clip_max * policy_loss` reads like a stray scale but is a normalization: `r` carries a
-  `1/C` (`r = clamp(adv, ±C)/(2C) + 0.5`), and the multiply cancels it. `total` then splits exactly
-  into `mean(adv/2 · (pos_loss − neg_loss)/β)`, which is **independent** of `adv_clip_max`, plus
-  `(C/2)·mean(pos_loss + neg_loss)/β`, which is not — so retuning the clip does not move the
-  advantage-driven RL signal. What it moves is that symmetric term, whose gradient w.r.t. `new_pred`
-  is exactly `4t²β²(new_pred − old_pred)`: a quadratic pull toward the EMA shadow (exact at
-  `use_adaptive_weight: false`; the adaptive weights skew it only slightly, measured cosine 0.9967).
-  `adv_clip_max` is therefore two knobs welded together — the advantage magnitude at which a sample
-  counts as fully good or fully bad, and the strength of an implicit trust region around the shadow.
-  `ref_deviation_coef` is the same shape of pull toward the frozen base, which is what makes the
-  ratio meaningful: raising `adv_clip_max` tightens the policy to its own EMA relative to the base,
-  it does not weaken the reward signal.
+- **`adv_clip_max` is the optimality-probability contrast, not a safety clamp** — write
+  `q = clamp(adv, ±C)/C ∈ [-1, 1]` so `r = 0.5 + q/2`. Then `total` splits exactly into
+  `(C/2)·mean(pos_loss + neg_loss)/β` plus `(C/2)·mean(q · (pos_loss − neg_loss))/β`. Both halves
+  carry the same `C/2`, so `total = policy_loss * adv_clip_max` is a **pure gain**: it cancels the
+  `1/C` inside `q` and leaves the objective's shape untouched, and the learning rate absorbs it. The
+  `/β` is a gain as well — the raw NFT gradient scales linearly in `β` (grad-norm/β is constant over
+  `β = 0.05 … 1.0`), so dividing by it makes the step β-independent. What `adv_clip_max` actually
+  sets is how many advantage σ map to full optimality, i.e. the reinforcement signal's weight against
+  the flow-matching term: `E|q|` is 0.63 at `C=1` versus 0.16 at `C=5`, and the signal-to-symmetric
+  ratio falls to 0.29x across that range. It is a first-class RL knob, not a guard rail.
+- **`adv_clip_max: 5.0` de-contrasts ~3.4x against the paper's parameterization** — DiffusionNFT
+  (arXiv:2509.16117, Alg. 1) uses `r = 0.5 + 0.5·clip(r_norm / Z_c, -1, 1)` with `Z_c` "some
+  normalizing factor, which could take the form of a global reward std", and its loss carries **no**
+  outer scale. UniRL's advantages already arrive std-normalized (`Part.compute_advantages(normalize=
+  True)` ⇒ `(reward − group_mean)/(group_std + eps)`), so `adv_clip_max` divides a z-score by another
+  5 and `r` spans only `[0.066, 0.966]` rather than saturating at 0 and 1. Consequence when porting
+  coefficients: the policy term carries an overall `adv_clip_max/β` gain that the upstream objective
+  does not — 50x at the H3 recipe's `β=0.1`, `adv_clip_max=5` — so `ref_deviation_coef` is **not** on
+  the same scale as verl-omni's `ref_kl_coef`. Check that factor before copying a value across.
+  (verl-omni documents its own knob as a "prediction-space reference MSE regularizer", the same
+  reading of the quantity this file takes above.)
 - **The reference penalty is uninformative while the adapter delta is sub-ULP** — both operands come
   straight out of a bf16 forward, and standard LoRA init (`B=0`) starts the delta at exactly zero.
   Below roughly 2 bf16 ULP (RMS delta ≲ 0.01 against O(1) predictions) the difference is mostly

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -93,17 +93,17 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   distribution; when unset it silently falls back to the `ARSamplingParams` default,
   *not* the engine's actual temperature, biasing every ratio with no raise. Watch
   `rollout_replay_logp_absdiff_mean` — it should be ~0 on an on-policy step.
-- **DiffusionNFT's `kl_coef > 0` anchors to the LoRA-disabled base, not the EMA shadow** — the
+- **DiffusionNFT's `ref_deviation_coef > 0` anchors to the LoRA-disabled base, not the EMA shadow** — the
   shadow tracks the policy by construction, so anchoring to it would bound no drift. The reference
   is a third `predict_noise_at_step` per trained timestep, on top of the trainable and shadow ones;
   it runs under `no_grad` and needs no backward (~+24% train phase rather than +50%), and under
   `train_timestep_mode: all` it is paid once per timestep in the K-loop. That wall-clock number is
   not the whole cost — the penalty competes with the reward gradient, so at equal step count a
-  `kl_coef > 0` run settles at a lower proxy reward than a `kl_coef = 0` one; budget steps for that
-  rather than reading the trade off the timing alone. `kl_coef=0` returns a `None` reference before
+  `ref_deviation_coef > 0` run settles at a lower proxy reward than a `ref_deviation_coef = 0` one; budget steps for that
+  rather than reading the trade off the timing alone. `ref_deviation_coef=0` returns a `None` reference before
   any of that, so it stays bit-identical to a build without the term.
 - **`ref_prediction_deviation` is the raw mean-difference², not the σ-normalized KL** — the metric
-  is named for what it measures rather than for `kl_coef`, which weighs it: the penalty is
+  is named for what it measures rather than for `ref_deviation_coef`, which weighs it: the penalty is
   `((new_pred - ref_pred)**2).mean()`, the same formula as the neighbouring `prediction_deviation`
   with the anchor swapped from the EMA shadow to the LoRA-disabled base, so the two share a scale
   and can be read side by side as drift-from-shadow against drift-from-base. DiffusionNFT trains on
@@ -116,9 +116,20 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   `_gaussian_kl_div`'s `/(2σ²)`. Measuring on the prediction rather than the reconstructed `x0`
   drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
   instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises
-  it several-fold). Also note `kl_coef` weighs a policy term already scaled by `adv_clip_max`, so
-  the effective relative strength is `kl_coef / adv_clip_max` and re-tuning the clip re-tunes the
-  penalty.
+  it several-fold).
+- **`ref_deviation_coef / adv_clip_max` is a base-anchor-to-shadow-anchor ratio, not an accident** —
+  `total = adv_clip_max * policy_loss` reads like a stray scale but is a normalization: `r` carries a
+  `1/C` (`r = clamp(adv, ±C)/(2C) + 0.5`), and the multiply cancels it. `total` then splits exactly
+  into `mean(adv/2 · (pos_loss − neg_loss)/β)`, which is **independent** of `adv_clip_max`, plus
+  `(C/2)·mean(pos_loss + neg_loss)/β`, which is not — so retuning the clip does not move the
+  advantage-driven RL signal. What it moves is that symmetric term, whose gradient w.r.t. `new_pred`
+  is exactly `4t²β²(new_pred − old_pred)`: a quadratic pull toward the EMA shadow (exact at
+  `use_adaptive_weight: false`; the adaptive weights skew it only slightly, measured cosine 0.9967).
+  `adv_clip_max` is therefore two knobs welded together — the advantage magnitude at which a sample
+  counts as fully good or fully bad, and the strength of an implicit trust region around the shadow.
+  `ref_deviation_coef` is the same shape of pull toward the frozen base, which is what makes the
+  ratio meaningful: raising `adv_clip_max` tightens the policy to its own EMA relative to the base,
+  it does not weaken the reward signal.
 - **The reference penalty is uninformative while the adapter delta is sub-ULP** — both operands come
   straight out of a bf16 forward, and standard LoRA init (`B=0`) starts the delta at exactly zero.
   Below roughly 2 bf16 ULP (RMS delta ≲ 0.01 against O(1) predictions) the difference is mostly

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -117,23 +117,23 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
   instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises
   it several-fold).
-- **`adv_sat_std` is how many advantage σ map to `r = 0` or `1`** — write `C` for the value and
+- **`adv_std_saturate` is how many advantage σ map to `r = 0` or `1`** — write `C` for the value and
   `q = clamp(adv, ±C)/C ∈ [-1, 1]` so `r = 0.5 + q/2`. Then `total` splits exactly into
   `(C/2)·mean(pos_loss + neg_loss)/β` plus `(C/2)·mean(q · (pos_loss − neg_loss))/β`. Both halves
-  carry the same `C/2`, so `total = policy_loss * adv_sat_std` is a **pure gain**: it cancels the
+  carry the same `C/2`, so `total = policy_loss * adv_std_saturate` is a **pure gain**: it cancels the
   `1/C` inside `q` and leaves the objective's shape untouched, and the learning rate absorbs it. The
   `/β` is a gain as well — the raw NFT gradient scales linearly in `β` (grad-norm/β is constant over
   `β = 0.05 … 1.0`), so dividing by it makes the step β-independent. Raising `C` shrinks `E|q|`
   (0.63 at `C=1` versus 0.16 at `C=5`) and the signal-to-symmetric ratio falls to 0.29x across that
   range. It is a first-class RL knob, not a safety clip.
-- **`adv_sat_std: 5.0` de-contrasts ~3.4x against the paper's parameterization** — DiffusionNFT
+- **`adv_std_saturate: 5.0` de-contrasts ~3.4x against the paper's parameterization** — DiffusionNFT
   (arXiv:2509.16117, Alg. 1) uses `r = 0.5 + 0.5·clip(r_norm / Z_c, -1, 1)` with `Z_c` "some
   normalizing factor, which could take the form of a global reward std", and its loss carries **no**
   outer scale. UniRL's advantages already arrive std-normalized (`Part.compute_advantages(normalize=
-  True)` ⇒ `(reward − group_mean)/(group_std + eps)`), so `adv_sat_std` divides a z-score by another
+  True)` ⇒ `(reward − group_mean)/(group_std + eps)`), so `adv_std_saturate` divides a z-score by another
   5 and `r` spans only `[0.066, 0.966]` rather than saturating at 0 and 1. Consequence when porting
-  coefficients: the policy term carries an overall `adv_sat_std/β` gain that the upstream objective
-  does not — 50x at the H3 recipe's `β=0.1`, `adv_sat_std=5` — so `ref_deviation_coef` is **not** on
+  coefficients: the policy term carries an overall `adv_std_saturate/β` gain that the upstream objective
+  does not — 50x at the H3 recipe's `β=0.1`, `adv_std_saturate=5` — so `ref_deviation_coef` is **not** on
   the same scale as verl-omni's `ref_kl_coef`. Check that factor before copying a value across.
   (verl-omni documents its own knob as a "prediction-space reference MSE regularizer", the same
   reading of the quantity this file takes above.)

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -117,24 +117,23 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   drops the `t²` Jacobian of `xt - t*pred`, spreading pressure uniformly over trained timesteps
   instead of `t²`-weighting it — the magnitude still moves with `t` (training lower timesteps raises
   it several-fold).
-- **`adv_clip_max` is the optimality-probability contrast, not a safety clamp** — write
+- **`adv_sat_std` is how many advantage σ map to `r = 0` or `1`** — write `C` for the value and
   `q = clamp(adv, ±C)/C ∈ [-1, 1]` so `r = 0.5 + q/2`. Then `total` splits exactly into
   `(C/2)·mean(pos_loss + neg_loss)/β` plus `(C/2)·mean(q · (pos_loss − neg_loss))/β`. Both halves
-  carry the same `C/2`, so `total = policy_loss * adv_clip_max` is a **pure gain**: it cancels the
+  carry the same `C/2`, so `total = policy_loss * adv_sat_std` is a **pure gain**: it cancels the
   `1/C` inside `q` and leaves the objective's shape untouched, and the learning rate absorbs it. The
   `/β` is a gain as well — the raw NFT gradient scales linearly in `β` (grad-norm/β is constant over
-  `β = 0.05 … 1.0`), so dividing by it makes the step β-independent. What `adv_clip_max` actually
-  sets is how many advantage σ map to full optimality, i.e. the reinforcement signal's weight against
-  the flow-matching term: `E|q|` is 0.63 at `C=1` versus 0.16 at `C=5`, and the signal-to-symmetric
-  ratio falls to 0.29x across that range. It is a first-class RL knob, not a guard rail.
-- **`adv_clip_max: 5.0` de-contrasts ~3.4x against the paper's parameterization** — DiffusionNFT
+  `β = 0.05 … 1.0`), so dividing by it makes the step β-independent. Raising `C` shrinks `E|q|`
+  (0.63 at `C=1` versus 0.16 at `C=5`) and the signal-to-symmetric ratio falls to 0.29x across that
+  range. It is a first-class RL knob, not a safety clip; the old name `adv_clip_max` hid that.
+- **`adv_sat_std: 5.0` de-contrasts ~3.4x against the paper's parameterization** — DiffusionNFT
   (arXiv:2509.16117, Alg. 1) uses `r = 0.5 + 0.5·clip(r_norm / Z_c, -1, 1)` with `Z_c` "some
   normalizing factor, which could take the form of a global reward std", and its loss carries **no**
   outer scale. UniRL's advantages already arrive std-normalized (`Part.compute_advantages(normalize=
-  True)` ⇒ `(reward − group_mean)/(group_std + eps)`), so `adv_clip_max` divides a z-score by another
+  True)` ⇒ `(reward − group_mean)/(group_std + eps)`), so `adv_sat_std` divides a z-score by another
   5 and `r` spans only `[0.066, 0.966]` rather than saturating at 0 and 1. Consequence when porting
-  coefficients: the policy term carries an overall `adv_clip_max/β` gain that the upstream objective
-  does not — 50x at the H3 recipe's `β=0.1`, `adv_clip_max=5` — so `ref_deviation_coef` is **not** on
+  coefficients: the policy term carries an overall `adv_sat_std/β` gain that the upstream objective
+  does not — 50x at the H3 recipe's `β=0.1`, `adv_sat_std=5` — so `ref_deviation_coef` is **not** on
   the same scale as verl-omni's `ref_kl_coef`. Check that factor before copying a value across.
   (verl-omni documents its own knob as a "prediction-space reference MSE regularizer", the same
   reading of the quantity this file takes above.)

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -125,7 +125,7 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   `/β` is a gain as well — the raw NFT gradient scales linearly in `β` (grad-norm/β is constant over
   `β = 0.05 … 1.0`), so dividing by it makes the step β-independent. Raising `C` shrinks `E|q|`
   (0.63 at `C=1` versus 0.16 at `C=5`) and the signal-to-symmetric ratio falls to 0.29x across that
-  range. It is a first-class RL knob, not a safety clip; the old name `adv_clip_max` hid that.
+  range. It is a first-class RL knob, not a safety clip.
 - **`adv_sat_std: 5.0` de-contrasts ~3.4x against the paper's parameterization** — DiffusionNFT
   (arXiv:2509.16117, Alg. 1) uses `r = 0.5 + 0.5·clip(r_norm / Z_c, -1, 1)` with `Z_c` "some
   normalizing factor, which could take the form of a global reward std", and its loss carries **no**

--- a/unirl/algorithms/base.py
+++ b/unirl/algorithms/base.py
@@ -186,24 +186,24 @@ def _reference_kl_loss(
     return kl_per_sample.mean()
 
 
-def _resolve_reference_model(backend: Any, *, beta: float, algo: str) -> Any:
+def _resolve_reference_model(backend: Any, *, beta: float, algo: str, coef_name: str = "beta") -> Any:
     """Resolve the trainable model for the adapter-disabled reference replay, or None."""
     if float(beta) < 0.0:
-        raise ValueError(f"{algo}: beta must be >= 0; got {beta!r}.")
+        raise ValueError(f"{algo}: {coef_name} must be >= 0; got {beta!r}.")
     if float(beta) == 0.0:
         return None
     model = getattr(backend, "model", None) if backend is not None else None
     if model is None:
         raise ValueError(
-            f"{algo}: beta>0 needs the trainable model to define the reference policy, but "
+            f"{algo}: {coef_name}>0 needs the trainable model to define the reference policy, but "
             f"no `backend` was injected. The v2 DiffusionTrainer injects it when the "
-            f"algorithm declares requires_backend=True."
+            f"algorithm declares requires_backend=True or requires_ema_rollout=True."
         )
     if not any("lora_" in name for name, _ in model.named_parameters()):
         raise ValueError(
-            f"{algo}: beta>0 computes KL against the LoRA-disabled base model (reference "
+            f"{algo}: {coef_name}>0 computes KL against the LoRA-disabled base model (reference "
             f"policy), which requires a LoRA adapter, but the trainable model has none. Use "
-            f"a LoRA recipe, or set beta=0."
+            f"a LoRA recipe, or set {coef_name}=0."
         )
     return model
 

--- a/unirl/algorithms/base.py
+++ b/unirl/algorithms/base.py
@@ -188,9 +188,10 @@ def _reference_kl_loss(
 
 def _resolve_reference_model(backend: Any, *, beta: float, algo: str, coef_name: str = "beta") -> Any:
     """Resolve the trainable model for the adapter-disabled reference replay, or None."""
-    if float(beta) < 0.0:
-        raise ValueError(f"{algo}: {coef_name} must be >= 0; got {beta!r}.")
-    if float(beta) == 0.0:
+    coef = float(beta)
+    if not math.isfinite(coef) or coef < 0.0:
+        raise ValueError(f"{algo}: {coef_name} must be finite and >= 0; got {beta!r}.")
+    if coef == 0.0:
         return None
     model = getattr(backend, "model", None) if backend is not None else None
     if model is None:
@@ -201,7 +202,7 @@ def _resolve_reference_model(backend: Any, *, beta: float, algo: str, coef_name:
         )
     if not any("lora_" in name for name, _ in model.named_parameters()):
         raise ValueError(
-            f"{algo}: {coef_name}>0 computes KL against the LoRA-disabled base model (reference "
+            f"{algo}: {coef_name}>0 anchors the policy to the LoRA-disabled base model (reference "
             f"policy), which requires a LoRA adapter, but the trainable model has none. Use "
             f"a LoRA recipe, or set {coef_name}=0."
         )

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -77,11 +77,6 @@ class DiffusionNFT(StageAlgorithm):
             )
         if float(kl_coef) < 0:
             raise ValueError(f"DiffusionNFT: kl_coef must be >= 0; got {kl_coef!r}.")
-        # The reference is the LoRA-disabled base policy, not the EMA shadow: the
-        # shadow tracks the policy, so it cannot anchor drift away from it.
-        self._ref_model = _resolve_reference_model(
-            backend, beta=float(kl_coef), algo="DiffusionNFT", coef_name="kl_coef"
-        )
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
         if not (0.0 < float(adv_clip_max)):
@@ -98,6 +93,12 @@ class DiffusionNFT(StageAlgorithm):
         self.params = params
         self.nft_lora_policy = nft_lora_policy
         self.conditions_cls = conditions_cls
+        # The reference is the LoRA-disabled base policy, not the EMA shadow: the
+        # shadow tracks the policy, so it cannot anchor drift away from it. Resolved
+        # after the scalar checks — it walks `named_parameters()` to find the adapter.
+        self._ref_model = _resolve_reference_model(
+            backend, beta=float(kl_coef), algo="DiffusionNFT", coef_name="kl_coef"
+        )
         self.config = DiffusionNFTConfig(
             beta=float(beta),
             adv_clip_max=float(adv_clip_max),
@@ -280,6 +281,7 @@ class DiffusionNFT(StageAlgorithm):
         }
         if kl_loss is not None:
             metrics["ref_kl_loss"] = float(kl_loss.detach().item())
+            metrics["kl_coef"] = float(self.config.kl_coef)
         return total, metrics
 
     def _reference_kl(

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -9,11 +9,12 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple, Type
 import torch
 
 from unirl.sde.index_schedule import normalize_timestep_fraction
+from unirl.train.lora import adapters_disabled
 from unirl.types.conditions import Condition
 from unirl.types.segments.latent import LatentSegment
 from unirl.utils.metrics import aggregate_numeric_metrics
 
-from .base import AlgorithmStepResult, BaseAlgorithmConfig, StageAlgorithm
+from .base import AlgorithmStepResult, BaseAlgorithmConfig, StageAlgorithm, _resolve_reference_model
 
 
 @dataclass
@@ -74,11 +75,11 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(
                 f"DiffusionNFT: training_timestep_fraction must lie in (0, 1]; got {training_timestep_fraction!r}."
             )
-        if float(kl_coef) > 0:
-            raise ValueError(
-                "DiffusionNFT: kl_coef > 0 not supported (KL penalty against base "
-                "model not implemented in this revision)."
-            )
+        if float(kl_coef) < 0:
+            raise ValueError(f"DiffusionNFT: kl_coef must be >= 0; got {kl_coef!r}.")
+        # The reference is the LoRA-disabled base policy, not the EMA shadow: the
+        # shadow tracks the policy, so it cannot anchor drift away from it.
+        self._ref_model = _resolve_reference_model(backend, beta=float(kl_coef), algo="DiffusionNFT")
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
         if not (0.0 < float(adv_clip_max)):
@@ -260,6 +261,10 @@ class DiffusionNFT(StageAlgorithm):
         policy_loss = (r * pos_loss / beta + (1.0 - r) * neg_loss / beta).mean()
         total = policy_loss * float(self.config.adv_clip_max)
 
+        kl_loss = self._reference_kl(conditions, xt=xt, t_batch=t_batch, new_pred=new_pred)
+        if kl_loss is not None:
+            total = total + float(self.config.kl_coef) * kl_loss
+
         metrics = {
             "policy_loss": float(policy_loss.detach().item()),
             "pos_loss_mean": float(pos_loss.mean().detach().item()),
@@ -271,7 +276,40 @@ class DiffusionNFT(StageAlgorithm):
             "x0_norm": float((x0**2).mean().detach().item()),
             "t_value": float(t_scalar.detach().item()),
         }
+        if kl_loss is not None:
+            metrics["ref_kl_loss"] = float(kl_loss.detach().item())
         return total, metrics
+
+    def _reference_kl(
+        self,
+        conditions: Any,
+        *,
+        xt: torch.Tensor,
+        t_batch: torch.Tensor,
+        new_pred: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        """Penalty pulling the policy back toward the LoRA-disabled base model.
+
+        Costs a third forward per timestep, on top of the trainable and shadow
+        ones. There is no cheaper reference available: the shadow follows the
+        policy by construction, so anchoring to it would not bound drift.
+
+        The two predictions are the means of Gaussians that share a variance at
+        this timestep, so their KL reduces to the squared difference between
+        them up to a constant factor. Measuring it on the prediction rather than
+        on the reconstructed ``x0`` keeps the penalty independent of ``t``, which
+        the ``xt - t * pred`` reconstruction is not.
+        """
+        if self._ref_model is None:
+            return None
+        with torch.no_grad(), adapters_disabled(self._ref_model):
+            ref_pred = self.stage.predict_noise_at_step(
+                conditions,
+                sample=xt,
+                sigma=t_batch,
+                params=self.params,
+            )
+        return ((new_pred - ref_pred.detach()) ** 2).mean()
 
     def _resolve_timesteps(
         self,

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -79,7 +79,9 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(f"DiffusionNFT: kl_coef must be >= 0; got {kl_coef!r}.")
         # The reference is the LoRA-disabled base policy, not the EMA shadow: the
         # shadow tracks the policy, so it cannot anchor drift away from it.
-        self._ref_model = _resolve_reference_model(backend, beta=float(kl_coef), algo="DiffusionNFT")
+        self._ref_model = _resolve_reference_model(
+            backend, beta=float(kl_coef), algo="DiffusionNFT", coef_name="kl_coef"
+        )
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
         if not (0.0 < float(adv_clip_max)):
@@ -288,18 +290,7 @@ class DiffusionNFT(StageAlgorithm):
         t_batch: torch.Tensor,
         new_pred: torch.Tensor,
     ) -> Optional[torch.Tensor]:
-        """Penalty pulling the policy back toward the LoRA-disabled base model.
-
-        Costs a third forward per timestep, on top of the trainable and shadow
-        ones. There is no cheaper reference available: the shadow follows the
-        policy by construction, so anchoring to it would not bound drift.
-
-        The two predictions are the means of Gaussians that share a variance at
-        this timestep, so their KL reduces to the squared difference between
-        them up to a constant factor. Measuring it on the prediction rather than
-        on the reconstructed ``x0`` keeps the penalty independent of ``t``, which
-        the ``xt - t * pred`` reconstruction is not.
-        """
+        """Squared-difference penalty pulling the policy toward the LoRA-disabled base model."""
         if self._ref_model is None:
             return None
         with torch.no_grad(), adapters_disabled(self._ref_model):

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -264,9 +264,9 @@ class DiffusionNFT(StageAlgorithm):
         policy_loss = (r * pos_loss / beta + (1.0 - r) * neg_loss / beta).mean()
         total = policy_loss * float(self.config.adv_clip_max)
 
-        kl_loss = self._reference_kl(conditions, xt=xt, t_batch=t_batch, new_pred=new_pred)
-        if kl_loss is not None:
-            total = total + float(self.config.kl_coef) * kl_loss
+        ref_deviation = self._reference_deviation(conditions, xt=xt, t_batch=t_batch, new_pred=new_pred)
+        if ref_deviation is not None:
+            total = total + float(self.config.kl_coef) * ref_deviation
 
         metrics = {
             "policy_loss": float(policy_loss.detach().item()),
@@ -279,12 +279,12 @@ class DiffusionNFT(StageAlgorithm):
             "x0_norm": float((x0**2).mean().detach().item()),
             "t_value": float(t_scalar.detach().item()),
         }
-        if kl_loss is not None:
-            metrics["ref_kl_loss"] = float(kl_loss.detach().item())
+        if ref_deviation is not None:
+            metrics["ref_prediction_deviation"] = float(ref_deviation.detach().item())
             metrics["kl_coef"] = float(self.config.kl_coef)
         return total, metrics
 
-    def _reference_kl(
+    def _reference_deviation(
         self,
         conditions: Any,
         *,

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -78,10 +78,8 @@ class DiffusionNFT(StageAlgorithm):
             )
         if kl_coef is not None:
             raise ValueError(
-                f"DiffusionNFT: kl_coef was renamed to ref_deviation_coef; got kl_coef={kl_coef!r}. "
-                f"The penalty is a squared difference against the LoRA-disabled base, not a KL — it "
-                f"carries neither the /2 nor the /sigma^2 that FlowGRPO's beta does, so the two are "
-                f"not on a common scale. Rename the key in your recipe."
+                f"DiffusionNFT: kl_coef was renamed to ref_deviation_coef; got {kl_coef!r}. "
+                f"It is a squared difference against the base, not a KL — see algorithms/README.md."
             )
         if not math.isfinite(float(ref_deviation_coef)) or float(ref_deviation_coef) < 0:
             raise ValueError(f"DiffusionNFT: ref_deviation_coef must be finite and >= 0; got {ref_deviation_coef!r}.")

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -22,7 +22,7 @@ class DiffusionNFTConfig(BaseAlgorithmConfig):
     """Per-call DiffusionNFT loss hyperparameters."""
 
     beta: float = 1.0
-    adv_sat_std: float = 5.0
+    adv_std_saturate: float = 5.0
     adv_mode: str = "raw"
     use_adaptive_weight: bool = True
     train_timestep_mode: str = "all"
@@ -47,7 +47,7 @@ class DiffusionNFT(StageAlgorithm):
         nft_lora_policy: Any = None,
         backend: Any = None,
         beta: float = 1.0,
-        adv_sat_std: float = 5.0,
+        adv_std_saturate: float = 5.0,
         adv_mode: str = "raw",
         use_adaptive_weight: bool = True,
         train_timestep_mode: str = "all",
@@ -79,8 +79,8 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(f"DiffusionNFT: ref_deviation_coef must be finite and >= 0; got {ref_deviation_coef!r}.")
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
-        if not (0.0 < float(adv_sat_std)):
-            raise ValueError(f"DiffusionNFT: adv_sat_std must be > 0; got {adv_sat_std!r}.")
+        if not (0.0 < float(adv_std_saturate)):
+            raise ValueError(f"DiffusionNFT: adv_std_saturate must be > 0; got {adv_std_saturate!r}.")
 
         if not callable(getattr(nft_lora_policy, "use_shadow", None)):
             raise TypeError(
@@ -101,7 +101,7 @@ class DiffusionNFT(StageAlgorithm):
         )
         self.config = DiffusionNFTConfig(
             beta=float(beta),
-            adv_sat_std=float(adv_sat_std),
+            adv_std_saturate=float(adv_std_saturate),
             adv_mode=str(adv_mode),
             use_adaptive_weight=bool(use_adaptive_weight),
             train_timestep_mode=str(train_timestep_mode),
@@ -158,7 +158,7 @@ class DiffusionNFT(StageAlgorithm):
 
         typed_conds = _typed_conditions(conditions, self.conditions_cls)
         adv = advantages.detach().to(dtype=compute_dtype, device=device)
-        sat = float(self.config.adv_sat_std)
+        sat = float(self.config.adv_std_saturate)
         adv_sat = torch.clamp(adv, -sat, sat)
         r = (adv_sat / sat) / 2.0 + 0.5
         r = torch.clamp(r, 0.0, 1.0)
@@ -263,7 +263,7 @@ class DiffusionNFT(StageAlgorithm):
             neg_loss = ((x0_neg - x0_for_mse) ** 2).mean(dim=reduce_dims)
 
         policy_loss = (r * pos_loss / beta + (1.0 - r) * neg_loss / beta).mean()
-        total = policy_loss * float(self.config.adv_sat_std)
+        total = policy_loss * float(self.config.adv_std_saturate)
 
         ref_deviation = self._reference_deviation(conditions, xt=xt, t_batch=t_batch, new_pred=new_pred)
         if ref_deviation is not None:

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -75,8 +75,8 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(
                 f"DiffusionNFT: training_timestep_fraction must lie in (0, 1]; got {training_timestep_fraction!r}."
             )
-        if float(kl_coef) < 0:
-            raise ValueError(f"DiffusionNFT: kl_coef must be >= 0; got {kl_coef!r}.")
+        if not math.isfinite(float(kl_coef)) or float(kl_coef) < 0:
+            raise ValueError(f"DiffusionNFT: kl_coef must be finite and >= 0; got {kl_coef!r}.")
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
         if not (0.0 < float(adv_clip_max)):

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -55,7 +55,6 @@ class DiffusionNFT(StageAlgorithm):
         apply_time_shift_in_loss: bool = False,
         training_timestep_fraction: float = 0.99,
         ref_deviation_coef: float = 0.0,
-        kl_coef: Optional[float] = None,
         conditions_cls: Optional[Type[Any]] = None,
     ) -> None:
         if stage is None and pipeline is not None:
@@ -75,11 +74,6 @@ class DiffusionNFT(StageAlgorithm):
         if not (0.0 < float(training_timestep_fraction) <= 1.0):
             raise ValueError(
                 f"DiffusionNFT: training_timestep_fraction must lie in (0, 1]; got {training_timestep_fraction!r}."
-            )
-        if kl_coef is not None:
-            raise ValueError(
-                f"DiffusionNFT: kl_coef was renamed to ref_deviation_coef; got {kl_coef!r}. "
-                f"It is a squared difference against the base, not a KL — see algorithms/README.md."
             )
         if not math.isfinite(float(ref_deviation_coef)) or float(ref_deviation_coef) < 0:
             raise ValueError(f"DiffusionNFT: ref_deviation_coef must be finite and >= 0; got {ref_deviation_coef!r}.")

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -48,7 +48,6 @@ class DiffusionNFT(StageAlgorithm):
         backend: Any = None,
         beta: float = 1.0,
         adv_sat_std: float = 5.0,
-        adv_clip_max: Optional[float] = None,
         adv_mode: str = "raw",
         use_adaptive_weight: bool = True,
         train_timestep_mode: str = "all",
@@ -80,11 +79,6 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(f"DiffusionNFT: ref_deviation_coef must be finite and >= 0; got {ref_deviation_coef!r}.")
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
-        if adv_clip_max is not None:
-            raise ValueError(
-                f"DiffusionNFT: adv_clip_max was renamed to adv_sat_std; got {adv_clip_max!r}. "
-                f"It is how many advantage σ map to r=0 or 1, not a safety clip — see algorithms/README.md."
-            )
         if not (0.0 < float(adv_sat_std)):
             raise ValueError(f"DiffusionNFT: adv_sat_std must be > 0; got {adv_sat_std!r}.")
 

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -22,7 +22,7 @@ class DiffusionNFTConfig(BaseAlgorithmConfig):
     """Per-call DiffusionNFT loss hyperparameters."""
 
     beta: float = 1.0
-    adv_clip_max: float = 5.0
+    adv_sat_std: float = 5.0
     adv_mode: str = "raw"
     use_adaptive_weight: bool = True
     train_timestep_mode: str = "all"
@@ -47,7 +47,8 @@ class DiffusionNFT(StageAlgorithm):
         nft_lora_policy: Any = None,
         backend: Any = None,
         beta: float = 1.0,
-        adv_clip_max: float = 5.0,
+        adv_sat_std: float = 5.0,
+        adv_clip_max: Optional[float] = None,
         adv_mode: str = "raw",
         use_adaptive_weight: bool = True,
         train_timestep_mode: str = "all",
@@ -79,8 +80,13 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(f"DiffusionNFT: ref_deviation_coef must be finite and >= 0; got {ref_deviation_coef!r}.")
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
-        if not (0.0 < float(adv_clip_max)):
-            raise ValueError(f"DiffusionNFT: adv_clip_max must be > 0; got {adv_clip_max!r}.")
+        if adv_clip_max is not None:
+            raise ValueError(
+                f"DiffusionNFT: adv_clip_max was renamed to adv_sat_std; got {adv_clip_max!r}. "
+                f"It is how many advantage σ map to r=0 or 1, not a safety clip — see algorithms/README.md."
+            )
+        if not (0.0 < float(adv_sat_std)):
+            raise ValueError(f"DiffusionNFT: adv_sat_std must be > 0; got {adv_sat_std!r}.")
 
         if not callable(getattr(nft_lora_policy, "use_shadow", None)):
             raise TypeError(
@@ -101,7 +107,7 @@ class DiffusionNFT(StageAlgorithm):
         )
         self.config = DiffusionNFTConfig(
             beta=float(beta),
-            adv_clip_max=float(adv_clip_max),
+            adv_sat_std=float(adv_sat_std),
             adv_mode=str(adv_mode),
             use_adaptive_weight=bool(use_adaptive_weight),
             train_timestep_mode=str(train_timestep_mode),
@@ -158,8 +164,9 @@ class DiffusionNFT(StageAlgorithm):
 
         typed_conds = _typed_conditions(conditions, self.conditions_cls)
         adv = advantages.detach().to(dtype=compute_dtype, device=device)
-        adv_clipped = torch.clamp(adv, -self.config.adv_clip_max, self.config.adv_clip_max)
-        r = (adv_clipped / self.config.adv_clip_max) / 2.0 + 0.5
+        sat = float(self.config.adv_sat_std)
+        adv_sat = torch.clamp(adv, -sat, sat)
+        r = (adv_sat / sat) / 2.0 + 0.5
         r = torch.clamp(r, 0.0, 1.0)
 
         per_iter_metrics: List[Dict[str, float]] = []
@@ -262,7 +269,7 @@ class DiffusionNFT(StageAlgorithm):
             neg_loss = ((x0_neg - x0_for_mse) ** 2).mean(dim=reduce_dims)
 
         policy_loss = (r * pos_loss / beta + (1.0 - r) * neg_loss / beta).mean()
-        total = policy_loss * float(self.config.adv_clip_max)
+        total = policy_loss * float(self.config.adv_sat_std)
 
         ref_deviation = self._reference_deviation(conditions, xt=xt, t_batch=t_batch, new_pred=new_pred)
         if ref_deviation is not None:

--- a/unirl/algorithms/diffusionnft.py
+++ b/unirl/algorithms/diffusionnft.py
@@ -29,7 +29,7 @@ class DiffusionNFTConfig(BaseAlgorithmConfig):
     shuffle_train_timesteps: bool = True
     apply_time_shift_in_loss: bool = False
     training_timestep_fraction: float = 0.99
-    kl_coef: float = 0.0
+    ref_deviation_coef: float = 0.0
 
 
 class DiffusionNFT(StageAlgorithm):
@@ -54,7 +54,8 @@ class DiffusionNFT(StageAlgorithm):
         shuffle_train_timesteps: bool = True,
         apply_time_shift_in_loss: bool = False,
         training_timestep_fraction: float = 0.99,
-        kl_coef: float = 0.0,
+        ref_deviation_coef: float = 0.0,
+        kl_coef: Optional[float] = None,
         conditions_cls: Optional[Type[Any]] = None,
     ) -> None:
         if stage is None and pipeline is not None:
@@ -75,8 +76,15 @@ class DiffusionNFT(StageAlgorithm):
             raise ValueError(
                 f"DiffusionNFT: training_timestep_fraction must lie in (0, 1]; got {training_timestep_fraction!r}."
             )
-        if not math.isfinite(float(kl_coef)) or float(kl_coef) < 0:
-            raise ValueError(f"DiffusionNFT: kl_coef must be finite and >= 0; got {kl_coef!r}.")
+        if kl_coef is not None:
+            raise ValueError(
+                f"DiffusionNFT: kl_coef was renamed to ref_deviation_coef; got kl_coef={kl_coef!r}. "
+                f"The penalty is a squared difference against the LoRA-disabled base, not a KL — it "
+                f"carries neither the /2 nor the /sigma^2 that FlowGRPO's beta does, so the two are "
+                f"not on a common scale. Rename the key in your recipe."
+            )
+        if not math.isfinite(float(ref_deviation_coef)) or float(ref_deviation_coef) < 0:
+            raise ValueError(f"DiffusionNFT: ref_deviation_coef must be finite and >= 0; got {ref_deviation_coef!r}.")
         if not (0.0 < float(beta)):
             raise ValueError(f"DiffusionNFT: beta must be > 0; got {beta!r}.")
         if not (0.0 < float(adv_clip_max)):
@@ -97,7 +105,7 @@ class DiffusionNFT(StageAlgorithm):
         # shadow tracks the policy, so it cannot anchor drift away from it. Resolved
         # after the scalar checks — it walks `named_parameters()` to find the adapter.
         self._ref_model = _resolve_reference_model(
-            backend, beta=float(kl_coef), algo="DiffusionNFT", coef_name="kl_coef"
+            backend, beta=float(ref_deviation_coef), algo="DiffusionNFT", coef_name="ref_deviation_coef"
         )
         self.config = DiffusionNFTConfig(
             beta=float(beta),
@@ -108,7 +116,7 @@ class DiffusionNFT(StageAlgorithm):
             shuffle_train_timesteps=bool(shuffle_train_timesteps),
             apply_time_shift_in_loss=bool(apply_time_shift_in_loss),
             training_timestep_fraction=float(training_timestep_fraction),
-            kl_coef=float(kl_coef),
+            ref_deviation_coef=float(ref_deviation_coef),
         )
 
     def compute_loss_and_backward(
@@ -266,7 +274,7 @@ class DiffusionNFT(StageAlgorithm):
 
         ref_deviation = self._reference_deviation(conditions, xt=xt, t_batch=t_batch, new_pred=new_pred)
         if ref_deviation is not None:
-            total = total + float(self.config.kl_coef) * ref_deviation
+            total = total + float(self.config.ref_deviation_coef) * ref_deviation
 
         metrics = {
             "policy_loss": float(policy_loss.detach().item()),
@@ -281,7 +289,7 @@ class DiffusionNFT(StageAlgorithm):
         }
         if ref_deviation is not None:
             metrics["ref_prediction_deviation"] = float(ref_deviation.detach().item())
-            metrics["kl_coef"] = float(self.config.kl_coef)
+            metrics["ref_deviation_coef"] = float(self.config.ref_deviation_coef)
         return total, metrics
 
     def _reference_deviation(


### PR DESCRIPTION
## Summary

`DiffusionNFTConfig.kl_coef` has existed since the algorithm landed, but
`__init__` rejected any positive value:

```
DiffusionNFT: kl_coef > 0 not supported (KL penalty against base model not
implemented in this revision).
```

This implements it. Nothing in the framework was missing —
`_resolve_reference_model` in `algorithms/base.py` is what FlowDPPO already
uses, `adapters_disabled` in `train/lora.py` already routes a PEFT model
through its frozen base weights, and the trainer already injects `backend`
because DiffusionNFT declares `requires_ema_rollout`. Only the code connecting
them was absent, and the reason was cost: the reference is a third forward per
timestep, alongside the trainable and shadow ones.

Two choices worth flagging for review:

- **The reference is the LoRA-disabled base policy, not the EMA shadow.** The
  shadow follows the policy by construction, so anchoring to it bounds nothing.
- **The penalty is measured on the prediction, not on the reconstructed `x0`.**
  Both predictions are means of Gaussians sharing a variance at that timestep,
  so the KL reduces to their squared difference; taking it on the prediction
  keeps the penalty independent of `t`, which `xt - t * pred` is not.

Default is unchanged at `0.0`, so no existing recipe changes behaviour and the
extra forward is only paid when a recipe asks for it.

## Related Issue

N/A

## Test Plan

Environment: MiniMax-H3 t2va (33B, LoRA rank 64, `beta` 0.1, `adv_clip_max` 5),
4 nodes x 8 H20, 8 rollout replicas at DiT TP2 x Ulysses2, 8 prompts x 16
samples, reward = CLAP 1.0 + ImageBind 1.0 (`audio_video`) with **no**
visual-quality term — i.e. deliberately the reward that is easiest to push
off-distribution.

- Full `pre-commit` suite on the changed files — clean. The first revision passed
  `ruff` but failed `check-docstring-lines`; that is fixed.
- `kl_coef=0`: `_ref_model` resolves to `None`, no reference forward runs, and
  `ref_prediction_deviation` is absent from the metrics. Behaviour is
  bit-identical to before this change.
- `kl_coef=0` full run (112 rollouts): video collapsed into saturated noise by
  roughly rollout 20 while the reward climbed 0.13 -> 0.41 — entirely on
  ImageBind (0.157 -> 0.34) while CLAP *fell* 0.11 -> 0.06. ImageBind in
  `audio_video` mode is a bare cosine between two streams the policy generates,
  with the prompt absent (`need_text` is False), so it can be raised by moving
  both off-distribution together.
- `kl_coef=1e-4` (94 rollouts so far, ongoing): video intact throughout, and the
  gain moved onto the prompt-anchored component — CLAP +0.043 against ImageBind
  +0.021. `ref_prediction_deviation` rises 0.008 -> 0.057, so the term is active
  rather than inert. An independent VideoPickScore probe, weighted `1e-6` so it contributes
  ~3e-7 of a total near 0.3 and cannot influence the gradient, stayed flat at
  0.78 across all 94 rollouts.
- Timing: train phase +24%, not the +50% a third forward suggests, because the
  reference runs under `no_grad` and needs no backward.

Not run: no unit test is included. `tests/` was deliberately removed from this
repo in #267 and `pyproject.toml` carries no `[tool.pytest]` section, so adding
one back for a single feature seemed wrong; I have local coverage (reference
resolution at `kl_coef=0` vs `>0`, the negative-coefficient and missing-backend
rejections, and that the penalty is strictly positive when the adapter is not a
no-op) and can attach it in whatever form you prefer.

## Compatibility / Risk

- Default `kl_coef=0.0` short-circuits before any reference work, so existing
  DiffusionNFT recipes (SD3, Qwen-Image, Qwen-Image-Edit-Plus) are unaffected.
- `kl_coef > 0` requires a LoRA recipe and an injected `backend`;
  `_resolve_reference_model` already raises with an explanatory message for both,
  and a negative coefficient is now rejected explicitly.
- Adds one forward per trained timestep when enabled. Under
  `train_timestep_mode: all` that is once per timestep in the K-loop, so the
  cost scales with the schedule length.
- `ref_prediction_deviation` and `kl_coef` are new metric keys, present only when
  the penalty is enabled.

## Reviewer Notes

- The measurement above is the reason I think this is worth having beyond
  feature parity: with this reward the collapse is not a tuning artefact, it is
  what the reward's own optimum looks like, and the penalty was what moved the
  optimiser onto the prompt-anchored term instead.
- It does not make a reward unhackable. It taxes the distance to the exploit
  rather than removing it, and verl-omni's own H3 DiffusionNFT recipe runs
  `ref_kl_coef=1e-4` with its `ref_kl_loss` climbing 0.02 -> 0.22 over 60 steps,
  so a policy can still drift a long way under this term.
- A forward-process objective has a mismatch this term does not address: it
  trains on `xt = (1-t)*x0 + t*noise`, while inference at the same `t` sees a
  latent that walked the denoising trajectory. Those distributions differ most
  at low `t`, and separately measured, moving the trained timesteps down (mode
  `random`, mean t 0.885 -> 0.514) made a visual-quality probe drift down 0.8
  sigma while `ref_prediction_deviation` rose 8x.
- Written with AI assistance (Cursor).

## Review follow-ups (pushed by @CjhHa1 via maintainer edits)

Three commits on top of the original, all confined to this PR's own surface:

- `282dd75b` — one-line the `_reference_deviation` docstring and move its rationale
  into `unirl/algorithms/README.md`; `check-docstring-lines` has no allowlist, so
  the 12-line version was a hard CI failure. Also threads a `coef_name` argument
  through `_resolve_reference_model` so DiffusionNFT's errors name `kl_coef` rather
  than `beta`: DiffusionNFT has its own `beta` that must be `> 0`, so the old text
  told a non-LoRA user to "set beta=0", which then raised.
- `f67d2bbc` — emit `kl_coef` beside the penalty metric, as FlowGRPO and FlowDPPO
  emit `beta` beside `kl_ref_mean`; move `_resolve_reference_model` below the scalar
  checks, so a config wrong in two places reports the cheap failure first and a 33B
  model is not walked before the rest is known sane; record in the README that the
  cost is not only the +24% wall-clock, since the penalty competes with the reward
  gradient and settles at a lower proxy reward for the same step count.
- `88118b80` — rename the metric to `ref_prediction_deviation` and the method to
  `_reference_deviation`. It carries no `/(2σ²)`, so it is not FlowGRPO/FlowDPPO's
  `kl_ref_mean`, and `_reference_kl` sat one word from `base.py`'s shared
  `_reference_kl_loss`, which *is* the σ-normalized one. It is the same formula as
  the neighbouring `prediction_deviation` with the anchor swapped from the EMA shadow
  to the LoRA-disabled base, so the two now share a readable scale. `kl_coef` itself
  is untouched — it predates this work and six recipes pin it. Note the dashboards
  behind the numbers above were logged under the old `ref_kl_loss` key.

Three review points were documented in `unirl/algorithms/README.md` rather than
changed, since each would alter what `kl_coef` means for a run already in flight:
the missing σ normalization, the `kl_coef / adv_clip_max` coupling, and the choice
of a static anchor. The last one is the most interesting as follow-up work — a
periodically refreshed reference is better supported than a fixed one — but the
anchor identity lives in `_resolve_reference_model`, which FlowGRPO and FlowDPPO
share, so it belongs in its own PR.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.

Made with [Cursor](https://cursor.com)
