### PR TITLE
perf(veomni-ep): reduce expert gather peak memory

### DIFF
--- a/unirl/train/backend/veomni/ep/placement.py
+++ b/unirl/train/backend/veomni/ep/placement.py
@@ -56,11 +56,27 @@ def gather_stacked_expert_block(
 ) -> torch.Tensor:
     """Gather contiguous ``[E/ep,...]`` blocks and concatenate the expert axis."""
     block = local_block.contiguous()
-    if block.device.type == "cpu" and dist.is_initialized() and dist.get_backend(ep_group) == "nccl":
+    backend = dist.get_backend(ep_group)
+    group_size = dist.get_world_size(ep_group)
+    if group_size != ep_size:
+        raise RuntimeError(f"EP placement: ep_size={ep_size} does not match group world_size={group_size}.")
+    if block.device.type == "cpu" and backend == "nccl":
         block = block.cuda()
-    gathered = [torch.empty_like(block) for _ in range(ep_size)]
-    dist.all_gather(gathered, block, group=ep_group)
-    return torch.cat(gathered, dim=0)
+
+    # Keep the list path for legacy Gloo (requirements.txt still permits torch 2.1).
+    if backend != "nccl":
+        gathered = [torch.empty_like(block) for _ in range(ep_size)]
+        dist.all_gather(gathered, block, group=ep_group)
+        return torch.cat(gathered, dim=0)
+
+    # Write rank-contiguous blocks directly into the final tensor, avoiding the
+    # extra full-size allocation and copy made by list all_gather + torch.cat.
+    stacked = block.new_empty((ep_size * block.shape[0], *block.shape[1:]))
+    gather_single = getattr(dist, "all_gather_single", None)  # PyTorch >= 2.13
+    if gather_single is None:
+        gather_single = dist.all_gather_into_tensor
+    gather_single(stacked, block, group=ep_group)
+    return stacked
 
 
 def assign_local_block(param: torch.Tensor, block: torch.Tensor) -> None:


### PR DESCRIPTION
## Summary

`gather_stacked_expert_block` currently allocates one receive tensor per EP rank and then allocates another full-size tensor for `torch.cat`. For a local block of `L` bytes and EP size `N`, that keeps roughly `2 * N * L + L` bytes live at peak.

On NCCL, write rank-contiguous blocks directly into the final `(N * E_local, ...)` tensor:

- Use PyTorch 2.13's `all_gather_single`, falling back to `all_gather_into_tensor` for the pinned PyTorch 2.11 stack.
- Validate that the configured `ep_size` matches the process-group world size before entering the collective.
- Keep the existing list-gather plus `torch.cat` path for non-NCCL backends, because the legacy `requirements.txt` still permits PyTorch 2.1 and old Gloo lacks reliable single-output gather support.

The resulting tensor shape, rank order, dtype, device, and synchronous behavior are unchanged. The NCCL path avoids one full stacked-expert allocation and copy per gather.

## Related Issue

N/A

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files unirl/train/backend/veomni/ep/placement.py` — all hooks passed.
- Two-rank Gloo/CPU smoke on PyTorch 2.13:
  - non-contiguous `[E_local, ...]` input is made contiguous;
  - gathered output is bit-identical to rank-ordered `torch.cat`;
  - mismatched `ep_size` fails before the collective.
- NCCL-branch contract smoke with the collective mocked:
  - verifies final output shape `(ep_size * E_local, ...)`;
  - verifies rank-contiguous values and `all_gather_single` selection.
- PyTorch 2.11 compatibility-branch smoke with `all_gather_single` absent:
  - verifies fallback to `all_gather_into_tensor` and identical output.
- Not run: real multi-GPU NCCL or VeOmni DTensor/checkpoint roundtrip. This environment has no accessible GPU/VeOmni runtime. Before merge, please run at least a 2-rank NCCL equivalence + CUDA peak-memory smoke; an 8-rank Qwen MoE EP run would cover the production shape.

## Compatibility / Risk

- No config, checkpoint schema, tensor layout, rank ordering, or wire-format change.
- The helper is shared by EP full-weight sync plus model and optimizer checkpoint gathering, so a wrong output layout would affect all three paths. The output shape is the concatenated dim-0 form accepted by both the PyTorch 2.11 and 2.13 NCCL APIs.
- PyTorch 2.13 renamed `all_gather_into_tensor` to `all_gather_single`; feature detection avoids the deprecated wrapper and its `FutureWarning` while retaining PyTorch 2.11 compatibility.
- Non-NCCL behavior is intentionally unchanged.
- Inputs must remain equal-shaped across EP ranks. The old `empty_like` receive-list path already had the same effective requirement.

## Reviewer Notes

- Peak-allocation reduction is approximately one full stacked expert tensor (`ep_size * local_block.nbytes`) per rank. This is a static allocation analysis, not a measured H20 result.
- This is independent of #377: that PR moves expert export policy out of generic weight-sync code but does not modify `gather_stacked_expert_block`.
- AI assistance was used; the diff and test outputs were reviewed before publishing.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
