### PR TITLE
feat(rollout): run the FastVideo engine on unmodified upstream and add WAN 2.2 A14B

### DIFF
--- a/examples/diffusion/wan21/wan21_t2v_dancegrpo_fastvideo.yaml
+++ b/examples/diffusion/wan21/wan21_t2v_dancegrpo_fastvideo.yaml
@@ -18,9 +18,10 @@
 #      weights and pushes the merged full model (FastVideo serves merged weights;
 #      it has no separate adapter path here).
 #
-# FastVideo dependency: https://github.com/Zcchill/FastVideo at or after
-# 7fe1d7db9a0b8aebb46679e7924f597431f23665. Set $FASTVIDEO_PATH to that
-# checkout; FastVideo is lazy-imported by the rollout engine only.
+# FastVideo dependency: unmodified upstream https://github.com/hao-ai-lab/FastVideo
+# at 2095477eac7e289c7a7ab13acb367ca60687c304. Set $FASTVIDEO_PATH to that
+# checkout; FastVideo is lazy-imported by the rollout engine only. UniRL installs
+# the RL contracts itself (rollout/engine/fastvideo/README.md: The pin).
 #
 # This recipe defaults to replay log-probs. Native mode is enabled by setting
 # rollout.config.native_logprob=true and algorithm.old_logp_source=rollout;

--- a/examples/diffusion/wan22/wan22_t2v_14b_dancegrpo_fastvideo.yaml
+++ b/examples/diffusion/wan22/wan22_t2v_14b_dancegrpo_fastvideo.yaml
@@ -1,0 +1,100 @@
+# @package _global_
+# DanceGRPO WAN 2.2 T2V A14B with the FastVideo rollout engine, colocate, v2 trainer, 1x8.
+#
+# This is wan22_t2v_14b_dancegrpo.yaml with rollout moved from the in-process
+# trainside engine to the dedicated FastVideo VideoGenerator engine (+ the
+# weight-sync block a dedicated engine requires). Reward, LoRA targets, Dance
+# SDE kernel, replay log-prob, sigma schedule, and SDE-index window remain
+# aligned with the official recipe. The deterministic non-SDE tail intentionally
+# uses UniPC instead of the trainside recipe's eta=0 Euler steps, so generated
+# trajectories can differ (unirl/sde/README.md).
+#
+# WAN 2.2 A14B delta over the WAN 2.1 FastVideo recipe:
+#   1. `model_family: wan2.2` selects boundary-routed dual-expert rollout. The
+#      engine pins `boundary_ratio` onto FastVideo's pipeline/dit configs and
+#      verifies the checkpoint declares both `transformer` and `transformer_2`.
+#   2. Two 14B experts do not fit alongside the trainer, so the rollout runs
+#      with layerwise DiT offload plus CPU text-encoder/VAE offload.
+#   3. The weight sync ships a checkpoint path; each worker splits it on the
+#      `high_noise.*` / `low_noise.*` prefixes and loads both experts.
+#
+# FastVideo dependency: see unirl/rollout/engine/fastvideo/README.md for the
+# pinned surface. Set $FASTVIDEO_PATH to that checkout; FastVideo is
+# lazy-imported by the rollout engine only.
+#
+# This recipe defaults to replay log-probs. Native mode is enabled by setting
+# rollout.config.native_logprob=true and algorithm.old_logp_source=rollout;
+# both modes use the same SDE sampling window.
+
+defaults:
+  - wan22_t2v_14b_dancegrpo
+  - _self_
+
+weight_sync_interval: 1      # push freshly-trained weights into FastVideo every rollout (on-policy)
+
+# Shared nodes (lifted from the trainside recipe so the dedicated FastVideo
+# engine can be injected with the same model config + SDE kernel).
+model_config:
+  _target_: unirl.models.wan22.config.WAN22PipelineConfig
+  pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,Wan-AI/Wan2.2-T2V-A14B-Diffusers}
+  model_precision: bf16
+  shift: 5.0
+  max_sequence_length: 512
+  # Sigma boundary routing the high-noise / low-noise experts; the engine pins
+  # the same value onto FastVideo's dit_config so both engines agree.
+  boundary_ratio: 0.875
+  num_train_timesteps: 1000
+  # Deterministic-solver SSOT: the engine verifies these against the
+  # checkpoint's scheduler/scheduler_config.json at init.
+  unipc_solver_order: 2
+  unipc_solver_type: bh2
+  unipc_lower_order_final: true
+  # FastVideo owns video decoding; the trainer-side pipeline only replays the
+  # returned latent trajectory and does not need a duplicate VAE on the same GPU.
+  load_vae: false
+
+strategy:
+  _target_: unirl.sde.kernels.DanceSDEStrategy
+
+bundle:
+  config: ${model_config}
+
+pipeline:
+  strategy: ${strategy}
+
+rollout:
+  _target_: unirl.rollout.engine.fastvideo.engine.FastVideoRolloutEngine
+  config:
+    _target_: unirl.rollout.engine.fastvideo.config.FastVideoEngineConfig
+    model_family: wan2.2
+    # replay recipe: engine returns the trajectory, trainer recomputes log-probs.
+    # Flip to true (+ algorithm.old_logp_source: rollout) for the native path.
+    native_logprob: false
+    init_same_noise: ${sampling.init_same_noise}
+    num_gpus: 1
+    tp_size: 1
+    sp_size: 1
+    local_mode: true
+    forward_batch_size: 1           # CPU-output concat cadence (NOT a GPU batch: the
+                                    # forward runs one video at a time regardless)
+    fastvideo_path: ${oc.env:FASTVIDEO_PATH,null}
+    engine_kwargs:
+      # Two 14B experts stay on CPU; only the active layers are prefetched.
+      dit_layerwise_offload: true
+      text_encoder_cpu_offload: true
+      vae_cpu_offload: true
+  model_config: ${model_config}
+  strategy: ${strategy}
+
+algorithm:
+  old_logp_source: replay
+
+sync:
+  _target_: unirl.distributed.weight_sync.full.checkpoint.CheckpointWeightSync
+  lora_merged: true
+  sync_dir: ${oc.env:WEIGHT_SYNC_DIR,/tmp/unirl_fastvideo_weight_sync_wan22}
+  flush_cache: true
+
+logging:
+  run_name: ${oc.env:WANDB_RUN_NAME,wan22_t2v_14b_dancegrpo_fastvideo}
+  tags: ["wan22", "t2v", "dancegrpo", "grpo", "video", "pickscore", "fastvideo", "dual-transformer", "v2"]

--- a/unirl/models/wan22/diffusion.py
+++ b/unirl/models/wan22/diffusion.py
@@ -17,11 +17,11 @@ from unirl.utils.dtypes import parse_torch_dtype
 
 from .bundle import WAN22Bundle
 
-_WAN_TIMESTEP_SCALE: float = 1000.0
-
 
 class WAN22DiffusionStep(DiffusionStep[WAN22Bundle, WAN21Conditions]):
     """Per-step WAN 2.2 denoising kernel — stateless, dual-transformer routing."""
+
+    TIMESTEP_SCALE: ClassVar[float] = 1000.0  # sigma [0, 1] -> WAN timestep [0, 1000]
 
     @staticmethod
     def _select_for_sigma(
@@ -64,7 +64,7 @@ class WAN22DiffusionStep(DiffusionStep[WAN22Bundle, WAN21Conditions]):
         )
 
         batch_size = int(sample.shape[0])
-        timestep = sigma * _WAN_TIMESTEP_SCALE
+        timestep = sigma * self.TIMESTEP_SCALE
         if timestep.dim() == 0:
             timestep = timestep.expand(batch_size)
         elif int(timestep.shape[0]) != batch_size:

--- a/unirl/rollout/engine/fastvideo/README.md
+++ b/unirl/rollout/engine/fastvideo/README.md
@@ -11,16 +11,23 @@ inference solver without integer-timestep loss.*
 
 ## The pin
 
-The integration targets
-**`Zcchill/FastVideo@7fe1d7db9a0b8aebb46679e7924f597431f23665`** (a snapshot of
-hao-ai-lab/FastVideo PR #1222, the Wan2.1 RL pipeline), injected via
-`cfg.fastvideo_path` / `$FASTVIDEO_PATH` — there is no pip pin. `_unipc.py`
-therefore fingerprints the patched surface at patch-install time (engine init
-and every spawned worker): the parameter lists of
-`FlowUniPCMultistepScheduler.set_timesteps` and `sde_step_with_logprob`, the
-`WorkerMultiprocProc.worker_main` entrypoint, and (engine side) the
-`ForwardBatch.RLData` fields. It also fingerprints the seams the weight and
-offload patches install onto — `MultiprocExecutor.collective_rpc`,
+The integration targets the **unmodified upstream**
+**`hao-ai-lab/FastVideo@2095477eac7e289c7a7ab13acb367ca60687c304`** (PR #1222's
+source snapshot), injected via `cfg.fastvideo_path` / `$FASTVIDEO_PATH` — there
+is no pip pin. Upstream ships none of the RL surface this engine needs, so
+UniRL owns it: `_contracts.py` adds the `RLData.sde_step_indices` / `sde_type`
+fields and the `eta` / `sde_type` parameters on `sde_step_with_logprob` (whose
+stock transition uses a different diffusion law than UniRL's Dance/Flow
+kernels), `_conditions.py` restores the `rl_data` / trajectory / prompt
+embeddings that upstream's `MultiprocExecutor.execute_forward` drops when it
+rebuilds its response batch, and `_weights.py` adds the full-weight update API
+upstream does not expose at all.
+
+`_unipc.py` fingerprints the surface at patch-install time (engine init and
+every spawned worker), taking the **stock** signatures before any UniRL patch
+rewrites them: `sde_step_with_logprob`'s stock parameter list plus the
+`DenoisingStage.forward` source markers, `FlowUniPCMultistepScheduler.set_timesteps`,
+`MultiprocExecutor.collective_rpc` / `execute_forward`, `Worker.execute_forward`,
 `ModuleHookManager.get_from` / `get_forward_hook`,
 `LayerwiseOffloadHook.mutate_params_scope`,
 `fsdp_load.load_model_from_full_model_state_dict`, and

--- a/unirl/rollout/engine/fastvideo/README.md
+++ b/unirl/rollout/engine/fastvideo/README.md
@@ -4,10 +4,10 @@
 > in-process `VideoGenerator` driven one prompt at a time through
 > `executor.execute_forward`. Full map: [`../README.md`](../README.md).
 
-*Runs WAN 2.1 rollouts on the pinned FastVideo RL fork and re-routes its
-hard-coded deterministic Euler steps through UniRL's canonical UniPC solver
-(`unirl/sde/unipc.py`), so rollouts follow the checkpoint's native inference
-solver without integer-timestep loss.*
+*Runs WAN 2.1 and WAN 2.2 A14B T2V rollouts on the pinned FastVideo RL fork and
+re-routes its hard-coded deterministic Euler steps through UniRL's canonical
+UniPC solver (`unirl/sde/unipc.py`), so rollouts follow the checkpoint's native
+inference solver without integer-timestep loss.*
 
 ## The pin
 
@@ -19,9 +19,14 @@ therefore fingerprints the patched surface at patch-install time (engine init
 and every spawned worker): the parameter lists of
 `FlowUniPCMultistepScheduler.set_timesteps` and `sde_step_with_logprob`, the
 `WorkerMultiprocProc.worker_main` entrypoint, and (engine side) the
-`ForwardBatch.RLData` fields. Drift fails closed at init instead of mid-rollout.
-Before editing a patch, read that exact commit (CLAUDE.md: monkey-patch
-doctrine), then update the fingerprints together with the patch.
+`ForwardBatch.RLData` fields. It also fingerprints the seams the weight and
+offload patches install onto — `MultiprocExecutor.collective_rpc`,
+`ModuleHookManager.get_from` / `get_forward_hook`,
+`LayerwiseOffloadHook.mutate_params_scope`,
+`fsdp_load.load_model_from_full_model_state_dict`, and
+`PipelineComponentLoader.load_module`. Drift fails closed at init instead of
+mid-rollout. Before editing a patch, read that exact commit (CLAUDE.md:
+monkey-patch doctrine), then update the fingerprints together with the patch.
 
 ## How the canonical UniPC path works
 
@@ -35,7 +40,8 @@ doctrine), then update the fingerprints together with the patch.
   `int64`, which truncates conditioning (`833` vs `833.333…`, the drift #248
   tracked).
 - **Solver SSOT.** `WAN21PipelineConfig.unipc_*` declares the deterministic
-  solver. At init the engine verifies it against the checkpoint's
+  solver (`WAN22PipelineConfig` inherits the same fields). At init the engine
+  verifies it against the checkpoint's
   `scheduler/scheduler_config.json`, resolving either a local diffusers-layout
   directory or a Hugging Face model repo — fail closed on a mismatch, a
   missing/unreadable file, a non-UniPC `_class_name`, or a non-empty
@@ -55,9 +61,46 @@ doctrine), then update the fingerprints together with the patch.
   zero log-prob column `_build_segment` slices off before building
   `LatentSegment`.
 - **Verification.** Every sample's worker-echoed `RLData.trajectory_timesteps`
-  goes through `verify_engine_used_sigmas` (scale-normalized), and
-  `_wan_timestep_scale` pins `num_train_timesteps == 1000` against the WAN21
-  model contract.
+  goes through `verify_engine_used_sigmas` (scale-normalized). The patched
+  `set_timesteps` pins the live scheduler's own `num_train_timesteps` onto the
+  scheduler, and dispatch fails closed unless it equals the
+  `timestep_scale` the request plan carries — the engine resolves that from the
+  selected family's step kernel (`WAN21DiffusionStep.TIMESTEP_SCALE` /
+  `WAN22DiffusionStep.TIMESTEP_SCALE`).
+
+## WAN 2.2 A14B dual expert
+
+`model_family: wan2.2` turns on boundary-routed dual-expert rollout.
+
+- **Boundary agreement.** FastVideo selects the expert on
+  `t >= boundary_ratio * num_train_timesteps` and UniRL's trainside routes on
+  `sigma >= boundary_ratio`. Those two agree only when the model config's
+  `num_train_timesteps` equals the step kernel's `TIMESTEP_SCALE`, so the engine
+  `require`s exactly that at init, then pins `boundary_ratio` onto both
+  `pipeline_config` and `dit_config` before boot and onto every request batch.
+  FastVideo's `transformer` is the high-noise expert and `transformer_2` the
+  low-noise one; the weight sync routes `high_noise.*` / `low_noise.*`
+  accordingly. The engine also verifies the checkpoint's `model_index.json`
+  declares both.
+- **Weight sync ships a path, not a state dict.** An A14B state dict through the
+  worker pipes exhausts `/dev/shm`, so `update_transformer_weights_from_path`
+  sends only the `CheckpointWeightSync` file path and each worker `torch.load`s
+  it (`weights_only=True`) and splits the experts itself. Every worker reads the
+  whole file, so host RAM — not `/dev/shm` — bounds `sp_size`.
+- **Mutating layerwise-offloaded blocks must use
+  `LayerwiseOffloadHook.mutate_params_scope()`.** The hooks are circularly
+  linked: the last block's `pre_forward` prefetches block 0's parameters onto
+  GPU, and `wait_and_replace_params` reuses a cached `gpu_named_parameters`
+  entry when one exists. Writing `state.cpu_named_parameters` directly therefore
+  leaves that prefetched copy stale, so block 0 of each expert would run the
+  previous policy's weights for one forward. The colocate loop currently hides
+  this by tearing the generator down every step; the scope keeps it correct if
+  that ever changes.
+- **Loading two 14B experts needs the offload patch.** Upstream stages a whole
+  DiT on GPU before attaching the layerwise hooks, which transiently exceeds the
+  device. `_offload.py` materializes those modules on CPU, then moves only the
+  stem/head parameters the hooks left real. It reads `cpu_offload` out of
+  `**kwargs`, which is why that signature is fingerprinted.
 
 ## Gotchas
 

--- a/unirl/rollout/engine/fastvideo/_conditions.py
+++ b/unirl/rollout/engine/fastvideo/_conditions.py
@@ -1,0 +1,130 @@
+"""Carry RL trajectories and text conditions back across FastVideo worker pipes; contract in README.md."""
+
+from __future__ import annotations
+
+from copy import copy
+from dataclasses import fields, is_dataclass
+from functools import wraps
+from typing import Any
+
+import torch
+
+
+def _to_cpu(value: Any) -> Any:
+    """Deep-copy a worker payload onto CPU so no CUDA tensor crosses the IPC boundary."""
+    if value is None:
+        return None
+    if torch.is_tensor(value):
+        return value.detach().cpu()
+    if isinstance(value, dict):
+        return {key: _to_cpu(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_to_cpu(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_to_cpu(item) for item in value)
+    if is_dataclass(value) and not isinstance(value, type):
+        result = copy(value)
+        for field in fields(value):
+            object.__setattr__(result, field.name, _to_cpu(getattr(value, field.name)))
+        return result
+    return value
+
+
+_CARRIED = (
+    "rl_data",
+    "trajectory_latents",
+    "trajectory_timesteps",
+    "prompt_embeds",
+    "negative_prompt_embeds",
+    "prompt_attention_mask",
+    "negative_attention_mask",
+)
+
+
+class _ForwardResultPipe:
+    """Connection proxy that attaches the RL fields upstream's response drops."""
+
+    def __init__(self, connection: Any, owner: Any) -> None:
+        self._connection = connection
+        self._owner = owner
+
+    def send(self, payload: Any) -> None:
+        worker = getattr(self._owner, "worker", None)
+        inner = getattr(worker, "worker", worker)
+        cached = getattr(inner, "_unirl_last_forward_batch", None) if inner is not None else None
+        if isinstance(payload, dict) and "output_batch" in payload and cached is not None:
+            for name in _CARRIED:
+                payload.setdefault(name, _to_cpu(getattr(cached, name, None)))
+            inner._unirl_last_forward_batch = None
+        self._connection.send(_to_cpu(payload))
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._connection, name)
+
+
+def patch_conditions() -> None:
+    """Round-trip RLData and text conditions; upstream's executor rebuilds a bare ForwardBatch."""
+    import fastvideo.envs as envs
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+    from fastvideo.worker.gpu_worker import Worker
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor, WorkerMultiprocProc
+
+    # ``WorkerWrapperBase`` has no own ``execute_forward``; it proxies through
+    # ``__getattr__``, and the busy loop calls ``self.worker.execute_forward``.
+    if not getattr(Worker, "_unirl_fastvideo_forward_cache", False):
+        original_execute = Worker.execute_forward
+
+        @wraps(original_execute)
+        def execute_forward(self, forward_batch, fastvideo_args):
+            output_batch = original_execute(self, forward_batch, fastvideo_args)
+            self._unirl_last_forward_batch = output_batch
+            return output_batch
+
+        Worker.execute_forward = execute_forward
+        Worker._unirl_fastvideo_forward_cache = True
+
+    original_init = WorkerMultiprocProc.__init__
+    if not getattr(original_init, "_unirl_fastvideo_conditions", False):
+
+        @wraps(original_init)
+        def init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            if not isinstance(self.pipe, _ForwardResultPipe):
+                self.pipe = _ForwardResultPipe(self.pipe, self)
+
+        init._unirl_fastvideo_conditions = True
+        WorkerMultiprocProc.__init__ = init
+
+    if getattr(MultiprocExecutor.execute_forward, "_unirl_fastvideo_conditions", False):
+        return
+
+    def execute_forward(self, forward_batch, fastvideo_args):
+        responses = self.collective_rpc(
+            "execute_forward",
+            kwargs={"forward_batch": forward_batch, "fastvideo_args": fastvideo_args},
+        )
+        if not responses or not isinstance(responses[0], dict):
+            raise RuntimeError(f"FastVideo execute_forward returned invalid worker responses: {responses!r}")
+        response = responses[0]
+        kwargs: dict[str, Any] = {
+            "data_type": forward_batch.data_type,
+            "output": response.get("output_batch"),
+            "logging_info": response.get("logging_info") if envs.FASTVIDEO_STAGE_LOGGING else None,
+            "extra": response.get("extra", {}),
+            "trajectory_latents": response.get("trajectory_latents"),
+            "trajectory_timesteps": response.get("trajectory_timesteps"),
+        }
+        if response.get("rl_data") is not None:
+            kwargs["rl_data"] = response["rl_data"]
+        result = ForwardBatch(**kwargs)
+        result.prompt_embeds = response.get("prompt_embeds") or []
+        result.negative_prompt_embeds = response.get("negative_prompt_embeds")
+        result.prompt_attention_mask = response.get("prompt_attention_mask")
+        result.negative_attention_mask = response.get("negative_attention_mask")
+        return result
+
+    execute_forward._unirl_fastvideo_conditions = True
+    MultiprocExecutor.execute_forward = execute_forward
+
+
+__all__ = ["patch_conditions"]

--- a/unirl/rollout/engine/fastvideo/_contracts.py
+++ b/unirl/rollout/engine/fastvideo/_contracts.py
@@ -49,11 +49,12 @@ def patch_contracts() -> None:
     ForwardBatch.RLData = UniRLFastVideoRLData
 
 
-def _unirl_std_dev_t(sde_type: str, sigma: torch.Tensor, sigma_max: torch.Tensor, eta: float) -> torch.Tensor:
+def _unirl_std_dev_t(sde_type: str, sigma: torch.Tensor, eta: float, sigma_max: float = 0.99) -> torch.Tensor:
     """Return the UniRL kernel's diffusion coefficient; must match ``unirl/sde/kernels.py``."""
     if sde_type == "dance":
         return torch.full_like(sigma, float(eta))
     if sde_type == "flow":
+        # sigma_max is UniRL's constant sigma==1 guard, not the schedule's second sigma.
         return torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma))) * float(eta)
     raise ValueError(f"FastVideo UniRL transition supports sde_type 'flow' or 'dance'; got {sde_type!r}")
 
@@ -101,7 +102,7 @@ def _sde_step_with_logprob(
         std = torch.zeros_like(sigma)
         return (result, zeros, result, std, sqrt_dt) if return_dt_and_std_dev_t else (result, zeros, result, std)
 
-    std_dev_t = _unirl_std_dev_t(kernel, sigma, sigmas[1].reshape(1, *([1] * (sample.ndim - 1))), resolved_eta)
+    std_dev_t = _unirl_std_dev_t(kernel, sigma, resolved_eta)
     prev_sample_mean = (
         sample * (1 + std_dev_t.square() / (2 * sigma) * dt)
         + model_output * (1 + std_dev_t.square() * (1 - sigma) / (2 * sigma)) * dt

--- a/unirl/rollout/engine/fastvideo/_contracts.py
+++ b/unirl/rollout/engine/fastvideo/_contracts.py
@@ -1,0 +1,167 @@
+"""Extend FastVideo's RL contract and transition math to UniRL's kernels; contract in README.md."""
+
+from __future__ import annotations
+
+import functools
+import math
+from contextvars import ContextVar
+from dataclasses import dataclass, fields
+from typing import Any, Optional
+
+import torch
+
+_CONTEXT: ContextVar[Optional["_TransitionContext"]] = ContextVar("unirl_fastvideo_transition", default=None)
+
+
+@dataclass(frozen=True)
+class _TransitionContext:
+    """Per-request transition data the stock loop cannot pass through its own signature."""
+
+    eta: float
+    sde_type: Any
+
+
+def patch_contracts() -> None:
+    """Add UniRL's resolved SDE-window fields to ``ForwardBatch.RLData`` idempotently."""
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+    original = ForwardBatch.RLData
+    existing = {field.name for field in fields(original)}
+    if {"sde_step_indices", "sde_type"} <= existing:
+        original._unirl_fastvideo_contract = True
+        return
+
+    missing_base = {"enabled", "collect_log_probs", "store_trajectory", "keep_trajectory_on_cpu"} - existing
+    if missing_base:
+        raise RuntimeError(f"FastVideo RLData is incompatible; missing base fields {sorted(missing_base)}")
+
+    @dataclass
+    class UniRLFastVideoRLData(original):  # type: ignore[valid-type,misc]
+        """Stock FastVideo RLData plus UniRL's resolved transition contract."""
+
+        sde_step_indices: Optional[list[int]] = None
+        sde_type: Any = "dance"
+
+    UniRLFastVideoRLData.__name__ = "RLData"
+    UniRLFastVideoRLData.__qualname__ = "ForwardBatch.RLData"
+    UniRLFastVideoRLData.__module__ = original.__module__
+    UniRLFastVideoRLData._unirl_fastvideo_contract = True
+    ForwardBatch.RLData = UniRLFastVideoRLData
+
+
+def _unirl_std_dev_t(sde_type: str, sigma: torch.Tensor, sigma_max: torch.Tensor, eta: float) -> torch.Tensor:
+    """Return the UniRL kernel's diffusion coefficient; must match ``unirl/sde/kernels.py``."""
+    if sde_type == "dance":
+        return torch.full_like(sigma, float(eta))
+    if sde_type == "flow":
+        return torch.sqrt(sigma / (1 - torch.where(sigma == 1, sigma_max, sigma))) * float(eta)
+    raise ValueError(f"FastVideo UniRL transition supports sde_type 'flow' or 'dance'; got {sde_type!r}")
+
+
+def _sde_step_with_logprob(
+    scheduler,
+    model_output: torch.Tensor,
+    timestep: Any,
+    sample: torch.Tensor,
+    prev_sample: Optional[torch.Tensor] = None,
+    generator: Any = None,
+    deterministic: bool = False,
+    return_pixel_log_prob: bool = False,
+    return_dt_and_std_dev_t: bool = False,
+    eta: Optional[float] = None,
+    sde_type: Any = None,
+):
+    """Apply the same Gaussian transition UniRL's trainer replays; stock upstream uses a different law."""
+    if return_pixel_log_prob:
+        raise NotImplementedError("FastVideo UniRL patch does not expose pixel-level log probabilities")
+    if prev_sample is not None and generator is not None:
+        raise ValueError("prev_sample and generator are mutually exclusive")
+
+    context = _CONTEXT.get()
+    resolved_eta = float(eta if eta is not None else (context.eta if context is not None else 0.0))
+    raw_type = sde_type if sde_type is not None else (context.sde_type if context is not None else "dance")
+    kernel = str(getattr(raw_type, "sde_type", raw_type)).strip().lower()
+
+    if isinstance(timestep, torch.Tensor):
+        values = timestep.reshape(-1).tolist() if timestep.ndim else [timestep.item()]
+    else:
+        values = [timestep]
+    indices = [int(scheduler.index_for_timestep(v)) for v in values]
+
+    sigmas = scheduler.sigmas.to(device=sample.device, dtype=sample.dtype)
+    view = (-1, *([1] * (sample.ndim - 1)))
+    sigma = sigmas[indices].reshape(view)
+    sigma_next = sigmas[[i + 1 for i in indices]].reshape(view)
+    dt = sigma_next - sigma
+    sqrt_dt = torch.sqrt(-dt)
+
+    if deterministic:
+        result = sample + dt * model_output
+        zeros = torch.zeros(sample.shape[0], device=sample.device, dtype=sample.dtype)
+        std = torch.zeros_like(sigma)
+        return (result, zeros, result, std, sqrt_dt) if return_dt_and_std_dev_t else (result, zeros, result, std)
+
+    std_dev_t = _unirl_std_dev_t(kernel, sigma, sigmas[1].reshape(1, *([1] * (sample.ndim - 1))), resolved_eta)
+    prev_sample_mean = (
+        sample * (1 + std_dev_t.square() / (2 * sigma) * dt)
+        + model_output * (1 + std_dev_t.square() * (1 - sigma) / (2 * sigma)) * dt
+    )
+
+    if prev_sample is None:
+        from fastvideo.pipelines.stages.denoising import randn_tensor
+
+        noise = randn_tensor(
+            model_output.shape, generator=generator, device=model_output.device, dtype=model_output.dtype
+        )
+        prev_sample = prev_sample_mean + std_dev_t * sqrt_dt * noise
+
+    std_var = std_dev_t * sqrt_dt
+    log_prob = (
+        -((prev_sample.detach() - prev_sample_mean).square()) / (2 * std_var.square())
+        - torch.log(std_var)
+        - 0.5 * math.log(2 * math.pi)
+    )
+    log_prob = log_prob.mean(dim=tuple(range(1, log_prob.ndim)))
+    if return_dt_and_std_dev_t:
+        return prev_sample, log_prob, prev_sample_mean, std_dev_t, sqrt_dt
+    return prev_sample, log_prob, prev_sample_mean, std_var
+
+
+_sde_step_with_logprob._unirl_fastvideo_sde = True  # type: ignore[attr-defined]
+
+
+def patch_transition() -> None:
+    """Install UniRL's transition kernel and pass request-local eta/sde_type into the stock loop."""
+    from fastvideo.pipelines.stages import denoising
+
+    if not getattr(denoising.sde_step_with_logprob, "_unirl_fastvideo_sde", False):
+        denoising.sde_step_with_logprob = _sde_step_with_logprob
+
+    original_forward = denoising.DenoisingStage.forward
+    if getattr(original_forward, "_unirl_fastvideo_denoising", False):
+        return
+
+    @functools.wraps(original_forward)
+    def forward(self, batch, fastvideo_args):
+        rl_data = batch.rl_data if batch.rl_data is not None and batch.rl_data.enabled else None
+        if rl_data is None:
+            return original_forward(self, batch, fastvideo_args)
+        collect = bool(rl_data.collect_log_probs)
+        # The stock loop gates its SDE branch on this flag; force it so replay mode also
+        # walks the UniRL kernel, then drop the log-probs the caller did not ask for.
+        rl_data.collect_log_probs = True
+        token = _CONTEXT.set(_TransitionContext(eta=float(batch.eta), sde_type=getattr(rl_data, "sde_type", "dance")))
+        try:
+            result = original_forward(self, batch, fastvideo_args)
+            if not collect and result.rl_data is not None:
+                result.rl_data.log_probs = None
+            return result
+        finally:
+            _CONTEXT.reset(token)
+            rl_data.collect_log_probs = collect
+
+    forward._unirl_fastvideo_denoising = True
+    denoising.DenoisingStage.forward = forward
+
+
+__all__ = ["patch_contracts", "patch_transition"]

--- a/unirl/rollout/engine/fastvideo/_offload.py
+++ b/unirl/rollout/engine/fastvideo/_offload.py
@@ -1,0 +1,67 @@
+"""Bound CUDA load peaks while materializing CPU-offloaded FastVideo transformers; contract in README.md."""
+
+from __future__ import annotations
+
+from functools import wraps
+
+import torch
+
+_DIT_MODULES = frozenset({"transformer", "transformer_2"})
+
+
+def patch_offload() -> None:
+    """Keep layerwise-offloaded DiT checkpoints off CUDA during materialization."""
+    from fastvideo.models.loader import fsdp_load
+    from fastvideo.models.loader.component_loader import PipelineComponentLoader
+
+    original_state_load = fsdp_load.load_model_from_full_model_state_dict
+    if not getattr(original_state_load, "_unirl_fastvideo_offload", False):
+
+        @wraps(original_state_load)
+        def load_state(model, full_sd_iterator, device, param_dtype, *args, **kwargs):
+            if bool(kwargs.get("cpu_offload", False)):
+                device = torch.device("cpu")
+            return original_state_load(model, full_sd_iterator, device, param_dtype, *args, **kwargs)
+
+        load_state._unirl_fastvideo_offload = True
+        fsdp_load.load_model_from_full_model_state_dict = load_state
+
+    original = PipelineComponentLoader.load_module
+    if getattr(original, "_unirl_fastvideo_offload", False):
+        return
+
+    @wraps(original)
+    def load_module(module_name, component_model_path, transformers_or_diffusers, fastvideo_args):
+        # Upstream stages the whole DiT on GPU before attaching the layerwise hooks, so two
+        # 14B experts transiently exceed the device even with layerwise offload requested.
+        force_cpu_load = (
+            module_name in _DIT_MODULES
+            and bool(getattr(fastvideo_args, "dit_layerwise_offload", False))
+            and not bool(getattr(fastvideo_args, "dit_cpu_offload", False))
+        )
+        if force_cpu_load:
+            fastvideo_args.dit_cpu_offload = True
+        try:
+            module = original(module_name, component_model_path, transformers_or_diffusers, fastvideo_args)
+            if force_cpu_load and torch.cuda.is_available():
+                # The hooks already swapped every ModuleList parameter for a 0-shape CUDA
+                # placeholder; this moves only the remaining stem/head parameters.
+                module.to(torch.device("cuda", torch.cuda.current_device()))
+        finally:
+            if force_cpu_load:
+                fastvideo_args.dit_cpu_offload = False
+        offloaded = force_cpu_load or (
+            (module_name in _DIT_MODULES and bool(getattr(fastvideo_args, "dit_cpu_offload", False)))
+            or (module_name == "text_encoder" and bool(getattr(fastvideo_args, "text_encoder_cpu_offload", False)))
+            or (module_name == "image_encoder" and bool(getattr(fastvideo_args, "image_encoder_cpu_offload", False)))
+            or (module_name == "vae" and bool(getattr(fastvideo_args, "vae_cpu_offload", False)))
+        )
+        if offloaded and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        return module
+
+    load_module._unirl_fastvideo_offload = True
+    PipelineComponentLoader.load_module = staticmethod(load_module)
+
+
+__all__ = ["patch_offload"]

--- a/unirl/rollout/engine/fastvideo/_unipc.py
+++ b/unirl/rollout/engine/fastvideo/_unipc.py
@@ -42,6 +42,7 @@ _SDE_STEP_PARAMS = (
     "eta",
     "sde_type",
 )
+_COLLECTIVE_RPC_PARAMS = ("self", "method", "timeout", "args", "kwargs")
 _RL_DATA_FIELDS = frozenset(
     {
         "enabled",
@@ -97,6 +98,32 @@ def _verify_rl_data_surface() -> None:
             f"FastVideo ForwardBatch.RLData lacks fields {missing} required by the UniPC "
             f"integration (pinned surface: {_PINNED_FORK})"
         )
+
+
+def _verify_weight_surface() -> None:
+    """Fail closed unless the worker/executor/generator seams the weight patch installs onto still exist."""
+    worker = _require_attr(_import_fastvideo_module("fastvideo.worker.gpu_worker", "Worker"), "Worker", "Worker")
+    _require_attr(worker, "execute_forward", "Worker.execute_forward")
+    executor = _require_attr(
+        _import_fastvideo_module("fastvideo.worker.multiproc_executor", "MultiprocExecutor"),
+        "MultiprocExecutor",
+        "MultiprocExecutor",
+    )
+    _require_signature(
+        _require_attr(executor, "collective_rpc", "MultiprocExecutor.collective_rpc"),
+        _COLLECTIVE_RPC_PARAMS,
+        "MultiprocExecutor.collective_rpc",
+    )
+    hooks = _import_fastvideo_module("fastvideo.hooks.hooks", "ModuleHookManager")
+    manager = _require_attr(hooks, "ModuleHookManager", "ModuleHookManager")
+    for name in ("get_from", "get_forward_hook"):
+        _require_attr(manager, name, f"ModuleHookManager.{name}")
+    offload = _import_fastvideo_module("fastvideo.hooks.layerwise_offload", "LayerwiseOffloadHook")
+    _require_attr(
+        _require_attr(offload, "LayerwiseOffloadHook", "LayerwiseOffloadHook"),
+        "mutate_params_scope",
+        "LayerwiseOffloadHook.mutate_params_scope",
+    )
 
 
 def _require_float_wan_timesteps() -> None:
@@ -378,6 +405,9 @@ def _patch_worker_runtime() -> None:
     _require_float_wan_timesteps()
     _patch_scheduler_set_timesteps()
     _patch_denoising_step()
+    from unirl.rollout.engine.fastvideo._weights import patch_weights
+
+    patch_weights()
 
 
 def _worker_main_with_unipc(*args, **kwargs):
@@ -405,6 +435,7 @@ def _patch_worker_entrypoint() -> None:
 def patch_fastvideo_unipc() -> None:
     """Install idempotent parent, worker-entrypoint, and runtime patches after fingerprinting the fork surface."""
     _verify_rl_data_surface()
+    _verify_weight_surface()
     _patch_worker_runtime()
     _patch_worker_entrypoint()
 

--- a/unirl/rollout/engine/fastvideo/_unipc.py
+++ b/unirl/rollout/engine/fastvideo/_unipc.py
@@ -46,6 +46,7 @@ _SDE_STEP_PARAMS = (
 )
 _STOCK_SDE_STEP_PARAMS = _SDE_STEP_PARAMS[:-2]
 _COLLECTIVE_RPC_PARAMS = ("self", "method", "timeout", "args", "kwargs")
+_EXECUTE_FORWARD_PARAMS = ("self", "forward_batch", "fastvideo_args")
 _LOAD_STATE_DICT_PARAMS = (
     "model",
     "full_sd_iterator",
@@ -161,6 +162,20 @@ def _verify_weight_surface() -> None:
         "mutate_params_scope",
         "LayerwiseOffloadHook.mutate_params_scope",
     )
+    # The response patch owns these seams; upstream's execute_forward rebuilds a bare
+    # ForwardBatch that drops rl_data, the trajectory, and the prompt embeddings.
+    _require_signature(
+        _require_attr(executor, "execute_forward", "MultiprocExecutor.execute_forward"),
+        _EXECUTE_FORWARD_PARAMS,
+        "MultiprocExecutor.execute_forward",
+    )
+    worker_proc = _require_attr(
+        _import_fastvideo_module("fastvideo.worker.multiproc_executor", "WorkerMultiprocProc"),
+        "WorkerMultiprocProc",
+        "WorkerMultiprocProc",
+    )
+    _require_attr(worker_proc, "__init__", "WorkerMultiprocProc.__init__")
+    _require_attr(worker, "execute_forward", "Worker.execute_forward")
 
 
 def _verify_offload_surface() -> None:
@@ -461,6 +476,7 @@ def _patch_denoising_step() -> None:
 def _patch_worker_runtime() -> None:
     _require_float_wan_timesteps()
     _verify_stock_surface()
+    from unirl.rollout.engine.fastvideo._conditions import patch_conditions
     from unirl.rollout.engine.fastvideo._contracts import patch_contracts, patch_transition
     from unirl.rollout.engine.fastvideo._offload import patch_offload
     from unirl.rollout.engine.fastvideo._weights import patch_weights
@@ -472,6 +488,7 @@ def _patch_worker_runtime() -> None:
     _verify_rl_data_surface()
     _patch_scheduler_set_timesteps()
     _patch_denoising_step()
+    patch_conditions()
     patch_offload()
     patch_weights()
 

--- a/unirl/rollout/engine/fastvideo/_unipc.py
+++ b/unirl/rollout/engine/fastvideo/_unipc.py
@@ -13,7 +13,6 @@ from typing import Any, Optional, Tuple
 import numpy as np
 import torch
 
-from unirl.models.wan21.diffusion import WAN21DiffusionStep
 from unirl.rollout.engine.sigma_verify import verify_engine_used_sigmas
 from unirl.sde.unipc import UniPCSpec, UniPCStrategy
 
@@ -109,16 +108,12 @@ def _require_float_wan_timesteps() -> None:
         )
 
 
-def _wan_timestep_scale(scheduler: Any) -> float:
-    """Return the model-owned scale after validating the worker scheduler contract."""
-    expected = float(WAN21DiffusionStep.TIMESTEP_SCALE)
+def _scheduler_timestep_scale(scheduler: Any) -> float:
+    """Return the live scheduler's own timestep scale, which ``index_for_timestep`` matches against."""
     actual = getattr(scheduler.config, "num_train_timesteps", None)
-    if actual != expected:
-        raise RuntimeError(
-            "FastVideo scheduler num_train_timesteps does not match the WAN21 model "
-            f"timestep scale: scheduler={actual!r}, model={expected:g}"
-        )
-    return expected
+    if not isinstance(actual, (int, float)) or not float(actual) > 0.0:
+        raise RuntimeError(f"FastVideo scheduler has no usable num_train_timesteps: {actual!r}")
+    return float(actual)
 
 
 @dataclass(frozen=True)
@@ -128,6 +123,7 @@ class FastVideoUniPCPlan:
     sde_type: str
     sde_indices: Tuple[int, ...]
     spec: UniPCSpec = field(default_factory=UniPCSpec)
+    timestep_scale: float = 0.0
 
     def __post_init__(self) -> None:
         canonical = str(self.sde_type).strip().lower()
@@ -138,8 +134,14 @@ class FastVideoUniPCPlan:
             raise ValueError(f"FastVideo UniPC requires sorted unique non-negative SDE indices; got {indices}")
         if not isinstance(self.spec, UniPCSpec):
             raise ValueError(f"FastVideo UniPC plan requires a UniPCSpec; got {type(self.spec).__name__}")
+        scale = float(self.timestep_scale)
+        if not scale > 0.0:
+            raise ValueError(
+                f"FastVideo UniPC requires the model-owned positive timestep_scale; got {self.timestep_scale!r}"
+            )
         object.__setattr__(self, "sde_type", canonical)
         object.__setattr__(self, "sde_indices", indices)
+        object.__setattr__(self, "timestep_scale", scale)
 
 
 def _strategy_from_plan(scheduler: Any, plan: FastVideoUniPCPlan) -> UniPCStrategy:
@@ -193,6 +195,7 @@ def _patch_scheduler_set_timesteps() -> None:
                 use_kerras_sigma=use_kerras_sigma,
             )
             self._unirl_canonical_schedule = False
+            self._unirl_timestep_scale = None
             self._unirl_unipc_strategy = None
             self._unirl_device_sigmas = None
             return
@@ -224,7 +227,7 @@ def _patch_scheduler_set_timesteps() -> None:
         if str(getattr(self.config, "final_sigmas_type", "zero")) != "zero":
             raise ValueError("FastVideo canonical UniPC requires final_sigmas_type='zero'")
 
-        timestep_scale = _wan_timestep_scale(self)
+        timestep_scale = _scheduler_timestep_scale(self)
         terminal = np.zeros(1, dtype=np.float32)
         schedule = np.concatenate([external, terminal])
         self.sigmas = torch.from_numpy(schedule).cpu()
@@ -242,6 +245,7 @@ def _patch_scheduler_set_timesteps() -> None:
         # The strategy is built lazily at the first UniPC-dispatched denoising
         # call, from the request plan's model-owned spec (README: dispatch).
         self._unirl_canonical_schedule = True
+        self._unirl_timestep_scale = timestep_scale
         self._unirl_unipc_strategy = None
         self._unirl_device_sigmas = None
 
@@ -329,6 +333,12 @@ def _patch_denoising_step() -> None:
             if not bool(getattr(scheduler, "_unirl_canonical_schedule", False)):
                 raise RuntimeError(
                     "FastVideo worker did not install the canonical UniPC schedule patch before denoising"
+                )
+            if float(getattr(scheduler, "_unirl_timestep_scale", 0.0)) != float(sde_type.timestep_scale):
+                raise RuntimeError(
+                    "FastVideo scheduler was pinned with a different model timestep scale than this request's "
+                    f"plan: scheduler={getattr(scheduler, '_unirl_timestep_scale', None)!r}, "
+                    f"plan={sde_type.timestep_scale!r}"
                 )
             strategy = _strategy_from_plan(scheduler, sde_type)
             strategy.init_schedule(scheduler.sigmas)

--- a/unirl/rollout/engine/fastvideo/_unipc.py
+++ b/unirl/rollout/engine/fastvideo/_unipc.py
@@ -16,8 +16,8 @@ import torch
 from unirl.rollout.engine.sigma_verify import verify_engine_used_sigmas
 from unirl.sde.unipc import UniPCSpec, UniPCStrategy
 
-# The exact fork surface these patches target; drift fails closed at patch time (README: pin).
-_PINNED_FORK = "Zcchill/FastVideo@7fe1d7db9a0b8aebb46679e7924f597431f23665"
+# The exact upstream surface these patches target; drift fails closed at patch time (README: pin).
+_PINNED_FORK = "hao-ai-lab/FastVideo@2095477eac7e289c7a7ab13acb367ca60687c304"
 
 _SET_TIMESTEPS_PARAMS = (
     "self",
@@ -29,6 +29,8 @@ _SET_TIMESTEPS_PARAMS = (
     "use_karras_sigmas",
     "use_kerras_sigma",
 )
+# Stock upstream stops at ``return_dt_and_std_dev_t``; ``eta``/``sde_type`` are appended by
+# ``_contracts.patch_transition``, which must therefore run before this fingerprint is taken.
 _SDE_STEP_PARAMS = (
     "scheduler",
     "model_output",
@@ -42,6 +44,7 @@ _SDE_STEP_PARAMS = (
     "eta",
     "sde_type",
 )
+_STOCK_SDE_STEP_PARAMS = _SDE_STEP_PARAMS[:-2]
 _COLLECTIVE_RPC_PARAMS = ("self", "method", "timeout", "args", "kwargs")
 _LOAD_STATE_DICT_PARAMS = (
     "model",
@@ -107,8 +110,31 @@ def _verify_rl_data_surface() -> None:
     if missing:
         raise RuntimeError(
             f"FastVideo ForwardBatch.RLData lacks fields {missing} required by the UniPC "
-            f"integration (pinned surface: {_PINNED_FORK})"
+            f"integration (pinned surface: {_PINNED_FORK}); _contracts.patch_contracts must run first"
         )
+
+
+def _verify_stock_surface() -> None:
+    """Fingerprint the untouched upstream seams before any UniRL patch rewrites them."""
+    denoising = _import_fastvideo_module(
+        "fastvideo.pipelines.stages.denoising", "pipelines.stages.denoising.sde_step_with_logprob"
+    )
+    original = _require_attr(denoising, "sde_step_with_logprob", "sde_step_with_logprob")
+    if getattr(original, "_unirl_fastvideo_sde", False):
+        return
+    _require_signature(original, _STOCK_SDE_STEP_PARAMS, "stock sde_step_with_logprob")
+    stage = _require_attr(denoising, "DenoisingStage", "DenoisingStage")
+    forward = _require_attr(stage, "forward", "DenoisingStage.forward")
+    try:
+        source = inspect.getsource(forward)
+    except (OSError, TypeError) as exc:
+        raise RuntimeError(f"cannot inspect FastVideo DenoisingStage.forward: {exc}") from exc
+    for marker in ("rl_data", "sde_step_with_logprob", "scheduler.step"):
+        if marker not in source:
+            raise RuntimeError(
+                f"FastVideo DenoisingStage.forward lacks required source marker {marker!r} "
+                f"(pinned surface: {_PINNED_FORK})"
+            )
 
 
 def _verify_weight_surface() -> None:
@@ -434,11 +460,18 @@ def _patch_denoising_step() -> None:
 
 def _patch_worker_runtime() -> None:
     _require_float_wan_timesteps()
-    _patch_scheduler_set_timesteps()
-    _patch_denoising_step()
+    _verify_stock_surface()
+    from unirl.rollout.engine.fastvideo._contracts import patch_contracts, patch_transition
     from unirl.rollout.engine.fastvideo._offload import patch_offload
     from unirl.rollout.engine.fastvideo._weights import patch_weights
 
+    # Contract and transition first: they add the RLData fields and the eta/sde_type
+    # parameters that the UniPC fingerprints and dispatch below rely on.
+    patch_contracts()
+    patch_transition()
+    _verify_rl_data_surface()
+    _patch_scheduler_set_timesteps()
+    _patch_denoising_step()
     patch_offload()
     patch_weights()
 
@@ -467,7 +500,6 @@ def _patch_worker_entrypoint() -> None:
 
 def patch_fastvideo_unipc() -> None:
     """Install idempotent parent, worker-entrypoint, and runtime patches after fingerprinting the fork surface."""
-    _verify_rl_data_surface()
     _verify_weight_surface()
     _verify_offload_surface()
     _patch_worker_runtime()

--- a/unirl/rollout/engine/fastvideo/_unipc.py
+++ b/unirl/rollout/engine/fastvideo/_unipc.py
@@ -43,6 +43,17 @@ _SDE_STEP_PARAMS = (
     "sde_type",
 )
 _COLLECTIVE_RPC_PARAMS = ("self", "method", "timeout", "args", "kwargs")
+_LOAD_STATE_DICT_PARAMS = (
+    "model",
+    "full_sd_iterator",
+    "device",
+    "param_dtype",
+    "strict",
+    "cpu_offload",
+    "param_names_mapping",
+    "training_mode",
+)
+_LOAD_MODULE_PARAMS = ("module_name", "component_model_path", "transformers_or_diffusers", "fastvideo_args")
 _RL_DATA_FIELDS = frozenset(
     {
         "enabled",
@@ -123,6 +134,26 @@ def _verify_weight_surface() -> None:
         _require_attr(offload, "LayerwiseOffloadHook", "LayerwiseOffloadHook"),
         "mutate_params_scope",
         "LayerwiseOffloadHook.mutate_params_scope",
+    )
+
+
+def _verify_offload_surface() -> None:
+    """Fail closed unless the loader seams the offload patch wraps keep their patched-for signatures."""
+    fsdp_load = _import_fastvideo_module("fastvideo.models.loader.fsdp_load", "fsdp_load")
+    state_load = _require_attr(
+        fsdp_load, "load_model_from_full_model_state_dict", "load_model_from_full_model_state_dict"
+    )
+    # The patch reads ``cpu_offload`` out of **kwargs; a positional call would silently no-op.
+    _require_signature(state_load, _LOAD_STATE_DICT_PARAMS, "load_model_from_full_model_state_dict")
+    loader = _import_fastvideo_module("fastvideo.models.loader.component_loader", "PipelineComponentLoader")
+    _require_signature(
+        _require_attr(
+            _require_attr(loader, "PipelineComponentLoader", "PipelineComponentLoader"),
+            "load_module",
+            "PipelineComponentLoader.load_module",
+        ),
+        _LOAD_MODULE_PARAMS,
+        "PipelineComponentLoader.load_module",
     )
 
 
@@ -405,8 +436,10 @@ def _patch_worker_runtime() -> None:
     _require_float_wan_timesteps()
     _patch_scheduler_set_timesteps()
     _patch_denoising_step()
+    from unirl.rollout.engine.fastvideo._offload import patch_offload
     from unirl.rollout.engine.fastvideo._weights import patch_weights
 
+    patch_offload()
     patch_weights()
 
 
@@ -436,6 +469,7 @@ def patch_fastvideo_unipc() -> None:
     """Install idempotent parent, worker-entrypoint, and runtime patches after fingerprinting the fork surface."""
     _verify_rl_data_surface()
     _verify_weight_surface()
+    _verify_offload_surface()
     _patch_worker_runtime()
     _patch_worker_entrypoint()
 

--- a/unirl/rollout/engine/fastvideo/_weights.py
+++ b/unirl/rollout/engine/fastvideo/_weights.py
@@ -1,0 +1,199 @@
+"""Strict full-parameter checkpoint hot-swap for FastVideo workers; contract in README.md."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+_MIN_COVERAGE = 0.99
+_TRAINING_PREFIXES = ("base_model.model.", "module.", "transformer.")
+
+
+def _strip_training_prefix(name: str) -> str:
+    """Drop the wrapper prefixes FSDP/peft add around the rollout-facing parameter names."""
+    for prefix in _TRAINING_PREFIXES:
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+    return name
+
+
+def _offloaded_blocks(module: Any) -> List[Tuple[str, Any, Any]]:
+    """Return ``(prefix, child, hook)`` for every layerwise-offloaded block, outermost first."""
+    try:
+        from fastvideo.hooks.hooks import ModuleHookManager
+    except ImportError:
+        return []
+
+    blocks: List[Tuple[str, Any, Any]] = []
+    for module_name, child in module.named_modules():
+        manager = ModuleHookManager.get_from(child)
+        if manager is None:
+            continue
+        hook = manager.get_forward_hook("LayerwiseOffloadHook")
+        if hook is None:
+            continue
+        blocks.append((f"{module_name}." if module_name else "", child, hook))
+    return blocks
+
+
+def _copy_into(targets: Dict[str, torch.Tensor], mapped: Dict[str, torch.Tensor], *, label: str) -> set[str]:
+    """Copy ``mapped`` into the given already-materialized target tensors."""
+    loaded: set[str] = set()
+    for name, target in targets.items():
+        source = mapped[name]
+        if tuple(source.shape) != tuple(target.shape):
+            raise RuntimeError(
+                f"FastVideo {label} shape mismatch for {name}: "
+                f"source={tuple(source.shape)} target={tuple(target.shape)}"
+            )
+        if source.is_floating_point():
+            source = source.to(dtype=target.dtype)
+        target.copy_(source.to(device=target.device), non_blocking=False)
+        loaded.add(name)
+    return loaded
+
+
+def _load_transformer_state(module: Any, state_dict: Dict[str, torch.Tensor], *, label: str) -> Dict[str, Any]:
+    """Copy a full state dict into one FastVideo transformer, failing closed on any key or shape drift."""
+    target_state = module.state_dict()
+    prepared = {str(name): tensor for name, tensor in state_dict.items() if torch.is_tensor(tensor)}
+    if not prepared:
+        raise RuntimeError(f"FastVideo weight update received no tensor entries for {label}")
+
+    mapping_dict = getattr(module, "param_names_mapping", None)
+    if mapping_dict:
+        from fastvideo.models.loader.utils import get_param_names_mapping, hf_to_custom_state_dict
+
+        mapped, _ = hf_to_custom_state_dict(prepared, get_param_names_mapping(mapping_dict))
+    else:
+        mapped = prepared
+
+    target_names = set(target_state)
+    mapped_names = set(mapped)
+    matched = target_names & mapped_names
+    coverage = len(matched) / max(1, len(target_names))
+    unexpected = sorted(mapped_names - target_names)
+    if coverage < _MIN_COVERAGE or unexpected:
+        raise RuntimeError(
+            f"FastVideo {label} key mapping failed closed: coverage={coverage:.2%}, "
+            f"matched={len(matched)}/{len(target_names)}, unexpected={unexpected[:10]}"
+        )
+
+    loaded: set[str] = set()
+    with torch.no_grad():
+        offloaded = _offloaded_blocks(module)
+        claimed: set[str] = set()
+        for prefix, child, hook in offloaded:
+            names = {f"{prefix}{n}" for n, _ in child.named_parameters()} & matched
+            claimed |= names
+            if not names:
+                continue
+            # One block at a time: ``mutate_params_scope`` pulls it onto GPU, then re-seeds
+            # both caches from the mutated params on exit. Holding every block's scope open
+            # at once would stage the whole expert on GPU, and writing
+            # ``state.cpu_named_parameters`` directly would leave the copy prefetched by the
+            # previous forward stale (README: layerwise offload).
+            with hook.mutate_params_scope():
+                targets = {f"{prefix}{n}": p.data for n, p in child.named_parameters() if f"{prefix}{n}" in names}
+                loaded |= _copy_into(targets, mapped, label=label)
+        rest = {name: target_state[name] for name in matched - claimed}
+        loaded |= _copy_into(rest, mapped, label=label)
+
+    missing = sorted(target_names - loaded)
+    if missing:
+        raise RuntimeError(f"FastVideo {label} load was incomplete: missing={missing[:10]}")
+    return {"label": label, "loaded": len(matched), "target": len(target_names), "coverage": coverage}
+
+
+def _split_experts(stripped: Dict[str, torch.Tensor]) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+    """Split a WAN 2.2 checkpoint into its boundary-routed high-noise and low-noise experts."""
+    high = {name[len("high_noise.") :]: t for name, t in stripped.items() if name.startswith("high_noise.")}
+    low = {name[len("low_noise.") :]: t for name, t in stripped.items() if name.startswith("low_noise.")}
+    unrelated = sorted(
+        set(stripped) - {f"high_noise.{n}" for n in high} - {f"low_noise.{n}" for n in low},
+    )
+    if not high or not low or unrelated:
+        raise RuntimeError(
+            "FastVideo dual-transformer update requires only high_noise.* and low_noise.* checkpoint keys: "
+            f"high={len(high)}, low={len(low)}, unrelated={unrelated[:10]}"
+        )
+    return high, low
+
+
+def _worker_update_transformer_weights(self, state_dict: Dict[str, torch.Tensor]) -> Dict[str, Any]:
+    transformer = self.pipeline.modules.get("transformer")
+    if transformer is None:
+        raise RuntimeError("FastVideo worker has no transformer module")
+
+    stripped = {_strip_training_prefix(str(n)): t for n, t in state_dict.items() if torch.is_tensor(t)}
+    transformer_2 = self.pipeline.modules.get("transformer_2")
+    if transformer_2 is None:
+        result = _load_transformer_state(transformer, stripped, label="transformer")
+        return {"status": "transformer_weights_updated", **result}
+
+    high, low = _split_experts(stripped)
+    results = [
+        _load_transformer_state(transformer, high, label="transformer/high_noise"),
+        _load_transformer_state(transformer_2, low, label="transformer_2/low_noise"),
+    ]
+    return {
+        "status": "transformer_weights_updated",
+        "loaded": sum(int(r["loaded"]) for r in results),
+        "target": sum(int(r["target"]) for r in results),
+        "coverage": min(float(r["coverage"]) for r in results),
+        "modules": results,
+    }
+
+
+def _worker_update_transformer_weights_from_path(self, checkpoint_path: str) -> Dict[str, Any]:
+    # CheckpointWeightSync writes a plain ``torch.save`` tensor dict; refuse arbitrary pickles.
+    state_dict = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+    if not isinstance(state_dict, dict):
+        raise TypeError(f"FastVideo checkpoint must contain a state-dict mapping; got {type(state_dict).__name__}")
+    try:
+        return _worker_update_transformer_weights(self, state_dict)
+    finally:
+        del state_dict
+
+
+def _check_responses(responses: Any, world_size: int) -> None:
+    """Fail closed unless every worker reported a complete load."""
+    if len(responses) != int(world_size):
+        raise RuntimeError(f"FastVideo weight update returned {len(responses)} responses for world_size={world_size}")
+    for rank, response in enumerate(responses):
+        if not isinstance(response, dict) or response.get("status") != "transformer_weights_updated":
+            raise RuntimeError(f"FastVideo worker {rank} weight update failed: {response!r}")
+        if float(response.get("coverage", 0.0)) < _MIN_COVERAGE:
+            raise RuntimeError(f"FastVideo worker {rank} reported incomplete weight coverage: {response!r}")
+
+
+def patch_weights() -> None:
+    """Install the additive full-weight update API upstream does not provide."""
+    from fastvideo.entrypoints.video_generator import VideoGenerator
+    from fastvideo.worker.gpu_worker import Worker
+    from fastvideo.worker.multiproc_executor import MultiprocExecutor
+
+    if getattr(VideoGenerator, "_unirl_fastvideo_weights", False):
+        return
+
+    Worker.update_transformer_weights = _worker_update_transformer_weights
+    Worker.update_transformer_weights_from_path = _worker_update_transformer_weights_from_path
+
+    def executor_update_from_path(self, checkpoint_path: str) -> None:
+        responses = self.collective_rpc(
+            "update_transformer_weights_from_path",
+            kwargs={"checkpoint_path": checkpoint_path},
+        )
+        _check_responses(responses, self.world_size)
+
+    MultiprocExecutor.update_transformer_weights_from_path = executor_update_from_path
+
+    def update_from_path(self, checkpoint_path: str) -> None:
+        self.executor.update_transformer_weights_from_path(checkpoint_path)
+
+    VideoGenerator.update_transformer_weights_from_path = update_from_path
+    VideoGenerator._unirl_fastvideo_weights = True
+
+
+__all__ = ["patch_weights"]

--- a/unirl/rollout/engine/fastvideo/config.py
+++ b/unirl/rollout/engine/fastvideo/config.py
@@ -57,8 +57,8 @@ class FastVideoEngineConfig(BaseEngineConfig):
             self.engine_kwargs = {}
         self.model_family = str(self.model_family or "").strip().lower()
         require(
-            self.model_family in {"wan2.1", "wan21"},
-            f"FastVideoEngineConfig.model_family currently supports only 'wan2.1'; got {self.model_family!r}",
+            self.model_family in {"wan2.1", "wan21", "wan2.2", "wan22"},
+            f"FastVideoEngineConfig.model_family supports 'wan2.1' and 'wan2.2'; got {self.model_family!r}",
         )
         require(self.num_gpus >= 1, f"num_gpus must be >= 1; got {self.num_gpus!r}")
         require(

--- a/unirl/rollout/engine/fastvideo/engine.py
+++ b/unirl/rollout/engine/fastvideo/engine.py
@@ -90,6 +90,17 @@ def _verify_checkpoint_unipc_spec(ckpt_path: str, spec: UniPCSpec) -> None:
         )
 
 
+def _model_timestep_scale(model_family: str) -> float:
+    """Return the declared WAN step-kernel timestep scale for ``model_family``."""
+    if model_family in {"wan2.2", "wan22"}:
+        from unirl.models.wan22.diffusion import WAN22DiffusionStep
+
+        return float(WAN22DiffusionStep.TIMESTEP_SCALE)
+    from unirl.models.wan21.diffusion import WAN21DiffusionStep
+
+    return float(WAN21DiffusionStep.TIMESTEP_SCALE)
+
+
 def _resolve_sde_window(raw_indices: Any, num_steps: int) -> List[int]:
     """Return sorted SDE step indices; ``None`` → all-steps SDE here but no-SDE trainside (README Gotchas)."""
     if raw_indices is None:
@@ -161,8 +172,14 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             "set the rollout node's `strategy:` in the recipe (a separate injection from pipeline.strategy)",
         )
         self._sde_type = str(strategy.canonical_name)
+        self._timestep_scale = _model_timestep_scale(config.model_family)
         # Probe plan so unsupported kernels (cps/dpm2) fail at init, not per request.
-        FastVideoUniPCPlan(sde_type=self._sde_type, sde_indices=(), spec=self._unipc_spec)
+        FastVideoUniPCPlan(
+            sde_type=self._sde_type,
+            sde_indices=(),
+            spec=self._unipc_spec,
+            timestep_scale=self._timestep_scale,
+        )
         _verify_checkpoint_unipc_spec(model_config.pretrained_model_ckpt_path, self._unipc_spec)
         patch_fastvideo_unipc()
         self._build_generator()
@@ -356,6 +373,7 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             sde_type=self._sde_type,
             sde_indices=tuple(resolved_sde_indices),
             spec=self._unipc_spec,
+            timestep_scale=self._timestep_scale,
         )
 
         all_log_probs: List[torch.Tensor] = []

--- a/unirl/rollout/engine/fastvideo/engine.py
+++ b/unirl/rollout/engine/fastvideo/engine.py
@@ -101,6 +101,33 @@ def _model_timestep_scale(model_family: str) -> float:
     return float(WAN21DiffusionStep.TIMESTEP_SCALE)
 
 
+def _verify_dual_expert_checkpoint(ckpt_path: str) -> None:
+    """Fail closed unless the A14B checkpoint declares both boundary-routed transformers."""
+    checkpoint = Path(ckpt_path).expanduser()
+    if checkpoint.is_dir():
+        path = checkpoint / "model_index.json"
+    else:
+        try:
+            from huggingface_hub import hf_hub_download
+
+            path = Path(hf_hub_download(repo_id=ckpt_path, filename="model_index.json"))
+        except Exception as exc:
+            raise RuntimeError(
+                f"FastVideo WAN 2.2 cannot resolve {ckpt_path!r}/model_index.json as either a local "
+                "diffusers-layout checkpoint or a Hugging Face model repo."
+            ) from exc
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"FastVideo WAN 2.2 cannot verify the dual-expert layout without {path}") from exc
+    missing = [name for name in ("transformer", "transformer_2") if name not in payload]
+    if missing:
+        raise RuntimeError(
+            f"Checkpoint {path} lacks {missing}; the WAN 2.2 A14B rollout requires both boundary-routed experts."
+        )
+
+
 def _resolve_sde_window(raw_indices: Any, num_steps: int) -> List[int]:
     """Return sorted SDE step indices; ``None`` → all-steps SDE here but no-SDE trainside (README Gotchas)."""
     if raw_indices is None:
@@ -173,6 +200,22 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         )
         self._sde_type = str(strategy.canonical_name)
         self._timestep_scale = _model_timestep_scale(config.model_family)
+        self._is_dual_expert = config.model_family in {"wan2.2", "wan22"}
+        if self._is_dual_expert:
+            boundary_ratio = float(getattr(model_config, "boundary_ratio", 0.0))
+            require(
+                0.0 < boundary_ratio < 1.0,
+                f"WAN 2.2 model_config.boundary_ratio must be in (0, 1); got {boundary_ratio}",
+            )
+            # FastVideo routes on t >= boundary_ratio * num_train_timesteps; UniRL routes on
+            # sigma >= boundary_ratio. The two agree only at this scale (README: dual expert).
+            require(
+                float(getattr(model_config, "num_train_timesteps", 0)) == self._timestep_scale,
+                "WAN 2.2 FastVideo rollout requires model_config.num_train_timesteps to equal the "
+                f"step kernel's TIMESTEP_SCALE ({self._timestep_scale:g})",
+            )
+            self._boundary_ratio = boundary_ratio
+            _verify_dual_expert_checkpoint(model_config.pretrained_model_ckpt_path)
         # Probe plan so unsupported kernels (cps/dpm2) fail at init, not per request.
         FastVideoUniPCPlan(
             sde_type=self._sde_type,
@@ -235,6 +278,8 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
         }
         fv_kwargs.update(ekw)
         self._fastvideo_args = FastVideoArgs.from_kwargs(**fv_kwargs)
+        if self._is_dual_expert:
+            self._align_dual_expert_args(self._fastvideo_args)
         backend = str(getattr(self._fastvideo_args, "distributed_executor_backend", "mp"))
         require(
             backend == "mp",
@@ -258,6 +303,18 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
                     max_port_attempts,
                     self._ports.master_port,
                 )
+
+    def _align_dual_expert_args(self, fastvideo_args: Any) -> None:
+        """Pin the boundary UniRL owns onto FastVideo's WAN 2.2 pipeline and dit configs."""
+        pipeline_config = fastvideo_args.pipeline_config
+        dit_config = getattr(pipeline_config, "dit_config", None)
+        require(dit_config is not None, "WAN 2.2 FastVideo pipeline has no dit_config")
+        require(
+            hasattr(dit_config, "boundary_ratio"),
+            "WAN 2.2 FastVideo requires a dual-expert pipeline config with dit_config.boundary_ratio",
+        )
+        pipeline_config.boundary_ratio = self._boundary_ratio
+        dit_config.boundary_ratio = self._boundary_ratio
 
     @distributed(dispatch_mode=Dispatch.DP_SCATTER)
     def generate(self, sample: Sample) -> Sample:
@@ -411,6 +468,9 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
                     sde_type=step_plan,
                 ),
             )
+            if self._is_dual_expert:
+                batch.boundary_ratio = self._boundary_ratio
+                batch.guidance_scale_2 = self._low_noise_guidance(params)
             out = self._generator.executor.execute_forward(batch, self._fastvideo_args)
             rl = out.rl_data
             verify_fastvideo_used_sigmas(
@@ -472,6 +532,13 @@ class FastVideoRolloutEngine(BaseRolloutEngine):
             "neg_embeds": all_neg_embeds,
             "neg_masks": all_neg_masks,
         }
+
+    def _low_noise_guidance(self, params: Any) -> float:
+        """Resolve the low-noise expert's CFG scale, falling back to the shared one."""
+        scale = getattr(params, "guidance_scale_2", None)
+        if scale is None:
+            scale = getattr(self.model_config, "guidance_scale_2", None)
+        return float(scale) if scale is not None else float(params.guidance_scale)
 
     def _build_response(
         self,


### PR DESCRIPTION
## Summary

Supersedes the WAN 2.2 work in #415, rebased onto current `main` instead of the 7-week-old `engine/fastvideo` branch, and extends the FastVideo rollout engine to WAN 2.2 A14B T2V.

The load-bearing finding is that **`main`'s FastVideo integration cannot run on unmodified upstream FastVideo** — it only works against the `Zcchill/FastVideo` fork. Verified directly against the pinned upstream snapshot `hao-ai-lab/FastVideo@2095477e`:

- `sde_step_with_logprob` takes 9 parameters upstream; there is no `eta` and no `sde_type`.
- `ForwardBatch.RLData` has neither `sde_step_indices` nor `sde_type`.
- Upstream exposes **no** weight-update API at all (`Worker` / `MultiprocExecutor` / `VideoGenerator` all lack `update_transformer_weights*`).
- `MultiprocExecutor.execute_forward` rebuilds a bare `ForwardBatch` keeping only `output` / `logging_info` / `extra`, discarding `rl_data`, the latent trajectory, and the prompt embeddings the trainer replays against.
- Most importantly, upstream's stock transition uses a **third diffusion law** (`sigma_min + (sigma_max - sigma_min) * sigma`, i.e. `std=0.6400` at `sigma=0.8`) matching neither UniRL Dance (`eta`, `0.7000`) nor Flow (`sqrt(sigma/(1-sigma)) * eta`). Running unpatched means rollout and train-side replay score different SDEs, so the GRPO ratio is wrong at the root.

So UniRL now owns those contracts (`_contracts.py`, `_conditions.py`, `_weights.py`) and the fingerprints are taken on the **stock** surface before any patch rewrites it. `unirl/sde/unipc.py` and the UniPC dispatch are reused from `main` unchanged — this PR adds no second solver.

WAN 2.2 delta on top: dual-expert boundary routing (`boundary_ratio` pinned onto FastVideo's pipeline/dit configs and every request batch, checkpoint verified to declare both experts), `high_noise.*` / `low_noise.*` weight-sync routing, and an offload patch that keeps the two 14B experts off CUDA during materialization. WAN 2.1 behavior is unchanged: every WAN 2.2 path is gated behind `_is_dual_expert`, and `examples/diffusion/wan21/` is untouched apart from a stale dependency comment.

## Related Issue

N/A — supersedes the WAN 2.2 portion of #415.

## Test Plan

Static gates (all four repo pre-commit guards, on this branch):

```
python lint/check_docstring_lines.py       # 3371 docstrings, all one line
python lint/check_recipe_targets.py        # 2663 recipe _target_ paths resolve
python lint/check_core_dependencies.py     # ok
python lint/check_experimental_boundaries.py  # ok
ruff check unirl/rollout/engine/fastvideo/ unirl/models/wan22/   # All checks passed
ruff format --check unirl/rollout/engine/fastvideo/             # 9 files already formatted
```

Real-hardware validation — 8×H20 (driver 535), `torch 2.11+cu129`, **unmodified** `hao-ai-lab/FastVideo@2095477e`, `Wan2.1-T2V-1.3B-Diffusers` and `Wan2.2-T2V-A14B-Diffusers`:

1. **WAN 2.1 end-to-end rollout → weight sync → rollout** (`ALL_DONE`):
   ```
   BOOT_OK
   sigmas=[1.0,0.9722,0.9375,0.8929,0.8333,0.75,0.625,0.4167,0.0]
   sde_indices=(0,1,2,3)  unipc_indices=(4,5,6,7)
   [rollout-1] traj=(1,9,16,2,16,16) logp=(1,8) decoded=(1,3,5,128,128) sigma_roundtrip=OK
   loaded 825 transformer tensors -> perturbed ckpt (x1.01) -> WEIGHT_SYNC_OK
   [rollout-2] traj=(1,9,16,2,16,16) logp=(1,8) sigma_roundtrip=OK
   ```
   What this does and does not show: the sync applies all 825 tensors with full key
   coverage and the next rollout runs cleanly on the swapped weights. It does **not**
   show the trajectory moved *because of* the new weights. A same-weights control
   rollout differs by `d_traj=2.75e+00`, i.e. as much as the post-sync one, because
   upstream's RL branch hard-codes `generator=None` in `sde_step_with_logprob`, so SDE
   noise is unseeded and no caller can make a rollout reproducible. That the swap
   reaches the model is instead established by the offline check in item 5
   (`coverage=1.0`, `stale_after_sync=0` on a real `WanTransformer3DModel`).
2. **Transition math is bit-exact against `unirl/sde/kernels.py`**: Dance and Flow × `eta` 0.7/0.3 × all 4 steps → `d_mean=0.0`, `d_logp=0.0` (16/16).
3. **UniPC dispatch equals FastVideo's own `scheduler.step()`**: `max_abs_diff=0.0` over 10 steps on a real `FlowUniPCMultistepScheduler` built from the A14B `scheduler_config.json`. Control: an Euler tail differs by `6.79e-01`, so the comparison is discriminating.
4. **Patched `set_timesteps` on a real scheduler**: sigmas consumed bitwise-verbatim, `index_for_timestep` round-trips 8/8, float32 timesteps (`833.333`, vs upstream's `int64` `833`), int-truncated echo rejected, and duplicate / terminal-zero / out-of-range sigma schedules all rejected.
5. **Dual-expert weight sync on a real `WanTransformer3DModel`** (real 18-regex `param_names_mapping`, real HF key names from the A14B index, real layerwise hooks): coverage `1.0`, CUDA peak `1.01` blocks, `stale_after_sync=0`.
6. **A14B structure and offload budget** (safetensors headers + live observation): one expert `53.23 GiB` = 40 × `1340 MiB` + `0.87 GiB` stem/head. With the offload patch the two experts need ≈ `4.35 GiB` of CUDA; without it upstream stages `106.5 GiB`, impossible on a 97 GiB card. Observed live: worker at `105 GiB` host RSS holding `0 MiB` GPU.

Harnesses were run and discarded per CLAUDE.md (`tests/` tree removed by #99/#267); commands and results are quoted above rather than committed.

7. **Sleep/wake needs no CUDA grace period.** Full teardown then rebuild on WAN 2.1 with
   `UNIRL_FASTVIDEO_CUDA_RELEASE_GRACE_S` unset: `SLEEP_OK in 4.9s` (free VRAM back to
   `9.58G`), `WAKE_OK in 32.7s`, weights re-applied and a third rollout ran clean. This
   is why the 30 s unconditional `time.sleep` from the earlier draft is not carried here.
   Caveat: measured on WAN 2.1, not on A14B.

Not run: WAN 2.2 A14B end-to-end rollout / weight sync / sleep-wake. Reason: on the test node forced-spin held ~85 GiB per card, and loading A14B off CephFS ran at 5–14 MB/s because FastVideo's loader uses `safe_open` + per-tensor `get_tensor` (random 4 KB page faults over FUSE; `dd` reads the same file at 4.8 GB/s). The boot did not complete inside the allocation window. This is an environment/upstream-loader property, not a code path in this PR, but it does mean A14B is verified structurally, not end-to-end.

## Compatibility / Risk

- **Pin changes from the fork to unmodified upstream.** `_PINNED_FORK` is now `hao-ai-lab/FastVideo@2095477e`; the README and the WAN 2.1 recipe comment were still telling readers to check out `Zcchill/FastVideo@7fe1d7db`, which would now be rejected by the fingerprints at init. Anyone with the fork checked out must repoint `$FASTVIDEO_PATH`. No pip pin is added here — that belongs in a separate PR together with retiring the fork allowlist.
- **`unirl/sde/` is untouched.** The UniPC solver, `UniPCSpec` frozen-ness, and the model-config solver SSOT from #251/#374 are all reused as-is.
- **WAN 2.1 numerics.** The deterministic non-SDE tail already ran UniPC rather than the trainside `eta=0` Euler on `main`; this PR does not change that, and the 6.79e-01 Euler control above quantifies the gap for anyone comparing engines.
- New config surface: `model_family: wan2.2`, and `WAN22PipelineConfig` inherits the existing `unipc_*` fields (spelled out explicitly in the new recipe).
- `_weights.py` loads the sync checkpoint with `weights_only=True`. Every worker reads the whole file, so host RAM — not `/dev/shm` — bounds `sp_size`.

## Reviewer Notes

AI-assisted (Claude Code); every changed line was reviewed and the validation above was run and inspected rather than assumed.

Duplicate-work check: this supersedes the WAN 2.2 portion of #415 and deliberately does **not** re-land the UniPC solver that #251/#374 already put on `main` — an AST and numeric comparison showed #415's copy and `main`'s produce bit-identical trajectories, so `main`'s (with #374's hardening) is kept.

Worth inspecting first:

1. `_contracts.py` — the diffusion-law divergence is the correctness argument for this whole approach.
2. `_weights.py::_load_transformer_state` — it mutates layerwise-offloaded blocks through upstream's `mutate_params_scope()`, **one block at a time**. Writing `state.cpu_named_parameters` directly (as the earlier draft did) leaves block 0's prefetched GPU copy stale: measured `stale_after_sync=44` on a real DiT, all of `blocks.0` in both experts. Holding every block's scope open at once instead stages the whole expert on GPU (measured peak 40 blocks vs 1).
3. `_unipc.py::_verify_stock_surface` and the `_*_PARAMS` tuples — these must be updated together with any patch edit.

Follow-ups deliberately left out: the pip pin plus removing the fork from the compatibility allowlist (changes the pin policy for existing WAN 2.1 users, so it deserves its own PR), and the A14B end-to-end run once a node without forced-spin is available.

