### PR TITLE
perf(train): keep eager AdamW step on CPU across offload/onload

### DIFF
--- a/unirl/train/backend/sharded_state.py
+++ b/unirl/train/backend/sharded_state.py
@@ -165,11 +165,22 @@ def drop_meta_entries(state_dict: StateDict) -> StateDict:
 
 
 def move_optimizer_state(optimizer: torch.optim.Optimizer, device: object) -> None:
-    """Move every tensor in the optimizer state to ``device`` (the on/offload loop)."""
-    for state in optimizer.state.values():
-        for k, v in state.items():
-            if isinstance(v, torch.Tensor):
-                state[k] = v.to(device)
+    """Move optimizer state to ``device`` for on/offload; eager Adam ``step`` stays on CPU."""
+    eager_adam = isinstance(optimizer, (torch.optim.Adam, torch.optim.AdamW))
+    for group in optimizer.param_groups:
+        host_step = eager_adam and not group.get("capturable", False) and not group.get("fused")
+        for param in group["params"]:
+            state = optimizer.state.get(param)
+            if not state:
+                continue
+            for k, v in state.items():
+                if not isinstance(v, torch.Tensor):
+                    continue
+                # Eager Adam reads `step` via .item() every update; upstream hosts it on CPU to avoid device syncs.
+                if host_step and k == "step":
+                    state[k] = v.cpu()
+                else:
+                    state[k] = v.to(device)
 
 
 def lora_state_dict(


### PR DESCRIPTION
## Summary

`move_optimizer_state` moved every state tensor to the target device, including the AdamW `step` counter that upstream PyTorch keeps on CPU when `fused`/`capturable` are off. After one onload, every `optimizer.step()` reads the counter back via `.item()`, one device sync per param entry.

The default AR colocated path hits this on every rollout cycle (`enable_fsdp_offload=True` plus a `weight_sync` block), starting after the first update. `step` now stays on CPU for eager Adam groups; `capturable`/`fused` groups and non-Adam optimizers keep the old routing. Only the `step` key is special-cased, so the 0-dim moments of genuine scalar params still migrate.

On an RTX 4090 this removes a steady 19-26% per-step optimizer overhead (exactly one DtoH copy per param entry); after the fix, step time matches vanilla within 1%.

## Related Issue

N/A

## Test Plan

- Three arms with identical params/grads/param groups/update counts (RTX 4090, torch 2.5.1): A = vanilla, B = pre-fix, C = this fix, median of timed runs.

| entries | A | B | C | B/A | C/A |
|---|---|---|---|---|---|
| 512 | 28.9ms | 34.6ms | 28.6ms | 1.20 | 0.99 |
| 2048 | 116.1ms | 138.9ms | 116.7ms | 1.20 | 1.01 |
| 512 lora-shaped | 29.3ms | 34.8ms | 29.2ms | 1.19 | 1.00 |

  Profiler over one step: DtoH copies 0 / N / 0; parameter updates agree across arms.
- CPU checks: eager `step` stays CPU, `capturable`/`fused` `step` and all moments migrate, non-Adam optimizers untouched, numeric parity through offload/onload cycles. Harnesses not committed (#99/#267).
- `ruff check` / `ruff format --check` / `check-docstring-lines` / `py_compile` pass.
- End-to-end colocated train: Not run; reason: rollout dominates colocated wall time and would bury the optimizer-step delta.

## Compatibility / Risk

No config, checkpoint, data-format, or API changes. Eager Adam already serializes `step` from CPU, so checkpoints are unaffected.

## Reviewer Notes

Single-function change in `unirl/train/backend/sharded_state.py`. No open PR touches `move_optimizer_state` or optimizer-state offload.

## Checklist

- [x] I reviewed the changed code and removed unrelated/generated artifacts.
- [x] I updated tests, docs, and configs where needed, or explained why not.
