### PR TITLE
feat(opd): harden teachers for video KL, meta-init, and resume

### DIFF
--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -88,6 +88,11 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   so `stage.replay` still emits log-probs) **with `add_kl_coefficient=false`**. Never pair a
   near-zero `eta` with `add_kl_coefficient=true` — the KL divides by a transition std that
   scales with `eta` (the algorithm raises at init on `eta == 0`, but cannot judge "too small").
+- **`_transition_sigma` is `[1, S']`; `_gaussian_kl_div` broadcasts it to the means' rank** —
+  image means are `[B, S', C, H, W]` and video means `[B, S', C, T, H, W]`. The old fixed
+  `[1, S', 1, 1, 1]` right-aligned `S'` onto the channel axis for video: a raise when
+  `C != S'`, a silently mis-scaled per-step KL when `C == S'`. Never reshape sigma to a
+  hardcoded rank in a new consumer; pass the `[1, S']` tensor through `_gaussian_kl_div`.
 - **AR `sampling_temperature` must equal the rollout `sampling.temperature`** —
   `ARStage.replay` rescales logits by it (`log_softmax(logits / T)`) to match SGLang's
   distribution; when unset it silently falls back to the `ARSamplingParams` default,

--- a/unirl/algorithms/base.py
+++ b/unirl/algorithms/base.py
@@ -126,7 +126,8 @@ def _grpo_clip_loss(
 
 
 def _gaussian_kl_div(p: torch.Tensor, q: torch.Tensor, sigma: torch.Tensor) -> torch.Tensor:
-    """Per-element Gaussian KL between means at shared variance: ``(p-q)^2 / (2 sigma^2)``."""
+    """Per-element Gaussian KL ``(p-q)^2 / (2 sigma^2)``; ``sigma`` ``[1, S']`` broadcasts over ``[B, S', *latent]``."""
+    sigma = sigma.reshape(*sigma.shape[:2], *([1] * (p.ndim - 2)))
     return (p - q) ** 2 / (2 * sigma**2)
 
 
@@ -139,9 +140,9 @@ def _transition_sigma(
     device: torch.device,
     add_coefficient: bool = True,
 ) -> torch.Tensor:
-    """Per-step SDE transition std ``sigma_t`` for KL normalization, shape ``[1, S', 1, 1, 1]``."""
+    """Per-step SDE transition std ``sigma_t`` for KL normalization, shape ``[1, S']`` (rank-agnostic, see README)."""
     if not add_coefficient:
-        return torch.ones(1, len(target_steps), 1, 1, 1, device=device)
+        return torch.ones(1, len(target_steps), device=device)
     if segment.sigmas is None:
         raise ValueError("_transition_sigma requires segment.sigmas (add_coefficient=True).")
     sigmas = segment.sigmas.to(device=device, dtype=torch.float32)
@@ -150,7 +151,7 @@ def _transition_sigma(
     s_next = sigmas[idx + 1]
     sigma_max = sigmas[1] if int(sigmas.shape[0]) > 1 else torch.tensor(0.99, device=device, dtype=sigmas.dtype)
     sigma_t = stage.strategy.transition_std(sigma=s, sigma_next=s_next, eta=float(eta), sigma_max=sigma_max)
-    return sigma_t.reshape(1, -1, 1, 1, 1)
+    return sigma_t.reshape(1, -1)
 
 
 def _reference_replay_means(

--- a/unirl/algorithms/flowdppo.py
+++ b/unirl/algorithms/flowdppo.py
@@ -265,7 +265,7 @@ class FlowDPPO(StageAlgorithm):
         target_steps: List[int],
         device: torch.device,
     ) -> torch.Tensor:
-        """Per-step KL-normalization sigma_t ``[1, S', 1, 1, 1]``; ones when ``add_kl_coefficient=False``."""
+        """Per-step KL-normalization sigma_t ``[1, S']``; ones when ``add_kl_coefficient=False``."""
         return _transition_sigma(
             self.stage,
             segment=segment,

--- a/unirl/train/backend/base_backend.py
+++ b/unirl/train/backend/base_backend.py
@@ -31,7 +31,7 @@ from unirl.train.backend.sharded_state import (
 )
 from unirl.train.configs import EmaFullConfig, EmaLoraConfig, FSDPConfig, LoraConfig, normalize_frozen_adapters
 from unirl.train.ema import EMA, Shadow, inject_mirror, inject_nft, make_decay_fn
-from unirl.train.lora import inject_frozen_adapter, inject_lora, resolve_target_modules_pattern
+from unirl.train.lora import adapter_of_lora_key, inject_frozen_adapter, inject_lora, resolve_target_modules_pattern
 from unirl.train.optim import build_lr_scheduler, build_optimizer
 
 if TYPE_CHECKING:
@@ -147,6 +147,7 @@ class BaseFSDP2Backend(Remote):
         ema_cfg: Optional[EmaFullConfig],
     ) -> Optional[Shadow]:
         """Structural injection on the (possibly meta) trainable module."""
+        self._frozen_adapters: Dict[str, str] = {}  # name -> weight sha256
         shadow: Optional[Shadow] = None
         if ema_lora_cfg is not None:
             shadow = inject_nft(
@@ -173,11 +174,11 @@ class BaseFSDP2Backend(Remote):
                 bias=lora_cfg.bias,
                 task_type=lora_cfg.task_type,
             )
-            # Frozen sibling adapters (e.g. OPD teachers): injected pre-wrap so FSDP
-            # shards them and checkpoints stay symmetric; requires_grad=False keeps
-            # them out of the optimizer and weight sync.
+            # Frozen sibling adapters (e.g. OPD teachers): structure injected pre-wrap so
+            # FSDP shards them, weights loaded post-materialize; requires_grad=False keeps
+            # them out of the optimizer, weight sync and adapter checkpoints (see README).
             for spec in normalize_frozen_adapters(getattr(lora_cfg, "frozen_adapters", None)):
-                inject_frozen_adapter(model, name=spec.name, path=spec.path)
+                self._frozen_adapters[spec.name] = inject_frozen_adapter(model, name=spec.name, path=spec.path)
         if ema_cfg is not None:
             shadow = inject_mirror(model, prefix=ema_cfg.shadow_prefix)
         return shadow
@@ -244,6 +245,7 @@ class BaseFSDP2Backend(Remote):
                 "dropout": active_lora.dropout,
                 "bias": active_lora.bias,
                 "task_type": active_lora.task_type,
+                "frozen_adapters": dict(self._frozen_adapters),
             }
             if active_lora is not None
             else None
@@ -395,7 +397,7 @@ class BaseFSDP2Backend(Remote):
         self._reject_meta(operation="save", checkpoint_format="dcp", mode=mode)
         model_sd = drop_meta_entries(sharded_model_state_dict(self.model))
         if mode == "adapter":
-            model_sd = {k: v for k, v in model_sd.items() if "lora_A" in k or "lora_B" in k}
+            model_sd = {k: v for k, v in model_sd.items() if self._is_student_lora_key(k)}
         sharded_state: Dict[str, object] = {
             "model": model_sd,
             "optim": sharded_optimizer_state_dict(self.model, self.optimizer),
@@ -482,7 +484,11 @@ class BaseFSDP2Backend(Remote):
         mode = checkpoint.get("save_mode", "full")
         strict = mode == "full"
         self._reject_meta(operation="load", checkpoint_format="torch", mode=mode)
-        self._load_model_state(checkpoint["policy_state_dict"], strict=strict)
+        self._check_frozen_adapters(checkpoint.get("lora_config"))
+        policy_state = checkpoint["policy_state_dict"]
+        if mode == "adapter":
+            policy_state = {k: v for k, v in policy_state.items() if self._is_student_lora_key(k)}
+        self._load_model_state(policy_state, strict=strict)
         self._load_optimizer_state(checkpoint["optimizer_state_dict"])
         if self.scheduler is not None and "scheduler_state_dict" in checkpoint:
             self.scheduler.load_state_dict(checkpoint["scheduler_state_dict"])
@@ -508,9 +514,10 @@ class BaseFSDP2Backend(Remote):
         has_meta_params = any(p.is_meta for p in self.model.parameters())
         strict = mode == "full" and not has_meta_params
 
+        self._check_frozen_adapters(meta.get("lora_config"))
         model_sd = drop_meta_entries(sharded_model_state_dict(self.model))
         if mode == "adapter":
-            model_sd = {k: v for k, v in model_sd.items() if "lora_A" in k or "lora_B" in k}
+            model_sd = {k: v for k, v in model_sd.items() if self._is_student_lora_key(k)}
         sharded_state: Dict[str, object] = {
             "model": model_sd,
             "optim": sharded_optimizer_state_dict(self.model, self.optimizer),
@@ -524,6 +531,24 @@ class BaseFSDP2Backend(Remote):
         if meta.get("optimizer_step_count") is not None:
             self._optimizer_step_count = int(meta["optimizer_step_count"])
         return int(meta.get("step") or 0)
+
+    def _is_student_lora_key(self, key: str) -> bool:
+        """True for LoRA keys of a non-frozen adapter (frozen teachers never enter adapter checkpoints)."""
+        if "lora_A" not in key and "lora_B" not in key:
+            return False
+        return adapter_of_lora_key(key) not in self._frozen_adapters
+
+    def _check_frozen_adapters(self, lora_config: object) -> None:
+        """Refuse to resume when the checkpoint's recorded frozen adapters differ from the live ones."""
+        recorded = (lora_config or {}).get("frozen_adapters") if isinstance(lora_config, dict) else None
+        if recorded is None:
+            return
+        if dict(recorded) != self._frozen_adapters:
+            raise RuntimeError(
+                f"{type(self).__name__}.load: frozen_adapters differ from the checkpoint's "
+                f"(checkpoint: {sorted(recorded)}, live: {sorted(self._frozen_adapters)}, or a weight sha256 "
+                "changed). Resume with the same teacher checkpoints or start a new run."
+            )
 
     def _reject_meta(
         self,
@@ -663,7 +688,7 @@ class BaseFSDP2Backend(Remote):
     def _gather_model_state(self, mode: str) -> StateDict:
         """Rank-0 model state for the single-file checkpoint."""
         if mode == "adapter":
-            return gather_lora_state_dict(self.model)
+            return {k: v for k, v in gather_lora_state_dict(self.model).items() if self._is_student_lora_key(k)}
         return gather_state_dict(self.model)
 
     def _load_model_state(self, model_state: StateDict, *, strict: bool) -> None:

--- a/unirl/train/backend/base_backend.py
+++ b/unirl/train/backend/base_backend.py
@@ -174,9 +174,7 @@ class BaseFSDP2Backend(Remote):
                 bias=lora_cfg.bias,
                 task_type=lora_cfg.task_type,
             )
-            # Frozen sibling adapters (e.g. OPD teachers): structure injected pre-wrap so
-            # FSDP shards them, weights loaded post-materialize; requires_grad=False keeps
-            # them out of the optimizer, weight sync and adapter checkpoints (see README).
+            # Frozen sibling adapters (e.g. OPD teachers) — see ../readme.md Gotchas.
             for spec in normalize_frozen_adapters(getattr(lora_cfg, "frozen_adapters", None)):
                 self._frozen_adapters[spec.name] = inject_frozen_adapter(model, name=spec.name, path=spec.path)
         if ema_cfg is not None:
@@ -543,12 +541,22 @@ class BaseFSDP2Backend(Remote):
         recorded = (lora_config or {}).get("frozen_adapters") if isinstance(lora_config, dict) else None
         if recorded is None:
             return
-        if dict(recorded) != self._frozen_adapters:
-            raise RuntimeError(
-                f"{type(self).__name__}.load: frozen_adapters differ from the checkpoint's "
-                f"(checkpoint: {sorted(recorded)}, live: {sorted(self._frozen_adapters)}, or a weight sha256 "
-                "changed). Resume with the same teacher checkpoints or start a new run."
-            )
+        recorded = dict(recorded)
+        if recorded == self._frozen_adapters:
+            return
+        live = self._frozen_adapters
+        added = sorted(set(live) - set(recorded))
+        removed = sorted(set(recorded) - set(live))
+        changed = sorted(
+            f"{name} ({recorded[name][:12]}... -> {live[name][:12]}...)"
+            for name in set(recorded) & set(live)
+            if recorded[name] != live[name]
+        )
+        raise RuntimeError(
+            f"{type(self).__name__}.load: frozen_adapters differ from the checkpoint's "
+            f"(added: {added}, removed: {removed}, weights changed: {changed}). "
+            "Resume with the same teacher checkpoints or start a new run."
+        )
 
     def _reject_meta(
         self,

--- a/unirl/train/lora.py
+++ b/unirl/train/lora.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -221,20 +222,15 @@ def inject_frozen_adapter(
     name: str,
     path: str,
     trainable_adapter: str = "default",
-) -> None:
-    """Inject a frozen, inference-only LoRA adapter with weights from ``path``."""
-    from peft import LoraConfig, inject_adapter_in_model, set_peft_model_state_dict
+) -> str:
+    """Inject a frozen LoRA adapter now, load its weights after materialization; returns the weight sha256."""
+    from peft import LoraConfig, inject_adapter_in_model
     from peft.tuners.lora import LoraLayer
 
     if not name or name == trainable_adapter:
         raise ValueError(
             f"inject_frozen_adapter: adapter name must be non-empty and differ from "
             f"the trainable adapter {trainable_adapter!r}; got {name!r}."
-        )
-    if any(p.is_meta for p in model.parameters()):
-        raise NotImplementedError(
-            "inject_frozen_adapter: the trainable module is meta-initialized; frozen "
-            "adapters load real weights at injection time and require an eager bundle."
         )
     if name in adapter_names(model):
         raise ValueError(f"inject_frozen_adapter: adapter {name!r} already exists on the model.")
@@ -260,54 +256,25 @@ def inject_frozen_adapter(
             "Wrong checkpoint for this architecture?"
         )
 
-    if weight_path.endswith(".safetensors"):
-        from safetensors.torch import load_file as _load_weights
-    else:
-        import torch
-
-        def _load_weights(p):
-            return torch.load(p, map_location="cpu", weights_only=True)
-
-    load_result = set_peft_model_state_dict(model, _load_weights(weight_path), adapter_name=name)
-    unexpected = list(getattr(load_result, "unexpected_keys", []) or [])
-    if unexpected:
-        raise ValueError(
-            f"inject_frozen_adapter: {len(unexpected)} tensor(s) in {weight_path!r} matched no "
-            f"parameter of adapter {name!r} (first: {unexpected[:3]}). The checkpoint does not "
-            "line up with this model — refusing a silently partial teacher."
-        )
-    # strict=False ``missing_keys`` spans the whole model; only THIS adapter's lora
-    # banks indicate a truncated checkpoint (peft zero-inits ``lora_B`` -> a missing
-    # tensor silently nulls the teacher on that layer).
-    missing: list = []
-    for key in getattr(load_result, "missing_keys", None) or []:
-        parts = key.split(".")
-        for bank in ("lora_A", "lora_B", "lora_embedding_A", "lora_embedding_B"):
-            if bank in parts:
-                bank_idx = parts.index(bank)
-                if bank_idx + 1 < len(parts) and parts[bank_idx + 1] == name:
-                    missing.append(key)
-                break
-    if missing:
-        raise ValueError(
-            f"inject_frozen_adapter: {len(missing)} tensor(s) of adapter {name!r} are absent from "
-            f"{weight_path!r} (first: {missing[:3]}). peft zero-initializes the missing side, which "
-            "would silently disable the teacher on those layers — refusing a partial teacher."
-        )
-
     _set_adapter_requires_grad(model, name, False)
-    # peft's inject/set paths flip other adapters' requires_grad; restore the resting state.
+    # peft's inject path flips other adapters' requires_grad; restore the resting state.
     _activate(model, trainable_adapter)
     _set_adapter_requires_grad(model, trainable_adapter, True)
     # Mirror inject_nft: keep diffusers' PeftAdapterMixin bookkeeping consistent.
     if hasattr(model, "_hf_peft_config_loaded"):
         model._hf_peft_config_loaded = True
 
+    # Weights need real (sharded) storage: FSDP/VeOmni materialize after injection.
+    defer_after_materialize(
+        model,
+        partial(_load_frozen_adapter, name=name, weight_path=weight_path, trainable_adapter=trainable_adapter),
+    )
+
     if _current_rank() == 0:
         total = sum(1 for m in model.modules() if isinstance(m, LoraLayer))
         n_params = sum(p.numel() for m in covered for p in (m.lora_A[name].weight, m.lora_B[name].weight))
         logger.info(
-            "inject_frozen_adapter: %r from %s — rank=%d, %d/%d LoraLayer(s) covered, %d params (frozen)",
+            "inject_frozen_adapter: %r from %s — rank=%d, %d/%d LoraLayer(s) covered, %d params (frozen, deferred load)",
             name,
             path,
             peft_cfg.r,
@@ -315,6 +282,88 @@ def inject_frozen_adapter(
             total,
             n_params,
         )
+    return _file_sha256(weight_path)
+
+
+_LORA_BANKS = ("lora_A", "lora_B", "lora_embedding_A", "lora_embedding_B")
+_PEFT_PREFIX = "base_model.model."
+
+
+def adapter_of_lora_key(key: str) -> Optional[str]:
+    """Adapter name of a model state-dict LoRA key (``...lora_A.<adapter>.weight``), else None."""
+    parts = key.split(".")
+    for bank in _LORA_BANKS:
+        if bank in parts:
+            idx = parts.index(bank)
+            return parts[idx + 1] if idx + 1 < len(parts) else None
+    return None
+
+
+def _to_model_lora_key(key: str, name: str) -> str:
+    """Map a peft checkpoint key (``base_model.model.<m>.lora_A.weight``) to ``<m>.lora_A.<name>.weight``."""
+    if key.startswith(_PEFT_PREFIX):
+        key = key[len(_PEFT_PREFIX) :]
+    parts = key.split(".")
+    for bank in _LORA_BANKS:
+        if bank in parts:
+            idx = parts.index(bank)
+            return ".".join(parts[: idx + 1] + [name] + parts[idx + 1 :])
+    return key
+
+
+def _load_frozen_adapter(model: nn.Module, *, name: str, weight_path: str, trainable_adapter: str) -> None:
+    """Post-materialize op: load ``weight_path`` into adapter ``name`` on every rank and re-freeze it."""
+    from unirl.train.backend.sharded_state import load_model_state_dict
+
+    if weight_path.endswith(".safetensors"):
+        from safetensors.torch import load_file
+
+        raw = load_file(weight_path, device="cpu")
+    else:
+        import torch
+
+        raw = torch.load(weight_path, map_location="cpu", weights_only=True)
+
+    model_sd = model.state_dict()
+    expected = {k for k in model_sd if adapter_of_lora_key(k) == name}
+    mapped = {_to_model_lora_key(k, name): v for k, v in raw.items()}
+    unexpected = sorted(set(mapped) - expected)
+    if unexpected:
+        raise ValueError(
+            f"inject_frozen_adapter: {len(unexpected)} tensor(s) in {weight_path!r} matched no "
+            f"parameter of adapter {name!r} (first: {unexpected[:3]}). The checkpoint does not "
+            "line up with this model — refusing a silently partial teacher."
+        )
+    # peft zero-inits ``lora_B``: a missing tensor would silently null the teacher on that layer.
+    missing = sorted(expected - set(mapped))
+    if missing:
+        raise ValueError(
+            f"inject_frozen_adapter: {len(missing)} tensor(s) of adapter {name!r} are absent from "
+            f"{weight_path!r} (first: {missing[:3]}) — refusing a partial teacher."
+        )
+    for key, value in mapped.items():
+        want = model_sd[key].shape
+        if tuple(value.shape) != tuple(want):
+            raise ValueError(
+                f"inject_frozen_adapter: {key!r} has shape {tuple(value.shape)} in {weight_path!r}, "
+                f"model expects {tuple(want)} (adapter rank mismatch?)."
+            )
+    # Every rank holds the full (small) adapter dict; DCP slices each rank's own shard.
+    load_model_state_dict(model, mapped, strict=False, broadcast_from_rank0=False)
+
+    _set_adapter_requires_grad(model, name, False)
+    _activate(model, trainable_adapter)
+    _set_adapter_requires_grad(model, trainable_adapter, True)
+    if _current_rank() == 0:
+        logger.info("_load_frozen_adapter(%r): %d tensor(s) from %s", name, len(mapped), weight_path)
+
+
+def _file_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 @contextmanager
@@ -345,6 +394,7 @@ __all__ = [
     "ModuleSelection",
     "adapter_active",
     "adapter_names",
+    "adapter_of_lora_key",
     "adapters_disabled",
     "inject_frozen_adapter",
     "inject_lora",

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -106,7 +106,10 @@ in `backend/base.py`; a multi-update-capable algorithm sets
   the peft checkpoint on every rank, maps `base_model.model.<m>.lora_A.weight` to
   `<m>.lora_A.<name>.weight`, refuses unexpected / missing / mis-shaped tensors, and
   reshards via `set_model_state_dict(full_state_dict=True)`. Anything that reads teacher
-  weights before `apply_deferred_ops` sees peft's zero-init `lora_B` (a null teacher).
+  weights before `apply_deferred_ops` gets something other than the checkpoint: peft's random
+  `lora_A` over a zeroed `lora_B` (a null teacher) on an eager bundle, and *uninitialized*
+  storage on a meta-init one, because `to_empty` wipes whatever peft wrote. `inject_lora`
+  defers `_reset_adapter` for the trainable adapter for exactly the same reason.
 - **Adapter checkpoints hold only the trainable adapter(s); frozen adapters are excluded on
   save *and* load** — they are re-created from `frozen_adapters` paths at build time, so
   loading them back would silently pin an old teacher over a changed recipe. The checkpoint

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -100,6 +100,19 @@ in `backend/base.py`; a multi-update-capable algorithm sets
   the model whenever `param_dtype` upcasts (fp32 compute over a bf16 checkpoint), so
   leave it `true` unless that copy is cheap. `defer_grad_sync: true` then gives one
   all-reduce per optimizer step. VeOmni only supports `full`.
+- **`frozen_adapters` (OPD teachers) load their weights *after* materialization, not at
+  injection** — `inject_frozen_adapter` only builds the adapter structure pre-wrap (meta-safe,
+  so VeOmni meta-init bundles work) and registers a `defer_after_materialize` op that reads
+  the peft checkpoint on every rank, maps `base_model.model.<m>.lora_A.weight` to
+  `<m>.lora_A.<name>.weight`, refuses unexpected / missing / mis-shaped tensors, and
+  reshards via `set_model_state_dict(full_state_dict=True)`. Anything that reads teacher
+  weights before `apply_deferred_ops` sees peft's zero-init `lora_B` (a null teacher).
+- **Adapter checkpoints hold only the trainable adapter(s); frozen adapters are excluded on
+  save *and* load** — they are re-created from `frozen_adapters` paths at build time, so
+  loading them back would silently pin an old teacher over a changed recipe. The checkpoint
+  records each frozen adapter's weight sha256 under `lora_config.frozen_adapters`, and
+  `load` raises when the live set or any hash differs (checkpoints written before this
+  field exist load without the check).
 
 ## Profiling → Perfetto
 


### PR DESCRIPTION
## Summary

Task **D1** of the on-policy-distillation RFC (#368): make the existing `DiffusionOPD` path correct beyond the eager SD3.5-M image recipe.

- **Video KL.** `_transition_sigma` is now `[1, S']`; `_gaussian_kl_div` broadcasts it over `[B, S', *latent]`. The old `[1, S', 1, 1, 1]` right-aligned `S'` onto the channel axis for video (raise, or a silently wrong per-step KL when `C == S'`). Image KL is bitwise-equal to before; FlowGRPO/FlowDPPO share the helper.
- **Meta-init teachers.** Frozen-adapter structure is injected pre-wrap; weights load after materialize. Meta bundles no longer raise; teachers stay `requires_grad=False`.
- **Checkpoint symmetry.** Adapter save/load skip frozen teachers and record `{name: sha256}`; resume refuses a different teacher set. Old checkpoints without the field still load.

## Related Issue

Part of #368 (D1)

## Test Plan
2-GPU validation
Hardware: 2× A800-80GB PCIe (same SeetaCloud box), torch 2.13.0+cu130, peft 0.20.0, branch head d6416ee (== b069195, identical file hashes). Same recipe/overrides as the 1-GPU runs except num_devices=2 +devices_per_node=2 (so batch_size=4 is split 2 prompts per rank). Harness scripts are 2-rank versions of the ones above (not committed); every step also ran under timeout 1500 to detect hangs — none occurred.

- Teacher weights vs files, per rank (torchrun --nproc_per_node=2, FSDPBackend eager and VeOmniBackend +bundle.config.meta_init_transformer=true): each rank's local DTensor shard of every teacher tensor (382 tensors × 3 teachers, 9,388,032 elements per teacher per rank) equals the matching slice of the safetensors file bitwise (max_abs_diff=0.0); the rank-0 gathered full tensors equal the files bitwise as well. requires_grad: teacher 0/1146 true, student 382/382 true; teacher_params_in_optimizer=0, meta_params_left=0 on both ranks. Peak alloc per rank 15.4 GB (FSDP) / 13.6 GB (VeOmni). Base-weight and teacher sha256s identical between the two backends (909/909, 3×382) and identical to the 1-GPU eager run; only the unseeded student lora_A differs.

- Run A (torch checkpoint): 6 rollouts, +save_interval=3 → rollout 3 loss=0.0006 gn=0.0001, rollout 6 loss=0.0006 gn=0.0001 (1-GPU: 0.0006 / 0.0007). checkpoint-3: save_mode=adapter, optimizer_step_count=1, 382 keys all default, zero teacher keys, lora_config.frozen_adapters sha256s equal sha256sum of the three teacher files.

- Run B (resume from A/checkpoint-3 → 6): loads at rollout 3, rollout 6 loss=0.0006 gn=0.0001.

- Teacher weights across a real 2-rank _load_torch: gathered and per-rank local shards — 3×382 teacher tensors unchanged, 909 base unchanged, 381/382 student replaced, loaded_step=3, on both ranks.

- Run A-dcp / B-dcp (+backend.fsdp_cfg.checkpoint_format=dcp): same losses (0.0006 / 0.0006, resume 0.0006); DCP checkpoint-3 holds __0_0.distcp, __1_0.distcp; .metadata lists 382 model keys, all default, zero teacher keys; metadata.pt save_mode=adapter with matching teacher sha256s. _load_dcp on 2 ranks: teachers bitwise unchanged (gathered + per-rank), loaded_step=3.

- Negative N1 (2 ranks, truncated OCR teacher): startup fails with inject_frozen_adapter: 1 tensor(s) of adapter 'ocr' are absent ...; exit 1 in 32 s, both ranks down, no hang.

- Negative N2 / N2-dcp (2 ranks, resume with TEACHER_OCR_PATH → GenEval teacher): FSDPBackend.load: frozen_adapters differ from the checkpoint's ...; exit 1 in ~33 s for both torch and DCP checkpoints, no hang.

## Compatibility / Risk

- Checkpoint format: adapter checkpoints no longer contain frozen-adapter tensors and gain `lora_config.frozen_adapters`. Old checkpoints load (teacher keys are dropped on load, no sha check).
- `inject_frozen_adapter` now returns the weight sha256 and defers loading; anything reading teacher weights before `apply_deferred_ops` sees peft's zero-init `lora_B`.
- `_transition_sigma` shape changed from `[1,S',1,1,1]` to `[1,S']`; all in-tree consumers go through `_gaussian_kl_div`.
- Not addressed (noted for follow-up): `lora_state_dict` used by weight sync is name-filtered and would still ship frozen adapters to an external rollout engine; OPD recipes use trainside rollout.