### PR TITLE
refactor(sglang): make Sample sampling parameters authoritative

### DIFF
--- a/CPPO/README.md
+++ b/CPPO/README.md
@@ -134,7 +134,7 @@ the canonical mode. (`old_logp_source: replay` is available for ablations.)
 | `cppo_delta` | Token-level Binary-TV threshold `δ`. Paper Table 3: 0.15 dense, 0.20 for 30B-A3B. |
 | `cppo_w_min` | Position-weight floor `w_min` (0.8). Earlier tokens get weight 1, late tokens `w_min`. |
 | `cppo_delta_b` | Dynamic prefix-budget floor `δ_b^min` (0.02); `δ_b^seq = clamp(P90(D), δ_b, 2·δ_b)`. |
-| `sampling_temperature` | **MUST equal `sampling.temperature`** (and the rollout engine's). |
+| `sampling_temperature` | **MUST equal `sampling.temperature`**. |
 | `loss_agg_mode` | `token-mean`, or the recipe's `seq-mean-token-sum-norm`. |
 | `horizon` | Fixed normalizer for `seq-mean-token-sum-norm`; recipe `16384`. |
 | `old_logp_source` | `rollout` (canonical: `µ` = the SGLang sampler's logp) or `replay` (ablation). |

--- a/CPPO/README.md
+++ b/CPPO/README.md
@@ -136,7 +136,7 @@ the canonical mode. (`old_logp_source: replay` is available for ablations.)
 | `cppo_delta_b` | Dynamic prefix-budget floor `δ_b^min` (0.02); `δ_b^seq = clamp(P90(D), δ_b, 2·δ_b)`. |
 | `sampling_temperature` | **MUST equal `sampling.temperature`**. |
 | `loss_agg_mode` | `token-mean`, or the recipe's `seq-mean-token-sum-norm`. |
-| `horizon` | Fixed normalizer for `seq-mean-token-sum-norm`; recipe `16384`. |
+| `horizon` | Fixed normalizer for `seq-mean-token-sum-norm`; the recipe derives it from `${sampling.max_new_tokens}`. |
 | `old_logp_source` | `rollout` (canonical: `µ` = the SGLang sampler's logp) or `replay` (ablation). |
 
 Metric source: `ratio_mean`, `ratio_max`, `approx_kl` (k3), `masked_fraction` (the budget-mask

--- a/CPPO/config.yaml
+++ b/CPPO/config.yaml
@@ -33,11 +33,11 @@ algorithm:
   cppo_delta_b: 0.02             # δ_b floor of the per-sequence dynamic prefix-average budget;
                                  #   δ_b^seq = clamp(P90(D_{1:T}), δ_b, 2·δ_b) (paper Eq. 22).
   loss_agg_mode: seq-mean-token-sum-norm  # per-seq Σ(token loss) / horizon, mean over seqs
-  horizon: 16384                 # fixed length normalizer for seq-mean-token-sum-norm
+  horizon: ${sampling.max_new_tokens}  # fixed length normalizer for seq-mean-token-sum-norm
   # 1.0 — MUST equal sampling.temperature below. Replay tempers logits
   #   (log_softmax(logits / T)) so new_logp (π) and rollout logp (μ) live on the
   #   same distribution ⇒ ratio_mean ≈ 1 on update 1.
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   # rollout = anchor the ratio AND the Binary-TV divergence μ = |π − μ| on the
   #   SGLang sampler's emitted logprobs for ALL mini-batch updates. This is the
   #   behavior policy CPPO's trust region is defined against (paper Sec. 4); = the
@@ -67,9 +67,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-30B-A3B-Base}
     tp_size: 8
-    max_new_tokens: 16384
-    temperature: 1.0             # keep == sampling.temperature / sampling_temperature
-    top_p: 1.0
     samples_pre_expanded: true   # trainer pre-expands req by samples_per_prompt; engine emits n=1
     chat_template_kwargs:
       enable_thinking: true       # base model + emergent long CoT; MUST match pipeline.enable_thinking

--- a/DRPO/README.md
+++ b/DRPO/README.md
@@ -146,7 +146,7 @@ Unlike FlowGRPO/FlowDPPO, `DRPO` does **not** freeze a train-side `old_logp` in
 | Knob | Meaning |
 |---|---|
 | `drpo_epsilon` | Regularization threshold `ε` (code) / `δ` (paper). Default `12.5` (paper §4). Larger ⇒ weaker regularization; per-token trust region is `ε_t = ε / µ`. |
-| `sampling_temperature` | **MUST equal `sampling.temperature`** (and the rollout engine's). Replay tempers logits so `π` and `µ` share a distribution (`ratio_mean ≈ 1`). |
+| `sampling_temperature` | **MUST equal `sampling.temperature`**. Replay tempers logits so `π` and `µ` share a distribution (`ratio_mean ≈ 1`). |
 | `loss_agg_mode` | `token-mean`, or the recipe's `seq-mean-token-sum-norm`. |
 | `horizon` | Fixed normalizer for `seq-mean-token-sum-norm`; recipe `8192`. |
 | `normalize_adv_by_std` | Recipe `false` → mean-center only (no std division). |
@@ -155,7 +155,7 @@ Unlike FlowGRPO/FlowDPPO, `DRPO` does **not** freeze a train-side `old_logp` in
 
 | Symptom | First files / variables to check |
 |---|---|
-| `ratio_mean` far from 1 at first update | `sampling_temperature` vs. `sampling.temperature` vs. rollout `temperature`; SGLang logprob config |
+| `ratio_mean` far from 1 at first update | `sampling_temperature` vs. `sampling.temperature`; SGLang logprob config |
 | Large `rollout_replay_logp_absdiff_mean` | train/rollout mismatch, weight sync, tokenization/chat-template mismatch |
 | No gradient on many tokens | `segment.loss_mask`; zero advantages from all-correct/all-wrong groups |
 | `drpo_penalty_mean` very large | `drpo_epsilon` too small for the model's off-policy gap |

--- a/DRPO/README.md
+++ b/DRPO/README.md
@@ -148,7 +148,7 @@ Unlike FlowGRPO/FlowDPPO, `DRPO` does **not** freeze a train-side `old_logp` in
 | `drpo_epsilon` | Regularization threshold `ε` (code) / `δ` (paper). Default `12.5` (paper §4). Larger ⇒ weaker regularization; per-token trust region is `ε_t = ε / µ`. |
 | `sampling_temperature` | **MUST equal `sampling.temperature`**. Replay tempers logits so `π` and `µ` share a distribution (`ratio_mean ≈ 1`). |
 | `loss_agg_mode` | `token-mean`, or the recipe's `seq-mean-token-sum-norm`. |
-| `horizon` | Fixed normalizer for `seq-mean-token-sum-norm`; recipe `8192`. |
+| `horizon` | Fixed normalizer for `seq-mean-token-sum-norm`; the recipe derives it from `${sampling.max_new_tokens}`. |
 | `normalize_adv_by_std` | Recipe `false` → mean-center only (no std division). |
 
 ## Debug checklist

--- a/DRPO/config.yaml
+++ b/DRPO/config.yaml
@@ -28,11 +28,11 @@ algorithm:
                                  #   token-adaptive SPO quadratic (per-token trust
                                  #   region ε_t = ε/µ); larger ε ⇒ weaker regularization.
   loss_agg_mode: seq-mean-token-sum-norm  # per-seq Σ(token loss) / horizon, mean over seqs
-  horizon: 8192                  # fixed length normalizer for seq-mean-token-sum-norm
+  horizon: ${sampling.max_new_tokens}  # fixed length normalizer for seq-mean-token-sum-norm
   # 1.0 — MUST equal sampling.temperature below. Replay tempers logits
   #   (log_softmax(logits / T)) so new_logp (π) and rollout logp (µ) live on the
   #   same distribution ⇒ ratio_mean ≈ 1 on update 1.
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions
@@ -57,9 +57,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0             # keep == sampling.temperature / sampling_temperature
-    top_p: 0.9
     samples_pre_expanded: true   # trainer pre-expands req by samples_per_prompt; engine emits n=1
     system_instruction: /no_think         # keep the base model from emitting a long <think>
     chat_template_kwargs:                  #   block before \boxed{}

--- a/examples/ar/qwen3_5_grpo_9b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_5_grpo_9b_base_dapo_sglang.yaml
@@ -88,9 +88,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_5_PATH,tiny-random/qwen3.5}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 128
     samples_pre_expanded: true
     response_forbidden_tokens: ["<|image_pad|>", "<|video_pad|>"]
@@ -120,8 +117,8 @@ algorithm:
   clip_range_high: null
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-mean
-  horizon: 8192
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3_5.conditions.Qwen3_5ARConditions

--- a/examples/ar/qwen3_5_grpo_9b_geo3k_mc_sglang.yaml
+++ b/examples/ar/qwen3_5_grpo_9b_geo3k_mc_sglang.yaml
@@ -96,9 +96,6 @@ rollout:
     # image_pad to match image_grid_thw; this value is not the full image marker.
     image_token: "<|image_pad|>"
     response_forbidden_tokens: ["<|image_pad|>", "<|video_pad|>"]
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     chat_template_kwargs:
       enable_thinking: false
@@ -126,7 +123,7 @@ algorithm:
   clip_range_high: 0.28  # DAPO clip-higher (ms-swift epsilon_high=0.28)
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-mean  # ms-swift loss_type=grpo
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3_5.conditions.Qwen3_5ARConditions

--- a/examples/ar/qwen3_5_moe_grpo_35b_a3b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_5_moe_grpo_35b_a3b_base_dapo_sglang.yaml
@@ -94,9 +94,6 @@ rollout:
     pretrained_model_ckpt_path: ${oc.env:QWEN3_5_MOE_PATH}
     tp_size: 8
     ep_size: 8
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 64
     samples_pre_expanded: true
     response_forbidden_tokens: ["<|image_pad|>", "<|video_pad|>"]
@@ -128,8 +125,8 @@ algorithm:
   clip_range_high: null
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-mean
-  horizon: 8192
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3_5.conditions.Qwen3_5ARConditions

--- a/examples/ar/qwen3_5_moe_grpo_35b_a3b_geo3k_mc_sglang.yaml
+++ b/examples/ar/qwen3_5_moe_grpo_35b_a3b_geo3k_mc_sglang.yaml
@@ -94,9 +94,6 @@ rollout:
     samples_pre_expanded: true
     image_token: "<|image_pad|>"
     response_forbidden_tokens: ["<|image_pad|>", "<|video_pad|>"]
-    max_new_tokens: 512
-    temperature: 0.7
-    top_p: 0.9
     concurrency: 8
     enable_memory_saver: true
     enable_weights_cpu_backup: true
@@ -124,7 +121,7 @@ algorithm:
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3_5.conditions.Qwen3_5ARConditions
-  sampling_temperature: 0.7
+  sampling_temperature: ${sampling.temperature}
 
 sync:
   _target_: unirl.distributed.weight_sync.full.tensor.TensorWeightSync

--- a/examples/ar/qwen3_cppo_30b_a3b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_cppo_30b_a3b_base_dapo_sglang.yaml
@@ -105,9 +105,6 @@ rollout:
     # TUNE: 30B-A3B needs tensor parallelism to fit the SGLang server; tp_size=8
     # is a starting point (one TP group per node of 8 GPUs).
     tp_size: 8
-    max_new_tokens: 16384
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     samples_pre_expanded: true
     chat_template_kwargs:
@@ -142,10 +139,10 @@ algorithm:
   cppo_w_min: 0.8 # position-weight floor; w_t = w_min + (1-w_min)*(T-t)/(T-1)
   cppo_delta_b: 0.02 # dynamic prefix-budget floor; delta_b^seq = clamp(P90(D), delta_b, 2*delta_b)
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 16384 # fixed length normalizer (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   # rollout = anchor the ratio AND the Binary-TV divergence mu on the SGLang
   # sampler's emitted logprobs for ALL mini-batch updates — this is the behavior
   # policy CPPO's trust region anchors on (paper Sec. 4; verl bypass-mode parity).

--- a/examples/ar/qwen3_cppo_30b_a3b_base_dapo_sglang_full_weight_sync.yaml
+++ b/examples/ar/qwen3_cppo_30b_a3b_base_dapo_sglang_full_weight_sync.yaml
@@ -99,9 +99,6 @@ rollout:
     ep_size: 8
     # SGLang enables MoE expert parallelism through ep_size; the pinned
     # ServerArgs has no separate enable_expert_parallel boolean.
-    max_new_tokens: 4096
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 64
     samples_pre_expanded: true
     # The trainer sleeps SGLang before restoring FSDP onto the same GPUs.
@@ -137,8 +134,8 @@ algorithm:
   cppo_w_min: 0.8
   cppo_delta_b: 0.02
   loss_agg_mode: seq-mean-token-sum-norm
-  horizon: 4096
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   old_logp_source: rollout
   conditions_cls:
     _target_: hydra.utils.get_class

--- a/examples/ar/qwen3_dppo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_dppo_4b_base_dapo_sglang.yaml
@@ -120,9 +120,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -168,11 +165,11 @@ algorithm:
   stage_attr: ar # resolves stage from the trainer-injected pipeline (.ar)
   dppo_delta: 0.15 # δ: uniform token-level Binary-TV threshold (0.15 dense; paper §4)
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 8192 # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1,
   # and the Binary-TV divergence |pi-mu| reflects only policy drift).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   # rollout = anchor the ratio AND the Binary-TV divergence μ on the SGLang
   # sampler's emitted logprobs for ALL 4 mini-batch updates below — exact parity
   # with the released verl run (rollout_correction.bypass_mode=True). This is the

--- a/examples/ar/qwen3_drgrpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drgrpo_4b_base_dapo_sglang.yaml
@@ -112,9 +112,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -174,10 +171,10 @@ algorithm:
   clip_range_high: null # symmetric clip — standard Dr.GRPO (the vanilla baseline uses 0.28)
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 8192 # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang.yaml
@@ -122,9 +122,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -181,10 +178,10 @@ algorithm:
   # wandb config). false = plain SPO with FIXED eps (= verl spo).
   penalty_mu_weighted: true
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 8192 # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   # rollout = anchor the PPO ratio on the SGLang sampler's emitted logprobs for ALL
   # 4 mini-batch updates below — exact parity with the released verl run, which sets
   # rollout_correction.bypass_mode=True (old_log_probs := rollout logprobs across its

--- a/examples/ar/qwen3_drpo_4b_base_dapo_sglang_async.yaml
+++ b/examples/ar/qwen3_drpo_4b_base_dapo_sglang_async.yaml
@@ -91,9 +91,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     samples_pre_expanded: true
     chat_template_kwargs:
@@ -124,8 +121,8 @@ algorithm:
   drpo_epsilon: 12.5
   penalty_mu_weighted: true
   loss_agg_mode: seq-mean-token-sum-norm
-  horizon: 8192
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   old_logp_source: rollout
   conditions_cls:
     _target_: hydra.utils.get_class

--- a/examples/ar/qwen3_drpo_4b_veomni_sp_sglang.yaml
+++ b/examples/ar/qwen3_drpo_4b_veomni_sp_sglang.yaml
@@ -122,9 +122,6 @@ rollout:
     backend: native  # in-process colocate backend (sleep/wake_up); default "http" spawns a server
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -173,10 +170,10 @@ algorithm:
   # wandb config). false = plain SPO with FIXED eps (= verl spo).
   penalty_mu_weighted: true
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 8192 # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   # rollout = anchor the PPO ratio on the SGLang sampler's emitted logprobs for ALL
   # 4 mini-batch updates below — exact parity with the released verl run, which sets
   # rollout_correction.bypass_mode=True (old_log_probs := rollout logprobs across its

--- a/examples/ar/qwen3_grpo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_grpo_4b_base_dapo_sglang.yaml
@@ -119,9 +119,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -180,10 +177,10 @@ algorithm:
   clip_range_high: null # symmetric clip — standard GRPO (the vanilla baseline uses 0.28)
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-mean # per-seq token-MEAN, mean over seqs (length-normalized)
-  horizon: 8192 # unused by seq-mean-token-mean; kept for parity with the sibling recipes
+  horizon: ${sampling.max_new_tokens} # unused by seq-mean-token-mean; kept for parity with the sibling recipes
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen3_grpo_4b_base_dapo_sglang_async.yaml
+++ b/examples/ar/qwen3_grpo_4b_base_dapo_sglang_async.yaml
@@ -94,9 +94,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     samples_pre_expanded: true
     chat_template_kwargs:
@@ -128,8 +125,8 @@ algorithm:
   clip_range_high: 0.28
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-sum-norm
-  horizon: 8192
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen3_grpo_4b_veomni_sp_sglang.yaml
+++ b/examples/ar/qwen3_grpo_4b_veomni_sp_sglang.yaml
@@ -123,9 +123,6 @@ rollout:
     backend: native  # in-process colocate backend (sleep/wake_up); default "http" spawns a server
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -181,10 +178,10 @@ algorithm:
   clip_range_high: 0.28
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 8192 # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen3_grpo_vanilla_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_grpo_vanilla_4b_base_dapo_sglang.yaml
@@ -121,9 +121,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     # ARTrainer pre-expands the req by samples_per_prompt, so the engine emits
     # one completion per entry (n=1); else samples double-count.
@@ -179,10 +176,10 @@ algorithm:
   clip_range_high: 0.28
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-sum-norm # per-seq token-sum / horizon, mean over seqs
-  horizon: 8192 # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
+  horizon: ${sampling.max_new_tokens} # fixed length normalizer for seq-mean-token-sum-norm (= max_new_tokens)
   # 1.0 — must equal sampling.temperature below so replay's log_softmax(logits/T)
   # matches the SGLang sampler's tempered output_token_logprobs (ratio_mean ≈ 1).
-  sampling_temperature: 1.0
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen3_moe_grpo_30b_a3b_veomni_ep_sglang.yaml
+++ b/examples/ar/qwen3_moe_grpo_30b_a3b_veomni_ep_sglang.yaml
@@ -98,9 +98,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_MOE_PATH}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     samples_pre_expanded: true
     chat_template_kwargs:
@@ -129,8 +126,8 @@ algorithm:
   clip_range_high: 0.28
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-sum-norm
-  horizon: 8192
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen3_ppo_4b_base_dapo_sglang.yaml
+++ b/examples/ar/qwen3_ppo_4b_base_dapo_sglang.yaml
@@ -78,9 +78,6 @@ rollout:
     backend: native
     pretrained_model_ckpt_path: ${oc.env:QWEN3_PATH,Qwen/Qwen3-4B-Base}
     tp_size: 1
-    max_new_tokens: 8192
-    temperature: 1.0
-    top_p: 1.0
     concurrency: 16
     samples_pre_expanded: true
     chat_template_kwargs:
@@ -114,8 +111,8 @@ algorithm:
   gae_gamma: 1.0
   gae_lambda: 0.95
   loss_agg_mode: seq-mean-token-mean
-  horizon: 8192
-  sampling_temperature: 1.0
+  horizon: ${sampling.max_new_tokens}
+  sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8.yaml
@@ -99,9 +99,6 @@ rollout:
     # which collapses the GRPO group size and the reward never learns.
     samples_pre_expanded: true
     image_token: "<|vision_start|><|image_pad|><|vision_end|>"
-    max_new_tokens: 512
-    temperature: 0.7
-    top_p: 0.9
     concurrency: 8
     engine_kwargs:
       # Colocate on 95GB H20: sglang server + FSDP train share the GPU. The 4x8
@@ -152,7 +149,7 @@ algorithm:
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen_vl.conditions.QwenVLARConditions
-  sampling_temperature: 0.7
+  sampling_temperature: ${sampling.temperature}
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8_lora.yaml
+++ b/examples/ar/qwen_vl_grpo_geo3k_mc_sglang_4x8_lora.yaml
@@ -94,9 +94,6 @@ rollout:
     tp_size: 1
     samples_pre_expanded: true
     image_token: "<|vision_start|><|image_pad|><|vision_end|>"
-    max_new_tokens: 512
-    temperature: 0.7
-    top_p: 0.9
     concurrency: 8
     engine_kwargs:
       mem_fraction_static: 0.3
@@ -137,7 +134,7 @@ algorithm:
   conditions_cls:
     _target_: hydra.utils.get_class
     path: unirl.models.qwen_vl.conditions.QwenVLARConditions
-  sampling_temperature: 0.7
+  sampling_temperature: ${sampling.temperature}
 
 stack:
   _target_: unirl.train.stack.TrainStack

--- a/examples/deep_research/deep_research_search_judge.yaml
+++ b/examples/deep_research/deep_research_search_judge.yaml
@@ -30,7 +30,7 @@ sampling:
   temperature: 1.0
   top_p: 1.0
   top_k: 0
-  max_new_tokens: 2048
+  max_new_tokens: 2048 # per TURN (reasoning + a tool call / the final answer)
 
 logging:
   report_to_wandb: false
@@ -92,9 +92,6 @@ rollout:
       backend: native
       pretrained_model_ckpt_path: ${oc.env:QWEN3_INSTRUCT_PATH,Qwen/Qwen3-4B-Instruct}
       tp_size: 1
-      max_new_tokens: 2048 # per TURN (reasoning + a tool call / the final answer)
-      temperature: 1.0
-      top_p: 1.0
       concurrency: 8
       # The deep-research framing — verbatim from AReaL's tongyi_deepresearch
       # SYSTEM_PROMPT, adapted for UniRL: the <tools> JSON block is dropped because
@@ -150,7 +147,7 @@ algorithm:
   clip_range_high: null
   clip_schedule: constant
   loss_agg_mode: seq-mean-token-mean
-  horizon: 2048
+  horizon: ${sampling.max_new_tokens}
   sampling_temperature: ${sampling.temperature}
   conditions_cls:
     _target_: hydra.utils.get_class

--- a/examples/pe/pe_sglang_full_pickscore.yaml
+++ b/examples/pe/pe_sglang_full_pickscore.yaml
@@ -207,6 +207,7 @@ ar:
     stage_attr: ar
     clip_range: 1.0e-2
     clip_schedule: constant
+    sampling_temperature: ${sampling.ar.temperature}
     conditions_cls:
       _target_: hydra.utils.get_class
       path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/pe/pe_sglang_full_pickscore.yaml
+++ b/examples/pe/pe_sglang_full_pickscore.yaml
@@ -251,9 +251,6 @@ rollout:
       _target_: unirl.rollout.engine.sglang.config.SGLangEngineConfig
       pretrained_model_ckpt_path: ${oc.env:LLM_MODEL,Qwen/Qwen3-0.6B}
       tp_size: 1
-      max_new_tokens: 512
-      temperature: 0.7
-      top_p: 0.9
       # Transport: in-process sglang.Engine (native). Use "http" (separate SRT
       # server subprocess) only if a native issue needs the HTTP fallback.
       backend: native

--- a/examples/pe/pe_sglang_full_wise.yaml
+++ b/examples/pe/pe_sglang_full_wise.yaml
@@ -187,6 +187,7 @@ ar:
     stage_attr: ar
     clip_range: 1.0e-2 # AR track — diffusion track above keeps 1e-4
     clip_schedule: constant
+    sampling_temperature: ${sampling.ar.temperature}
     conditions_cls:
       _target_: hydra.utils.get_class
       path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/pe/pe_sglang_full_wise.yaml
+++ b/examples/pe/pe_sglang_full_wise.yaml
@@ -227,9 +227,6 @@ rollout:
       backend: native
       pretrained_model_ckpt_path: ${oc.env:LLM_MODEL,Qwen/Qwen3-0.6B}
       tp_size: 1
-      max_new_tokens: 1024          # headroom for Qwen3 <think> + the revised prompt
-      temperature: 0.7
-      top_p: 0.9
       concurrency: 4
       engine_kwargs:
         mem_fraction_static: 0.25

--- a/examples/pe/pe_sglang_lora_pickscore.yaml
+++ b/examples/pe/pe_sglang_lora_pickscore.yaml
@@ -192,6 +192,7 @@ ar:
     stage_attr: ar
     clip_range: 1.0e-2 # AR track — diffusion track above keeps 1e-4
     clip_schedule: constant
+    sampling_temperature: ${sampling.ar.temperature}
     conditions_cls:
       _target_: hydra.utils.get_class
       path: unirl.models.qwen3.conditions.Qwen3ARConditions

--- a/examples/pe/pe_sglang_lora_pickscore.yaml
+++ b/examples/pe/pe_sglang_lora_pickscore.yaml
@@ -237,9 +237,6 @@ rollout:
       backend: native
       pretrained_model_ckpt_path: ${oc.env:LLM_MODEL,Qwen/Qwen3-0.6B}
       tp_size: 1
-      max_new_tokens: 512
-      temperature: 0.7
-      top_p: 0.9
       concurrency: 4
       engine_kwargs:
         mem_fraction_static: 0.25

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -91,7 +91,7 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
 - **AR `sampling_temperature` must equal the rollout `sampling.temperature`** —
   `ARStage.replay` rescales logits by it (`log_softmax(logits / T)`) to match SGLang's
   distribution; when unset it silently falls back to the `ARSamplingParams` default,
-  *not* the engine's actual temperature, biasing every ratio with no raise. Watch
+  *not* the request Sample's actual temperature, biasing every ratio with no raise. Watch
   `rollout_replay_logp_absdiff_mean` — it should be ~0 on an on-policy step.
 - **DiffusionNFT's `ref_deviation_coef > 0` anchors to the LoRA-disabled base, not the EMA shadow** — the
   shadow tracks the policy by construction, so anchoring to it would bound no drift. The reference

--- a/unirl/rollout/engine/README.md
+++ b/unirl/rollout/engine/README.md
@@ -73,3 +73,9 @@ handler in `../../distributed/weight_sync`.
   deterministic fan-out as `n=1` requests each carrying one derived
   `sampling_seed`. Re-check both halves on a SGLang bump: dropping either one
   restores the clone, silently.
+- **SGLang request sampling lives on the Sample, not the engine config.** Direct
+  callers must `fork(..., sampling_params=ARSamplingParams(...))` before
+  `generate`. Missing or non-`ARSamplingParams` frontiers now error; in-tree
+  trainer, PE, and agentic paths already stamp this. `temperature` / `top_p` /
+  `top_k` / `max_new_tokens` are gone from `SGLangEngineConfig` — there is no
+  engine-config fallback.

--- a/unirl/rollout/engine/sglang/config.py
+++ b/unirl/rollout/engine/sglang/config.py
@@ -119,10 +119,6 @@ class SGLangEngineConfig(BaseEngineConfig):
 
     image_token: Optional[str] = None
 
-    max_new_tokens: int = 512
-    temperature: float = 0.7
-    top_p: float = 0.9
-    top_k: int = 0
     response_forbidden_tokens: Optional[List[str]] = None
 
     system_instruction: Optional[str] = None
@@ -180,18 +176,6 @@ class SGLangEngineConfig(BaseEngineConfig):
         require(
             self.concurrency >= 1,
             f"SGLangEngineConfig.concurrency must be >= 1; got {self.concurrency!r}",
-        )
-        require(
-            self.max_new_tokens >= 1,
-            f"SGLangEngineConfig.max_new_tokens must be >= 1; got {self.max_new_tokens!r}",
-        )
-        require(
-            self.temperature > 0,
-            f"SGLangEngineConfig.temperature must be > 0; got {self.temperature!r}",
-        )
-        require(
-            0.0 < self.top_p <= 1.0,
-            f"SGLangEngineConfig.top_p must be in (0, 1]; got {self.top_p!r}",
         )
 
         self.backend = str(self.backend).strip().lower()

--- a/unirl/rollout/engine/sglang/engine.py
+++ b/unirl/rollout/engine/sglang/engine.py
@@ -161,11 +161,11 @@ class SGLangRolloutEngine(BaseRolloutEngine):
         self._version = 0
 
     def _prepare_generation(self, sample: Sample) -> Any:
+        sampling = resolve_sampling(self.cfg, sample)
         require(
             int(sample.parts[-1].batch_size) > 0,
             "SGLangRolloutEngine.generate requires a non-empty Sample (gen batch_size > 0)",
         )
-        sampling = resolve_sampling(self.cfg, sample)
         prepared = self.adapter.build_inputs(sample, sampling=sampling)
         active_adapter = self._weight_sync.active_adapter
         if active_adapter:

--- a/unirl/rollout/engine/sglang/utils/sampling.py
+++ b/unirl/rollout/engine/sglang/utils/sampling.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from numbers import Integral
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
-from unirl.types.sample import Sample
+from unirl.types.sample import Part, Sample
 from unirl.types.sampling import ARSamplingParams
 
 _DEFAULT_SGLANG_SAMPLING_SEED = 42
@@ -53,28 +53,24 @@ def deterministic_inference_enabled(engine_kwargs: Dict[str, Any]) -> bool:
     )
 
 
-def _require_ar_sampling(sample: Sample) -> ARSamplingParams:
+def _require_ar_frontier(sample: Sample) -> Part:
     """Require ``ARSamplingParams`` on the request ``Sample`` frontier."""
-    if not sample.parts:
-        got = "an empty Sample"
-    else:
-        ar = sample.parts[-1].sampling_params
-        if isinstance(ar, ARSamplingParams):
-            return ar
-        got = "missing sampling_params" if ar is None else type(ar).__name__
-    raise TypeError(
-        "SGLang generation requires ARSamplingParams on the request Sample frontier "
-        f"(sample.parts[-1].sampling_params); got {got}. Direct callers must "
-        "fork(..., sampling_params=ARSamplingParams(...)); in-tree trainer, PE, and "
-        "agentic paths already stamp this. Engine-config temperature / top_p / "
-        "top_k / max_new_tokens is no longer a fallback."
-    )
+    try:
+        return sample.frontier_gen_part(ARSamplingParams)
+    except ValueError as exc:
+        raise TypeError(
+            "SGLang generation requires ARSamplingParams on the request Sample frontier. "
+            f"{exc}. Direct callers must fork(..., sampling_params=ARSamplingParams(...)); "
+            "in-tree trainer, PE, and agentic paths already stamp this. Engine-config "
+            "temperature / top_p / top_k / max_new_tokens is no longer a fallback."
+        ) from exc
 
 
 def resolve_sampling(config: Any, sample: Sample) -> ResolvedSampling:
     """Resolve the SRT sampling block from the request Sample's ARSamplingParams."""
-    ar = _require_ar_sampling(sample)
-    input_part, gen_part = sample.parts[0], sample.parts[-1]
+    gen_part = _require_ar_frontier(sample)
+    ar = cast(ARSamplingParams, gen_part.sampling_params)
+    input_part = sample.parts[0]
     control_ar: Dict[str, Any] = dict(input_part.control.get("ar") or {})
 
     parent_part = sample.parts[-2] if len(sample.parts) >= 2 else input_part

--- a/unirl/rollout/engine/sglang/utils/sampling.py
+++ b/unirl/rollout/engine/sglang/utils/sampling.py
@@ -8,6 +8,7 @@ from numbers import Integral
 from typing import Any, Dict, Optional
 
 from unirl.types.sample import Sample
+from unirl.types.sampling import ARSamplingParams
 
 _DEFAULT_SGLANG_SAMPLING_SEED = 42
 _MAX_SGLANG_SAMPLING_SEED = (1 << 63) - 1
@@ -52,10 +53,28 @@ def deterministic_inference_enabled(engine_kwargs: Dict[str, Any]) -> bool:
     )
 
 
+def _require_ar_sampling(sample: Sample) -> ARSamplingParams:
+    """Require ``ARSamplingParams`` on the request ``Sample`` frontier."""
+    if not sample.parts:
+        got = "an empty Sample"
+    else:
+        ar = sample.parts[-1].sampling_params
+        if isinstance(ar, ARSamplingParams):
+            return ar
+        got = "missing sampling_params" if ar is None else type(ar).__name__
+    raise TypeError(
+        "SGLang generation requires ARSamplingParams on the request Sample frontier "
+        f"(sample.parts[-1].sampling_params); got {got}. Direct callers must "
+        "fork(..., sampling_params=ARSamplingParams(...)); in-tree trainer, PE, and "
+        "agentic paths already stamp this. Engine-config temperature / top_p / "
+        "top_k / max_new_tokens is no longer a fallback."
+    )
+
+
 def resolve_sampling(config: Any, sample: Sample) -> ResolvedSampling:
-    """Resolve the SRT sampling block for one request ``Sample``."""
+    """Resolve the SRT sampling block from the request Sample's ARSamplingParams."""
+    ar = _require_ar_sampling(sample)
     input_part, gen_part = sample.parts[0], sample.parts[-1]
-    ar = gen_part.sampling_params
     control_ar: Dict[str, Any] = dict(input_part.control.get("ar") or {})
 
     parent_part = sample.parts[-2] if len(sample.parts) >= 2 else input_part
@@ -64,7 +83,7 @@ def resolve_sampling(config: Any, sample: Sample) -> ResolvedSampling:
 
     engine_kwargs = getattr(config, "engine_kwargs", None) or {}
     deterministic = deterministic_inference_enabled(engine_kwargs)
-    configured_seed = _validated_base_seed(ar.seed) if ar is not None and ar.seed is not None else None
+    configured_seed = _validated_base_seed(ar.seed) if ar.seed is not None else None
     if configured_seed is not None and not deterministic:
         raise ValueError(
             "sampling.seed requires deterministic SGLang inference via "
@@ -75,11 +94,11 @@ def resolve_sampling(config: Any, sample: Sample) -> ResolvedSampling:
         base_seed = _DEFAULT_SGLANG_SAMPLING_SEED  # SGLang's own deterministic default; see rollout/engine README
     n = 1 if base_seed is not None else fanout
 
-    raw_top_k = ar.top_k if ar is not None else config.top_k
+    raw_top_k = ar.top_k
     block: Dict[str, Any] = {
-        "temperature": float(ar.temperature if ar is not None else config.temperature),
-        "max_new_tokens": int(ar.max_new_tokens if ar is not None else config.max_new_tokens),
-        "top_p": float(ar.top_p if ar is not None else config.top_p),
+        "temperature": float(ar.temperature),
+        "max_new_tokens": int(ar.max_new_tokens),
+        "top_p": float(ar.top_p),
         "top_k": raw_top_k if raw_top_k > 0 else -1,
         "n": n,
     }


### PR DESCRIPTION
## Summary

SGLang request sampling (`temperature` / `top_p` / `top_k` / `max_new_tokens`) now comes only from `ARSamplingParams` on the request `Sample` frontier. Those four fields are removed from `SGLangEngineConfig`, in-tree SGLang recipes no longer duplicate them under `rollout.config`, and missing or non-`ARSamplingParams` frontiers fail closed with an actionable error.

`top_k: 0 → -1`, the deterministic-seed path, and `system_instruction` on engine config are unchanged. Where `horizon` / `sampling_temperature` already hardcoded the same number as `sampling`, they now interpolate from that block.

## Related Issue

Fixes #424

## Test Plan

- `SKIP=no-commit-to-branch uvx --python /app/apps/python/3.12.1-gcc11/bin/python pre-commit run --files <changed> --show-diff-on-failure` — passed (check yaml, ruff check/format, recipe `_target_` paths, experimental-tier boundaries, one-line docstrings, core dependency directions).
- `python lint/check_recipe_targets.py` — `check-recipe-targets: 2683 recipe _target_ paths resolve.`
- Hydra compose + resolve (`DATA_PATH=/tmp/dummy.jsonl`, no `instantiate`):
  - `ar/qwen3_grpo_4b_base_dapo_sglang` — engine sampling fields remaining `[]`; `algorithm.horizon` resolves to `8192`; `algorithm.sampling_temperature` resolves to `1.0`
  - `ar/qwen3_cppo_30b_a3b_base_dapo_sglang_lora` — engine fields `[]`; horizon `4096`; temperature `1.0`
  - `pe/pe_sglang_full_pickscore` — `root.rollout.config.ar` fields `[]`; `sampling.ar` still `temperature=0.7`, `max_new_tokens=512`, `top_k=1024`
  - `deep_research/deep_research_search_judge` — `root.rollout.config.inner` fields `[]`; horizon `2048`; temperature `1.0`
- Uncommitted resolver smoke (not committed): typed `ARSamplingParams` used (`top_k=0` maps to `-1`); missing / empty / `DiffusionSamplingParams` frontiers raise `TypeError` naming `fork(..., sampling_params=ARSamplingParams(...))`; `top_k=20` passes through.
- `pytest`: Not run; reason: the repository policy removes committed unit-test harnesses (`#99` / `#267`).

## Compatibility / Risk

**Breaking for direct `generate(Sample)` callers** that relied on engine-config fallbacks (`512`, `0.7`, `0.9`, `0`). There is no deprecation window: missing or wrongly typed frontier params now error. In-tree trainer, PE, composed-engine, and agentic paths already stamp `ARSamplingParams` via `fork(..., sampling_params=...)`.

YAML that still sets `temperature` / `top_p` / `top_k` / `max_new_tokens` on `SGLangEngineConfig` will fail Hydra instantiate (`unexpected keyword argument`). Recipes in this repo are updated; out-of-tree copies need the same strip (or to move values onto `sampling:`).

No checkpoint or data-format changes. `system_instruction` stays on engine config.

## Reviewer Notes

AI-assisted implementation; the submitter reviewed the full diff. Duplicate-work check: #424 was unassigned with no comments or linked PR before the claim comment; open SGLang PR #392 addresses #261 (`ServerArgs` key-drop), not sampling ownership. Template recipe `examples/ar/qwen3_cppo_30b_a3b_base_dapo_sglang_lora.yaml` was already cleaned in #382 and is unchanged here.

Please inspect `resolve_sampling` fail-closed first, then one AR recipe + one PE nested `rollout.config.ar` block.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.