### PR TITLE
fix(reward): nest T2AV composite scorers and require a prompt-video term

### DIFF
--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -12,8 +12,8 @@
 #   - clap           (audio-text alignment, LAION CLAP; zero extra deps)
 # ImageBind (audio-video alignment) is also available as an inner scorer but is
 # NOT enabled here: it requires the facebookresearch/ImageBind package and is
-# CC-BY-NC-SA 4.0 (NonCommercial). To enable, nest an ImageBindRewardScorer
-# under `scorers` with mode: text_video or all (audio_video does not relate
+# CC-BY-NC-SA 4.0 (NonCommercial). To enable, add `imagebind: <weight>` and set
+# `scorers.imagebind.mode` to text_video or all (audio_video does not relate
 # the prompt to the video and the composite will refuse to start).
 #
 # With audio_joint_sde=true, audio is part of the SDE policy AND now receives a
@@ -126,27 +126,12 @@ reward:
       _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
       batch_size: 4
       device: auto
-      # videopickscore reads the video (prompt-frame alignment); clap reads the
-      # parallel audio side-channel. Inner fields (frame_selection, mode, ...)
-      # live on the nested spec, not on the composite.
+      # Inner scorer name -> blend weight. videopickscore reads the video,
+      # clap reads the parallel audio side-channel. To add imagebind, install
+      # ImageBind and set `imagebind: <w>` plus `scorers.imagebind.mode: all`.
       weights:
         videopickscore: 0.5
         clap: 0.5
-      scorers:
-        videopickscore:
-          _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
-          base_device: cuda
-          config:
-            _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
-            batch_size: 4
-            device: auto
-        clap:
-          _target_: unirl.reward.local.clap.CLAPRewardScorer
-          base_device: cuda
-          config:
-            _target_: unirl.reward.local.clap.CLAPSpec
-            batch_size: 4
-            device: auto
 
 algorithm:
   _target_: unirl.algorithms.flowgrpo.FlowGRPO

--- a/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
+++ b/examples/diffusion/ltx2/ltx2_3_t2av_audioreward_trainside.yaml
@@ -12,8 +12,9 @@
 #   - clap           (audio-text alignment, LAION CLAP; zero extra deps)
 # ImageBind (audio-video alignment) is also available as an inner scorer but is
 # NOT enabled here: it requires the facebookresearch/ImageBind package and is
-# CC-BY-NC-SA 4.0 (NonCommercial). To enable, add `imagebind: <weight>` to the
-# composite weights (and install the package).
+# CC-BY-NC-SA 4.0 (NonCommercial). To enable, nest an ImageBindRewardScorer
+# under `scorers` with mode: text_video or all (audio_video does not relate
+# the prompt to the video and the composite will refuse to start).
 #
 # With audio_joint_sde=true, audio is part of the SDE policy AND now receives a
 # direct reward signal, so it is optimized toward prompt alignment (not just
@@ -125,12 +126,27 @@ reward:
       _target_: unirl.reward.local.t2av_composite.T2AVCompositeSpec
       batch_size: 4
       device: auto
-      # Inner scorer name -> blend weight. videopickscore reads the video,
-      # clap reads the parallel audio side-channel. To add audio-video
-      # alignment, install ImageBind and add `imagebind: <w>` here.
+      # videopickscore reads the video (prompt-frame alignment); clap reads the
+      # parallel audio side-channel. Inner fields (frame_selection, mode, ...)
+      # live on the nested spec, not on the composite.
       weights:
         videopickscore: 0.5
         clap: 0.5
+      scorers:
+        videopickscore:
+          _target_: unirl.reward.local.video_pickscore.VideoPickScoreScorer
+          base_device: cuda
+          config:
+            _target_: unirl.reward.local.video_pickscore.VideoPickScoreSpec
+            batch_size: 4
+            device: auto
+        clap:
+          _target_: unirl.reward.local.clap.CLAPRewardScorer
+          base_device: cuda
+          config:
+            _target_: unirl.reward.local.clap.CLAPSpec
+            batch_size: 4
+            device: auto
 
 algorithm:
   _target_: unirl.algorithms.flowgrpo.FlowGRPO

--- a/unirl/reward/base.py
+++ b/unirl/reward/base.py
@@ -36,6 +36,16 @@ class RewardBackend(ABC):
         """The decoded media kind this backend consumes (image/video/text)."""
         return str(getattr(self, "input_kind", "image") or "image").strip().lower()
 
+    def covers_prompt_video(self) -> bool:
+        """Whether this backend scores alignment between the prompt and the video.
+
+        T2AVCompositeScorer refuses to start when no positive-weight inner
+        scorer returns True here. Default is False; video-text scorers opt in.
+        ImageBind returns True only for ``text_video`` / ``all`` (with a
+        nonzero ``text_video`` mix weight), not for ``audio_video``.
+        """
+        return False
+
     @abstractmethod
     def compute_rewards(self, request: RewardRequest) -> RewardResponse:
         """Score the request."""

--- a/unirl/reward/base.py
+++ b/unirl/reward/base.py
@@ -37,13 +37,7 @@ class RewardBackend(ABC):
         return str(getattr(self, "input_kind", "image") or "image").strip().lower()
 
     def covers_prompt_video(self) -> bool:
-        """Whether this backend scores alignment between the prompt and the video.
-
-        T2AVCompositeScorer refuses to start when no positive-weight inner
-        scorer returns True here. Default is False; video-text scorers opt in.
-        ImageBind returns True only for ``text_video`` / ``all`` (with a
-        nonzero ``text_video`` mix weight), not for ``audio_video``.
-        """
+        """Whether this backend scores prompt-to-video alignment (default False)."""
         return False
 
     @abstractmethod

--- a/unirl/reward/local/imagebind.py
+++ b/unirl/reward/local/imagebind.py
@@ -55,6 +55,13 @@ class ImageBindRewardScorer(LocalRewardBackend):
             batch_size=config.batch_size,
         )
 
+    def covers_prompt_video(self) -> bool:
+        if self._mode == "text_video":
+            return True
+        if self._mode == "all":
+            return float(self._weights.get("text_video", 0.0)) != 0.0
+        return False
+
     def _load_model(self) -> None:
         warnings.warn(_IMAGEBIND_LICENSE_WARNING, stacklevel=2)
         try:

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -2,12 +2,25 @@
 
 from __future__ import annotations
 
+import dataclasses
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Any, Dict, List, Mapping
 
 from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
 from unirl.types.reward import RewardRequest, RewardResponse
+
+from .registry import resolve_builtin_reward_scorer_class, resolve_builtin_reward_spec_class
+
+_SKIP_INNER_OVERRIDE = frozenset({"weights", "scorers"})
+
+
+def _plain_mapping(value: Any) -> Dict[str, Any]:
+    if not value:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    return dict(value)
 
 
 def _require_prompt_video_term(weights: Dict[str, float], scorers: Dict[str, RewardBackend]) -> None:
@@ -22,46 +35,48 @@ def _require_prompt_video_term(weights: Dict[str, float], scorers: Dict[str, Rew
     raise ValueError(
         "T2AVCompositeScorer: no positive-weight inner scorer relates the prompt to the video. "
         f"Current mix: {details}. "
-        "Add videopickscore / videoalign / videoclipdelta, or nest imagebind with mode "
+        "Add videopickscore / videoalign / videoclipdelta, or set scorers.imagebind.mode to "
         "'text_video' or 'all'. clap and imagebind mode='audio_video' do not cover this."
     )
 
 
 class T2AVCompositeScorer(RewardBackend):
-    """Weighted blend of Hydra-instantiated inner reward scorers for T2AV."""
+    """Weighted blend of inner reward scorers for T2AV (video + audio)."""
 
     input_kind = "video"
 
     def __init__(self, *, config: "T2AVCompositeSpec", base_device: str) -> None:
         super().__init__(model_name="t2av_composite", batch_size=config.batch_size)
-        del base_device
         self.weights: Dict[str, float] = dict(config.weights or {})
-        if not config.scorers:
-            raise ValueError(
-                "T2AVCompositeScorer requires a non-empty `scorers` mapping (name -> RewardBackend), "
-                "the same nested `_target_` pattern as PerDomainRewardScorer."
-            )
         if not self.weights:
             raise ValueError("T2AVCompositeScorer requires a non-empty `weights` dict (scorer_name -> weight).")
 
-        for name, scorer in config.scorers.items():
-            if not isinstance(scorer, RewardBackend):
-                raise TypeError(
-                    f"T2AVCompositeScorer: scorers[{name!r}] is {type(scorer).__name__}, not a "
-                    "RewardBackend — each entry needs its own `_target_` for Hydra to instantiate."
+        named_overrides = _plain_mapping(config.scorers)
+        extra = sorted(set(named_overrides) - set(self.weights))
+        if extra:
+            raise ValueError(f"T2AVCompositeScorer: scorers keys {extra} are not in weights {sorted(self.weights)}.")
+
+        self._scorers: Dict[str, RewardBackend] = {}
+        for name in self.weights:
+            inner_cls = resolve_builtin_reward_scorer_class(name)
+            inner_spec_cls = resolve_builtin_reward_spec_class(name)
+            inner_spec = inner_spec_cls()
+            overrides: Dict[str, Any] = {}
+            for f in dataclasses.fields(config):
+                if f.name in _SKIP_INNER_OVERRIDE or not hasattr(inner_spec, f.name):
+                    continue
+                overrides[f.name] = getattr(config, f.name)
+            per_scorer = _plain_mapping(named_overrides.get(name))
+            unknown = sorted(k for k in per_scorer if not hasattr(inner_spec, k))
+            if unknown:
+                raise ValueError(
+                    f"T2AVCompositeScorer: scorers[{name!r}] has fields {unknown} not on {inner_spec_cls.__name__}."
                 )
+            overrides.update(per_scorer)
+            if overrides:
+                inner_spec = dataclasses.replace(inner_spec, **overrides)
+            self._scorers[name] = inner_cls(config=inner_spec, base_device=base_device)
 
-        weight_names = set(self.weights)
-        scorer_names = set(config.scorers)
-        if weight_names != scorer_names:
-            missing = sorted(weight_names - scorer_names)
-            extra = sorted(scorer_names - weight_names)
-            raise ValueError(
-                "T2AVCompositeScorer: `weights` and `scorers` must use the same keys "
-                f"(weights missing scorers={missing}, scorers missing weights={extra})."
-            )
-
-        self._scorers: Dict[str, RewardBackend] = dict(config.scorers)
         _require_prompt_video_term(self.weights, self._scorers)
 
     def compute_rewards(self, request: RewardRequest) -> RewardResponse:
@@ -127,10 +142,13 @@ class T2AVCompositeSpec(BaseRewardComponentSpec):
 
     batch_size: int = 8
     device: str = "auto"
-    weights: Dict[str, float] = field(default_factory=dict)
-    # Hydra-instantiated inner backends (same nested `_target_` pattern as PerDomainSpec).
-    # Inner fields such as mode / frame_selection / model_id live on those specs.
-    scorers: Dict[str, RewardBackend] = field(default_factory=dict)
+    # Copied onto inner specs that declare it (videopickscore). "first" keeps
+    # historical behaviour; "middle" avoids scoring a blank opening frame.
+    frame_selection: str = "first"
+    weights: Dict[str, float] = field(default_factory=lambda: {"videopickscore": 0.5, "clap": 0.5})
+    # Optional per-name inner-spec overrides (e.g. imagebind: {mode: all}).
+    # Unknown keys are rejected against that inner spec; not an allow-list.
+    scorers: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
 
 __all__ = ["T2AVCompositeScorer", "T2AVCompositeSpec"]

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -9,33 +9,60 @@ from typing import Dict, List
 from unirl.reward.base import BaseRewardComponentSpec, RewardBackend
 from unirl.types.reward import RewardRequest, RewardResponse
 
-from .registry import resolve_builtin_reward_scorer_class, resolve_builtin_reward_spec_class
+
+def _require_prompt_video_term(weights: Dict[str, float], scorers: Dict[str, RewardBackend]) -> None:
+    covering = [
+        name for name, weight in weights.items() if float(weight) != 0.0 and scorers[name].covers_prompt_video()
+    ]
+    if covering:
+        return
+    details = ", ".join(
+        f"{name}(weight={weights[name]}, covers_prompt_video={scorers[name].covers_prompt_video()})" for name in weights
+    )
+    raise ValueError(
+        "T2AVCompositeScorer: no positive-weight inner scorer relates the prompt to the video. "
+        f"Current mix: {details}. "
+        "Add videopickscore / videoalign / videoclipdelta, or nest imagebind with mode "
+        "'text_video' or 'all'. clap and imagebind mode='audio_video' do not cover this."
+    )
 
 
 class T2AVCompositeScorer(RewardBackend):
-    """Weighted blend of inner reward scorers for T2AV (video + audio)."""
+    """Weighted blend of Hydra-instantiated inner reward scorers for T2AV."""
 
     input_kind = "video"
 
     def __init__(self, *, config: "T2AVCompositeSpec", base_device: str) -> None:
         super().__init__(model_name="t2av_composite", batch_size=config.batch_size)
+        del base_device
         self.weights: Dict[str, float] = dict(config.weights or {})
+        if not config.scorers:
+            raise ValueError(
+                "T2AVCompositeScorer requires a non-empty `scorers` mapping (name -> RewardBackend), "
+                "the same nested `_target_` pattern as PerDomainRewardScorer."
+            )
         if not self.weights:
             raise ValueError("T2AVCompositeScorer requires a non-empty `weights` dict (scorer_name -> weight).")
 
-        self._scorers: Dict[str, RewardBackend] = {}
-        for name in self.weights:
-            inner_cls = resolve_builtin_reward_scorer_class(name)
-            inner_spec_cls = resolve_builtin_reward_spec_class(name)
-            inner_spec = inner_spec_cls()
-            import dataclasses
+        for name, scorer in config.scorers.items():
+            if not isinstance(scorer, RewardBackend):
+                raise TypeError(
+                    f"T2AVCompositeScorer: scorers[{name!r}] is {type(scorer).__name__}, not a "
+                    "RewardBackend — each entry needs its own `_target_` for Hydra to instantiate."
+                )
 
-            # Propagate only fields BOTH the composite and the inner spec declare.
-            shared = ("device", "batch_size", "frame_selection")
-            overrides = {f: getattr(config, f) for f in shared if hasattr(inner_spec, f) and hasattr(config, f)}
-            if overrides:
-                inner_spec = dataclasses.replace(inner_spec, **overrides)
-            self._scorers[name] = inner_cls(config=inner_spec, base_device=base_device)
+        weight_names = set(self.weights)
+        scorer_names = set(config.scorers)
+        if weight_names != scorer_names:
+            missing = sorted(weight_names - scorer_names)
+            extra = sorted(scorer_names - weight_names)
+            raise ValueError(
+                "T2AVCompositeScorer: `weights` and `scorers` must use the same keys "
+                f"(weights missing scorers={missing}, scorers missing weights={extra})."
+            )
+
+        self._scorers: Dict[str, RewardBackend] = dict(config.scorers)
+        _require_prompt_video_term(self.weights, self._scorers)
 
     def compute_rewards(self, request: RewardRequest) -> RewardResponse:
         start = time.time()
@@ -75,6 +102,9 @@ class T2AVCompositeScorer(RewardBackend):
     def preferred_input_kind(self) -> str:
         return self.input_kind
 
+    def covers_prompt_video(self) -> bool:
+        return True
+
     def is_available(self) -> bool:
         return all(s.is_available() for s in self._scorers.values())
 
@@ -93,12 +123,18 @@ class T2AVCompositeScorer(RewardBackend):
 
 @dataclass
 class T2AVCompositeSpec(BaseRewardComponentSpec):
-    """Typed config for the T2AV composite reward."""
+    """Typed config for the T2AV composite reward.
+
+    Inner scorers are Hydra-instantiated backends under ``scorers``, not names
+    looked up from ``weights``. Put ``mode``, ``frame_selection``, ``model_id``
+    and any other inner field on that inner spec — the composite does not
+    forward a field allow-list.
+    """
 
     batch_size: int = 8
     device: str = "auto"
-    # Forwarded to inner scorers that declare it (videopickscore). "first"
-    # keeps the historical behaviour; "middle" avoids scoring a blank opening
-    # frame on clips that fade or reveal in.
-    frame_selection: str = "first"
-    weights: Dict[str, float] = field(default_factory=lambda: {"videopickscore": 0.5, "clap": 0.5})
+    weights: Dict[str, float] = field(default_factory=dict)
+    scorers: Dict[str, RewardBackend] = field(default_factory=dict)
+
+
+__all__ = ["T2AVCompositeScorer", "T2AVCompositeSpec"]

--- a/unirl/reward/local/t2av_composite.py
+++ b/unirl/reward/local/t2av_composite.py
@@ -123,17 +123,13 @@ class T2AVCompositeScorer(RewardBackend):
 
 @dataclass
 class T2AVCompositeSpec(BaseRewardComponentSpec):
-    """Typed config for the T2AV composite reward.
-
-    Inner scorers are Hydra-instantiated backends under ``scorers``, not names
-    looked up from ``weights``. Put ``mode``, ``frame_selection``, ``model_id``
-    and any other inner field on that inner spec — the composite does not
-    forward a field allow-list.
-    """
+    """Typed config for the T2AV composite reward."""
 
     batch_size: int = 8
     device: str = "auto"
     weights: Dict[str, float] = field(default_factory=dict)
+    # Hydra-instantiated inner backends (same nested `_target_` pattern as PerDomainSpec).
+    # Inner fields such as mode / frame_selection / model_id live on those specs.
     scorers: Dict[str, RewardBackend] = field(default_factory=dict)
 
 

--- a/unirl/reward/local/video_clip_delta.py
+++ b/unirl/reward/local/video_clip_delta.py
@@ -31,6 +31,9 @@ class VideoCLIPDeltaScorer(PickScoreRewardScorer):
         self.source_sim_floor = float(getattr(config, "source_sim_floor", 0.3))
         super().__init__(config=config, base_device=base_device)
 
+    def covers_prompt_video(self) -> bool:
+        return True
+
     @staticmethod
     def _sample_frames_pil(video: "Video", k: int) -> list["Image.Image"]:
         """K evenly-spaced frames of a per-sample ``Video`` (frames ``[T, C, H, W]``)."""

--- a/unirl/reward/local/video_pickscore.py
+++ b/unirl/reward/local/video_pickscore.py
@@ -33,6 +33,9 @@ class VideoPickScoreScorer(PickScoreRewardScorer):
                 f"VideoPickScoreSpec.frame_selection must be 'first' or 'middle'; got {self.frame_selection!r}"
             )
 
+    def covers_prompt_video(self) -> bool:
+        return True
+
     @staticmethod
     def _extract_frame(video: torch.Tensor, which: str = "first") -> "Image.Image":
         """Extract one frame of a channel-first video tensor."""

--- a/unirl/reward/local/videoalign.py
+++ b/unirl/reward/local/videoalign.py
@@ -607,6 +607,9 @@ class VideoAlignRewardScorer(LocalRewardBackend):
         self._mq_coef = float(getattr(config, "mq_coef", 1.0))
         self._ta_coef = float(getattr(config, "ta_coef", 1.0))
 
+    def covers_prompt_video(self) -> bool:
+        return self._ta_coef != 0.0
+
     def _load_model(self) -> None:
         os.environ.setdefault("FORCE_QWENVL_VIDEO_READER", "decord")
         checkpoint_path = self.model_kwargs.get("checkpoint_path") or os.environ.get("VIDEOALIGN_CKPT")


### PR DESCRIPTION
## Summary

`T2AVCompositeScorer` rebuilt every inner spec from dataclass defaults and forwarded a hardcoded allow-list (`device`, `batch_size`, `frame_selection`). Inner-only fields such as `ImageBindSpec.mode` were unreachable from any recipe, so `imagebind` inside the composite was always `cos(audio, video)`. Combined with `clap` (prompt↔audio only), a T2AV objective can have **no term that relates the prompt to the video**.

This keeps the existing recipe shape: inner scorers are still constructed from `weights` names. The allow-list is gone. Overlapping composite fields (`device`, `batch_size`, `frame_selection`) still copy onto inners that declare them, so current YAML does not need to move. Additional inner fields go on an optional per-name map, not onto the composite spec:

```yaml
weights:
  imagebind: 1.0
  clap: 1.0
scorers:
  imagebind:
    mode: all
```

The composite refuses to start unless some positive-weight inner scorer returns `covers_prompt_video()`. `clap` and `imagebind` with `mode: audio_video` do not; `videopickscore` / `videoalign` / `videoclipdelta` do; `imagebind` does only for `text_video` or `all` with a nonzero `text_video` mix weight.

## Related Issue

N/A. Alternative to #404 (which only adds `mode` to the allow-list). Interacts with #403: that `imagebind`+`clap` recipe cannot start until it sets `scorers.imagebind.mode` to `text_video` or `all`.

## Test Plan

- `python3 lint/check_recipe_targets.py` — pass (pre-push)
- pre-push hooks (yaml, ruff, one-line docstrings, dependency directions) — pass
- One-off harness `/tmp/verify_t2av_inplace.py` (not committed; `tests/` removed by #99/#267):
  - default weights-only `videopickscore`+`clap` still starts
  - `frame_selection: middle` still forwards in-place to videopickscore only
  - `imagebind`+`clap` at default mode is refused
  - `scorers.imagebind.mode: all` starts without rewriting the recipe into nested `_target_` backends
  - unknown inner field is refused
  - `scorers` key outside `weights` is refused
  Result: `ALL PASSED`
- End-to-end T2AV run: Not run; reason: init/config plumbing plus a start-up guard; the in-tree LTX-2 recipe is still weights-only `videopickscore`+`clap`.

## Compatibility / Risk

Existing weights-only recipes keep working, including `frame_selection` on the composite. New: `imagebind`+`clap` without a prompt-video term fails at init. Downstream #403 must set `scorers.imagebind.mode`. `VideoRewardScorer` still uses a small allow-list; out of scope.

## Reviewer Notes

- Duplicate-work check: #404 is the two-line allow-list hotfix for the same hole. This PR does not extend that list.
- Cannot push onto celve's #404 branch; this is the in-place version on a new PR.
- AI-assisted implementation; the submitting human should still review the diff.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.