### PR TITLE
fix(checkpoint): preserve cold AdamW state during checkpoint export

### DIFF
--- a/unirl/train/backend/sharded_state.py
+++ b/unirl/train/backend/sharded_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Iterator, Optional
+from typing import Dict, Iterator, List, Optional
 
 import torch
 from torch import nn
@@ -54,18 +54,9 @@ def load_model_state_dict(
 
 
 def gather_optimizer_state_dict(model: nn.Module, optimizer: torch.optim.Optimizer) -> StateDict:
-    """Rank-0 DCP gather of optimizer state.  Full state on rank 0, empty on others."""
-    from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
-
+    """Rank-0 DCP optimizer gather (empty on other ranks); cold AdamW stays unstepped. See ``../readme.md`` Gotchas."""
     options = _build_state_dict_options(full_state_dict=True, cpu_offload=True)
-    try:
-        full = dict(get_optimizer_state_dict(model, optimizer, options=options))
-    except TypeError:
-        full = dict(get_optimizer_state_dict(model, optimizer))
-
-    if _current_rank() != 0:
-        return {}
-    return full
+    return _export_optimizer_state_dict(model, optimizer, options=options, rank0_only=True)
 
 
 def gather_lora_state_dict(model: nn.Module) -> StateDict:
@@ -93,18 +84,13 @@ def load_optimizer_state_dict(
     *,
     broadcast_from_rank0: bool = True,
 ) -> None:
-    """Load a full optimizer state dict and reshard it into ``optimizer``."""
-    from torch.distributed.checkpoint.state_dict import set_optimizer_state_dict
-
+    """Load a full optimizer state dict; a cold checkpoint leaves AdamW unstepped. See ``../readme.md`` Gotchas."""
     options = _build_state_dict_options(
         full_state_dict=True,
         broadcast_from_rank0=broadcast_from_rank0,
         cpu_offload=False,
     )
-    try:
-        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict, options=options)
-    except TypeError:
-        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict)
+    _apply_optimizer_state_dict(model, optimizer, state_dict, options=options)
 
 
 def sharded_model_state_dict(model: nn.Module) -> StateDict:
@@ -119,14 +105,9 @@ def sharded_model_state_dict(model: nn.Module) -> StateDict:
 
 
 def sharded_optimizer_state_dict(model: nn.Module, optimizer: torch.optim.Optimizer) -> StateDict:
-    """Per-rank sharded optimizer state for DCP (symmetric with"""
-    from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
-
+    """Per-rank sharded optimizer state for DCP; cold AdamW stays unstepped. See ``../readme.md`` Gotchas."""
     options = _build_state_dict_options(full_state_dict=False)
-    try:
-        return dict(get_optimizer_state_dict(model, optimizer, options=options))
-    except TypeError:
-        return dict(get_optimizer_state_dict(model, optimizer))
+    return _export_optimizer_state_dict(model, optimizer, options=options, rank0_only=False)
 
 
 def load_sharded_model_state_dict(model: nn.Module, state_dict: StateDict, *, strict: bool = True) -> None:
@@ -143,14 +124,9 @@ def load_sharded_model_state_dict(model: nn.Module, state_dict: StateDict, *, st
 def load_sharded_optimizer_state_dict(
     model: nn.Module, optimizer: torch.optim.Optimizer, state_dict: StateDict
 ) -> None:
-    """Load a per-rank sharded optimizer state read by ``dcp.load`` in place."""
-    from torch.distributed.checkpoint.state_dict import set_optimizer_state_dict
-
+    """Load sharded optimizer state; a cold checkpoint leaves AdamW unstepped. See ``../readme.md`` Gotchas."""
     options = _build_state_dict_options(full_state_dict=False)
-    try:
-        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict, options=options)
-    except TypeError:
-        set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict)
+    _apply_optimizer_state_dict(model, optimizer, state_dict, options=options)
 
 
 def drop_meta_entries(state_dict: StateDict) -> StateDict:
@@ -280,6 +256,116 @@ def _to_cpu_state_dict(state_dict: StateDict) -> StateDict:
         else:
             converted[key] = tensor_or_obj
     return converted
+
+
+def _is_cold_optimizer(optimizer: torch.optim.Optimizer) -> bool:
+    if optimizer.state:
+        return False
+    for group in optimizer.param_groups:
+        for param in group["params"]:
+            if param.grad is not None:
+                return False
+    return True
+
+
+def _optimizer_state_entries(state_dict: StateDict) -> Iterator[Dict[str, object]]:
+    state = state_dict.get("state")
+    if not isinstance(state, dict):
+        return
+    for entry in state.values():
+        if isinstance(entry, dict) and "step" in entry:
+            yield entry
+
+
+def _zero_optimizer_steps(state_dict: StateDict) -> None:
+    for entry in _optimizer_state_entries(state_dict):
+        step = entry["step"]
+        entry["step"] = torch.zeros_like(step) if isinstance(step, torch.Tensor) else 0
+
+
+def _optimizer_state_dict_is_cold(state_dict: StateDict) -> bool:
+    if not state_dict.get("state"):
+        return True
+    entries = list(_optimizer_state_entries(state_dict))
+    if not entries:
+        return False
+    for entry in entries:
+        step = entry["step"]
+        if isinstance(step, torch.Tensor):
+            if bool(local_view(step).detach().cpu().any()):
+                return False
+        elif step != 0:
+            return False
+    return True
+
+
+def _restore_cold_optimizer(
+    optimizer: torch.optim.Optimizer,
+    *,
+    step_count: Optional[int],
+    lrs: List[object],
+) -> None:
+    optimizer.state.clear()
+    for group, lr in zip(optimizer.param_groups, lrs):
+        if "lr" in group:
+            group["lr"] = lr
+    if step_count is not None:
+        optimizer._step_count = step_count
+    optimizer.zero_grad(set_to_none=True)
+
+
+def _export_optimizer_state_dict(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    *,
+    options: object,
+    rank0_only: bool,
+) -> StateDict:
+    """Call ``get_optimizer_state_dict`` without advancing a cold AdamW clock. See ``../readme.md`` Gotchas."""
+    from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
+
+    cold = _is_cold_optimizer(optimizer)
+    step_count = getattr(optimizer, "_step_count", None)
+    lrs = [group.get("lr") for group in optimizer.param_groups]
+    try:
+        try:
+            exported = dict(get_optimizer_state_dict(model, optimizer, options=options))
+        except TypeError:
+            exported = dict(get_optimizer_state_dict(model, optimizer))
+        if cold:
+            _zero_optimizer_steps(exported)
+        if rank0_only and _current_rank() != 0:
+            return {}
+        return exported
+    finally:
+        if cold:
+            _restore_cold_optimizer(optimizer, step_count=step_count, lrs=lrs)
+
+
+def _apply_optimizer_state_dict(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    state_dict: StateDict,
+    *,
+    options: object,
+) -> None:
+    """Call ``set_optimizer_state_dict`` without leaving a dummy step on a cold AdamW. See ``../readme.md`` Gotchas."""
+    from torch.distributed.checkpoint.state_dict import set_optimizer_state_dict
+
+    was_cold = _is_cold_optimizer(optimizer)
+    incoming_cold = _optimizer_state_dict_is_cold(state_dict)
+    step_count = getattr(optimizer, "_step_count", None)
+    lrs = [group.get("lr") for group in optimizer.param_groups]
+    applied = False
+    try:
+        try:
+            set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict, options=options)
+        except TypeError:
+            set_optimizer_state_dict(model, optimizer, optim_state_dict=state_dict)
+        applied = True
+    finally:
+        if was_cold and (not applied or incoming_cold):
+            _restore_cold_optimizer(optimizer, step_count=step_count, lrs=lrs)
 
 
 __all__ = [

--- a/unirl/train/readme.md
+++ b/unirl/train/readme.md
@@ -68,6 +68,14 @@ in `backend/base.py`; a multi-update-capable algorithm sets
 - **`optimizer_step` silently *skips* (does not crash) on a non-finite grad norm**
   and zeroes grads — a flat loss curve with a logged warning means grads went
   non-finite.
+- **Saving a never-stepped AdamW used to bump its internal clock** —
+  stock DCP `get_optimizer_state_dict` dummy-`step()`s an empty optimizer
+  (`lr=0`) to materialize moments, which advances Adam `state['step']` 0→1.
+  UniRL hits this when `optimizer_step` skips (non-finite grad, or a window
+  with no backward) and `maybe_save_checkpoint` still fires. `sharded_state`
+  materializes the export, writes `step=0`, and restores the live optimizer
+  to empty; loading that checkpoint does the same. Already-stepped optimizers
+  are unchanged.
 - **`master_dtype` defaults to `None`, so the optimizer master follows `param_dtype`** —
   a bf16-loaded base then keeps a bf16 LoRA master and the ~1e-6 AdamW steps round
   away (the policy drifts into a degenerate reward-hack). An fp32-loaded model gets an


### PR DESCRIPTION
## Summary

When `optimizer_step` skips and `maybe_save_checkpoint` still fires, DCP `get_optimizer_state_dict` dummy-steps the empty AdamW and leaves `state['step']=1` on the live process and in the file. `sharded_state` now writes `step=0` in the exported state and restores the live optimizer to empty. Loading that step-0 state preserves the first real AdamW update. Already-stepped optimizers are unchanged.

## Related Issue

N/A

## Test Plan

- `ruff check` / `ruff format --check` / `python lint/check_docstring_lines.py` on `unirl/train/backend/sharded_state.py` — pass
- CPU three-way (never-save / save-continue / save-resume) first AdamW update matches; raw DCP dummy-step does not. 2×4090 FSDP2 gather + `dcp.save`/`dcp.load` same. No test files included in this PR.

## Compatibility / Risk

No config or public API changes. Already-stepped checkpoints are unchanged. A never-stepped AdamW file now stores `step=0` rather than the dummy `1`; old dummy-`1` files are not rewritten on load.

## Reviewer Notes

No overlapping open PR touches `sharded_state.py`. Draft #432 still calls `sharded_optimizer_state_dict`.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
