### PR TITLE
perf(vllm-omni): restore cuDNN SDPA for colocated training

### DIFF
--- a/unirl/rollout/engine/vllm_omni/backends/native.py
+++ b/unirl/rollout/engine/vllm_omni/backends/native.py
@@ -21,6 +21,19 @@ logger = logging.getLogger(__name__)
 _ENGINE_PROC_PREFIX = "VLLM::"
 
 
+@contextmanager
+def _preserve_cudnn_sdp_state():
+    """Restore the process-wide cuDNN SDPA setting after vLLM imports."""
+    import torch
+
+    enabled = torch.backends.cuda.cudnn_sdp_enabled() if torch.cuda.is_available() else None
+    try:
+        yield
+    finally:
+        if enabled is not None:
+            torch.backends.cuda.enable_cudnn_sdp(enabled)
+
+
 def _import_omni_runtime() -> Dict[str, Any]:
     """Lazy import of the vllm-omni runtime types. Imported once per process."""
     from transformers import AutoTokenizer
@@ -117,10 +130,6 @@ class VLLMOmniBackend:
     @classmethod
     def boot(cls, intent: Dict[str, Any]) -> "VLLMOmniBackend":
         """Spell the intent into ``Omni`` ctor kwargs and spawn."""
-        from unirl.rollout.engine.vllm_omni.patches import install as install_patches
-
-        install_patches()
-
         import multiprocessing as mp
 
         try:
@@ -128,7 +137,13 @@ class VLLMOmniBackend:
         except RuntimeError:
             pass
 
-        rt = _import_omni_runtime()
+        # vLLM disables cuDNN SDPA process-wide at import. Preserve the
+        # colocated train actor's state; spawned workers initialize their own.
+        with _preserve_cudnn_sdp_state():
+            from unirl.rollout.engine.vllm_omni.patches import install as install_patches
+
+            install_patches()
+            rt = _import_omni_runtime()
 
         if intent.get("clear_cuda_visible"):
             os.environ.pop("CUDA_VISIBLE_DEVICES", None)

--- a/unirl/rollout/engine/vllm_omni/engine.py
+++ b/unirl/rollout/engine/vllm_omni/engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import Any, Dict, List, Optional
 
@@ -146,6 +147,11 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def wake_up(self) -> None:
         """Fan ``handle_wake_task`` to every stage's workers + restore LoRA."""
+        # vLLM disables cuDNN SDPA process-wide at import, including for colocated training.
+        if os.environ.get("UNIRL_KEEP_CUDNN_SDP_OFF"):
+            pass
+        elif torch.cuda.is_available():
+            torch.backends.cuda.enable_cudnn_sdp(True)
         if self._transition_failed:
             # Recover an unknown partial stage state to one known boundary
             # before attempting another wake. If this retry fails, retain the

--- a/unirl/rollout/engine/vllm_omni/engine.py
+++ b/unirl/rollout/engine/vllm_omni/engine.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from typing import Any, Dict, List, Optional
 
@@ -147,11 +146,6 @@ class VLLMOmniRolloutEngine(BaseRolloutEngine):
     @distributed(dispatch_mode=Dispatch.BROADCAST)
     def wake_up(self) -> None:
         """Fan ``handle_wake_task`` to every stage's workers + restore LoRA."""
-        # vLLM disables cuDNN SDPA process-wide at import, including for colocated training.
-        if os.environ.get("UNIRL_KEEP_CUDNN_SDP_OFF"):
-            pass
-        elif torch.cuda.is_available():
-            torch.backends.cuda.enable_cudnn_sdp(True)
         if self._transition_failed:
             # Recover an unknown partial stage state to one known boundary
             # before attempting another wake. If this retry fails, retain the


### PR DESCRIPTION
## Summary

Importing vLLM disables cuDNN SDPA process-wide. In colocated mode, that import-side state can leak into the training actor and reroute train-side diffusion attention from cuDNN flash to the slower PyTorch memory-efficient CUTLASS backend.

During `VLLMOmniBackend.boot`, preserve the actor's existing cuDNN SDPA setting around UniRL patch installation and vLLM/vLLM-Omni runtime imports, then restore the exact original value. Spawned engine workers initialize their own process-local backend state.

Stable-step timing: vLLM-Omni `train_time_s` improved from ~170s to ~137s; the trainside baseline was ~130.5s. `generate_time_s` remained ~36s versus ~77s for trainside, and **end-to-end `step_time_s` improved from ~240s to ~205s.**

<img width="1924" height="586" alt="eb6336fb6cfbb8d686a3cd64a499e843" src="https://github.com/user-attachments/assets/54cbce99-642f-4722-a1c9-5c4abf3507d5" />

## Related Issue

N/A

## Test Plan

- Environment: HunyuanVideo-1.5, 8×H800, identical recipe, data, seed, batch size, and Diffusers native PyTorch SDPA backend across timing runs. Recipe: [`hunyuan_video15_t2v_vllmomni_colocate`](https://github.com/Tencent-Hunyuan/UniRL/blob/main/examples/diffusion/hunyuan_video15/hunyuan_video15_t2v_vllmomni_colocate.yaml).
- In the CUDA training environment, verified that importing `vllm.platforms.cuda` changes `torch.backends.cuda.cudnn_sdp_enabled()` from `True` to `False`, and the scoped restoration changes it back to the original value.
- Profiler: train attention forward and backward changed from PyTorchMemEffAttention/CUTLASS (~31.2s per update) to cuDNN flash (~16.2s per update).
- Local focused behavioral test covers initial `True`/`False` states and restoration on both success and injected exceptions: 4 cases passed. The test is intentionally not included in this focused PR.
- `python3 -m py_compile unirl/rollout/engine/vllm_omni/backends/native.py`
- `SKIP=no-commit-to-branch pre-commit run --files unirl/rollout/engine/vllm_omni/backends/native.py --show-diff-on-failure` — all applicable hooks passed.

## Compatibility / Risk

No API, configuration, checkpoint, or data-format changes. The code restores the exact pre-import cuDNN SDPA setting rather than forcing it on, so actors that already require cuDNN SDPA disabled remain disabled. Model-specific safeguards that disable it at their owning execution boundary remain unchanged.

## Reviewer Notes

Only `unirl/rollout/engine/vllm_omni/backends/native.py` is changed in the final diff. The preservation scope includes patch installation because importing the patch bundle also imports vLLM modules. Profiling artifacts and the focused local test are intentionally excluded.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.