### PR TITLE
feat(hv15): add FlashAttention support for training and rollout

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,12 @@ uv venv --python 3.12 --seed .venv && source .venv/bin/activate
 uv pip install -e ".[vllm,train,infer]" --prerelease=allow
 ```
 
+To use a FlashAttention backend for diffusion training or rollout:
+
+```bash
+MAX_JOBS=8 uv pip install -e ".[flash-attn]" --no-build-isolation
+```
+
 ## sglang
 
 ```bash
@@ -48,6 +54,7 @@ can survive.
 | Extra | Adds | Use when |
 |---|---|---|
 | `vllm` | `vllm`, `vllm-omni`, torch +cu130 stack, PyAV | Running any vllm-omni-based example |
+| `flash-attn` | FlashAttention 2 | Selecting a FlashAttention backend for diffusion training or rollout |
 | `sglang` | `sglang[diffusion]`, `flash-attn-4`, torch +cu130 stack, PyAV | Running VLM/LLM examples or `sd3_sglang_*` |
 | `train` | `wandb`, `aiohttp` | Training runs (almost always wanted) |
 | `infer` | `accelerate` | HunyuanImage3 and similar models |

--- a/examples/diffusion/hunyuan_video15/hunyuan_video15_t2v_vllmomni_colocate.yaml
+++ b/examples/diffusion/hunyuan_video15/hunyuan_video15_t2v_vllmomni_colocate.yaml
@@ -54,6 +54,7 @@ bundle:
     _target_: unirl.models.hunyuan_video15.config.HunyuanVideo15PipelineConfig
     pretrained_model_ckpt_path: ${oc.env:PRETRAINED_MODEL,hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v}
     model_precision: bf16
+    attention_backend: flash_varlen
     shift: 5.0
     load_vae: false
 
@@ -120,6 +121,7 @@ rollout:
     _target_: unirl.rollout.engine.vllm_omni.config.VLLMOmniEngineConfig
     model_path: ${oc.env:PRETRAINED_MODEL,hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v}
     modality: hv15_t2v
+    diffusion_attention_backend: FLASH_ATTN
     # Colocate time-shares the GPU: the engine sleeps (releases GPU memory)
     # while the trainer runs and wakes to generate.
     enable_sleep_mode: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ vllm = [
   # torchaudio >=2.12 on the cu130 index, so this extra does not pin it.
   "av>=14.2,<19 ; sys_platform == 'linux'",
 ]
+flash-attn = [
+  "flash-attn>=2.6.3 ; sys_platform == 'linux'",
+]
 train = [
   "wandb>=0.16,<0.20",
   "aiohttp>=3.9",

--- a/unirl/models/hunyuan_video15/bundle.py
+++ b/unirl/models/hunyuan_video15/bundle.py
@@ -87,6 +87,7 @@ class HunyuanVideo15Bundle(Bundle):
                 path, subfolder="transformer", torch_dtype=dtype
             )
             transformer = transformer.to(device=device, dtype=dtype)
+        transformer.set_attention_backend(config.attention_backend)
         if bool(getattr(getattr(transformer, "config", None), "use_meanflow", False)):
             raise NotImplementedError(
                 "HunyuanVideo15Bundle does not support transformers with "

--- a/unirl/models/hunyuan_video15/config.py
+++ b/unirl/models/hunyuan_video15/config.py
@@ -21,6 +21,7 @@ class HunyuanVideo15PipelineConfig:
     text_encoder_dtype: Any = None
     model_precision: Any = "bf16"
     device: Any = None
+    attention_backend: str = "native"
 
     autocast_precision: str = "bf16"
     trajectory_precision: str = "fp16"

--- a/unirl/rollout/engine/vllm_omni/adapters/hv15.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/hv15.py
@@ -119,6 +119,12 @@ class Hv15T2vAdapter(ModelAdapter):
     stage_yaml = "hunyuan_video15_t2v_rl.yaml"
     needs_driver_tokenizer = False
 
+    def boot_kwargs(self) -> Dict[str, Any]:
+        """Select the rollout diffusion attention backend."""
+        kwargs = super().boot_kwargs()
+        kwargs["diffusion_attention_backend"] = self.cfg.diffusion_attention_backend or "TORCH_SDPA"
+        return kwargs
+
     def __init__(self, config: Any, model_config: Any, *, strategy: Any = None, tokenize_fn: Any = None) -> None:
         super().__init__(config, model_config, strategy=strategy, tokenize_fn=tokenize_fn)
         self.input_adapter = Hv15InputAdapter(self.modality)

--- a/unirl/rollout/engine/vllm_omni/backends/native.py
+++ b/unirl/rollout/engine/vllm_omni/backends/native.py
@@ -117,6 +117,9 @@ class VLLMOmniBackend:
     @classmethod
     def boot(cls, intent: Dict[str, Any]) -> "VLLMOmniBackend":
         """Spell the intent into ``Omni`` ctor kwargs and spawn."""
+        if attention_backend := intent.get("diffusion_attention_backend"):
+            os.environ["DIFFUSION_ATTENTION_BACKEND"] = str(attention_backend)
+
         from unirl.rollout.engine.vllm_omni.patches import install as install_patches
 
         install_patches()

--- a/unirl/rollout/engine/vllm_omni/config.py
+++ b/unirl/rollout/engine/vllm_omni/config.py
@@ -30,6 +30,7 @@ class VLLMOmniEngineConfig(BaseEngineConfig):
     modality: str = "hi3_t2i"
 
     enable_sleep_mode: bool = True
+    diffusion_attention_backend: Optional[str] = None
 
     stage_yaml_override: Optional[str] = None
 
@@ -67,6 +68,7 @@ class VLLMOmniEngineConfig(BaseEngineConfig):
         intent: Dict[str, Any] = {
             "model_path": str(self.model_path),
             "enable_sleep_mode": bool(self.enable_sleep_mode),
+            "diffusion_attention_backend": self.diffusion_attention_backend,
             "ports": ports,
         }
         intent.update(extra)

--- a/unirl/rollout/engine/vllm_omni/patches/README.md
+++ b/unirl/rollout/engine/vllm_omni/patches/README.md
@@ -80,6 +80,5 @@ known-invalid adapter.
   submodules, loaded lazily — `import unirl.rollout.engine.vllm_omni.patches` must
   not pull vllm.
 - **Every patch needs a DELETE-WHEN row.** Without one it is permanent by default.
-- **0.27 honors `engine_args.diffusion_attention_backend`, not `attention_backend`.**
-  The old AR field is silently dropped by `OmniDiffusionConfig.from_kwargs`;
-  HV1.5 pins the diffusion backend in its stage YAML.
+- **0.27 honors `diffusion_attention_backend`, not the AR field `attention_backend`.**
+  The HV1.5 adapter exports the recipe's rollout backend before Omni spawns.

--- a/unirl/rollout/engine/vllm_omni/stage_configs/hunyuan_video15_t2v_rl.yaml
+++ b/unirl/rollout/engine/vllm_omni/stage_configs/hunyuan_video15_t2v_rl.yaml
@@ -32,9 +32,6 @@ stage_args:
       cache_backend: null
       cache_config: null
       enable_cache_dit_summary: false
-      # Match the trainer's PyTorch SDPA forward path.
-      # 0.27 reads ``diffusion_attention_backend`` (not the AR field ``attention_backend``).
-      diffusion_attention_backend: TORCH_SDPA
       # Required for vLLM to wrap DiT Linear modules in LoRA-aware variants.
       # Without ``enable_lora``, ``add_lora`` still registers the adapter in
       # ``DiffusionLoRAManager._registered_adapters`` (so checksum probes


### PR DESCRIPTION
## Summary

Add explicit YAML controls for the HunyuanVideo 1.5 train-side Diffusers attention backend and the vLLM-Omni rollout diffusion attention backend.

The config defaults remain `native` for training and `TORCH_SDPA` for HV1.5 rollout. The colocated HV1.5 recipe opts into `flash_varlen` for training and `FLASH_ATTN` for rollout without requiring launcher-level environment variables.

**Stable-step timing: vLLM-Omni train_time_s improved from ~170s to ~125s; the trainside baseline was ~130.5s. generate_time_s remained ~36s versus ~77s for trainside, and end-to-end step_time_s improved from ~240s to ~190s. See Wandb figure below：**

<img width="2712" height="796" alt="acd7e8ce19fb43ac735e94e8a8f66a16" src="https://github.com/user-attachments/assets/1c93b73d-6095-4a62-a226-e3ce37dac8a3" />

**This PR reaches more significant accelerate compared with https://github.com/Tencent-Hunyuan/UniRL/pull/426.**

## Related Issue

N/A

## Test Plan

- Environment: HunyuanVideo 1.5, 8×H800, Diffusers 0.38.0, vLLM-Omni 0.27.0rc1. Recipe: [`hunyuan_video15_t2v_vllmomni_colocate.yaml`](https://github.com/yuxiaooye/UniRL/blob/feat/hv15-flash-attention-config/examples/diffusion/hunyuan_video15/hunyuan_video15_t2v_vllmomni_colocate.yaml).
- Verified train-side `flash_varlen` forward and backward with padded attention masks; outputs and gradients were finite.
- Verified vLLM-Omni resolved the rollout diffusion backend as `FLASH_ATTN` and completed rollout plus training steps.
- Verified the config defaults preserve train `native` and rollout `TORCH_SDPA` behavior.
- Reviewed the resolved rollout stage config: [`hunyuan_video15_t2v_rl.yaml`](https://github.com/yuxiaooye/UniRL/blob/feat/hv15-flash-attention-config/unirl/rollout/engine/vllm_omni/stage_configs/hunyuan_video15_t2v_rl.yaml).
- `python -m py_compile unirl/models/hunyuan_video15/config.py unirl/models/hunyuan_video15/bundle.py unirl/rollout/engine/vllm_omni/config.py unirl/rollout/engine/vllm_omni/adapters/hv15.py unirl/rollout/engine/vllm_omni/backends/native.py`
- `SKIP=no-commit-to-branch pre-commit run --from-ref upstream/main --to-ref HEAD --show-diff-on-failure` — all applicable hooks passed.
- `uv pip install --dry-run --no-build-isolation -e '.[flash-attn]'` — resolved `flash-attn==2.8.3.post1` in the active validation environment.

Environment limitation: the end-to-end run used `torch==2.13.0+cu129` with a locally built cu128 FlashAttention overlay. Current UniRL `main` pins `torch==2.13.0+cu130` for the vLLM extra. A fresh cu130 installation without the overlay has not been validated, so this PR does not claim full compatibility with that installation path.

## Compatibility / Risk

The config defaults and recipes other than `hunyuan_video15_t2v_vllmomni_colocate` retain their current attention backends. The colocated HV1.5 recipe now selects FlashAttention explicitly and requires the optional `flash-attn` installation.

## Reviewer Notes

No local wheel, virtual environment, benchmark log, profiler trace, or experiment-only script is included. No overlapping open PR or issue was found before submission. AI assistance was used to prepare the implementation and PR text; the full diff and reported commands were manually reviewed.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
