### PR TITLE
fix(ar): prepare replay anchors using the planned microbatches

### DIFF
--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -10,7 +10,7 @@
   <img src="../../assets/algorithm-contract-new.png" alt="UniRL algorithm contract: a StageAlgorithm combines new_logp from replay, the frozen pi_old anchor, and advantages into a loss (four interchangeable families: GRPO, FlowDPPO, DRPO, and DiffusionNFT as the ratio-free exception), and declares knobs — requires_ema_rollout, supports_multi_update, anchor_fields/recomputes_anchor — that reconfigure the sampler and train stack around it" width="100%">
 </div>
 
-*A `StageAlgorithm` is two things: a **loss combine** (`stage.replay → new_logp`, mixed with the frozen **π_old** anchor and advantages — four interchangeable families) and a few **declared knobs** (`requires_ema_rollout`, `supports_multi_update`, `anchor_fields`/`recomputes_anchor()`) that reconfigure the sampler and the train loop around it.*
+*A `StageAlgorithm` is two things: a **loss combine** (`stage.replay → new_logp`, mixed with the frozen **π_old** anchor and advantages — four interchangeable families) and a few **declared knobs** (`requires_ema_rollout`, `supports_multi_update`, `anchor_fields`/`recomputes_anchor`) that reconfigure the sampler and the train loop around it.*
 
 ## What it is
 
@@ -30,7 +30,7 @@ the sampler whether to roll out under EMA weights (DiffusionNFT sets it `True`; 
 `supports_multi_update` tells `TrainStack` whether one rollout may be split into N
 optimizer steps (it *raises* if a `False` algorithm meets `num_updates_per_batch > 1`).
 The π_old anchor geometry is *not* centralized here — the algorithm only declares
-`anchor_fields` / `recomputes_anchor()`; `TrainStack` does the per-slice recompute.
+`anchor_fields` / `recomputes_anchor`; `TrainStack` does the per-slice recompute.
 So this module keeps four rollout/update **contracts** selectable at the loss node,
 not just three-tensor arithmetic.
 
@@ -54,7 +54,7 @@ not just three-tensor arithmetic.
 - **The anchor contract — the subtle part.** bf16 forwards are batch-shape
   sensitive, so a π_old anchor computed at a different geometry than `new_logp`
   drifts the on-policy ratio off 1 (and FlowDPPO's KL off 0). Algorithms just declare
-  `anchor_fields` (which segment fields to freeze) and `recomputes_anchor()`
+  `anchor_fields` (which segment fields to freeze) and `recomputes_anchor`
   (whether `prepare_segment` replays); `TrainStack` then recomputes the anchor over
   the *exact same* mini/micro slices it will train on. No hardcoded field names.
 - **Variants are recipes, not classes.** DanceGRPO and MixGRPO are `FlowGRPO`

--- a/unirl/algorithms/README.md
+++ b/unirl/algorithms/README.md
@@ -64,7 +64,8 @@ not just three-tensor arithmetic.
 **Extending it:** a new diffusion loss subclasses `StageAlgorithm`, calls
 `stage.replay(...)`, computes a per-element loss, and `(loss * loss_scale).backward()`;
 if it needs multi-update, set `anchor_fields` and `supports_multi_update = True` and
-mirror `FlowGRPO`. A new AR loss mirrors `GRPO` (early-return on an empty
+declare `recomputes_anchor` when `prepare_segment` must follow the planned micro
+geometry (see `FlowGRPO`). A new AR loss mirrors `GRPO` (early-return on an empty
 segment, expand advantages per token), keeping `supports_multi_update = False`.
 
 ## Gotchas
@@ -73,11 +74,10 @@ segment, expand advantages per token), keeping `supports_multi_update = False`.
   SGLang rollout emits no per-step `sde_logp`, so the `rollout` source raises in
   `prepare_segment`. Use `replay` (the cost is one extra `torch.no_grad` replay).
 - **`num_updates_per_batch > 1` on DiffusionNFT** raises in `TrainStack.__init__` — DiffusionNFT keeps
-  the default `supports_multi_update = False`. The four that allow it all freeze a
-  stable anchor: `FlowGRPO`/`FlowDPPO` freeze `sde_logp` once in
-  `prepare_segment`, while `GRPO`/`DRPO` reuse the rollout log-prob as the anchor
-  for all N steps (verl `bypass_mode` parity — so the AR ratio also carries the
-  rollout-vs-train engine gap, by design).
+  the default `supports_multi_update = False`. Multi-update algorithms freeze their
+  declared anchors: `FlowGRPO`/`FlowDPPO` prepare `sde_logp`; `GRPO` always reuses
+  the rollout log-prob, while DPPO/CPPO/DRPO do so under `old_logp_source: rollout`
+  and recompute it over the planned training micros under `replay`.
 - **FlowDPPO isn't fully on-policy under `rollout`** — it always replays `sde_means`
   (KL = 0) but keeps the engine's `sde_logp`, so its ratio isn't pinned to 1. Use
   `replay` to also pin the ratio.

--- a/unirl/algorithms/base.py
+++ b/unirl/algorithms/base.py
@@ -245,11 +245,8 @@ class StageAlgorithm(Remote, ABC):
     requires_backend: bool = False
     requires_advantages: bool = True
     loss_weighting: str = "sample"
+    recomputes_anchor: bool = False
     anchor_fields: Tuple[str, ...] = ()
-
-    def recomputes_anchor(self) -> bool:
-        """Whether the anchor must be recomputed at the exact ``(mini, micro)`` geometry training uses."""
-        return False
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/cppo.py
+++ b/unirl/algorithms/cppo.py
@@ -124,6 +124,10 @@ class CPPO(StageAlgorithm):
     """CPPO (Binary-TV) for AR token-level policies — the paper's proposed method."""
 
     supports_multi_update = True
+    anchor_fields = ("log_probs",)
+
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
 
     def __init__(
         self,

--- a/unirl/algorithms/cppo.py
+++ b/unirl/algorithms/cppo.py
@@ -126,6 +126,10 @@ class CPPO(StageAlgorithm):
     supports_multi_update = True
     anchor_fields = ("log_probs",)
 
+    @property
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
+
     def __init__(
         self,
         *,
@@ -165,7 +169,6 @@ class CPPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"CPPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
-        self.recomputes_anchor = self.old_logp_source == "replay"
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/cppo.py
+++ b/unirl/algorithms/cppo.py
@@ -126,9 +126,6 @@ class CPPO(StageAlgorithm):
     supports_multi_update = True
     anchor_fields = ("log_probs",)
 
-    def recomputes_anchor(self) -> bool:
-        return self.old_logp_source == "replay"
-
     def __init__(
         self,
         *,
@@ -168,6 +165,7 @@ class CPPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"CPPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
+        self.recomputes_anchor = self.old_logp_source == "replay"
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/dppo.py
+++ b/unirl/algorithms/dppo.py
@@ -87,6 +87,10 @@ class DPPO(StageAlgorithm):
     """DPPO for AR token-level policies — the foundational Binary-TV trust region."""
 
     supports_multi_update = True
+    anchor_fields = ("log_probs",)
+
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
 
     def __init__(
         self,

--- a/unirl/algorithms/dppo.py
+++ b/unirl/algorithms/dppo.py
@@ -89,9 +89,6 @@ class DPPO(StageAlgorithm):
     supports_multi_update = True
     anchor_fields = ("log_probs",)
 
-    def recomputes_anchor(self) -> bool:
-        return self.old_logp_source == "replay"
-
     def __init__(
         self,
         *,
@@ -125,6 +122,7 @@ class DPPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"DPPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
+        self.recomputes_anchor = self.old_logp_source == "replay"
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/dppo.py
+++ b/unirl/algorithms/dppo.py
@@ -89,6 +89,10 @@ class DPPO(StageAlgorithm):
     supports_multi_update = True
     anchor_fields = ("log_probs",)
 
+    @property
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
+
     def __init__(
         self,
         *,
@@ -122,7 +126,6 @@ class DPPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"DPPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
-        self.recomputes_anchor = self.old_logp_source == "replay"
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/drpo.py
+++ b/unirl/algorithms/drpo.py
@@ -73,9 +73,6 @@ class DRPO(StageAlgorithm):
 
     anchor_fields = ("log_probs",)
 
-    def recomputes_anchor(self) -> bool:
-        return self.old_logp_source == "replay"
-
     def __init__(
         self,
         *,
@@ -106,6 +103,7 @@ class DRPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"DRPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
+        self.recomputes_anchor = self.old_logp_source == "replay"
         self.supports_multi_update = True
 
     def prepare_segment(

--- a/unirl/algorithms/drpo.py
+++ b/unirl/algorithms/drpo.py
@@ -73,6 +73,10 @@ class DRPO(StageAlgorithm):
 
     anchor_fields = ("log_probs",)
 
+    @property
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
+
     def __init__(
         self,
         *,
@@ -103,7 +107,6 @@ class DRPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"DRPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
-        self.recomputes_anchor = self.old_logp_source == "replay"
         self.supports_multi_update = True
 
     def prepare_segment(

--- a/unirl/algorithms/drpo.py
+++ b/unirl/algorithms/drpo.py
@@ -71,6 +71,11 @@ def _drpo_loss(
 class DRPO(StageAlgorithm):
     """DRPO for AR token-level policies — the paper's proposed method (§3)."""
 
+    anchor_fields = ("log_probs",)
+
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
+
     def __init__(
         self,
         *,

--- a/unirl/algorithms/flowdppo.py
+++ b/unirl/algorithms/flowdppo.py
@@ -95,10 +95,8 @@ class FlowDPPO(StageAlgorithm):
 
     supports_multi_update = True
     requires_backend = True
+    recomputes_anchor = True
     anchor_fields = ("sde_logp", "sde_means")
-
-    def recomputes_anchor(self) -> bool:
-        return True
 
     def __init__(
         self,

--- a/unirl/algorithms/flowgrpo.py
+++ b/unirl/algorithms/flowgrpo.py
@@ -46,6 +46,10 @@ class FlowGRPO(StageAlgorithm):
     requires_backend = True
     anchor_fields = ("sde_logp",)
 
+    @property
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
+
     def __init__(
         self,
         *,
@@ -76,7 +80,6 @@ class FlowGRPO(StageAlgorithm):
             self.old_logp_source in ("rollout", "replay"),
             f"FlowGRPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}",
         )
-        self.recomputes_anchor = self.old_logp_source == "replay"
         _require_replay_anchor_for_batched_replay(self.stage, self.old_logp_source, algo="FlowGRPO")
         self.conditions_cls = conditions_cls
 

--- a/unirl/algorithms/flowgrpo.py
+++ b/unirl/algorithms/flowgrpo.py
@@ -46,9 +46,6 @@ class FlowGRPO(StageAlgorithm):
     requires_backend = True
     anchor_fields = ("sde_logp",)
 
-    def recomputes_anchor(self) -> bool:
-        return self.old_logp_source == "replay"
-
     def __init__(
         self,
         *,
@@ -79,6 +76,7 @@ class FlowGRPO(StageAlgorithm):
             self.old_logp_source in ("rollout", "replay"),
             f"FlowGRPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}",
         )
+        self.recomputes_anchor = self.old_logp_source == "replay"
         _require_replay_anchor_for_batched_replay(self.stage, self.old_logp_source, algo="FlowGRPO")
         self.conditions_cls = conditions_cls
 

--- a/unirl/algorithms/gspo.py
+++ b/unirl/algorithms/gspo.py
@@ -37,9 +37,6 @@ class GSPO(StageAlgorithm):
     supports_multi_update = True
     anchor_fields = ("log_probs", "rollout_log_probs")
 
-    def recomputes_anchor(self) -> bool:
-        return self.old_logp_source == "replay"
-
     _MAX_LOG_RATIO = 10.0
 
     def __init__(
@@ -75,6 +72,7 @@ class GSPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"GSPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
+        self.recomputes_anchor = self.old_logp_source == "replay"
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/gspo.py
+++ b/unirl/algorithms/gspo.py
@@ -37,6 +37,10 @@ class GSPO(StageAlgorithm):
     supports_multi_update = True
     anchor_fields = ("log_probs", "rollout_log_probs")
 
+    @property
+    def recomputes_anchor(self) -> bool:
+        return self.old_logp_source == "replay"
+
     _MAX_LOG_RATIO = 10.0
 
     def __init__(
@@ -72,7 +76,6 @@ class GSPO(StageAlgorithm):
         self.old_logp_source = str(old_logp_source).strip().lower()
         if self.old_logp_source not in ("rollout", "replay"):
             raise ValueError(f"GSPO: old_logp_source must be 'rollout' or 'replay'; got {old_logp_source!r}")
-        self.recomputes_anchor = self.old_logp_source == "replay"
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/ppo.py
+++ b/unirl/algorithms/ppo.py
@@ -85,6 +85,7 @@ class PPO(StageAlgorithm):
     """PPO over an AR ``TextSegment`` with a train-side value head."""
 
     supports_multi_update = True
+    recomputes_anchor = True
     anchor_fields = ("values",)
 
     def __init__(
@@ -138,10 +139,6 @@ class PPO(StageAlgorithm):
 
             sampling_temperature = ARSamplingParams.__dataclass_fields__["temperature"].default
         self.sampling_temperature = float(sampling_temperature)
-
-    def recomputes_anchor(self) -> bool:
-        """Critic anchors must use the exact micro geometry of the train forward."""
-        return True
 
     def prepare_segment(
         self,

--- a/unirl/algorithms/ppo.py
+++ b/unirl/algorithms/ppo.py
@@ -85,7 +85,7 @@ class PPO(StageAlgorithm):
     """PPO over an AR ``TextSegment`` with a train-side value head."""
 
     supports_multi_update = True
-    recomputes_anchor = True
+    recomputes_anchor = True  # Critic values must use the exact training micro geometry.
     anchor_fields = ("values",)
 
     def __init__(

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -55,7 +55,8 @@ knows nothing about DTensor sharding or wrap topology.
 before `fsdp_wrap`, plus a config in `configs.py`; a new optimizer or LR schedule
 is a branch in `optim.py` plus fields on `OptimizerConfig` / `LrSchedulerConfig`
 in `backend/base.py`; a multi-update-capable algorithm sets
-`supports_multi_update = True` and declares `anchor_fields` (see
+`supports_multi_update = True`, declares `anchor_fields`, and exposes
+`recomputes_anchor` when its anchor must follow the planned micro geometry (see
 `../algorithms/README.md`).
 
 ## Gotchas

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -104,7 +104,7 @@ class TrainStack(Remote):
         if part.segment is None:
             return
         algorithm = self.algorithm
-        if not algorithm.recomputes_anchor():
+        if not algorithm.recomputes_anchor:
             algorithm.prepare_segment(conditions=part.conditions, segment=part.segment)
             return
         micro_slices = [r for update in plans for r in update]

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -64,6 +64,13 @@ def _align_track_to_model(part: Part, *, device: torch.device) -> None:
         part.advantages = part.advantages.to(device=device)
 
 
+def _validate_anchor_contract(algorithm: StageAlgorithm) -> None:
+    if not isinstance(algorithm.recomputes_anchor, bool):
+        raise TypeError(f"{type(algorithm).__name__}.recomputes_anchor must be a bool attribute.")
+    if algorithm.recomputes_anchor and not algorithm.anchor_fields:
+        raise ValueError(f"{type(algorithm).__name__} recomputes its anchor but declares no anchor_fields.")
+
+
 class TrainStack(Remote):
     """Single-stage stage-driven train stack — family-agnostic."""
 
@@ -97,6 +104,7 @@ class TrainStack(Remote):
         self.micro_batch_size = int(micro_batch_size)
         self.max_grad_norm = float(max_grad_norm)
         self.micro_planner: MicroPlanner = micro_planner if micro_planner is not None else CountPlanner()
+        _validate_anchor_contract(algorithm)
         self.micro_planner.validate(algorithm)
 
     def prepare_segment(self, part: Part, *, plans: Plan) -> None:

--- a/unirl/train/stack/base.py
+++ b/unirl/train/stack/base.py
@@ -65,9 +65,11 @@ def _align_track_to_model(part: Part, *, device: torch.device) -> None:
 
 
 def _validate_anchor_contract(algorithm: StageAlgorithm) -> None:
-    if not isinstance(algorithm.recomputes_anchor, bool):
+    """Reject anchor declarations whose per-micro outputs would be discarded."""
+    recomputes_anchor = algorithm.recomputes_anchor
+    if not isinstance(recomputes_anchor, bool):
         raise TypeError(f"{type(algorithm).__name__}.recomputes_anchor must be a bool attribute.")
-    if algorithm.recomputes_anchor and not algorithm.anchor_fields:
+    if recomputes_anchor and not algorithm.anchor_fields:
         raise ValueError(f"{type(algorithm).__name__} recomputes its anchor but declares no anchor_fields.")
 
 
@@ -91,7 +93,7 @@ class TrainStack(Remote):
         if float(max_grad_norm) <= 0.0:
             raise ValueError(f"{cls}.max_grad_norm must be > 0; got {max_grad_norm}.")
         self.num_updates_per_batch = _positive_int(name=f"{cls}.num_updates_per_batch", value=num_updates_per_batch)
-        if self.num_updates_per_batch > 1 and not getattr(algorithm, "supports_multi_update", False):
+        if self.num_updates_per_batch > 1 and not algorithm.supports_multi_update:
             raise ValueError(
                 f"num_updates_per_batch={self.num_updates_per_batch} requires an algorithm whose "
                 f"old_logp anchor stays frozen across the N optimizer steps "

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -81,8 +81,7 @@ class UnifiedModelTrainStack(Remote):
         prepare = getattr(algorithm, "prepare_segment", None)
         if prepare is None:
             return
-        recomputes = getattr(algorithm, "recomputes_anchor", None)
-        if recomputes is None or not recomputes():
+        if not algorithm.recomputes_anchor:
             prepare(conditions=part.conditions, segment=part.segment)
             return
         micro_slices = [sl for step in self._optimizer_step_slices(int(part.batch_size)) for sl in step]

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -15,7 +15,7 @@ from unirl.distributed.group.dispatch import Dispatch, distributed
 from unirl.distributed.group.remote import Remote
 from unirl.train.backend.fsdp import FSDPBackend
 from unirl.train.stack import TrainStepResult, _build_micro_batch_slices
-from unirl.train.stack.base import _aggregate_update_results
+from unirl.train.stack.base import _aggregate_update_results, _validate_anchor_contract
 from unirl.train.stack.planner.types import _positive_int, _update_ranges
 from unirl.types.sample import Part, Sample
 from unirl.types.sampling import ARSamplingParams, DiffusionSamplingParams
@@ -50,6 +50,8 @@ class UnifiedModelTrainStack(Remote):
         self.num_updates_per_batch = _positive_int(
             name="UnifiedModelTrainStack.num_updates_per_batch", value=num_updates_per_batch
         )
+        _validate_anchor_contract(self.ar_algorithm)
+        _validate_anchor_contract(self.image_algorithm)
         if self.num_updates_per_batch > 1:
             for name, algo in (("ar", self.ar_algorithm), ("image", self.image_algorithm)):
                 if not getattr(algo, "supports_multi_update", False):

--- a/unirl/train/unified_model_stack.py
+++ b/unirl/train/unified_model_stack.py
@@ -54,7 +54,7 @@ class UnifiedModelTrainStack(Remote):
         _validate_anchor_contract(self.image_algorithm)
         if self.num_updates_per_batch > 1:
             for name, algo in (("ar", self.ar_algorithm), ("image", self.image_algorithm)):
-                if not getattr(algo, "supports_multi_update", False):
+                if not algo.supports_multi_update:
                     raise ValueError(
                         f"num_updates_per_batch={self.num_updates_per_batch} requires every algorithm's "
                         f"π_old anchor to stay frozen across the N optimizer steps, but the {name!r} "
@@ -80,21 +80,17 @@ class UnifiedModelTrainStack(Remote):
         """Freeze one algorithm's π_old anchor once, before the multi-update loop."""
         if part.segment is None:
             return
-        prepare = getattr(algorithm, "prepare_segment", None)
-        if prepare is None:
-            return
         if not algorithm.recomputes_anchor:
-            prepare(conditions=part.conditions, segment=part.segment)
+            algorithm.prepare_segment(conditions=part.conditions, segment=part.segment)
             return
         micro_slices = [sl for step in self._optimizer_step_slices(int(part.batch_size)) for sl in step]
         if len(micro_slices) == 1:
-            prepare(conditions=part.conditions, segment=part.segment)
+            algorithm.prepare_segment(conditions=part.conditions, segment=part.segment)
             return
-        anchor_fields = getattr(algorithm, "anchor_fields", ())
-        collected: Dict[str, List[torch.Tensor]] = {field: [] for field in anchor_fields}
+        collected: Dict[str, List[torch.Tensor]] = {field: [] for field in algorithm.anchor_fields}
         for start, end in micro_slices:
             micro = part.slice(start, end)
-            prepare(conditions=micro.conditions, segment=micro.segment)
+            algorithm.prepare_segment(conditions=micro.conditions, segment=micro.segment)
             for field in collected:
                 value = getattr(micro.segment, field, None)
                 if value is None:


### PR DESCRIPTION
## Summary

When `old_logp_source=replay`, DPPO/CPPO/DRPO already freeze π_old into `segment.log_probs`, but `recomputes_anchor()` stayed false, so TrainStack prepared the whole worker shard in one forward. They now declare it like GSPO, and replay uses the same micros as the training step.

## Related Issue

N/A

## Test Plan

- `ruff check` / `ruff format --check` on `unirl/algorithms/{dppo,cppo,drpo}.py` — pass
- Local smoke checks for `rollout` (still whole-shard), `replay` (follows the planned micros), and a missing declared field (raises). No test files included in this PR.
- Live train: Not run; reason: this is the `recomputes_anchor` declaration; TrainStack's sliced path is the existing GSPO / FlowGRPO one.

## Compatibility / Risk

No config, checkpoint, data format, or public API changes expected. Risk is limited to `old_logp_source=replay` on DPPO/CPPO/DRPO; default recipes stay on `rollout`.

## Reviewer Notes

No overlapping open PR touches `dppo.py` / `cppo.py` / `drpo.py`.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
