### PR TITLE
fix(diffusion): remove duplicate sampling fields

### DIFF
--- a/examples/diffusion/bagel/bagel_editreward.yaml
+++ b/examples/diffusion/bagel/bagel_editreward.yaml
@@ -176,15 +176,16 @@ data_source:
     algorithm:
       prompts_per_rollout: ${batch_size}
 
-# BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the INSTRUCTION,
-# cfg_img amplifies the SOURCE (cfg_img active only when guidance_scale>1; cfg_img>1 = 3rd forward).
+# BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the
+# INSTRUCTION; cfg_img_scale adds a SOURCE-CFG forward, whose result is combined
+# only when guidance_scale>1.
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14
-  guidance_scale: 1                    # 1 = No-CFG single forward (validated config). >1 enables CFG
+  guidance_scale: 1.0                  # 1 = No-CFG single forward (validated config). >1 enables CFG
                                        # (amplifies the instruction) = +1 forward/step -> more memory.
-  cfg_img_scale: 1.0                   # source<->diversity knob; only active when guidance_scale>1
-  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when guidance_scale>1
+  cfg_img_scale: 1.0                   # >1 adds a source-CFG forward; keep 1 unless guidance_scale>1
+  cfg_interval: [0.4, 1.0]             # timestep interval for both CFG scales
   cfg_renorm_min: 0.0
   cfg_renorm_type: text_channel        # CFG renorm; only active when guidance_scale>1
   eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)

--- a/examples/diffusion/bagel/bagel_editreward.yaml
+++ b/examples/diffusion/bagel/bagel_editreward.yaml
@@ -176,18 +176,17 @@ data_source:
     algorithm:
       prompts_per_rollout: ${batch_size}
 
-# BAGEL edit sampling (BagelDiffusionParams). Dual-CFG: cfg_text amplifies the INSTRUCTION,
-# cfg_img amplifies the SOURCE (cfg_img active only when cfg_text_scale>1; cfg_img>1 = 3rd forward).
+# BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the INSTRUCTION,
+# cfg_img amplifies the SOURCE (cfg_img active only when guidance_scale>1; cfg_img>1 = 3rd forward).
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14
-  guidance_scale: 1.0
-  cfg_text_scale: 1                    # 1 = No-CFG single forward (validated config). >1 enables CFG
+  guidance_scale: 1                    # 1 = No-CFG single forward (validated config). >1 enables CFG
                                        # (amplifies the instruction) = +1 forward/step -> more memory.
-  cfg_img_scale: 1.0                   # source<->diversity knob; only active when cfg_text_scale>1
-  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when cfg_text_scale>1
+  cfg_img_scale: 1.0                   # source<->diversity knob; only active when guidance_scale>1
+  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when guidance_scale>1
   cfg_renorm_min: 0.0
-  cfg_renorm_type: text_channel        # CFG renorm; only active when cfg_text_scale>1
+  cfg_renorm_type: text_channel        # CFG renorm; only active when guidance_scale>1
   eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)
   samples_per_prompt: 8                # GRPO group size
   height: 512

--- a/examples/diffusion/bagel/bagel_it2i_managed_editscore.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_managed_editscore.yaml
@@ -253,13 +253,14 @@ data_source:
       prompts_per_rollout: ${batch_size}
 
 # BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the
-# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when guidance_scale>1).
+# INSTRUCTION; cfg_img_scale adds a SOURCE-CFG forward, whose result is combined
+# only when guidance_scale>1.
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); the adapter sends +1 to the worker
-  guidance_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
-  cfg_img_scale: 1.0                   # source<->diversity knob; only active when guidance_scale>1
-  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when guidance_scale>1
+  guidance_scale: 1.0                  # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
+  cfg_img_scale: 1.0                   # >1 adds a source-CFG forward; keep 1 unless guidance_scale>1
+  cfg_interval: [0.4, 1.0]             # timestep interval for both CFG scales
   cfg_renorm_min: 0.0
   cfg_renorm_type: text_channel        # CFG renorm; only active when guidance_scale>1
   eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)

--- a/examples/diffusion/bagel/bagel_it2i_managed_editscore.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_managed_editscore.yaml
@@ -252,17 +252,16 @@ data_source:
     algorithm:
       prompts_per_rollout: ${batch_size}
 
-# BAGEL edit sampling (BagelDiffusionParams). Dual-CFG: cfg_text amplifies the
-# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when cfg_text_scale>1).
+# BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the
+# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when guidance_scale>1).
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); the adapter sends +1 to the worker
-  guidance_scale: 1.0
-  cfg_text_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
-  cfg_img_scale: 1.0                   # source<->diversity knob; only active when cfg_text_scale>1
-  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when cfg_text_scale>1
+  guidance_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
+  cfg_img_scale: 1.0                   # source<->diversity knob; only active when guidance_scale>1
+  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when guidance_scale>1
   cfg_renorm_min: 0.0
-  cfg_renorm_type: text_channel        # CFG renorm; only active when cfg_text_scale>1
+  cfg_renorm_type: text_channel        # CFG renorm; only active when guidance_scale>1
   eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)
   samples_per_prompt: 8                # GRPO group size; it2i sends one worker request per sample
   height: 512                          # the OUTPUT canvas. Fixed square: the driver's x_T recipe carries ONE

--- a/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
@@ -244,17 +244,16 @@ data_source:
     algorithm:
       prompts_per_rollout: ${batch_size}
 
-# BAGEL edit sampling (BagelDiffusionParams). Dual-CFG: cfg_text amplifies the
-# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when cfg_text_scale>1).
+# BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the
+# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when guidance_scale>1).
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); the adapter sends +1 to the worker
-  guidance_scale: 1.0
-  cfg_text_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
-  cfg_img_scale: 1.0                   # source<->diversity knob; only active when cfg_text_scale>1
-  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when cfg_text_scale>1
+  guidance_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
+  cfg_img_scale: 1.0                   # source<->diversity knob; only active when guidance_scale>1
+  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when guidance_scale>1
   cfg_renorm_min: 0.0
-  cfg_renorm_type: text_channel        # CFG renorm; only active when cfg_text_scale>1
+  cfg_renorm_type: text_channel        # CFG renorm; only active when guidance_scale>1
   eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)
   samples_per_prompt: 8                # GRPO group size; it2i sends one worker request per sample
   height: 512                          # the OUTPUT canvas. Fixed square: the driver's x_T recipe carries ONE

--- a/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_it2i_vllmomni.yaml
@@ -245,13 +245,14 @@ data_source:
       prompts_per_rollout: ${batch_size}
 
 # BAGEL edit sampling (BagelDiffusionParams). guidance_scale amplifies the
-# INSTRUCTION, cfg_img amplifies the SOURCE (cfg_img active only when guidance_scale>1).
+# INSTRUCTION; cfg_img_scale adds a SOURCE-CFG forward, whose result is combined
+# only when guidance_scale>1.
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); the adapter sends +1 to the worker
-  guidance_scale: 1                    # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
-  cfg_img_scale: 1.0                   # source<->diversity knob; only active when guidance_scale>1
-  cfg_interval: [0.4, 1.0]             # CFG schedule; only active when guidance_scale>1
+  guidance_scale: 1.0                  # 1 = No-CFG single forward (validated). >1 = +1 forward/step -> more memory
+  cfg_img_scale: 1.0                   # >1 adds a source-CFG forward; keep 1 unless guidance_scale>1
+  cfg_interval: [0.4, 1.0]             # timestep interval for both CFG scales
   cfg_renorm_min: 0.0
   cfg_renorm_type: text_channel        # CFG renorm; only active when guidance_scale>1
   eta: 1.0                             # SDE noise scale (per-step stochasticity = GRPO exploration)

--- a/examples/diffusion/bagel/bagel_trainside_lora.yaml
+++ b/examples/diffusion/bagel/bagel_trainside_lora.yaml
@@ -156,8 +156,7 @@ data_source:
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points; == old 15-point bagel schedule, 14 stepped)
-  guidance_scale: 1.0                  # cfg=1 (bagel uses cfg_text_scale below; kept consistent)
-  cfg_text_scale: 1.0                  # cfg=1 → single-forward "No CFG" path in _forward_flow
+  guidance_scale: 1.0                  # cfg=1 → single-forward "No CFG" path in _forward_flow
   cfg_img_scale: 1.0
   cfg_interval: [0.0, 1.0]
   cfg_renorm_min: 0.0

--- a/examples/diffusion/bagel/bagel_vllmomni.yaml
+++ b/examples/diffusion/bagel/bagel_vllmomni.yaml
@@ -171,8 +171,7 @@ data_source:
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); adapter sends +1 to the worker
-  guidance_scale: 1.0
-  cfg_text_scale: 1.0                  # cfg=1 → single-forward "No CFG" path
+  guidance_scale: 1.0                  # cfg=1 → single-forward "No CFG" path
   cfg_img_scale: 1.0
   cfg_interval: [0.0, 1.0]
   cfg_renorm_min: 0.0

--- a/examples/diffusion/bagel/bagel_vllmomni_async.yaml
+++ b/examples/diffusion/bagel/bagel_vllmomni_async.yaml
@@ -160,8 +160,7 @@ data_source:
 sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14              # STEPS (σ schedule = steps+1 = 15 points); adapter sends +1 to the worker
-  guidance_scale: 1.0
-  cfg_text_scale: 1.0                  # cfg=1 → single-forward "No CFG" path
+  guidance_scale: 1.0                  # cfg=1 → single-forward "No CFG" path
   cfg_img_scale: 1.0
   cfg_interval: [0.0, 1.0]
   cfg_renorm_min: 0.0

--- a/examples/diffusion/sensenova_u1_5/sensenova_u1_5_ocr_trainside_fullft_4x8.yaml
+++ b/examples/diffusion/sensenova_u1_5/sensenova_u1_5_ocr_trainside_fullft_4x8.yaml
@@ -175,7 +175,3 @@ eval_sampling:
   height: 320
   width: 320
   eta: 0.0
-  # DiffusionSamplingParams keeps a legacy alias. Set both so replacing a
-  # training value of four really produces one deterministic eval sample.
-  samples_per_prompt: 1
-  num_samples_per_prompt: 1

--- a/examples/diffusion/sensenova_u1_5/sensenova_u1_5_ocr_trainside_lora_4x8.yaml
+++ b/examples/diffusion/sensenova_u1_5/sensenova_u1_5_ocr_trainside_lora_4x8.yaml
@@ -170,7 +170,3 @@ eval_sampling:
   height: 320
   width: 320
   eta: 0.0
-  # DiffusionSamplingParams keeps a legacy alias. Set both so replacing a
-  # training value of six really produces one deterministic eval sample.
-  samples_per_prompt: 1
-  num_samples_per_prompt: 1

--- a/examples/diffusion/sensenova_u1_5/sensenova_u1_5_ocr_trainside_lora_kl_4x8.yaml
+++ b/examples/diffusion/sensenova_u1_5/sensenova_u1_5_ocr_trainside_lora_kl_4x8.yaml
@@ -178,7 +178,3 @@ eval_sampling:
   height: 320
   width: 320
   eta: 0.0
-  # DiffusionSamplingParams keeps a legacy alias. Set both so replacing a
-  # training value of six really produces one deterministic eval sample.
-  samples_per_prompt: 1
-  num_samples_per_prompt: 1

--- a/examples/sft/bagel_sft_lora.yaml
+++ b/examples/sft/bagel_sft_lora.yaml
@@ -137,7 +137,6 @@ sampling:
   _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
   num_inference_steps: 14
   guidance_scale: 1.0
-  cfg_text_scale: 1.0
   cfg_img_scale: 1.0
   height: 512
   width: 512

--- a/examples/unified_model/bagel_trainside_unigrpo.yaml
+++ b/examples/unified_model/bagel_trainside_unigrpo.yaml
@@ -18,7 +18,7 @@
 # Key UniGRPO alignment:
 #   - N = ar.samples_per_prompt = G (group of thinking chains); M = 1 image/chain.
 #   - image SHARES the AR's prompt-level advantage (UnifiedModelTrainer M=1 path).
-#   - no CFG during training (cfg_*_scale = 1 -> single-forward).
+#   - no CFG during training (guidance_scale = cfg_img_scale = 1 -> single-forward).
 #   - velocity-MSE regularization (mse_weight) replaces the latent-KL; text KL = 0.
 #   - per-expert LR in one optimizer: reasoning(und) 1e-6, denoising(gen) 3e-5.
 #   - GRPO-Guard RatioNorm on the off-policy PPO update(s).

--- a/examples/unified_model/bagel_trainside_unigrpo.yaml
+++ b/examples/unified_model/bagel_trainside_unigrpo.yaml
@@ -222,8 +222,7 @@ sampling:
     _target_: unirl.models.bagel.diffusion.BagelDiffusionParams
     samples_per_prompt: 1             # M=1 image per chain
     num_inference_steps: 25           # diffusion timesteps
-    guidance_scale: 1.0
-    cfg_text_scale: 1.0               # cfg=1 -> single forward (no CFG during training)
+    guidance_scale: 1.0               # cfg=1 -> single forward (no CFG during training)
     cfg_img_scale: 1.0
     cfg_interval: [0.0, 1.0]
     cfg_renorm_min: 0.0

--- a/examples/unified_model/hi3_it2i.yaml
+++ b/examples/unified_model/hi3_it2i.yaml
@@ -56,10 +56,9 @@ adv_use_global_std: false      # per-group GRPO normalization
 num_rollouts: 10000            # intentionally large; stop manually
 
 # Periodic eval is DISABLED: not yet validated for it2i (the eval path must
-# carry the source-image condition end-to-end). The old blocker — the trainer
-# replacing the BAGEL-only ``cfg_text_scale`` sampling field (TypeError on hi3)
-# — was fixed by #202 (field-checked, falls back to ``guidance_scale``), so
-# this can be enabled once an it2i eval run is validated.
+# carry the source-image condition end-to-end). Diffusion families now share
+# the canonical ``guidance_scale`` field, so this can be enabled once an it2i
+# eval run is validated.
 eval_interval: 0
 
 transport_kind: colocate_store

--- a/unirl/models/bagel/diffusion.py
+++ b/unirl/models/bagel/diffusion.py
@@ -36,7 +36,6 @@ class BagelDiffusionParams(DiffusionSamplingParams):
     width: int = 512
     eta: float = 1.0
 
-    cfg_text_scale: float = 1.0
     cfg_img_scale: float = 1.0
     cfg_interval: Tuple[float, float] = (0.0, 1.0)
     cfg_renorm_min: float = 0.0
@@ -318,7 +317,7 @@ class BagelDiffusionStage(DiffusionStage[BagelDiffusionConditions]):
         """CFG scales after the per-step ``cfg_interval`` gate (matches generate_image)."""
         lo, hi = float(params.cfg_interval[0]), float(params.cfg_interval[1])
         if lo < t_value <= hi:
-            return float(params.cfg_text_scale), float(params.cfg_img_scale)
+            return float(params.guidance_scale), float(params.cfg_img_scale)
         return 1.0, 1.0
 
     def diffuse(

--- a/unirl/models/bagel/pipeline.py
+++ b/unirl/models/bagel/pipeline.py
@@ -227,7 +227,8 @@ class BagelPipeline(Pipeline):
         if negatives is not None:
             raise ValueError(
                 "BagelPipeline.build_conditions: Bagel CFG uses prefilled cfg contexts, not "
-                "negative prompt embeddings — pass negatives=None and set cfg_*_scale on the params."
+                "negative prompt embeddings — pass negatives=None and set "
+                "guidance_scale/cfg_img_scale on the params."
             )
         contexts = [self._build_contexts(prompt, image=None) for prompt in texts.texts]
         shape = image_shape

--- a/unirl/rollout/engine/vllm_omni/adapters/bagel.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/bagel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from unirl.models.bagel.conditions import BagelDiffusionConditions
+from unirl.models.bagel.diffusion import BagelDiffusionParams
 from unirl.rollout.engine.vllm_omni.adapters.base import ModelAdapter, register_adapter
 from unirl.rollout.engine.vllm_omni.adapters.dit import (
     DitInputAdapter,
@@ -27,7 +28,6 @@ from unirl.rollout.engine.vllm_omni.utils.sigmas import sigmas_list_from_diffusi
 from unirl.sde.runtime import FlowMatchSchedulePolicy
 from unirl.types.primitives import Images, Texts
 from unirl.types.sample import Sample
-from unirl.types.sampling import DiffusionSamplingParams
 
 
 def _conditioning_rows(
@@ -43,7 +43,7 @@ def _conditioning_rows(
         raise ValueError(f"{caller}: expected exactly one Texts conditioning batch, got {len(text_batches)}")
 
     prompt_rows = list(text_batches[0].texts)
-    n_samples = len(sample.frontier_gen_part(DiffusionSamplingParams).sample_ids)
+    n_samples = len(sample.frontier_gen_part(BagelDiffusionParams).sample_ids)
     if len(prompt_rows) != n_samples:
         raise RuntimeError(f"{caller}: prompt count {len(prompt_rows)} != diffusion sample count {n_samples}")
 
@@ -70,9 +70,8 @@ class BagelInputAdapter(DitInputAdapter):
 
     def _spp(self, sample: Sample) -> int:
         """``samples_per_prompt`` — the GRPO group size; 1 disables packing."""
-        diff_params = sample.frontier_gen_part(DiffusionSamplingParams).sampling_params
-        raw_spp = getattr(diff_params, "samples_per_prompt", 1)
-        spp = 1 if raw_spp is None else int(raw_spp)
+        diff_params = sample.frontier_gen_part(BagelDiffusionParams).sampling_params
+        spp = int(diff_params.samples_per_prompt)
         if spp < 1:
             raise ValueError(f"{self.modality}: samples_per_prompt must be >= 1, got {spp}")
         return spp
@@ -83,7 +82,7 @@ class BagelInputAdapter(DitInputAdapter):
             return False
         if self._spp(sample) <= 1:
             return False
-        diff_params = sample.frontier_gen_part(DiffusionSamplingParams).sampling_params
+        diff_params = sample.frontier_gen_part(BagelDiffusionParams).sampling_params
         return float(diff_params.guidance_scale) <= 1.0 and float(diff_params.cfg_img_scale) <= 1.0
 
     def build_prompts(self, sample: Sample) -> List[Any]:
@@ -94,7 +93,7 @@ class BagelInputAdapter(DitInputAdapter):
             image_input=self.image_input,
             caller=caller,
         )
-        gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
+        gen_part = sample.frontier_gen_part(BagelDiffusionParams)
         n_samples = len(gen_part.sample_ids)
         if self.image_input:
             return [
@@ -130,7 +129,7 @@ class BagelInputAdapter(DitInputAdapter):
     def build_sampling(self, sample: Sample) -> List[StageSampling]:
         """One diffusion-stage intent with the BAGEL-specific kwargs."""
         spp = self._spp(sample)
-        gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
+        gen_part = sample.frontier_gen_part(BagelDiffusionParams)
         diff_params = gen_part.sampling_params
         pack = self._is_packable_t2i(sample)
 
@@ -166,7 +165,7 @@ class BagelInputAdapter(DitInputAdapter):
             return_trajectory_decoded=False,
             num_outputs_per_prompt=num_outputs_per_prompt,
         )
-        seed = getattr(diff_params, "seed", None)
+        seed = diff_params.seed
         if seed is not None:
             diff_kwargs["seed"] = int(seed)
 
@@ -178,25 +177,23 @@ class BagelInputAdapter(DitInputAdapter):
         extra_args: Dict[str, Any] = {
             # Translate the canonical field to BAGEL's worker API.
             "cfg_text_scale": float(diff_params.guidance_scale),
-            "cfg_img_scale": float(getattr(diff_params, "cfg_img_scale", 1.0)),
-            "cfg_interval": tuple(getattr(diff_params, "cfg_interval", (0.0, 1.0))),
-            "cfg_renorm_min": float(getattr(diff_params, "cfg_renorm_min", 0.0)),
-            "cfg_renorm_type": str(getattr(diff_params, "cfg_renorm_type", "global")),
+            "cfg_img_scale": float(diff_params.cfg_img_scale),
+            "cfg_interval": tuple(diff_params.cfg_interval),
+            "cfg_renorm_min": float(diff_params.cfg_renorm_min),
+            "cfg_renorm_type": str(diff_params.cfg_renorm_type),
         }
-        sde_indices = getattr(diff_params, "sde_indices", None)
+        sde_indices = diff_params.sde_indices
         # eta == 0 (deterministic eval) means no step is stochastic. Shipping a
         # non-empty gate anyway makes the worker scheduler raise ("step_index=N is in
         # the SDE gate but eta=0.0"); an absent gate is its documented pure-Euler
         # path, and matches trainside, whose ``diffuse`` gates per-step eta on the same
         # params.eta and simply records no log-probs. FlowSDEStrategy uses 1e-7
         # as the deterministic cutoff; the wire gate must use the same threshold.
-        if sde_indices is not None and float(getattr(diff_params, "eta", 0.0)) >= 1e-7:
+        if sde_indices is not None and float(diff_params.eta) >= 1e-7:
             extra_args["sde_indices"] = sorted({int(i) for i in sde_indices})
         if diff_params.sigmas is not None and int(diff_params.sigmas.shape[0]) > 1:
             extra_args["sigma_max"] = float(diff_params.sigmas[1].item())
-        traj_prec = getattr(diff_params, "trajectory_precision", None)
-        if traj_prec is not None:
-            extra_args["trajectory_precision"] = str(traj_prec)
+        extra_args["trajectory_precision"] = diff_params.trajectory_precision
 
         pack_initial_noise_extra_args(extra_args, gen_part, diff_params, caller=self.modality)
         diff_kwargs["extra_args"] = extra_args
@@ -216,7 +213,7 @@ class BagelOutputAdapter(DitOutputAdapter):
         diff_outputs, _, _ = collect_dit_outputs(
             per_request, final_output_type=self.final_output_type, stage_id=self.stage_id, modality=self.modality
         )
-        diff_params = sample.frontier_gen_part(DiffusionSamplingParams).sampling_params
+        diff_params = sample.frontier_gen_part(BagelDiffusionParams).sampling_params
         return build_image_segment(diff_outputs, expected_sigmas=diff_params.sigmas)
 
     def build_decoded(self, sample: Sample, per_request: List[List[OmniRawResult]]) -> Any:
@@ -234,7 +231,7 @@ class BagelOutputAdapter(DitOutputAdapter):
             image_input=self.image_input,
             caller=f"{self.modality}.build_conditions",
         )
-        gen_part = sample.frontier_gen_part(DiffusionSamplingParams)
+        gen_part = sample.frontier_gen_part(BagelDiffusionParams)
         diff_params = gen_part.sampling_params
         image_shape = (int(diff_params.height), int(diff_params.width))
         conditions = BagelDiffusionConditions(

--- a/unirl/rollout/engine/vllm_omni/adapters/bagel.py
+++ b/unirl/rollout/engine/vllm_omni/adapters/bagel.py
@@ -84,7 +84,7 @@ class BagelInputAdapter(DitInputAdapter):
         if self._spp(sample) <= 1:
             return False
         diff_params = sample.frontier_gen_part(DiffusionSamplingParams).sampling_params
-        return float(diff_params.cfg_text_scale) <= 1.0 and float(diff_params.cfg_img_scale) <= 1.0
+        return float(diff_params.guidance_scale) <= 1.0 and float(diff_params.cfg_img_scale) <= 1.0
 
     def build_prompts(self, sample: Sample) -> List[Any]:
         """Plain ``{"prompt": text}`` dicts (no ``modalities`` → image path)."""
@@ -176,7 +176,8 @@ class BagelInputAdapter(DitInputAdapter):
         sigmas_list_from_diffusion(diff_params, num_steps)
 
         extra_args: Dict[str, Any] = {
-            "cfg_text_scale": float(getattr(diff_params, "cfg_text_scale", 1.0)),
+            # Translate the canonical field to BAGEL's worker API.
+            "cfg_text_scale": float(diff_params.guidance_scale),
             "cfg_img_scale": float(getattr(diff_params, "cfg_img_scale", 1.0)),
             "cfg_interval": tuple(getattr(diff_params, "cfg_interval", (0.0, 1.0))),
             "cfg_renorm_min": float(getattr(diff_params, "cfg_renorm_min", 0.0)),

--- a/unirl/rollout/engine/vllm_omni/stage_configs/bagel_t2i_rl.yaml
+++ b/unirl/rollout/engine/vllm_omni/stage_configs/bagel_t2i_rl.yaml
@@ -23,9 +23,10 @@
 #
 # Contract notes:
 #   - The adapter translates canonical guidance_scale to BAGEL's
-#     extra_args.cfg_text_scale and also sends cfg_img_scale. It always sends
-#     both because upstream BAGEL defaults a missing cfg_text_scale to 4.0
-#     (CFG ON); trainside cfg=1 must remain a single-forward path.
+#     extra_args.cfg_text_scale; guidance_scale is not forwarded as a top-level
+#     worker argument. It also always sends cfg_img_scale because upstream
+#     BAGEL defaults a missing cfg_text_scale to 4.0 (CFG ON); trainside cfg=1
+#     must remain a single-forward path.
 #   - num_inference_steps is sent as trainside_steps + 1: BAGEL builds
 #     linspace(1, 0, num_timesteps) and loops num_timesteps-1 steps. BAGEL builds
 #     its sigma schedule internally (it ignores sampling_params.sigmas), with a

--- a/unirl/rollout/engine/vllm_omni/stage_configs/bagel_t2i_rl.yaml
+++ b/unirl/rollout/engine/vllm_omni/stage_configs/bagel_t2i_rl.yaml
@@ -22,10 +22,10 @@
 #     paths the trainer's LoRA sync needs.
 #
 # Contract notes:
-#   - CFG is steered through extra_args (cfg_text_scale / cfg_img_scale / ...),
-#     NOT guidance_scale — and the adapter ALWAYS sends them, because upstream
-#     BAGEL defaults a missing cfg_text_scale to 4.0 (CFG ON). The trainside
-#     recipe runs cfg=1 (single-forward), so the adapter passes 1.0/1.0.
+#   - The adapter translates canonical guidance_scale to BAGEL's
+#     extra_args.cfg_text_scale and also sends cfg_img_scale. It always sends
+#     both because upstream BAGEL defaults a missing cfg_text_scale to 4.0
+#     (CFG ON); trainside cfg=1 must remain a single-forward path.
 #   - num_inference_steps is sent as trainside_steps + 1: BAGEL builds
 #     linspace(1, 0, num_timesteps) and loops num_timesteps-1 steps. BAGEL builds
 #     its sigma schedule internally (it ignores sampling_params.sigmas), with a

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -295,10 +295,11 @@ logging:
   log_media: true         # also uploads the eval panel (below)
 ```
 
-`eval_samples_per_prompt: 1` is a real override even when the rollout's
-`samples_per_prompt` is larger. Diffusion sampling has one field per value:
-`samples_per_prompt` controls fan-out and `guidance_scale` controls text CFG,
-including for BAGEL. The retired `num_samples_per_prompt` and
+`eval_samples_per_prompt` is a real override whenever it differs from the
+rollout's `samples_per_prompt`; the retired alias previously caused the
+rollout fan-out to win silently. Diffusion sampling now has one field per
+value: `samples_per_prompt` controls fan-out and `guidance_scale` controls
+text CFG, including for BAGEL. The retired `num_samples_per_prompt` and
 `cfg_text_scale` fields are not accepted.
 
 CFG has no eval knob of its own: leave `guidance_scale` unmentioned and eval

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -296,14 +296,15 @@ logging:
 ```
 
 `eval_samples_per_prompt: 1` is a real override even when the rollout's
-`samples_per_prompt` is larger. `samples_per_prompt` is the sole diffusion
-fan-out field; the retired `num_samples_per_prompt` alias is not accepted.
+`samples_per_prompt` is larger. Diffusion sampling has one field per value:
+`samples_per_prompt` controls fan-out and `guidance_scale` controls text CFG,
+including for BAGEL. The retired `num_samples_per_prompt` and
+`cfg_text_scale` fields are not accepted.
 
 CFG has no eval knob of its own: leave `guidance_scale` unmentioned and eval
 runs at the training guidance (a CFG-off run cannot silently evaluate with CFG
-on); name it in `eval_sampling:` to decouple the two. BAGEL-family params
-consume `cfg_text_scale`, and passing the inert `guidance_scale` there raises.
-Unknown overlay fields raise, and the retired per-field knobs
+on); name it in `eval_sampling:` to decouple the two. Unknown overlay fields
+raise, and the retired per-field knobs
 (`eval_cfg_text_scale`, `eval_num_inference_steps`, ...) fail fast with a
 migration hint. Dynamic-shift models re-derive μ from the eval
 steps/resolution, so a decoupled eval stays on the model's official schedule;

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -295,6 +295,11 @@ logging:
   log_media: true         # also uploads the eval panel (below)
 ```
 
+`eval_samples_per_prompt: 1` is a real override even when the rollout's
+`samples_per_prompt` is larger: the resolver keeps the legacy
+`num_samples_per_prompt` alias in lockstep, and a split between the two
+raises.
+
 CFG has no eval knob of its own: leave `guidance_scale` unmentioned and eval
 runs at the training guidance (a CFG-off run cannot silently evaluate with CFG
 on); name it in `eval_sampling:` to decouple the two. BAGEL-family params

--- a/unirl/trainer/README.md
+++ b/unirl/trainer/README.md
@@ -296,9 +296,8 @@ logging:
 ```
 
 `eval_samples_per_prompt: 1` is a real override even when the rollout's
-`samples_per_prompt` is larger: the resolver keeps the legacy
-`num_samples_per_prompt` alias in lockstep, and a split between the two
-raises.
+`samples_per_prompt` is larger. `samples_per_prompt` is the sole diffusion
+fan-out field; the retired `num_samples_per_prompt` alias is not accepted.
 
 CFG has no eval knob of its own: leave `guidance_scale` unmentioned and eval
 runs at the training guidance (a CFG-off run cannot silently evaluate with CFG

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -228,23 +228,6 @@ def build_eval_sampling(
         updates["samples_per_prompt"] = int(samples_per_prompt)
     updates.update(_resolve_overrides(overrides, field_names))
 
-    # Legacy alias default 1 means unset. replace() copies the training alias,
-    # so a canonical override of 1 has to move both fields or it reverts.
-    if "num_samples_per_prompt" in field_names:
-        if "samples_per_prompt" in updates:
-            canonical = int(updates["samples_per_prompt"])
-            alias = updates.get("num_samples_per_prompt")
-            if alias is not None and int(alias) != canonical:
-                raise ValueError(
-                    f"eval fan-out is split: samples_per_prompt={canonical} vs "
-                    f"num_samples_per_prompt={int(alias)}. {type(base).__name__} keeps the "
-                    "latter as a legacy alias of the former, so the split would be silent. "
-                    "Set one fan-out, or set both to the same value."
-                )
-            updates["num_samples_per_prompt"] = canonical
-        elif "num_samples_per_prompt" in updates:
-            updates["samples_per_prompt"] = int(updates["num_samples_per_prompt"])
-
     # Only the cfg_text_scale families declare both; elsewhere the sibling is not a
     # field at all and _resolve_overrides already rejected it.
     if "cfg_text_scale" in field_names and "guidance_scale" in updates:

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -174,7 +174,7 @@ def _preflight_trainside_geometry(
 
 # Per-field eval knobs the overlay replaced (or dropped), and what to write instead.
 _RETIRED_EVAL_KEYS = {
-    "eval_cfg_text_scale": "eval_sampling: {guidance_scale: X}   (BAGEL family: cfg_text_scale)",
+    "eval_cfg_text_scale": "eval_sampling: {guidance_scale: X}",
     "eval_num_inference_steps": "eval_sampling: {num_inference_steps: X}",
     "eval_height": "eval_sampling: {height: X}",
     "eval_width": "eval_sampling: {width: X}",
@@ -190,12 +190,6 @@ _RETIRED_EVAL_KEYS = {
 _UNSUPPORTED_OVERLAY_FIELDS = frozenset(
     {"scheduler", "sde_strategy", "sigmas", "noise_group_ids", "init_noise_latent_shape"}
 )
-
-
-def cfg_scale_of(params: Any) -> float:
-    """The CFG scale a diffusion params object will actually be sampled with."""
-    scale = getattr(params, "cfg_text_scale", None)
-    return float(params.guidance_scale if scale is None else scale)
 
 
 def reject_retired_eval_keys(cfg: Any) -> None:
@@ -227,15 +221,6 @@ def build_eval_sampling(
     if samples_per_prompt is not None:
         updates["samples_per_prompt"] = int(samples_per_prompt)
     updates.update(_resolve_overrides(overrides, field_names))
-
-    # Only the cfg_text_scale families declare both; elsewhere the sibling is not a
-    # field at all and _resolve_overrides already rejected it.
-    if "cfg_text_scale" in field_names and "guidance_scale" in updates:
-        raise ValueError(
-            f"eval_sampling sets `guidance_scale`, which {type(base).__name__} declares but its "
-            "pipeline discards — the eval would silently run at the training CFG. "
-            "Set `cfg_text_scale` instead."
-        )
 
     steps = int(updates.get("num_inference_steps", base.num_inference_steps))
     if float(updates["eta"]) <= 0.0:
@@ -902,7 +887,7 @@ class DiffusionTrainer(BaseTrainer):
             int(eval_diffusion.num_inference_steps),
             int(eval_diffusion.height),
             int(eval_diffusion.width),
-            cfg_scale_of(eval_diffusion),
+            float(eval_diffusion.guidance_scale),
             float(eval_diffusion.eta),
             "  ".join(f"{k}={v:.4f}" for k, v in metrics.items()),
         )

--- a/unirl/trainer/diffusion.py
+++ b/unirl/trainer/diffusion.py
@@ -228,6 +228,23 @@ def build_eval_sampling(
         updates["samples_per_prompt"] = int(samples_per_prompt)
     updates.update(_resolve_overrides(overrides, field_names))
 
+    # Legacy alias default 1 means unset. replace() copies the training alias,
+    # so a canonical override of 1 has to move both fields or it reverts.
+    if "num_samples_per_prompt" in field_names:
+        if "samples_per_prompt" in updates:
+            canonical = int(updates["samples_per_prompt"])
+            alias = updates.get("num_samples_per_prompt")
+            if alias is not None and int(alias) != canonical:
+                raise ValueError(
+                    f"eval fan-out is split: samples_per_prompt={canonical} vs "
+                    f"num_samples_per_prompt={int(alias)}. {type(base).__name__} keeps the "
+                    "latter as a legacy alias of the former, so the split would be silent. "
+                    "Set one fan-out, or set both to the same value."
+                )
+            updates["num_samples_per_prompt"] = canonical
+        elif "num_samples_per_prompt" in updates:
+            updates["samples_per_prompt"] = int(updates["num_samples_per_prompt"])
+
     # Only the cfg_text_scale families declare both; elsewhere the sibling is not a
     # field at all and _resolve_overrides already rejected it.
     if "cfg_text_scale" in field_names and "guidance_scale" in updates:

--- a/unirl/trainer/pe.py
+++ b/unirl/trainer/pe.py
@@ -235,12 +235,11 @@ class PETrainer(BaseTrainer):
     def evaluate(self, step: int) -> float:
         """Periodic eval on the eval set (no training); returns the mean image reward."""
         base_diffusion = self.sampling_params.get("diffusion")
-        replace_kwargs = dict(eta=self.eval_eta)
-        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
-            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
-        else:
-            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
-        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
+        eval_diffusion = dataclasses.replace(
+            base_diffusion,
+            eta=self.eval_eta,
+            guidance_scale=self.eval_cfg_text_scale,
+        )
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
         self.rollout.wake_up()
         try:

--- a/unirl/trainer/unified_model.py
+++ b/unirl/trainer/unified_model.py
@@ -465,12 +465,11 @@ class UnifiedModelTrainer(BaseTrainer):
     def evaluate(self, step: int) -> float:
         """Periodic eval on the eval set (no training); returns the mean image reward."""
         base_diffusion = self.sampling_params.get("diffusion")
-        replace_kwargs = dict(eta=self.eval_eta)
-        if "cfg_text_scale" in {f.name for f in dataclasses.fields(base_diffusion)}:
-            replace_kwargs["cfg_text_scale"] = self.eval_cfg_text_scale
-        else:
-            replace_kwargs["guidance_scale"] = self.eval_cfg_text_scale
-        eval_diffusion = dataclasses.replace(base_diffusion, **replace_kwargs)
+        eval_diffusion = dataclasses.replace(
+            base_diffusion,
+            eta=self.eval_eta,
+            guidance_scale=self.eval_cfg_text_scale,
+        )
         eval_sp = {**self.sampling_params, "diffusion": eval_diffusion}
         if not self._single_engine and self.weight_sync is not None:
             if self._enable_fsdp_offload:

--- a/unirl/types/sampling.py
+++ b/unirl/types/sampling.py
@@ -88,14 +88,7 @@ class DiffusionSamplingParams(BaseSamplingParams):
     guidance_scale_2: Optional[float] = None
     strength: Optional[float] = None
 
-    num_samples_per_prompt: int = 1
-
     def __post_init__(self) -> None:
-        if self.num_samples_per_prompt != 1 and self.samples_per_prompt == 1:
-            object.__setattr__(self, "samples_per_prompt", self.num_samples_per_prompt)
-        elif self.samples_per_prompt != 1 and self.num_samples_per_prompt == 1:
-            object.__setattr__(self, "num_samples_per_prompt", self.samples_per_prompt)
-
         reserved = {f.name for f in fields(self) if f.name != "sampler_kwargs"}
         shadowed = reserved & set(self.sampler_kwargs)
         require(


### PR DESCRIPTION
## Summary

Diffusion sampling carried two duplicate sources of truth:

- `samples_per_prompt` plus the legacy `num_samples_per_prompt` alias. `dataclasses.replace()` copied both fields, so any eval fan-out differing from a training fan-out greater than one could be silently restored to the training value.
- BAGEL inherited `guidance_scale` while separately storing and consuming `cfg_text_scale`, forcing recipes and eval code to keep both fields aligned.

Remove both duplicate fields. Runtime sampling now uses only `samples_per_prompt` for fan-out and `guidance_scale` for text CFG across every diffusion family. The vLLM-Omni adapter requires `BagelDiffusionParams` and translates `guidance_scale` to BAGEL's external `cfg_text_scale` worker argument at that boundary.

Redundant SenseNova and BAGEL recipe settings, model-family eval branches, duplicate adapter defaults, and the one-use CFG resolver are removed.

## Related Issue

N/A

## Test Plan

- Focused CPU checks cover `dataclasses.replace(..., samples_per_prompt=1)` for base and SenseNova params.
- Focused BAGEL checks cover canonical `guidance_scale`, eval overrides, CFG interval gating, wire translation, and rejection of generic diffusion params by the BAGEL adapter.
- Confirmed both retired sampling fields fail at construction/overlay boundaries.
- Hydra-instantiated every changed BAGEL sampling recipe successfully.
- `pre-commit run --all-files` — pass.
- Full pre-push hook suite — pass.

## Compatibility / Risk

This intentionally removes the sampling-level `num_samples_per_prompt` and `cfg_text_scale` configuration/API fields. Configurations using them now fail instead of maintaining duplicate runtime state. BAGEL's vendor/worker API still receives `cfg_text_scale`; the adapter derives it from canonical `guidance_scale`. The PE/Unified top-level `eval_cfg_text_scale` trainer knob remains unchanged and writes canonical `guidance_scale`.

Five shipped DiffusionTrainer recipes now honor their declared `eval_samples_per_prompt: 4` instead of silently using the larger training fan-out (BAGEL 8→4 and LTX2 16→4). This intentionally changes eval cost and sample aggregation to match configuration.

## Reviewer Notes

The final diff was reviewed against the PR base. Repository-wide scans found no additional sampling aliases. Remaining `cfg_text_scale` occurrences are the rejected retired eval key, the unchanged PE/Unified trainer-knob name, or BAGEL vendor/wire-boundary names—not duplicate runtime sampling state. Qwen `distilled_guidance_scale` remains because it controls a transformer guidance embedding independently of true CFG.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.