### PR TITLE
fix(hunyuan-video10): keep scaled timestep in fp32

### DIFF
--- a/unirl/models/hunyuan_video10/diffusion.py
+++ b/unirl/models/hunyuan_video10/diffusion.py
@@ -60,7 +60,8 @@ class HunyuanVideo10DiffusionStep(DiffusionStep[HunyuanVideo10Bundle, HunyuanVid
             timestep = sigma.expand(batch_size)
         else:
             timestep = sigma
-        timestep = timestep.to(device=device, dtype=dtype) * self.TIMESTEP_SCALE
+        # Match Diffusers/SGLang: scale fp32 sigma before casting to the transformer dtype.
+        timestep = (timestep.to(device=device, dtype=torch.float32) * self.TIMESTEP_SCALE).to(dtype=dtype)
 
         guidance = torch.full((batch_size,), guidance_scale, device=device, dtype=dtype)
 

--- a/unirl/models/hunyuan_video10/diffusion.py
+++ b/unirl/models/hunyuan_video10/diffusion.py
@@ -60,8 +60,8 @@ class HunyuanVideo10DiffusionStep(DiffusionStep[HunyuanVideo10Bundle, HunyuanVid
             timestep = sigma.expand(batch_size)
         else:
             timestep = sigma
-        # Match Diffusers/SGLang: scale fp32 sigma before casting to the transformer dtype.
-        timestep = (timestep.to(device=device, dtype=torch.float32) * self.TIMESTEP_SCALE).to(dtype=dtype)
+        # Match Diffusers/SGLang: keep the scaled timestep in fp32 through the sinusoidal embedding.
+        timestep = timestep.to(device=device, dtype=torch.float32) * self.TIMESTEP_SCALE
 
         guidance = torch.full((batch_size,), guidance_scale, device=device, dtype=dtype)
 


### PR DESCRIPTION
## Summary

`HunyuanVideo10DiffusionStep.predict_noise` cast σ to the transformer dtype and
*then* multiplied by `TIMESTEP_SCALE`:

```python
timestep = timestep.to(device=device, dtype=dtype) * self.TIMESTEP_SCALE
```

So the bf16 rounding landed on σ ∈ [0, 1], where bf16 has ~3 decimal digits,
instead of on the timestep ∈ [0, 1000]. Diffusers
(`FlowMatchEulerDiscreteScheduler.set_timesteps`: `timesteps = sigmas * num_train_timesteps`)
and the SGLang scheduler (`runtime/models/schedulers/flow_match_pair.py:89`) both
keep the scaled timestep in fp32 through the sinusoidal embedding. The trainside
replay therefore fed the DiT a different timestep than the rollout engine used to
produce the trajectory.

On the recipe's own schedule (`num_inference_steps=10`, `shift=5.0`) **2 of 10
steps disagree**:

| step | σ | old (`bf16 × 1000`) | fixed (`fp32 × 1000`) | SGLang / Diffusers (fp32) |
| --- | --- | --- | --- | --- |
| 1 | 0.97826087 | 976.0 | **978.2609** | 978.2609 |
| 7 | 0.68181819 | 684.0 | **681.8182** | 681.8182 |

After the fix the trainside timestep remains fp32 through the sinusoidal
embedding, exactly matching the value the engines use. All 10 recipe steps now
receive the same timestep values on rollout and replay; previously 9/10 were
quantized to bf16, with the largest double-rounding errors at steps 1 and 7.

This is the same defect and the same one-line change that #390 applied to
HunyuanVideo-1.5 (`unirl/models/hunyuan_video15/diffusion.py:83`); HV1.0 was not
touched by that PR. Aligning them makes the two video bundles consistent.

## Related Issue

Related to #412 (HunyuanVideo-1.0 SGLang-vs-trainside reward divergence). This
is **a** train/inference mismatch on that recipe's path, but see Reviewer Notes
— I am explicitly *not* claiming it resolves that issue.

## Test Plan

- `SKIP=no-commit-to-branch pre-commit run --files unirl/models/hunyuan_video10/diffusion.py --show-diff-on-failure` → all hooks pass (ruff check, ruff format, docstrings-are-one-line, dependency directions).
- Numeric check of the schedule actually used by
  `examples/diffusion/hunyuan_video10/hunyuan_video10_t2v_sglang.yaml`
  (`num_inference_steps=10`, `shift=5.0`), on an H20 node with the repo's
  `torch 2.11.0+cu129`:

  ```python
  t = torch.linspace(1, 0, 11, dtype=torch.float32)
  sig = 5.0 * t / (1 + 4.0 * t)
  old = sig.to(torch.bfloat16) * 1000.0
  new = (sig.to(torch.float32) * 1000.0).to(torch.bfloat16)
  # old: [1000, 976, 952, 920, 884, 832, 768, 684, 556, 358]
  # new / SGLang / Diffusers fp32:
  # [1000, 978.26, 952.38, 921.05, 882.35, 833.33, 769.23, 681.82, 555.56, 357.14]
  ```

  → mismatched timestep values vs. the engine schedule: 9/10 before, 0/10
  after. The trainside sinusoidal embedding now receives the same fp32 values as
  the rollout engine.

- Training smoke test, HunyuanVideo-1.0 720×1280×5f, PickScore reward,
  `hunyuan_video10_t2v_sglang` recipe unmodified, 2×8 H20, 97 rollouts so far:
  runs clean, reward rises monotonically over 20-rollout bins
  (0.7357 → 0.7492 → 0.7651 → 0.7803 → 0.8048), no clipping, no errors.
  `train/ratio` deviation from 1.0 improved from 3.12e-6 to 2.40e-6
  (`clip_fraction = 0` both before and after, so this recipe's `clip_range=1e-4`
  was never the binding constraint).

## Compatibility / Risk

Low. One expression, one model bundle, no config/checkpoint/API surface change.
It changes the numeric timestep fed to the DiT on 9/10 steps of the recipe's
10-step schedule (the largest corrections are at 2/10 steps), so bitwise
reproductions of previous HV1.0 runs will differ; the new values are the ones the
rollout engines already use. No other bundle is touched
— `wan21`, `wan22`, `ltx2`, `sd3`, and `hunyuan_image3` all multiply σ while it
is still fp32 and cast later (or never cast), so they do not have this defect.

## Reviewer Notes

AI-assisted (Claude Code); I reviewed the one-line diff and ran the checks above.

Duplicate-work check: `grep`ed `TIMESTEP_SCALE` across `unirl/models/`, and
diffed the open PRs that touch `unirl/models/hunyuan_video10/diffusion.py`
(#394 — batched replay timesteps, #388, #436, #434). #394 touches the same file
but only adds `BatchedStepReplayMixin` and the batched-replay branch; it does
not change the scaling expression, so this should not conflict beyond a trivial
merge. #390 is the HV1.5 precedent.

**Please read this part before treating it as a fix for #412.** I have a 220-rollout
paired baseline (SGLang vs trainside, same seed, unmodified recipe) and a
97-rollout run with this patch, and I do **not** consider the training evidence
conclusive:

- My patched run was launched with `batch_size=16` on 2×8 GPUs while the
  baselines were `batch_size=8` on 1×8. Per-rollout curves are therefore not
  comparable — at equal *prompts consumed* the patched run is at or slightly
  below the SGLang baseline, not above it. The favourable-looking per-rollout
  comparison I initially computed was confounded by that difference. I am
  reporting the effect as **not yet demonstrated at the reward level.**
- Independently of that, `log_ratio` is a poor detector here: it is quadratic in
  the per-step engine discrepancy (≈ −δ²/2σ²), so a ~0.1% per-step mean shift
  shows up as ~1e-6 and reads as noise. That is consistent with the issue
  reporter's observation that the measured log-ratio is tiny, and is why I think
  timestep-level exactness is worth fixing on its own terms rather than being
  judged solely by the reward curve.
- Also worth noting for #412 specifically: steps 5–9 of this recipe are always
  ODE (`timestep_fraction: [0.0, 0.5]`, `num_sde_steps: 4`), so they contribute
  no log-prob and are structurally invisible to `ratio` while still determining
  the final sample. Step 7 — one of the two timesteps this patch corrects — is
  in that ODE-only region.

So: I'm proposing this as a correctness fix that makes HV1.0 match HV1.5, the
engines, and Diffusers, justified by the numeric table above. Whether it moves
the #412 reward curves is a separate claim that I have not established, and I'd
rather say so than overstate it. Happy to run a matched-`batch_size` A/B if
that's useful for the issue.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not. (No
      config or doc surface changes; the repo has no tests/ tree by policy
      (#99/#267), so the numeric verification is quoted in the Test Plan.)
